### PR TITLE
bf: ZENKO-498 - fix sproxy location config

### DIFF
--- a/lib/management/configuration.js
+++ b/lib/management/configuration.js
@@ -164,6 +164,7 @@ function patchConfiguration(newConf, log, cb) {
                     if (l.details && l.details.bootstrapList &&
                         l.details.proxyPath) {
                         location.details = {
+                            supportsVersioning: true,
                             connector: {
                                 sproxyd: {
                                     chordCos: l.details.chordCos || null,

--- a/tests/unit/management/configuration.js
+++ b/tests/unit/management/configuration.js
@@ -250,6 +250,7 @@ describe('patchConfiguration', () => {
                                     path: '/proxy/path',
                                 },
                             },
+                            supportsVersioning: true,
                         },
                         legacyAwsBehavior: false,
                         isTransient: false,


### PR DESCRIPTION
Adds missing `supportsVersioning` property for `sproxyd` location when setting through orbit.