### PR TITLE
FIX: S3C-1105 Add env variable modify client port for testing

### DIFF
--- a/tests/functional/aws-node-sdk/test/support/config.js
+++ b/tests/functional/aws-node-sdk/test/support/config.js
@@ -7,6 +7,8 @@ const conf = require('../../../../../lib/Config').config;
 
 const transport = conf.https ? 'https' : 'http';
 
+const port = process.env.CI_S3_FRONTEND_PORT || 8000;
+
 const ssl = conf.https;
 let httpOptions;
 if (ssl && ssl.ca) {
@@ -24,7 +26,7 @@ const DEFAULT_GLOBAL_OPTIONS = {
     sslEnabled: ssl !== undefined,
 };
 const DEFAULT_MEM_OPTIONS = {
-    endpoint: `${transport}://127.0.0.1:8000`,
+    endpoint: `${transport}://127.0.0.1:${port}`,
     s3ForcePathStyle: true,
 };
 const DEFAULT_AWS_OPTIONS = {};
@@ -50,7 +52,7 @@ function _getMemConfig(profile, config) {
         , { credentials }, config);
 
     if (process.env.IP) {
-        memConfig.endpoint = `${transport}://${process.env.IP}:8000`;
+        memConfig.endpoint = `${transport}://${process.env.IP}:${port}`;
     }
 
     return memConfig;

--- a/tests/functional/boto/boto/tests/test_boto.py
+++ b/tests/functional/boto/boto/tests/test_boto.py
@@ -8,13 +8,17 @@ class Test(object):
 
     connection = None
 
+    port = 8000
+    if os.getenv('CI_S3_FRONTEND_PORT'):
+        port = os.getenv('CI_S3_FRONTEND_PORT')
+
     def setup_method(self, _):
         """setup the connection"""
         # OrdinaryCallingFormat ==> tell boto not to use DNS for bucket
         self.connection = S3Connection(aws_access_key_id='accessKey1',
                                        aws_secret_access_key='verySecretKey1',
                                        is_secure=False,
-                                       port=8000,
+                                       port=self.port,
                                        calling_format=OrdinaryCallingFormat(),
                                        host=os.getenv('IP'))
 

--- a/tests/functional/fog/tests.rb
+++ b/tests/functional/fog/tests.rb
@@ -9,7 +9,8 @@ rubyConfig = JSON.parse(config)
 
 transport = rubyConfig["transport"];
 ipAddress = rubyConfig["ipAddress"];
-endpoint = "#{transport}://#{ipAddress}:8000";
+port = ENV['CI_S3_FRONTEND_PORT'] || 8000;
+endpoint = "#{transport}://#{ipAddress}:#{port}";
 
 if(rubyConfig["certPath"])
     Excon.defaults[:ssl_ca_path] = rubyConfig["caCertPath"]

--- a/tests/functional/healthchecks/test/checkRoutes.js
+++ b/tests/functional/healthchecks/test/checkRoutes.js
@@ -19,10 +19,11 @@ redis.on('error', () => {});
 
 const transportStr = conf.transport;
 const transport = transportStr === 'http' ? http : https;
+const port = process.env.CI_S3_FRONTEND_PORT || 8000;
 const options = {
     host: conf.ipAddress,
     path: '/_/healthcheck',
-    port: 8000,
+    port,
 };
 
 function checkResult(expectedStatus, res) {

--- a/tests/functional/raw-node/test/routes/routeBackbeat.js
+++ b/tests/functional/raw-node/test/routes/routeBackbeat.js
@@ -46,10 +46,11 @@ function checkObjectData(s3, objectKey, dataValue, done) {
 function makeBackbeatRequest(params, callback) {
     const { method, headers, bucket, objectKey, resourceType,
             authCredentials, requestBody } = params;
+    const port = process.env.CI_S3_FRONTEND_PORT || 8000;
     const options = {
         authCredentials,
         hostname: ipAddress,
-        port: 8000,
+        port,
         method,
         headers,
         path: `/_/backbeat/${resourceType}/${bucket}/${objectKey}`,

--- a/tests/functional/report/checkRoutes.js
+++ b/tests/functional/report/checkRoutes.js
@@ -17,10 +17,11 @@ const reportAttributes = [
 ];
 
 function options(token = 'report-token-1') {
+    const port = process.env.CI_S3_FRONTEND_PORT || 8000;
     return {
         host: conf.ipAddress,
         path: '/_/report',
-        port: 8000,
+        port,
         headers: { 'x-scal-report-token': token },
     };
 }

--- a/tests/functional/s3curl/tests.js
+++ b/tests/functional/s3curl/tests.js
@@ -13,6 +13,7 @@ if (conf.https && conf.https.ca) {
     sslArguments = ['-s', '--cacert', conf.httpsPath.ca];
 }
 const ipAddress = process.env.IP ? process.env.IP : '127.0.0.1';
+const port = process.env.CI_S3_FRONTEND_PORT || 8000;
 const program = `${__dirname}/s3curl.pl`;
 const upload = 'test1MB';
 const aclUpload = 'test500KB';
@@ -24,7 +25,7 @@ const prefix = 'topLevel';
 const delimiter = '/';
 let ownerCanonicalId = '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d52'
     + '18e7cd47ef2be';
-const endpoint = `${transport}://${ipAddress}:8000`;
+const endpoint = `${transport}://${ipAddress}:${port}`;
 
 // Let's precompute a few paths
 const bucketPath = `${endpoint}/${bucket}`;


### PR DESCRIPTION
Running functional tests on a different port (S3 with Nginx on top for example).