### PR TITLE
Fix: s3curl random failure

### DIFF
--- a/tests/functional/aws-node-sdk/test/legacy/authV4QueryTests.js
+++ b/tests/functional/aws-node-sdk/test/legacy/authV4QueryTests.js
@@ -9,9 +9,9 @@ import conf from '../../../../../lib/Config';
 const random = Math.round(Math.random() * 100).toString();
 const bucket = `mybucket-${random}`;
 const ssl = conf.https;
-let transportArgs = [];
+let transportArgs = ['-s'];
 if (ssl && ssl.ca) {
-    transportArgs = ['--cacert', conf.httpsPath.ca];
+    transportArgs = ['-s --cacert', conf.httpsPath.ca];
 }
 
 // Get stdout and stderr stringified

--- a/tests/functional/s3curl/tests.js
+++ b/tests/functional/s3curl/tests.js
@@ -9,9 +9,9 @@ require('babel-core/register');
 const conf = require('../../../lib/Config').default;
 
 const transport = conf.https ? 'https' : 'http';
-let sslArguments = [];
+let sslArguments = ['-s'];
 if (conf.https && conf.https.ca) {
-    sslArguments = ['--cacert', conf.httpsPath.ca];
+    sslArguments = ['-s --cacert', conf.httpsPath.ca];
 }
 const ipAddress = process.env.IP ? process.env.IP : '127.0.0.1';
 const program = `${__dirname}/s3curl.pl`;


### PR DESCRIPTION
- Add return error when process.spawn fail
- Writing status code of s3curl
- If no httpcode, return an error with stderr
- If no stderr, return an error with stdout

Add few more infos to be able to debug an failure in provideRawOutput in s3curl tests

Update:
- Fix stderr output corrupted by the progress bar, sometimes,
  the progress bar of curl do not add an new line to stderr,
  so the search of the HTTP response is wrong, and get an
  undefined error
