### PR TITLE
ft: batch delete backbeat route

### DIFF
--- a/lib/api/apiUtils/authorization/aclChecks.js
+++ b/lib/api/apiUtils/authorization/aclChecks.js
@@ -3,7 +3,7 @@ const constants = require('../../../../constants');
 function isBackbeatUser(canonicalID) {
     const canonicalIDArray = canonicalID.split('/');
     const serviceName = canonicalIDArray[canonicalIDArray.length - 1];
-    return ['replication', 'lifecycle'].includes(serviceName);
+    return ['replication', 'lifecycle', 'gc'].includes(serviceName);
 }
 
 function isBucketAuthorized(bucket, requestType, canonicalID) {

--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -5,6 +5,7 @@ const { auth, errors, s3middleware } = require('arsenal');
 const { responseJSONBody } = require('arsenal').s3routes.routesUtils;
 const { getSubPartIds } = s3middleware.azureHelper.mpuUtils;
 const vault = require('../auth/vault');
+const data = require('../data/wrapper');
 const metadata = require('../metadata/wrapper');
 const locationConstraintCheck = require(
     '../api/apiUtils/object/locationConstraintCheck');
@@ -34,7 +35,7 @@ function _decodeURI(uri) {
     return decodeURIComponent(uri.replace(/\+/g, ' '));
 }
 
-function normalizeBackbeatRequest(req) {
+function _normalizeBackbeatRequest(req) {
     /* eslint-disable no-param-reassign */
     const parsedUrl = url.parse(req.url, true);
     req.path = _decodeURI(parsedUrl.pathname);
@@ -44,6 +45,11 @@ function normalizeBackbeatRequest(req) {
     req.bucketName = pathArr[4];
     req.objectKey = pathArr.slice(5).join('/');
     /* eslint-enable no-param-reassign */
+}
+
+function _isObjectRequest(req) {
+    return ['data', 'metadata', 'multiplebackenddata']
+        .includes(req.resourceType);
 }
 
 function _respond(response, payload, log, callback) {
@@ -215,10 +221,17 @@ PUT /_/backbeat/multiplebackenddata/<bucket name>/<object key>
     ?operation=putobject
 PUT /_/backbeat/multiplebackenddata/<bucket name>/<object key>
     ?operation=putpart
+DELETE /_/backbeat/multiplebackenddata/<bucket name>/<object key>
+    ?operation=deleteobject
+DELETE /_/backbeat/multiplebackenddata/<bucket name>/<object key>
+    ?operation=deleteobjecttagging
 POST /_/backbeat/multiplebackenddata/<bucket name>/<object key>
     ?operation=initiatempu
 POST /_/backbeat/multiplebackenddata/<bucket name>/<object key>
     ?operation=completempu
+POST /_/backbeat/multiplebackenddata/<bucket name>/<object key>
+    ?operation=puttagging
+POST /_/backbeat/batchdelete
 */
 
 function putData(request, response, bucketInfo, objMd, log, callback) {
@@ -609,6 +622,41 @@ function deleteObjectTagging(request, response, log, callback) {
         dataStoreVersionId, log, callback);
 }
 
+function batchDelete(request, response, log, callback) {
+    _getRequestPayload(request, (err, payload) => {
+        if (err) {
+            return callback(err);
+        }
+        let request;
+        try {
+            request = JSON.parse(payload);
+        } catch (e) {
+            // FIXME: add error type MalformedJSON
+            return callback(errors.MalformedPOSTRequest);
+        }
+        if (!request || !Array.isArray(request.Locations)) {
+            return callback(errors.MalformedPOSTRequest);
+        }
+        const locations = request.Locations;
+        log.trace('batch delete locations', { locations });
+        return async.eachLimit(locations, 5, (loc, next) => {
+            data.delete(loc, log, next);
+        }, err => {
+            if (err) {
+                log.error('batch delete failed', {
+                    method: 'batchDelete',
+                    locations,
+                    error: err,
+                });
+                return callback(err);
+            }
+            log.debug('batch delete successful', { locations });
+            return _respond(response, null, log, callback);
+        });
+    });
+    return undefined;
+}
+
 const backbeatRoutes = {
     PUT: {
         data: putData,
@@ -624,6 +672,7 @@ const backbeatRoutes = {
             completempu: completeMultipartUpload,
             puttagging: putObjectTagging,
         },
+        batchdelete: batchDelete,
     },
     DELETE: {
         multiplebackenddata: {
@@ -637,20 +686,40 @@ const backbeatRoutes = {
 };
 
 function routeBackbeat(clientIP, request, response, log) {
-    log.debug('routing request', { method: 'routeBackbeat' });
-    normalizeBackbeatRequest(request);
+    log.debug('routing request', {
+        method: 'routeBackbeat',
+        url: request.url,
+    });
+    _normalizeBackbeatRequest(request);
     const useMultipleBackend = request.resourceType === 'multiplebackenddata';
-    const invalidRequest = (!request.bucketName ||
-                            !request.objectKey ||
-                            !request.resourceType ||
-                            (!request.query.operation && useMultipleBackend));
-    if (invalidRequest) {
-        log.debug('invalid request', {
+    const invalidRequest =
+          (!request.resourceType ||
+           (_isObjectRequest(request) &&
+            (!request.bucketName || !request.objectKey)) ||
+           (!request.query.operation && useMultipleBackend));
+    const invalidRoute =
+          (backbeatRoutes[request.method] === undefined ||
+           backbeatRoutes[request.method][request.resourceType] === undefined ||
+           (backbeatRoutes[request.method][request.resourceType]
+            [request.query.operation] === undefined &&
+            useMultipleBackend));
+    if (invalidRequest || invalidRoute) {
+        log.debug(invalidRequest ? 'invalid request' : 'no such route', {
             method: request.method, bucketName: request.bucketName,
             objectKey: request.objectKey, resourceType: request.resourceType,
             query: request.query,
         });
         return responseJSONBody(errors.MethodNotAllowed, null, response, log);
+    }
+
+    if (!_isObjectRequest(request)) {
+        const route = backbeatRoutes[request.method][request.resourceType];
+        return route(request, response, log, err => {
+            if (err) {
+                return responseJSONBody(err, null, response, log);
+            }
+            return undefined;
+        });
     }
     const requestContexts = prepareRequestContexts('objectReplicate', request);
     const decodedVidResult = decodeVersionId(request.query);
@@ -687,21 +756,6 @@ function routeBackbeat(clientIP, request, response, log) {
             return metadataValidateBucketAndObj(mdValParams, log, next);
         },
         (bucketInfo, objMd, next) => {
-            const invalidRoute = backbeatRoutes[request.method] === undefined ||
-                backbeatRoutes[request.method][request.resourceType] ===
-                    undefined ||
-                (backbeatRoutes[request.method][request.resourceType]
-                    [request.query.operation] === undefined &&
-                    useMultipleBackend);
-            if (invalidRoute) {
-                log.debug('no such route', { method: request.method,
-                    bucketName: request.bucketName,
-                    objectKey: request.objectKey,
-                    resourceType: request.resourceType,
-                    query: request.query,
-                });
-                return next(errors.MethodNotAllowed);
-            }
             if (useMultipleBackend) {
                 return backbeatRoutes[request.method][request.resourceType]
                     [request.query.operation](request, response, log, next);

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "ft_awssdk_external_backends": "cd tests/functional/aws-node-sdk && mocha test/multipleBackend",
     "ft_management": "cd tests/functional/report && npm test",
     "ft_node": "cd tests/functional/raw-node && npm test",
+    "ft_node_routes": "cd tests/functional/raw-node && npm run test-routes",
     "ft_gcp": "cd tests/functional/raw-node && npm run test-gcp",
     "ft_healthchecks": "cd tests/functional/healthchecks && npm test",
     "ft_s3cmd": "cd tests/functional/s3cmd && mocha -t 40000 *.js",

--- a/tests/functional/raw-node/package.json
+++ b/tests/functional/raw-node/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "test-aws": "AWS_ON_AIR=true mocha -t 40000 test/",
     "test-gcp": "mocha -t 40000 test/GCP/",
+    "test-routes": "mocha -t 40000 test/routes/",
     "test": "mocha -t 40000 test/",
     "test-debug": "_mocha -t 40000 test/"
   },

--- a/tests/functional/raw-node/test/routes/routeBackbeat.js
+++ b/tests/functional/raw-node/test/routes/routeBackbeat.js
@@ -102,7 +102,7 @@ function makeBackbeatRequest(params, callback) {
     makeRequest(options, callback);
 }
 
-describeSkipIfAWS('backbeat routes:', () => {
+describeSkipIfAWS('backbeat routes', () => {
     let bucketUtil;
     let s3;
 
@@ -130,7 +130,7 @@ describeSkipIfAWS('backbeat routes:', () => {
             .then(() => done());
     });
 
-    describe('backbeat PUT routes:', () => {
+    describe('backbeat PUT routes', () => {
         describe('PUT data + metadata should create a new complete object',
         () => {
             [{
@@ -322,7 +322,7 @@ describeSkipIfAWS('backbeat routes:', () => {
             });
         });
     });
-    describe('backbeat authorization checks:', () => {
+    describe('backbeat authorization checks', () => {
         [{ method: 'PUT', resourceType: 'metadata' },
          { method: 'PUT', resourceType: 'data' }].forEach(test => {
              it(`${test.method} ${test.resourceType} should respond with ` +
@@ -397,7 +397,7 @@ describeSkipIfAWS('backbeat routes:', () => {
          });
     });
 
-    describe('GET Metadata route:', () => {
+    describe('GET Metadata route', () => {
         beforeEach(done => makeBackbeatRequest({
             method: 'PUT', bucket: TEST_BUCKET,
             objectKey: TEST_KEY,
@@ -422,7 +422,7 @@ describeSkipIfAWS('backbeat routes:', () => {
             });
         });
 
-        it('should return error if bucket does not exist ', done => {
+        it('should return error if bucket does not exist', done => {
             makeBackbeatRequest({
                 method: 'GET', bucket: 'blah',
                 objectKey: TEST_KEY, resourceType: 'metadata',
@@ -437,7 +437,7 @@ describeSkipIfAWS('backbeat routes:', () => {
             });
         });
 
-        it('should return error if object does not exist ', done => {
+        it('should return error if object does not exist', done => {
             makeBackbeatRequest({
                 method: 'GET', bucket: TEST_BUCKET,
                 objectKey: 'blah', resourceType: 'metadata',
@@ -450,6 +450,105 @@ describeSkipIfAWS('backbeat routes:', () => {
                 assert.strictEqual(JSON.parse(data.body).code, 'ObjNotFound');
                 done();
             });
+        });
+    });
+    describe('Batch Delete Route', () => {
+        it('should batch delete a location', done => {
+            let versionId;
+            let location;
+
+            async.series([
+                done => s3.putObject({
+                    Bucket: TEST_BUCKET,
+                    Key: 'batch-delete-test-key',
+                    Body: new Buffer('hello'),
+                }, done),
+                done => s3.getObject({
+                    Bucket: TEST_BUCKET,
+                    Key: 'batch-delete-test-key',
+                }, (err, data) => {
+                    assert.ifError(err);
+                    assert.strictEqual(data.Body.toString(), 'hello');
+                    versionId = data.VersionId;
+                    done();
+                }),
+                done => {
+                    makeBackbeatRequest({
+                        method: 'GET', bucket: TEST_BUCKET,
+                        objectKey: 'batch-delete-test-key',
+                        resourceType: 'metadata',
+                        authCredentials: backbeatAuthCredentials,
+                        queryObj: {
+                            versionId,
+                        },
+                    }, (err, data) => {
+                        assert.ifError(err);
+                        assert.strictEqual(data.statusCode, 200);
+                        const metadata = JSON.parse(
+                            JSON.parse(data.body).Body);
+                        location = metadata.location;
+                        done();
+                    });
+                },
+                done => {
+                    const options = {
+                        authCredentials: backbeatAuthCredentials,
+                        hostname: ipAddress,
+                        port: 8000,
+                        method: 'POST',
+                        path: '/_/backbeat/batchdelete',
+                        requestBody:
+                        `{"Locations":${JSON.stringify(location)}}`,
+                        jsonResponse: true,
+                    };
+                    makeRequest(options, done);
+                },
+                done => s3.getObject({
+                    Bucket: TEST_BUCKET,
+                    Key: 'batch-delete-test-key',
+                }, err => {
+                    // should error out as location shall no longer exists
+                    assert(err);
+                    done();
+                }),
+            ], done);
+        });
+        it('should fail with error if given malformed JSON', done => {
+            async.series([
+                done => {
+                    const options = {
+                        authCredentials: backbeatAuthCredentials,
+                        hostname: ipAddress,
+                        port: 8000,
+                        method: 'POST',
+                        path: '/_/backbeat/batchdelete',
+                        requestBody: 'NOTJSON',
+                        jsonResponse: true,
+                    };
+                    makeRequest(options, done);
+                },
+            ], err => {
+                assert(err);
+                done();
+            });
+        });
+        it('should skip batch delete of a non-existent location', done => {
+            async.series([
+                done => {
+                    const options = {
+                        authCredentials: backbeatAuthCredentials,
+                        hostname: ipAddress,
+                        port: 8000,
+                        method: 'POST',
+                        path: '/_/backbeat/batchdelete',
+                        requestBody:
+                        '{"Locations":' +
+                            '[{"key":"abcdef","dataStoreName":"us-east-1"}]}',
+                        jsonResponse: true,
+                    };
+                    makeRequest(options, done);
+                },
+            ], done);
         });
     });
 });


### PR DESCRIPTION
Implement 'POST /_/backbeat/batchdelete' backbeat route to get rid of
an array of data locations.

The route will be used by the garbage collector service.
