### PR TITLE
[Log](FT): Add content length to route get object

### DIFF
--- a/lib/routes/routeGET.js
+++ b/lib/routes/routeGET.js
@@ -36,6 +36,11 @@ export default function routerGET(request, response, log) {
             // GET object
             api.callApiMethod('objectGet', request, log, (err, dataGetInfo,
                     resMetaHeaders, range) => {
+                if (resMetaHeaders && resMetaHeaders['Content-Length']) {
+                    log.end().addDefaultFields({
+                        contentLength: resMetaHeaders['Content-Length'],
+                    });
+                }
                 routesUtils.responseStreamData(err, request.headers,
                     resMetaHeaders, dataGetInfo, response, range, log);
             });


### PR DESCRIPTION
- Provide Content-Length in logs when getting an object

Part of https://github.com/scality/S3/issues/15
