### PR TITLE
Disable bucketPut location constraint check

### DIFF
--- a/lib/api/bucketPut.js
+++ b/lib/api/bucketPut.js
@@ -1,10 +1,7 @@
 import { errors } from 'arsenal';
 import { parseString } from 'xml2js';
 
-import utils from '../utils';
 import { createBucket } from './apiUtils/bucket/bucketCreation';
-
-const possibleLocations = utils.getAllRegions();
 
 /*
    Format of xml request:
@@ -43,11 +40,6 @@ export default function bucketPut(authInfo, request, log, callback) {
             }
             const locationConstraint =
                 result.CreateBucketConfiguration.LocationConstraint[0];
-            if (possibleLocations.indexOf(locationConstraint) < 0) {
-                log.debug('invalid location constraint',
-                          { locationConstraint });
-                return callback(errors.InvalidLocationConstraint);
-            }
             log.trace('location constraint', { locationConstraint });
             return createBucket(authInfo, bucketName, request.headers,
                                          locationConstraint, log, callback);

--- a/tests/unit/api/bucketPut.js
+++ b/tests/unit/api/bucketPut.js
@@ -67,7 +67,7 @@ describe('bucketPut API', () => {
         });
     });
 
-    it('should return an error if LocationConstraint ' +
+    it('should not return an error if LocationConstraint ' +
        'specified is not valid', done => {
         const testRequest = {
             bucketName,
@@ -81,7 +81,7 @@ describe('bucketPut API', () => {
                 + '</CreateBucketConfiguration>',
         };
         bucketPut(authInfo, testRequest, log, err => {
-            assert.deepStrictEqual(err, errors.InvalidLocationConstraint);
+            assert.deepStrictEqual(err, undefined);
             done();
         });
     });


### PR DESCRIPTION
Different clients (such as boto) seem to send location constraints that are not actual valid region names.  We are currently rejecting these requests causing frustration for users.

Regions do not currently have meaning in our system so am disabling this for now.
