### PR TITLE
ft: add "no_proxy" environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ RUN apt-get update \
 
 VOLUME ["/usr/src/app/localData","/usr/src/app/localMetadata"]
 
+ENV NO_PROXY localhost,127.0.0.1
+ENV no_proxy localhost,127.0.0.1
+
 ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"]
 CMD [ "npm", "start" ]
 


### PR DESCRIPTION
This adds the no_proxy and NO_PROXY environmental variables, which should always have these values.