### PR TITLE
fix: Ensure CRR reports are full bytes

### DIFF
--- a/lib/utilities/reportHandler.js
+++ b/lib/utilities/reportHandler.js
@@ -115,16 +115,16 @@ function getCRRStats(log, cb) {
         }
         const stats = {
             completions: {
-                count: completions.results.count,
-                size: completions.results.size,
+                count: parseInt(completions.results.count, 10),
+                size: parseInt(completions.results.size, 10),
             },
             backlog: {
-                count: backlog.results.count,
-                size: backlog.results.size,
+                count: parseInt(backlog.results.count, 10),
+                size: parseInt(backlog.results.size, 10),
             },
             throughput: {
-                count: parseFloat(throughput.results.count),
-                size: parseFloat(throughput.results.size),
+                count: parseInt(throughput.results.count, 10),
+                size: parseInt(throughput.results.size, 10),
             },
         };
         return cb(null, stats);


### PR DESCRIPTION
Now that CRR values published to Redis are bytes, this fixes stats being rejected by orbit in some cases.