### PR TITLE
FIX: Add flaky test retry and additional logging

### DIFF
--- a/tests/functional/aws-node-sdk/test/multipleBackend/get/getAzure.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/get/getAzure.js
@@ -73,7 +73,8 @@ function testSuite() {
 
                 it(`should get an ${key.describe} object from Azure`, done => {
                     // Log the key name to help investigate potential flakiness.
-                    process.stdout.write(`key: ${testKey}`);
+                    process.stdout.write(`should get an ${key.describe} ` +
+                        `object from Azure test key name: ${testKey}`);
                     s3.getObject({ Bucket: azureContainerName, Key:
                       testKey },
                         (err, res) => {

--- a/tests/functional/aws-node-sdk/test/multipleBackend/get/getAzure.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/get/getAzure.js
@@ -53,7 +53,10 @@ function testSuite() {
             });
         });
         keys.forEach(key => {
-            describe(`${key.describe} size`, () => {
+            describe(`${key.describe} size`, function fn() {
+                // This test has been observed to be flaky, so allow the test to
+                // fail three times consecutively before the suite itself fails.
+                this.retries(2);
                 const testKey = `${key.name}-${Date.now()}`;
                 before(done => {
                     setTimeout(() => {
@@ -69,6 +72,8 @@ function testSuite() {
                 });
 
                 it(`should get an ${key.describe} object from Azure`, done => {
+                    // Log the key name to help investigate potential flakiness.
+                    process.stdout.write(`key: ${testKey}`);
                     s3.getObject({ Bucket: azureContainerName, Key:
                       testKey },
                         (err, res) => {

--- a/tests/functional/aws-node-sdk/test/multipleBackend/mpuComplete/azureCompleteMPU.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/mpuComplete/azureCompleteMPU.js
@@ -103,6 +103,10 @@ function mpuSetup(key, location, cb) {
 describeSkipIfNotMultiple('Complete MPU API for Azure data backend',
 function testSuite() {
     this.timeout(150000);
+    // This test has been observed to be flaky, so allow the test to fail three
+    // times consecutively before the suite itself fails.
+    this.retries(2);
+
     withV4(sigCfg => {
         beforeEach(function beFn() {
             this.currentTest.key = `somekey-${Date.now()}`;

--- a/tests/functional/aws-node-sdk/test/multipleBackend/put/putAzure.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/put/putAzure.js
@@ -106,7 +106,11 @@ describeF() {
             });
         });
 
-        describe('with no bucket location header', () => {
+        describe('with no bucket location header', function fn() {
+            // This test has been observed to be flaky, so allow the test to
+            // fail three times consecutively before the suite itself fails.
+            this.retries(2);
+
             beforeEach(() =>
               s3.createBucketAsync({ Bucket: azureContainerName })
                 .catch(err => {


### PR DESCRIPTION
This test has been observed both passing and failing with the same code base (see node 6):

Passed: http://ci.ironmann.io/gh/scality/Integration/20988
Failed: http://ci.ironmann.io/gh/scality/Integration/20997

The proposed change is to let the test run three consecutive times before the suite fails and log additional output for further investigation, should the issue arise again. This is a step towards reducing its flakiness but not a final solution. A reliable fix should be made, or the test parameters (e.g., timeout length) could be re-evaluated.