### PR TITLE
Fix backwards compatibility for data wrapper get

### DIFF
--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -40,7 +40,9 @@ const data = {
     },
 
     get: (objectGetInfo, log, cb) => {
-        const key = objectGetInfo.key;
+        // If objectGetInfo.key exists the md-model-version is 2 or greater.
+        // Otherwise, the objectGetInfo is just the key string.
+        const key = objectGetInfo.key ? objectGetInfo.key : objectGetInfo;
         const range = objectGetInfo.range;
         log.debug('sending get to datastore', { implName, key,
             range, method: 'get' });


### PR DESCRIPTION
Our prior data model had an array of strings for keys.  We now have an array of objects with a key property.
