### PR TITLE
FIX: CI processMPUParts - too many logs

### DIFF
--- a/lib/api/apiUtils/object/processMpuParts.js
+++ b/lib/api/apiUtils/object/processMpuParts.js
@@ -145,6 +145,11 @@ splitter, log) {
     let extraParts = [];
     const extraPartLocations = [];
 
+    if (process.env.MPU_TESTING) {
+        log.info('MPU_TESTING env variable setting',
+            { setting: process.env.MPU_TESTING });
+    }
+
     for (let i = 0; i < partLength; i++) {
         const part = jsonList.Part[i];
         const partNumber = Number.parseInt(part.PartNumber[0], 10);
@@ -193,10 +198,6 @@ splitter, log) {
                 const storedPartSize =
                     Number.parseInt(storedPart.size, 10);
                 // allow smaller parts for testing
-                if (process.env.MPU_TESTING) {
-                    log.info('MPU_TESTING env variable setting',
-                        { setting: process.env.MPU_TESTING });
-                }
                 if (process.env.MPU_TESTING !== 'yes' &&
                 i < jsonList.Part.length - 1 &&
                 storedPartSize < constants.minimumAllowedPartSize) {


### PR DESCRIPTION
Moved the MPU_TESTING setting output out of the loops