### PR TITLE
cleanup: remove bunyan-logstash dep. and unused config

### DIFF
--- a/config.json
+++ b/config.json
@@ -30,10 +30,6 @@
     "clusters": 10,
     "log": {
         "logLevel": "info",
-        "dumpLevel": "error",
-        "logstash": {
-            "host": "127.0.0.1",
-            "port": 5505
-        }
+        "dumpLevel": "error"
     }
 }

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -97,7 +97,7 @@ export default class Config {
             }
         }
 
-        this.log = { logLevel: 'debug', dumpLevel: 'error', logstash: {} };
+        this.log = { logLevel: 'debug', dumpLevel: 'error' };
         if (config.log !== undefined) {
             if (config.log.logLevel !== undefined) {
                 assert(typeof config.log.logLevel === 'string',
@@ -108,16 +108,6 @@ export default class Config {
                 assert(typeof config.log.dumpLevel === 'string',
                         'bad config: log.dumpLevel must be a string');
                 this.log.dumpLevel = config.log.dumpLevel;
-            }
-            if (config.log.logstash !== undefined) {
-                assert(config.log.logstash instanceof Object
-                       && (config.log.logstash.host !== undefined ||
-                           config.log.logstash.port !== undefined),
-                       'bad config: log.logstash.host and log.logstash.port ' +
-                       'must be defined');
-
-                this.log.logstash.host = config.log.logstash.host;
-                this.log.logstash.port = config.log.logstash.port;
             }
         }
     }

--- a/lib/utilities/logger.js
+++ b/lib/utilities/logger.js
@@ -1,5 +1,4 @@
 import Logger from 'werelogs';
-import bunyanLogstash from 'bunyan-logstash';
 
 import Config from '../Config';
 
@@ -8,14 +7,4 @@ const _config = new Config();
 export const logger = new Logger('S3', {
     level: _config.log.logLevel,
     dump: _config.log.dumpLevel,
-    streams: [
-        { stream: process.stdout },
-        {
-            type: 'raw',
-            stream: bunyanLogstash.createStream({
-                host: _config.log.logstash.host,
-                port: _config.log.logstash.port,
-            }),
-        },
-    ],
 });

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.2.0",
     "babel-plugin-transform-es2015-parameters": "^6.2.0",
     "bucketclient": "scality/bucketclient#rel/1.0",
-    "bunyan-logstash": "^0.3.4",
     "node-uuid": "^1.4.3",
     "sproxydclient": "scality/sproxydclient#rel/1.0",
     "utf8": "~2.1.1",


### PR DESCRIPTION
This commit removes bunyan-logstash dependency and it's config that is no longer required by Werelogs.
