### PR TITLE
FT: ZENKO-20 Redesigned monitoring to use labels

### DIFF
--- a/lib/api/bucketDelete.js
+++ b/lib/api/bucketDelete.js
@@ -4,6 +4,7 @@ const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const { deleteBucket } = require('./apiUtils/bucket/bucketDeletion');
 const { metadataValidateBucket } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
+const monitoring = require('../utilities/monitoringHandler');
 
 /**
  * bucketDelete - DELETE bucket (currently supports only non-versioned buckets)
@@ -20,6 +21,8 @@ function bucketDelete(authInfo, request, log, cb) {
 
     if (authInfo.isRequesterPublicUser()) {
         log.debug('operation not available for public user');
+        monitoring.promMetrics(
+            'DELETE', request.bucketName, 403, 'deleteBucket');
         return cb(errors.AccessDenied);
     }
     const bucketName = request.bucketName;
@@ -37,6 +40,8 @@ function bucketDelete(authInfo, request, log, cb) {
             if (err) {
                 log.debug('error processing request',
                     { method: 'metadataValidateBucket', error: err });
+                monitoring.promMetrics(
+                    'DELETE', bucketName, err.code, 'deleteBucket');
                 return cb(err, corsHeaders);
             }
             log.trace('passed checks',
@@ -44,12 +49,16 @@ function bucketDelete(authInfo, request, log, cb) {
             return deleteBucket(bucketMD, bucketName, authInfo.getCanonicalID(),
                 log, err => {
                     if (err) {
+                        monitoring.promMetrics(
+                            'DELETE', bucketName, err.code, 'deleteBucket');
                         return cb(err, corsHeaders);
                     }
                     pushMetric('deleteBucket', log, {
                         authInfo,
                         bucket: bucketName,
                     });
+                    monitoring.promMetrics(
+                        'DELETE', bucketName, '204', 'deleteBucket');
                     return cb(null, corsHeaders);
                 });
         });

--- a/lib/api/bucketDeleteCors.js
+++ b/lib/api/bucketDeleteCors.js
@@ -5,6 +5,7 @@ const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const { isBucketAuthorized } = require('./apiUtils/authorization/aclChecks');
 const metadata = require('../metadata/wrapper');
 const { pushMetric } = require('../utapi/utilities');
+const monitoring = require('../utilities/monitoringHandler');
 
 const requestType = 'bucketOwnerAction';
 
@@ -25,9 +26,13 @@ function bucketDeleteCors(authInfo, request, log, callback) {
             request.method, bucket);
         if (err) {
             log.debug('metadata getbucket failed', { error: err });
+            monitoring.promMetrics('DELETE', bucketName, 400,
+                'deleteBucketCors');
             return callback(err);
         }
         if (bucketShield(bucket, requestType)) {
+            monitoring.promMetrics('DELETE', bucketName, 400,
+                'deleteBucketCors');
             return callback(errors.NoSuchBucket);
         }
         log.trace('found bucket in metadata');
@@ -37,6 +42,8 @@ function bucketDeleteCors(authInfo, request, log, callback) {
                 requestType,
                 method: 'bucketDeleteCors',
             });
+            monitoring.promMetrics('DELETE', bucketName, 403,
+                'deleteBucketCors');
             return callback(errors.AccessDenied, corsHeaders);
         }
 
@@ -56,12 +63,16 @@ function bucketDeleteCors(authInfo, request, log, callback) {
         bucket.setCors(null);
         return metadata.updateBucket(bucketName, bucket, log, err => {
             if (err) {
+                monitoring.promMetrics('DELETE', bucketName, 400,
+                    'deleteBucketCors');
                 return callback(err, corsHeaders);
             }
             pushMetric('deleteBucketCors', log, {
                 authInfo,
                 bucket: bucketName,
             });
+            monitoring.promMetrics(
+                'DELETE', bucketName, '204', 'deleteBucketCors');
             return callback(err, corsHeaders);
         });
     });

--- a/lib/api/bucketDeleteLifecycle.js
+++ b/lib/api/bucketDeleteLifecycle.js
@@ -2,6 +2,7 @@ const metadata = require('../metadata/wrapper');
 const { metadataValidateBucket } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
+const monitoring = require('../utilities/monitoringHandler');
 
 /**
  * bucketDeleteLifecycle - Delete the bucket Lifecycle configuration
@@ -26,6 +27,8 @@ function bucketDeleteLifecycle(authInfo, request, log, callback) {
                 error: err,
                 method: 'bucketDeleteLifecycle',
             });
+            monitoring.promMetrics(
+                'DELETE', bucketName, err.code, 'deleteBucketLifecycle');
             return callback(err, corsHeaders);
         }
         if (!bucket.getLifecycleConfiguration()) {
@@ -42,12 +45,16 @@ function bucketDeleteLifecycle(authInfo, request, log, callback) {
         bucket.setLifecycleConfiguration(null);
         return metadata.updateBucket(bucketName, bucket, log, err => {
             if (err) {
+                monitoring.promMetrics(
+                    'DELETE', bucketName, err.code, 'deleteBucketLifecycle');
                 return callback(err, corsHeaders);
             }
             pushMetric('deleteBucketLifecycle', log, {
                 authInfo,
                 bucket: bucketName,
             });
+            monitoring.promMetrics(
+                'DELETE', bucketName, '200', 'deleteBucketLifecycle');
             return callback(null, corsHeaders);
         });
     });

--- a/lib/api/bucketDeleteReplication.js
+++ b/lib/api/bucketDeleteReplication.js
@@ -2,6 +2,7 @@ const metadata = require('../metadata/wrapper');
 const { metadataValidateBucket } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
+const monitoring = require('../utilities/monitoringHandler');
 
 /**
  * bucketDeleteReplication - Delete the bucket replication configuration
@@ -26,6 +27,8 @@ function bucketDeleteReplication(authInfo, request, log, callback) {
                 error: err,
                 method: 'bucketDeleteReplication',
             });
+            monitoring.promMetrics(
+                'DELETE', bucketName, err.code, 'deleteBucketReplication');
             return callback(err, corsHeaders);
         }
         if (!bucket.getReplicationConfiguration()) {
@@ -42,12 +45,16 @@ function bucketDeleteReplication(authInfo, request, log, callback) {
         bucket.setReplicationConfiguration(null);
         return metadata.updateBucket(bucketName, bucket, log, err => {
             if (err) {
+                monitoring.promMetrics(
+                    'DELETE', bucketName, err.code, 'deleteBucketReplication');
                 return callback(err, corsHeaders);
             }
             pushMetric('deleteBucketReplication', log, {
                 authInfo,
                 bucket: bucketName,
             });
+            monitoring.promMetrics(
+                'DELETE', bucketName, '200', 'deleteBucketReplication');
             return callback(null, corsHeaders);
         });
     });

--- a/lib/api/bucketDeleteWebsite.js
+++ b/lib/api/bucketDeleteWebsite.js
@@ -5,6 +5,7 @@ const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const { isBucketAuthorized } = require('./apiUtils/authorization/aclChecks');
 const metadata = require('../metadata/wrapper');
 const { pushMetric } = require('../utapi/utilities');
+const monitoring = require('../utilities/monitoringHandler');
 
 const requestType = 'bucketOwnerAction';
 
@@ -17,9 +18,13 @@ function bucketDeleteWebsite(authInfo, request, log, callback) {
             request.method, bucket);
         if (err) {
             log.debug('metadata getbucket failed', { error: err });
+            monitoring.promMetrics(
+                'DELETE', bucketName, err.code, 'deleteBucketWebsite');
             return callback(err);
         }
         if (bucketShield(bucket, requestType)) {
+            monitoring.promMetrics(
+                'DELETE', bucketName, 404, 'deleteBucketWebsite');
             return callback(errors.NoSuchBucket);
         }
         log.trace('found bucket in metadata');
@@ -29,6 +34,8 @@ function bucketDeleteWebsite(authInfo, request, log, callback) {
                 requestType,
                 method: 'bucketDeleteWebsite',
             });
+            monitoring.promMetrics(
+                'DELETE', bucketName, 403, 'deleteBucketWebsite');
             return callback(errors.AccessDenied, corsHeaders);
         }
 
@@ -48,12 +55,16 @@ function bucketDeleteWebsite(authInfo, request, log, callback) {
         bucket.setWebsiteConfiguration(null);
         return metadata.updateBucket(bucketName, bucket, log, err => {
             if (err) {
+                monitoring.promMetrics(
+                    'DELETE', bucketName, err.code, 'deleteBucketWebsite');
                 return callback(err, corsHeaders);
             }
             pushMetric('deleteBucketWebsite', log, {
                 authInfo,
                 bucket: bucketName,
             });
+            monitoring.promMetrics(
+                'DELETE', bucketName, '200', 'deleteBucketWebsite');
             return callback(null, corsHeaders);
         });
     });

--- a/lib/api/bucketGet.js
+++ b/lib/api/bucketGet.js
@@ -9,6 +9,7 @@ const { pushMetric } = require('../utapi/utilities');
 const validateSearchParams = require('../api/apiUtils/bucket/validateSearch');
 const parseWhere = require('../api/apiUtils/bucket/parseWhere');
 const versionIdUtils = versioning.VersionID;
+const monitoring = require('../utilities/monitoringHandler');
 
 /*	Sample XML response for GET bucket objects:
 <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
@@ -214,6 +215,7 @@ function handleResult(listParams, requestMaxKeys, encoding, authInfo,
         res = processMasterVersions(bucketName, listParams, list);
     }
     pushMetric('listBucket', log, { authInfo, bucket: bucketName });
+    monitoring.promMetrics('GET', bucketName, '200', 'listBucket');
     return callback(null, res, corsHeaders);
 }
 
@@ -233,12 +235,16 @@ function bucketGet(authInfo, request, log, callback) {
     const bucketName = request.bucketName;
     const encoding = params['encoding-type'];
     if (encoding !== undefined && encoding !== 'url') {
+        monitoring.promMetrics(
+            'GET', bucketName, 400, 'listBucket');
         return callback(errors.InvalidArgument.customizeDescription('Invalid ' +
             'Encoding Method specified in Request'));
     }
     const requestMaxKeys = params['max-keys'] ?
         Number.parseInt(params['max-keys'], 10) : 1000;
     if (Number.isNaN(requestMaxKeys) || requestMaxKeys < 0) {
+        monitoring.promMetrics(
+            'GET', bucketName, 400, 'listBucket');
         return callback(errors.InvalidArgument);
     }
     let validatedAst;
@@ -272,6 +278,8 @@ function bucketGet(authInfo, request, log, callback) {
             request.method, bucket);
         if (err) {
             log.debug('error processing request', { error: err });
+            monitoring.promMetrics(
+                'GET', bucketName, err.code, 'listBucket');
             return callback(err, null, corsHeaders);
         }
         if (params.versions !== undefined) {
@@ -299,6 +307,8 @@ function bucketGet(authInfo, request, log, callback) {
                 log.debug(err.message, {
                     stack: err.stack,
                 });
+                monitoring.promMetrics(
+                    'GET', bucketName, 400, 'listBucket');
                 return callback(errors.InvalidArgument
                 .customizeDescription('Invalid sql where clause ' +
                 'sent as search query'));
@@ -308,6 +318,8 @@ function bucketGet(authInfo, request, log, callback) {
         (err, list) => {
             if (err) {
                 log.debug('error processing request', { error: err });
+                monitoring.promMetrics(
+                    'GET', bucketName, err.code, 'listBucket');
                 return callback(err, null, corsHeaders);
             }
             return handleResult(listParams, requestMaxKeys, encoding, authInfo,

--- a/lib/api/bucketGetACL.js
+++ b/lib/api/bucketGetACL.js
@@ -4,6 +4,7 @@ const { metadataValidateBucket } = require('../metadata/metadataUtils');
 const vault = require('../auth/vault');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const { pushMetric } = require('../utapi/utilities');
+const monitoring = require('../utilities/monitoringHandler');
 
 //  Sample XML response:
 /*
@@ -65,6 +66,8 @@ function bucketGetACL(authInfo, request, log, callback) {
         if (err) {
             log.debug('error processing request',
                 { method: 'bucketGetACL', error: err });
+            monitoring.promMetrics(
+                'GET', bucketName, err.code, 'getBucketAcl');
             return callback(err, null, corsHeaders);
         }
         const bucketACL = bucket.getAcl();
@@ -136,6 +139,8 @@ function bucketGetACL(authInfo, request, log, callback) {
             if (err) {
                 log.debug('error processing request',
                     { method: 'vault.getEmailAddresses', error: err });
+                monitoring.promMetrics(
+                    'GET', bucketName, err.code, 'getBucketAcl');
                 return callback(err, null, corsHeaders);
             }
             const individualGrants = canonicalIDs.map(canonicalID => {
@@ -166,6 +171,7 @@ function bucketGetACL(authInfo, request, log, callback) {
                 authInfo,
                 bucket: bucketName,
             });
+            monitoring.promMetrics('GET', bucketName, '200', 'getBucketAcl');
             return callback(null, xml, corsHeaders);
         });
     });

--- a/lib/api/bucketGetCors.js
+++ b/lib/api/bucketGetCors.js
@@ -6,6 +6,7 @@ const { convertToXml } = require('./apiUtils/bucket/bucketCors');
 const { isBucketAuthorized } = require('./apiUtils/authorization/aclChecks');
 const metadata = require('../metadata/wrapper');
 const { pushMetric } = require('../utapi/utilities');
+const monitoring = require('../utilities/monitoringHandler');
 
 const requestType = 'bucketOwnerAction';
 
@@ -24,9 +25,13 @@ function bucketGetCors(authInfo, request, log, callback) {
     metadata.getBucket(bucketName, log, (err, bucket) => {
         if (err) {
             log.debug('metadata getbucket failed', { error: err });
+            monitoring.promMetrics(
+                'GET', bucketName, err.code, 'getBucketCors');
             return callback(err);
         }
         if (bucketShield(bucket, requestType)) {
+            monitoring.promMetrics(
+                'GET', bucketName, 404, 'getBucketCors');
             return callback(errors.NoSuchBucket);
         }
         log.trace('found bucket in metadata');
@@ -38,6 +43,8 @@ function bucketGetCors(authInfo, request, log, callback) {
                 requestType,
                 method: 'bucketGetCors',
             });
+            monitoring.promMetrics(
+                'GET', bucketName, 403, 'getBucketCors');
             return callback(errors.AccessDenied, null, corsHeaders);
         }
 
@@ -46,6 +53,8 @@ function bucketGetCors(authInfo, request, log, callback) {
             log.debug('cors configuration does not exist', {
                 method: 'bucketGetCors',
             });
+            monitoring.promMetrics(
+                'GET', bucketName, 404, 'getBucketCors');
             return callback(errors.NoSuchCORSConfiguration, null, corsHeaders);
         }
         log.trace('converting cors configuration to xml');
@@ -55,6 +64,7 @@ function bucketGetCors(authInfo, request, log, callback) {
             authInfo,
             bucket: bucketName,
         });
+        monitoring.promMetrics('GET', bucketName, '200', 'getBucketCors');
         return callback(null, xml, corsHeaders);
     });
 }

--- a/lib/api/bucketGetLifecycle.js
+++ b/lib/api/bucketGetLifecycle.js
@@ -5,6 +5,7 @@ const LifecycleConfiguration =
 const { metadataValidateBucket } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
+const monitoring = require('../utilities/monitoringHandler');
 
 /**
  * bucketGetLifecycle - Get the bucket lifecycle configuration
@@ -29,6 +30,8 @@ function bucketGetLifecycle(authInfo, request, log, callback) {
                 error: err,
                 method: 'bucketGetLifecycle',
             });
+            monitoring.promMetrics(
+                'GET', bucketName, err.code, 'getBucketLifecycle');
             return callback(err, null, corsHeaders);
         }
         const lifecycleConfig = bucket.getLifecycleConfiguration();
@@ -37,6 +40,8 @@ function bucketGetLifecycle(authInfo, request, log, callback) {
                 error: errors.NoSuchLifecycleConfiguration,
                 method: 'bucketGetLifecycle',
             });
+            monitoring.promMetrics(
+                'GET', bucketName, 404, 'getBucketLifecycle');
             return callback(errors.NoSuchLifecycleConfiguration, null,
                 corsHeaders);
         }
@@ -45,6 +50,7 @@ function bucketGetLifecycle(authInfo, request, log, callback) {
             authInfo,
             bucket: bucketName,
         });
+        monitoring.promMetrics('GET', bucketName, '200', 'getBucketLifecycle');
         return callback(null, xml, corsHeaders);
     });
 }

--- a/lib/api/bucketGetLocation.js
+++ b/lib/api/bucketGetLocation.js
@@ -6,6 +6,7 @@ const metadata = require('../metadata/wrapper');
 const { pushMetric } = require('../utapi/utilities');
 const escapeForXml = s3middleware.escapeForXml;
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
+const monitoring = require('../utilities/monitoringHandler');
 
 const requestType = 'bucketOwnerAction';
 
@@ -25,9 +26,13 @@ function bucketGetLocation(authInfo, request, log, callback) {
     return metadata.getBucket(bucketName, log, (err, bucket) => {
         if (err) {
             log.debug('metadata getbucket failed', { error: err });
+            monitoring.promMetrics(
+                'GET', bucketName, err.code, 'getBucketLocation');
             return callback(err);
         }
         if (bucketShield(bucket, requestType)) {
+            monitoring.promMetrics(
+                'GET', bucketName, 404, 'getBucketLocation');
             return callback(errors.NoSuchBucket);
         }
         log.trace('found bucket in metadata');
@@ -40,6 +45,8 @@ function bucketGetLocation(authInfo, request, log, callback) {
                 requestType,
                 method: 'bucketGetLocation',
             });
+            monitoring.promMetrics(
+                'GET', bucketName, 403, 'getBucketLocation');
             return callback(errors.AccessDenied, null, corsHeaders);
         }
 
@@ -58,7 +65,8 @@ function bucketGetLocation(authInfo, request, log, callback) {
             authInfo,
             bucket: bucketName,
         });
-
+        monitoring.promMetrics(
+            'GET', bucketName, '200', 'getBucketLocation');
         return callback(null, xml, corsHeaders);
     });
 }

--- a/lib/api/bucketGetReplication.js
+++ b/lib/api/bucketGetReplication.js
@@ -5,6 +5,7 @@ const { pushMetric } = require('../utapi/utilities');
 const { getReplicationConfigurationXML } =
     require('./apiUtils/bucket/getReplicationConfiguration');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
+const monitoring = require('../utilities/monitoringHandler');
 
 /**
  * bucketGetReplication - Get the bucket replication configuration
@@ -29,6 +30,8 @@ function bucketGetReplication(authInfo, request, log, callback) {
                 error: err,
                 method: 'bucketGetReplication',
             });
+            monitoring.promMetrics(
+                'GET', bucketName, err.code, 'getBucketReplication');
             return callback(err, null, corsHeaders);
         }
         const replicationConfig = bucket.getReplicationConfiguration();
@@ -37,6 +40,8 @@ function bucketGetReplication(authInfo, request, log, callback) {
                 error: errors.ReplicationConfigurationNotFoundError,
                 method: 'bucketGetReplication',
             });
+            monitoring.promMetrics(
+                'GET', bucketName, 404, 'getBucketReplication');
             return callback(errors.ReplicationConfigurationNotFoundError, null,
                 corsHeaders);
         }
@@ -45,6 +50,8 @@ function bucketGetReplication(authInfo, request, log, callback) {
             authInfo,
             bucket: bucketName,
         });
+        monitoring.promMetrics(
+            'GET', bucketName, '200', 'getBucketReplication');
         return callback(null, xml, corsHeaders);
     });
 }

--- a/lib/api/bucketGetVersioning.js
+++ b/lib/api/bucketGetVersioning.js
@@ -1,6 +1,7 @@
 const { metadataValidateBucket } = require('../metadata/metadataUtils');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const { pushMetric } = require('../utapi/utilities');
+const monitoring = require('../utilities/monitoringHandler');
 
 //  Sample XML response:
 /*
@@ -62,6 +63,8 @@ function bucketGetVersioning(authInfo, request, log, callback) {
         if (err) {
             log.debug('error processing request',
                 { method: 'bucketGetVersioning', error: err });
+            monitoring.promMetrics(
+                'GET', bucketName, err.code, 'getBucketVersioning');
             return callback(err, null, corsHeaders);
         }
         const versioningConfiguration = bucket.getVersioningConfiguration();
@@ -70,6 +73,8 @@ function bucketGetVersioning(authInfo, request, log, callback) {
             authInfo,
             bucket: bucketName,
         });
+        monitoring.promMetrics(
+            'GET', bucketName, '200', 'getBucketVersioning');
         return callback(null, xml, corsHeaders);
     });
 }

--- a/lib/api/bucketGetWebsite.js
+++ b/lib/api/bucketGetWebsite.js
@@ -6,6 +6,7 @@ const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const { isBucketAuthorized } = require('./apiUtils/authorization/aclChecks');
 const metadata = require('../metadata/wrapper');
 const { pushMetric } = require('../utapi/utilities');
+const monitoring = require('../utilities/monitoringHandler');
 
 const requestType = 'bucketOwnerAction';
 
@@ -24,9 +25,13 @@ function bucketGetWebsite(authInfo, request, log, callback) {
     metadata.getBucket(bucketName, log, (err, bucket) => {
         if (err) {
             log.debug('metadata getbucket failed', { error: err });
+            monitoring.promMetrics(
+                'GET', bucketName, err.code, 'getBucketWebsite');
             return callback(err);
         }
         if (bucketShield(bucket, requestType)) {
+            monitoring.promMetrics(
+                'GET', bucketName, 404, 'getBucketWebsite');
             return callback(errors.NoSuchBucket);
         }
         log.trace('found bucket in metadata');
@@ -38,6 +43,8 @@ function bucketGetWebsite(authInfo, request, log, callback) {
                 requestType,
                 method: 'bucketGetWebsite',
             });
+            monitoring.promMetrics(
+                'GET', bucketName, 403, 'getBucketWebsite');
             return callback(errors.AccessDenied, null, corsHeaders);
         }
 
@@ -46,6 +53,8 @@ function bucketGetWebsite(authInfo, request, log, callback) {
             log.debug('bucket website configuration does not exist', {
                 method: 'bucketGetWebsite',
             });
+            monitoring.promMetrics(
+                'GET', bucketName, 404, 'getBucketWebsite');
             return callback(errors.NoSuchWebsiteConfiguration, null,
                 corsHeaders);
         }
@@ -56,6 +65,8 @@ function bucketGetWebsite(authInfo, request, log, callback) {
             authInfo,
             bucket: bucketName,
         });
+        monitoring.promMetrics(
+            'GET', bucketName, '200', 'getBucketWebsite');
         return callback(null, xml, corsHeaders);
     });
 }

--- a/lib/api/bucketHead.js
+++ b/lib/api/bucketHead.js
@@ -2,6 +2,7 @@ const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const { metadataValidateBucket } = require('../metadata/metadataUtils');
 
 const { pushMetric } = require('../utapi/utilities');
+const monitoring = require('../utilities/monitoringHandler');
 
 /**
  * Determine if bucket exists and if user has permission to access it
@@ -24,12 +25,16 @@ function bucketHead(authInfo, request, log, callback) {
         const corsHeaders = collectCorsHeaders(request.headers.origin,
             request.method, bucket);
         if (err) {
+            monitoring.promMetrics(
+                        'HEAD', bucketName, err.code, 'headBucket');
             return callback(err, corsHeaders);
         }
         pushMetric('headBucket', log, {
             authInfo,
             bucket: bucketName,
         });
+        monitoring.promMetrics(
+                    'HEAD', bucketName, '200', 'headBucket');
         return callback(null, corsHeaders);
     });
 }

--- a/lib/api/bucketPut.js
+++ b/lib/api/bucketPut.js
@@ -10,6 +10,7 @@ const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const { config } = require('../Config');
 const aclUtils = require('../utilities/aclUtils');
 const { pushMetric } = require('../utapi/utilities');
+const monitoring = require('../utilities/monitoringHandler');
 
 let { restEndpoints, locationConstraints } = config;
 config.on('rest-endpoints-update', () => {
@@ -103,10 +104,14 @@ function bucketPut(authInfo, request, log, callback) {
 
     if (authInfo.isRequesterPublicUser()) {
         log.debug('operation not available for public user');
+        monitoring.promMetrics(
+            'PUT', request.bucketName, 403, 'createBucket');
         return callback(errors.AccessDenied);
     }
     if (!aclUtils.checkGrantHeaderValidity(request.headers)) {
         log.trace('invalid acl header');
+        monitoring.promMetrics(
+            'PUT', request.bucketName, 400, 'createBucket');
         return callback(errors.InvalidArgument);
     }
     const { bucketName } = request;
@@ -116,6 +121,8 @@ function bucketPut(authInfo, request, log, callback) {
     // Note: for this to work with Vault, would need way to set
     // canonical ID to http://acs.zenko.io/accounts/service/clueso
         && !authInfo.isRequesterThisServiceAccount('clueso')) {
+        monitoring.promMetrics(
+            'PUT', bucketName, 403, 'createBucket');
         return callback(errors.AccessDenied
             .customizeDescription('The bucket METADATA is used ' +
             'for internal purposes'));
@@ -178,6 +185,7 @@ function bucketPut(authInfo, request, log, callback) {
                   authInfo,
                   bucket: bucketName,
               });
+              monitoring.promMetrics('PUT', bucketName, '200', 'createBucket');
               return next(null, corsHeaders);
           }),
     ], callback);

--- a/lib/api/bucketPutACL.js
+++ b/lib/api/bucketPutACL.js
@@ -9,6 +9,7 @@ const constants = require('../../constants');
 const { metadataValidateBucket } = require('../metadata/metadataUtils');
 const vault = require('../auth/vault');
 const { pushMetric } = require('../utapi/utilities');
+const monitoring = require('../utilities/monitoringHandler');
 
 /*
    Format of xml request:
@@ -58,10 +59,12 @@ function bucketPutACL(authInfo, request, log, callback) {
             acl: newCannedACL,
             method: 'bucketPutACL',
         });
+        monitoring.promMetrics('PUT', bucketName, 400, 'bucketPutACL');
         return callback(errors.InvalidArgument);
     }
     if (!aclUtils.checkGrantHeaderValidity(request.headers)) {
         log.trace('invalid acl header');
+        monitoring.promMetrics('PUT', bucketName, 400, 'bucketPutACL');
         return callback(errors.InvalidArgument);
     }
     const possibleGroups = [constants.allAuthedUsersId,
@@ -229,6 +232,8 @@ function bucketPutACL(authInfo, request, log, callback) {
                         id,
                         method: 'bucketPutACL',
                     });
+                    monitoring.promMetrics('PUT', bucketName, 400,
+                        'bucketPutACL');
                     return callback(errors.InvalidArgument, bucket);
                 }
             }
@@ -284,11 +289,13 @@ function bucketPutACL(authInfo, request, log, callback) {
         if (err) {
             log.trace('error processing request', { error: err,
                 method: 'bucketPutACL' });
+            monitoring.promMetrics('PUT', bucketName, err.code, 'bucketPutACL');
         } else {
             pushMetric('putBucketAcl', log, {
                 authInfo,
                 bucket: bucketName,
             });
+            monitoring.promMetrics('PUT', bucketName, '200', 'bucketPutACL');
         }
         return callback(err, corsHeaders);
     });

--- a/lib/api/bucketPutCors.js
+++ b/lib/api/bucketPutCors.js
@@ -8,6 +8,7 @@ const { isBucketAuthorized } = require('./apiUtils/authorization/aclChecks');
 const metadata = require('../metadata/wrapper');
 const { parseCorsXml } = require('./apiUtils/bucket/bucketCors');
 const { pushMetric } = require('../utapi/utilities');
+const monitoring = require('../utilities/monitoringHandler');
 
 const requestType = 'bucketOwnerAction';
 
@@ -27,6 +28,7 @@ function bucketPutCors(authInfo, request, log, callback) {
     if (!request.post) {
         log.debug('CORS xml body is missing',
         { error: errors.MissingRequestBodyError });
+        monitoring.promMetrics('PUT', bucketName, 400, 'putBucketCors');
         return callback(errors.MissingRequestBodyError);
     }
 
@@ -34,12 +36,14 @@ function bucketPutCors(authInfo, request, log, callback) {
         .update(request.post, 'utf8').digest('base64');
     if (md5 !== request.headers['content-md5']) {
         log.debug('bad md5 digest', { error: errors.BadDigest });
+        monitoring.promMetrics('PUT', bucketName, 400, 'putBucketCors');
         return callback(errors.BadDigest);
     }
 
     if (parseInt(request.headers['content-length'], 10) > 65536) {
         const errMsg = 'The CORS XML document is limited to 64 KB in size.';
         log.debug(errMsg, { error: errors.MalformedXML });
+        monitoring.promMetrics('PUT', bucketName, 400, 'putBucketCors');
         return callback(errors.MalformedXML.customizeDescription(errMsg));
     }
 
@@ -83,11 +87,14 @@ function bucketPutCors(authInfo, request, log, callback) {
         if (err) {
             log.trace('error processing request', { error: err,
                 method: 'bucketPutCors' });
+            monitoring.promMetrics('PUT', bucketName, err.code,
+                'putBucketCors');
         }
         pushMetric('putBucketCors', log, {
             authInfo,
             bucket: bucketName,
         });
+        monitoring.promMetrics('PUT', bucketName, '200', 'putBucketCors');
         return callback(err, corsHeaders);
     });
 }

--- a/lib/api/bucketPutLifecycle.js
+++ b/lib/api/bucketPutLifecycle.js
@@ -7,6 +7,7 @@ const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const metadata = require('../metadata/wrapper');
 const { metadataValidateBucket } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
+const monitoring = require('../utilities/monitoringHandler');
 
 /**
  * Bucket Put Lifecycle - Create or update bucket lifecycle configuration
@@ -55,12 +56,15 @@ function bucketPutLifecycle(authInfo, request, log, callback) {
         if (err) {
             log.trace('error processing request', { error: err,
                 method: 'bucketPutLifecycle' });
+            monitoring.promMetrics(
+                'PUT', bucketName, err.code, 'putBucketLifecycle');
             return callback(err, corsHeaders);
         }
         pushMetric('putBucketLifecycle', log, {
             authInfo,
             bucket: bucketName,
         });
+        monitoring.promMetrics('PUT', bucketName, '200', 'putBucketLifecycle');
         return callback(null, corsHeaders);
     });
 }

--- a/lib/api/bucketPutReplication.js
+++ b/lib/api/bucketPutReplication.js
@@ -9,6 +9,7 @@ const { getReplicationConfiguration } =
 const validateConfiguration =
     require('./apiUtils/bucket/validateReplicationConfig');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
+const monitoring = require('../utilities/monitoringHandler');
 
 // The error response when a bucket does not have versioning 'Enabled'.
 const versioningNotEnabledError = errors.InvalidRequest.customizeDescription(
@@ -70,12 +71,16 @@ function bucketPutReplication(authInfo, request, log, callback) {
                 error: err,
                 method: 'bucketPutReplication',
             });
+            monitoring.promMetrics(
+                'PUT', bucketName, err.code, 'putBucketReplication');
             return callback(err, corsHeaders);
         }
         pushMetric('putBucketReplication', log, {
             authInfo,
             bucket: bucketName,
         });
+        monitoring.promMetrics(
+            'PUT', bucketName, '200', 'putBucketReplication');
         return callback(null, corsHeaders);
     });
 }

--- a/lib/api/bucketPutVersioning.js
+++ b/lib/api/bucketPutVersioning.js
@@ -9,6 +9,7 @@ const { pushMetric } = require('../utapi/utilities');
 const versioningNotImplBackends =
     require('../../constants').versioningNotImplBackends;
 const { config } = require('../Config');
+const monitoring = require('../utilities/monitoringHandler');
 
 const externalVersioningErrorMessage = 'We do not currently support putting ' +
 'a versioned object to a location-constraint of type Azure or GCP.';
@@ -135,11 +136,15 @@ function bucketPutVersioning(authInfo, request, log, callback) {
         if (err) {
             log.trace('error processing request', { error: err,
                 method: 'bucketPutVersioning' });
+            monitoring.promMetrics(
+                'PUT', bucketName, err.code, 'putBucketVersioning');
         } else {
             pushMetric('putBucketVersioning', log, {
                 authInfo,
                 bucket: bucketName,
             });
+            monitoring.promMetrics(
+                'PUT', bucketName, '200', 'putBucketVersioning');
         }
         return callback(err, corsHeaders);
     });

--- a/lib/api/bucketPutWebsite.js
+++ b/lib/api/bucketPutWebsite.js
@@ -7,6 +7,7 @@ const { isBucketAuthorized } = require('./apiUtils/authorization/aclChecks');
 const metadata = require('../metadata/wrapper');
 const { parseWebsiteConfigXml } = require('./apiUtils/bucket/bucketWebsite');
 const { pushMetric } = require('../utapi/utilities');
+const monitoring = require('../utilities/monitoringHandler');
 
 const requestType = 'bucketOwnerAction';
 
@@ -24,6 +25,8 @@ function bucketPutWebsite(authInfo, request, log, callback) {
     const canonicalID = authInfo.getCanonicalID();
 
     if (!request.post) {
+        monitoring.promMetrics(
+            'PUT', bucketName, 400, 'putBucketWebsite');
         return callback(errors.MissingRequestBodyError);
     }
     return async.waterfall([
@@ -67,11 +70,15 @@ function bucketPutWebsite(authInfo, request, log, callback) {
         if (err) {
             log.trace('error processing request', { error: err,
                 method: 'bucketPutWebsite' });
+            monitoring.promMetrics(
+                'PUT', bucketName, err.code, 'putBucketWebsite');
         } else {
             pushMetric('putBucketWebsite', log, {
                 authInfo,
                 bucket: bucketName,
             });
+            monitoring.promMetrics(
+                'PUT', bucketName, '200', 'putBucketWebsite');
         }
         return callback(err, corsHeaders);
     });

--- a/lib/api/initiateMultipartUpload.js
+++ b/lib/api/initiateMultipartUpload.js
@@ -14,6 +14,7 @@ const validateWebsiteHeader = require('./apiUtils/object/websiteServing')
     .validateWebsiteHeader;
 const { config } = require('../Config');
 const multipleBackendGateway = require('../data/multipleBackendGateway');
+const monitoring = require('../utilities/monitoringHandler');
 
 const externalVersioningErrorMessage = 'We do not currently support putting ' +
 'a versioned object to a location-constraint of type Azure or GCP.';
@@ -142,6 +143,8 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
                             log.trace('error storing multipart object', {
                                 error: err,
                             });
+                            monitoring.promMetrics('PUT', bucketName, err.code,
+                                'initiateMultipartUpload');
                             return callback(err, null, corsHeaders);
                         }
                         log.addDefaultFields({ uploadId });
@@ -151,6 +154,8 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
                             bucket: bucketName,
                             keys: [objectKey],
                         });
+                        monitoring.promMetrics('PUT', bucketName, '200',
+                            'initiateMultipartUpload');
                         return callback(null, xml, corsHeaders);
                     });
             });
@@ -184,6 +189,8 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
             undefined, undefined, undefined, log,
             (err, dataBackendResObj) => {
                 if (err) {
+                    monitoring.promMetrics('PUT', bucketName, err.code,
+                                'initiateMultipartUpload');
                     return callback(err);
                 }
                 if (locConstraint &&
@@ -198,6 +205,8 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
                         log.debug(externalVersioningErrorMessage,
                             { method: 'initiateMultipartUpload',
                                 error: errors.NotImplemented });
+                        monitoring.promMetrics('PUT', bucketName, 501,
+                            'initiateMultipartUpload');
                         return callback(errors.NotImplemented
                         .customizeDescription(externalVersioningErrorMessage));
                     }
@@ -229,12 +238,16 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
                     error: err,
                     method: 'metadataValidateBucketAndObj',
                 });
+                monitoring.promMetrics('PUT', bucketName, err.code,
+                    'initiateMultipartUpload');
                 return callback(err, null, corsHeaders);
             }
             if (destinationBucket.hasDeletedFlag() &&
                 accountCanonicalID !== destinationBucket.getOwner()) {
                 log.trace('deleted flag on bucket and request ' +
                     'from non-owner account');
+                monitoring.promMetrics('PUT', bucketName, 404,
+                    'initiateMultipartUpload');
                 return callback(errors.NoSuchBucket);
             }
             if (destinationBucket.hasTransientFlag() ||
@@ -255,6 +268,8 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
                                 // To avoid confusing user with error
                                 // from cleaning up
                                 // bucket return InternalError
+                                monitoring.promMetrics('PUT', bucketName, 500,
+                                    'initiateMultipartUpload');
                                 return callback(errors.InternalError,
                                     null, corsHeaders);
                             }

--- a/lib/api/listMultipartUploads.js
+++ b/lib/api/listMultipartUploads.js
@@ -8,6 +8,7 @@ const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const services = require('../services');
 const { metadataValidateBucket } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
+const monitoring = require('../utilities/monitoringHandler');
 
 //  Sample XML response:
 /*
@@ -118,6 +119,8 @@ function listMultipartUploads(authInfo, request, log, callback) {
             let maxUploads = query['max-uploads'] !== undefined ?
                 Number.parseInt(query['max-uploads'], 10) : 1000;
             if (maxUploads < 0) {
+                monitoring.promMetrics('GET', bucketName, 400,
+                    'listMultipartUploads');
                 return callback(errors.InvalidArgument, bucket);
             }
             if (maxUploads > constants.listingHardLimit) {
@@ -141,6 +144,8 @@ function listMultipartUploads(authInfo, request, log, callback) {
         const corsHeaders = collectCorsHeaders(request.headers.origin,
             request.method, bucket);
         if (err) {
+            monitoring.promMetrics('GET', bucketName, err.code,
+                'listMultipartUploads');
             return callback(err, null, corsHeaders);
         }
         const xmlParams = {
@@ -156,6 +161,8 @@ function listMultipartUploads(authInfo, request, log, callback) {
             authInfo,
             bucket: bucketName,
         });
+        monitoring.promMetrics(
+            'GET', bucketName, '200', 'listMultipartUploads');
         return callback(null, xml, corsHeaders);
     });
 }

--- a/lib/api/listParts.js
+++ b/lib/api/listParts.js
@@ -9,6 +9,7 @@ const services = require('../services');
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const escapeForXml = s3middleware.escapeForXml;
 const { pushMetric } = require('../utapi/utilities');
+const monitoring = require('../utilities/monitoringHandler');
 
 const { config } = require('../../lib/Config');
 const multipleBackendGateway = require('../data/multipleBackendGateway');
@@ -80,6 +81,8 @@ function listParts(authInfo, request, log, callback) {
     let maxParts = Number.parseInt(request.query['max-parts'], 10) ?
         Number.parseInt(request.query['max-parts'], 10) : 1000;
     if (maxParts < 0) {
+        monitoring.promMetrics('GET', bucketName, 400,
+            'listMultipartUploadParts');
         return callback(errors.InvalidArgument);
     }
     if (maxParts > constants.listingHardLimit) {
@@ -263,11 +266,15 @@ function listParts(authInfo, request, log, callback) {
                 authInfo,
                 bucket: bucketName,
             });
+            monitoring.promMetrics(
+                    'GET', bucketName, '200', 'listMultipartUploadParts');
             next(null, destBucket, xml.join(''));
         },
     ], (err, destinationBucket, xml) => {
         const corsHeaders = collectCorsHeaders(request.headers.origin,
             request.method, destinationBucket);
+        monitoring.promMetrics('GET', bucketName, 400,
+            'listMultipartUploadParts');
         return callback(err, xml, corsHeaders);
     });
     return undefined;

--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -16,6 +16,7 @@ const { preprocessingVersioningDelete }
     = require('./apiUtils/object/versioning');
 const createAndStoreObject = require('./apiUtils/object/createAndStoreObject');
 const { metadataGetObject } = require('../metadata/metadataUtils');
+const monitoring = require('../utilities/monitoringHandler');
 
 const versionIdUtils = versioning.VersionID;
 
@@ -195,6 +196,8 @@ function getObjMetadataAndDelete(authInfo, canonicalID, request,
                         'null' : versionIdUtils.decode(entry.versionId);
                 }
                 if (decodedVersionId instanceof Error) {
+                    monitoring.promMetrics('DELETE', bucketName, 404,
+                        'multiObjectDelete');
                     return callback(errors.NoSuchVersion);
                 }
                 return callback(null, decodedVersionId);
@@ -205,6 +208,8 @@ function getObjMetadataAndDelete(authInfo, canonicalID, request,
                 versionId, log, (err, objMD) => {
                     // if general error from metadata return error
                     if (err && !err.NoSuchKey) {
+                        monitoring.promMetrics('DELETE', bucketName, err.code,
+                            'multiObjectDelete');
                         return callback(err);
                     }
                     if (err && err.NoSuchKey) {
@@ -306,11 +311,15 @@ function getObjMetadataAndDelete(authInfo, canonicalID, request,
 function multiObjectDelete(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'multiObjectDelete' });
     if (!request.post) {
+        monitoring.promMetrics('DELETE', request.bucketName, 400,
+            'multiObjectDelete');
         return callback(errors.MissingRequestBodyError);
     }
     const md5 = crypto.createHash('md5')
         .update(request.post, 'utf8').digest('base64');
     if (md5 !== request.headers['content-md5']) {
+        monitoring.promMetrics('DELETE', request.bucketName, 400,
+            'multiObjectDelete');
         return callback(errors.BadDigest);
     }
 
@@ -478,6 +487,8 @@ function multiObjectDelete(authInfo, request, log, callback) {
         const corsHeaders = collectCorsHeaders(request.headers.origin,
             request.method, bucket);
         if (err) {
+            monitoring.promMetrics('DELETE', bucketName, err.code,
+                'multiObjectDelete');
             return callback(err, null, corsHeaders);
         }
         const xml = _formatXML(quietSetting, errorResults,
@@ -490,6 +501,10 @@ function multiObjectDelete(authInfo, request, log, callback) {
             byteLength: Number.parseInt(totalContentLengthDeleted, 10),
             numberOfObjects: numOfObjectsRemoved,
         });
+        monitoring.promMetrics('DELETE', bucketName, '200',
+        'multiObjectDelete',
+        Number.parseInt(totalContentLengthDeleted, 10), null, null,
+        numOfObjectsRemoved);
         return callback(null, xml, corsHeaders);
     });
 }

--- a/lib/api/multipartDelete.js
+++ b/lib/api/multipartDelete.js
@@ -10,6 +10,7 @@ const { pushMetric } = require('../utapi/utilities');
 const isLegacyAWSBehavior = require('../utilities/legacyAWSBehavior');
 const { config } = require('../Config');
 const multipleBackendGateway = require('../data/multipleBackendGateway');
+const monitoring = require('../utilities/monitoringHandler');
 
 /**
  * multipartDelete - DELETE an open multipart upload from a bucket
@@ -148,6 +149,8 @@ function multipartDelete(authInfo, request, log, callback) {
                         keys: [objectKey],
                         byteLength: partSizeSum,
                     });
+                    monitoring.promMetrics('DELETE', bucketName, '200',
+                        'abortMultipartUpload', partSizeSum);
                     return next(null, destBucket);
                 });
         },
@@ -168,6 +171,8 @@ function multipartDelete(authInfo, request, log, callback) {
             // otherwise ignore error and return 204 status code
             return callback(null, corsHeaders);
         }
+        monitoring.promMetrics('DELETE', bucketName, 400,
+            'abortMultipartUpload');
         return callback(err, corsHeaders);
     });
 }

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -20,6 +20,7 @@ const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const validateWebsiteHeader = require('./apiUtils/object/websiteServing')
     .validateWebsiteHeader;
 const { config } = require('../Config');
+const monitoring = require('../utilities/monitoringHandler');
 
 const versionIdUtils = versioning.VersionID;
 const locationHeader = constants.objectLocationConstraintHeader;
@@ -218,6 +219,8 @@ function objectCopy(authInfo, request, sourceBucket,
         const err = errors.InvalidRedirectLocation;
         log.debug('invalid x-amz-website-redirect-location' +
             `value ${websiteRedirectHeader}`, { error: err });
+        monitoring.promMetrics(
+            'PUT', destBucketName, err.code, 'copyObject');
         return callback(err);
     }
     const queryContainsVersionId = checkQueryVersionId(request.query);
@@ -449,6 +452,8 @@ function objectCopy(authInfo, request, sourceBucket,
             request.method, destBucketMD);
 
         if (err) {
+            monitoring.promMetrics(
+                'PUT', destBucketName, err.code, 'copyObject');
             return callback(err, null, corsHeaders);
         }
         const xml = [
@@ -485,6 +490,8 @@ function objectCopy(authInfo, request, sourceBucket,
             newByteLength: sourceObjSize,
             oldByteLength: isVersioned ? null : destObjPrevSize,
         });
+        monitoring.promMetrics('PUT', destBucketName, '200',
+                'copyObject', sourceObjSize, destObjPrevSize, isVersioned);
         // Add expiration header if lifecycle enabled
         return callback(null, xml, additionalHeaders);
     });

--- a/lib/api/objectDelete.js
+++ b/lib/api/objectDelete.js
@@ -8,6 +8,7 @@ const createAndStoreObject = require('./apiUtils/object/createAndStoreObject');
 const { decodeVersionId, preprocessingVersioningDelete }
     = require('./apiUtils/object/versioning');
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
+const monitoring = require('../utilities/monitoringHandler');
 
 const versionIdUtils = versioning.VersionID;
 
@@ -24,6 +25,8 @@ function objectDelete(authInfo, request, log, cb) {
     log.debug('processing request', { method: 'objectDelete' });
     if (authInfo.isRequesterPublicUser()) {
         log.debug('operation not available for public user');
+        monitoring.promMetrics(
+            'DELETE', request.bucketName, 403, 'deleteObject');
         return cb(errors.AccessDenied);
     }
     const bucketName = request.bucketName;
@@ -149,6 +152,8 @@ function objectDelete(authInfo, request, log, cb) {
         if (err) {
             log.debug('error processing request', { error: err,
                 method: 'objectDelete' });
+            monitoring.promMetrics(
+                'DELETE', bucketName, err.code, 'deleteObject');
             return cb(err, resHeaders);
         }
         if (deleteInfo.newDeleteMarker) {
@@ -171,6 +176,8 @@ function objectDelete(authInfo, request, log, cb) {
                 keys: [objectKey],
                 byteLength: Number.parseInt(objectMD['content-length'], 10),
                 numberOfObjects: 1 });
+            monitoring.promMetrics('DELETE', bucketName, '200', 'deleteObject',
+                Number.parseInt(objectMD['content-length'], 10));
         }
         return cb(err, resHeaders);
     });

--- a/lib/api/objectDeleteTagging.js
+++ b/lib/api/objectDeleteTagging.js
@@ -6,6 +6,7 @@ const { decodeVersionId, getVersionIdResHeader }
 
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
+const monitoring = require('../utilities/monitoringHandler');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const metadata = require('../metadata/wrapper');
 const getReplicationInfo = require('./apiUtils/object/getReplicationInfo');
@@ -96,12 +97,16 @@ function objectDeleteTagging(authInfo, request, log, callback) {
         if (err) {
             log.trace('error processing request', { error: err,
                 method: 'objectDeleteTagging' });
+            monitoring.promMetrics(
+                'DELETE', bucketName, err.code, 'deleteObjectTagging');
         } else {
             pushMetric('deleteObjectTagging', log, {
                 authInfo,
                 bucket: bucketName,
                 keys: [objectKey],
             });
+            monitoring.promMetrics(
+                'DELETE', bucketName, '200', 'deleteObjectTagging');
             const verCfg = bucket.getVersioningConfiguration();
             additionalResHeaders['x-amz-version-id'] =
                 getVersionIdResHeader(verCfg, objectMD);

--- a/lib/api/objectGet.js
+++ b/lib/api/objectGet.js
@@ -17,6 +17,8 @@ const checkReadLocation = require('./apiUtils/object/checkReadLocation');
 
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { config } = require('../Config');
+const { locationConstraints } = config;
+const monitoring = require('../utilities/monitoringHandler');
 
 const validateHeaders = s3middleware.validateConditionalHeaders;
 
@@ -72,10 +74,14 @@ function objectGet(authInfo, request, returnTagCount, log, callback) {
                 error: err,
                 method: 'metadataValidateBucketAndObj',
             });
+            monitoring.promMetrics(
+                'GET', bucketName, err.code, 'getObject');
             return callback(err, null, corsHeaders);
         }
         if (!objMD) {
             const err = versionId ? errors.NoSuchVersion : errors.NoSuchKey;
+            monitoring.promMetrics(
+                'GET', bucketName, err.code, 'getObject');
             return callback(err, null, corsHeaders);
         }
         const verCfg = bucket.getVersioningConfiguration();
@@ -83,12 +89,16 @@ function objectGet(authInfo, request, returnTagCount, log, callback) {
             const responseMetaHeaders = Object.assign({},
                 { 'x-amz-delete-marker': true }, corsHeaders);
             if (!versionId) {
+                monitoring.promMetrics(
+                    'GET', bucketName, 404, 'getObject');
                 return callback(errors.NoSuchKey, null, responseMetaHeaders);
             }
             // return MethodNotAllowed if requesting a specific
             // version that has a delete marker
             responseMetaHeaders['x-amz-version-id'] =
                 getVersionIdResHeader(verCfg, objMD);
+            monitoring.promMetrics(
+                'GET', bucketName, 405, 'getObject');
             return callback(errors.MethodNotAllowed, null,
                 responseMetaHeaders);
         }
@@ -108,6 +118,8 @@ function objectGet(authInfo, request, returnTagCount, log, callback) {
             const { range, error } = parseRange(request.headers.range,
                                                 objLength);
             if (error) {
+                monitoring.promMetrics(
+                    'GET', bucketName, 400, 'getObject');
                 return callback(error, null, corsHeaders);
             }
             responseMetaHeaders['Accept-Ranges'] = 'bytes';
@@ -167,18 +179,24 @@ function objectGet(authInfo, request, returnTagCount, log, callback) {
                     const error = errors.InvalidRequest
                         .customizeDescription('Cannot specify both Range ' +
                             'header and partNumber query parameter.');
+                    monitoring.promMetrics(
+                        'GET', bucketName, 400, 'getObject');
                     return callback(error, null, corsHeaders);
                 }
                 partNumber = Number.parseInt(request.query.partNumber, 10);
                 if (Number.isNaN(partNumber)) {
                     const error = errors.InvalidArgument
                         .customizeDescription('Part number must be a number.');
+                    monitoring.promMetrics(
+                        'GET', bucketName, 400, 'getObject');
                     return callback(error, null, corsHeaders);
                 }
                 if (partNumber < 1 || partNumber > 10000) {
                     const error = errors.InvalidArgument
                         .customizeDescription('Part number must be an ' +
                             'integer between 1 and 10000, inclusive.');
+                    monitoring.promMetrics(
+                        'GET', bucketName, 400, 'getObject');
                     return callback(error, null, corsHeaders);
                 }
             }
@@ -186,6 +204,8 @@ function objectGet(authInfo, request, returnTagCount, log, callback) {
             // get range for objects with multiple parts
             if (byteRange && dataLocator.length > 1 &&
                 dataLocator[0].start === undefined) {
+                monitoring.promMetrics(
+                    'GET', bucketName, 501, 'getObject');
                 return callback(errors.NotImplemented, null, corsHeaders);
             }
             if (objMD['x-amz-server-side-encryption']) {
@@ -203,6 +223,8 @@ function objectGet(authInfo, request, returnTagCount, log, callback) {
                     // Location objects prior to GA7.1 do not include the
                     // dataStoreETag field so we cannot find the part range
                     if (dataStoreETag === undefined) {
+                        monitoring.promMetrics(
+                            'GET', bucketName, 400, 'getObject');
                         return callback(errors.NotImplemented
                             .customizeDescription('PartNumber parameter for ' +
                             'this object is not supported'));
@@ -217,6 +239,8 @@ function objectGet(authInfo, request, returnTagCount, log, callback) {
                     }
                 }
                 if (locations.length === 0) {
+                    monitoring.promMetrics(
+                        'GET', bucketName, 400, 'getObject');
                     return callback(errors.InvalidPartNumber, null,
                         corsHeaders);
                 }
@@ -234,6 +258,8 @@ function objectGet(authInfo, request, returnTagCount, log, callback) {
             if (err) {
                 log.error('error from external backend checking for ' +
                 'object existence', { error: err });
+                monitoring.promMetrics(
+                    'GET', bucketName, err.code, 'getObject');
                 return callback(err);
             }
             pushMetric('getObject', log, {
@@ -242,6 +268,8 @@ function objectGet(authInfo, request, returnTagCount, log, callback) {
                 newByteLength:
                 Number.parseInt(responseMetaHeaders['Content-Length'], 10),
             });
+            monitoring.promMetrics('GET', bucketName, '200', 'getObject',
+                Number.parseInt(responseMetaHeaders['Content-Length'], 10));
             return callback(null, dataLocator, responseMetaHeaders,
                 byteRange);
         });

--- a/lib/api/objectGetACL.js
+++ b/lib/api/objectGetACL.js
@@ -9,6 +9,7 @@ const { decodeVersionId, getVersionIdResHeader }
     = require('./apiUtils/object/versioning');
 const vault = require('../auth/vault');
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
+const monitoring = require('../utilities/monitoringHandler');
 
 //  Sample XML response:
 /*
@@ -210,12 +211,15 @@ function objectGetACL(authInfo, request, log, callback) {
         const resHeaders = collectCorsHeaders(request.headers.origin,
             request.method, bucket);
         if (err) {
+            monitoring.promMetrics(
+                    'GET', bucketName, err.code, 'getObjectAcl');
             return callback(err, null, resHeaders);
         }
         pushMetric('getObjectAcl', log, {
             authInfo,
             bucket: bucketName,
         });
+        monitoring.promMetrics('GET', bucketName, '200', 'getObjectAcl');
         resHeaders['x-amz-version-id'] = resVersionId;
         return callback(null, xml, resHeaders);
     });

--- a/lib/api/objectGetTagging.js
+++ b/lib/api/objectGetTagging.js
@@ -8,6 +8,7 @@ const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const { convertToXml } = s3middleware.tagging;
+const monitoring = require('../utilities/monitoringHandler');
 
 /**
  * Object Get Tagging - Return tag for object
@@ -79,11 +80,15 @@ function objectGetTagging(authInfo, request, log, callback) {
         if (err) {
             log.trace('error processing request', { error: err,
                 method: 'objectGetTagging' });
+            monitoring.promMetrics(
+                    'GET', bucketName, err.code, 'getObjectTagging');
         } else {
             pushMetric('getObjectTagging', log, {
                 authInfo,
                 bucket: bucketName,
             });
+            monitoring.promMetrics(
+                'GET', bucketName, '200', 'getObjectTagging');
             const verCfg = bucket.getVersioningConfiguration();
             additionalResHeaders['x-amz-version-id'] =
                 getVersionIdResHeader(verCfg, objectMD);

--- a/lib/api/objectHead.js
+++ b/lib/api/objectHead.js
@@ -6,6 +6,7 @@ const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const collectResponseHeaders = require('../utilities/collectResponseHeaders');
 const { pushMetric } = require('../utapi/utilities');
 const { getVersionIdResHeader } = require('./apiUtils/object/versioning');
+const monitoring = require('../utilities/monitoringHandler');
 
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 
@@ -51,10 +52,14 @@ function objectHead(authInfo, request, log, callback) {
                     error: err,
                     method: 'objectHead',
                 });
+                monitoring.promMetrics(
+                        'HEAD', bucketName, err.code, 'headObject');
                 return callback(err, corsHeaders);
             }
             if (!objMD) {
                 const err = versionId ? errors.NoSuchVersion : errors.NoSuchKey;
+                monitoring.promMetrics(
+                    'HEAD', bucketName, err.code, 'headObject');
                 return callback(err, corsHeaders);
             }
             const verCfg = bucket.getVersioningConfiguration();
@@ -62,12 +67,16 @@ function objectHead(authInfo, request, log, callback) {
                 const responseHeaders = Object.assign({},
                     { 'x-amz-delete-marker': true }, corsHeaders);
                 if (!versionId) {
+                    monitoring.promMetrics(
+                        'HEAD', bucketName, 404, 'headObject');
                     return callback(errors.NoSuchKey, responseHeaders);
                 }
                 // return MethodNotAllowed if requesting a specific
                 // version that has a delete marker
                 responseHeaders['x-amz-version-id'] =
                     getVersionIdResHeader(verCfg, objMD);
+                monitoring.promMetrics(
+                    'HEAD', bucketName, 405, 'headObject');
                 return callback(errors.MethodNotAllowed, responseHeaders);
             }
             const headerValResult = validateHeaders(request.headers,
@@ -78,6 +87,7 @@ function objectHead(authInfo, request, log, callback) {
             const responseHeaders =
                 collectResponseHeaders(objMD, corsHeaders, verCfg);
             pushMetric('headObject', log, { authInfo, bucket: bucketName });
+            monitoring.promMetrics('HEAD', bucketName, '200', 'headObject');
             return callback(null, responseHeaders);
         });
 }

--- a/lib/api/objectPut.js
+++ b/lib/api/objectPut.js
@@ -9,6 +9,7 @@ const { checkQueryVersionId } = require('./apiUtils/object/versioning');
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
 const kms = require('../kms/wrapper');
+const monitoring = require('../utilities/monitoringHandler');
 
 const versionIdUtils = versioning.VersionID;
 
@@ -35,6 +36,8 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
     log.debug('processing request', { method: 'objectPut' });
     if (!aclUtils.checkGrantHeaderValidity(request.headers)) {
         log.trace('invalid acl header');
+        monitoring.promMetrics('PUT', request.bucketName, 400,
+            'putObject');
         return callback(errors.InvalidArgument);
     }
     const queryContainsVersionId = checkQueryVersionId(request.query);
@@ -57,11 +60,13 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
                 error: err,
                 method: 'metadataValidateBucketAndObj',
             });
+            monitoring.promMetrics('PUT', bucketName, err.code, 'putObject');
             return callback(err, responseHeaders);
         }
         if (bucket.hasDeletedFlag() && canonicalID !== bucket.getOwner()) {
             log.trace('deleted flag on bucket and request ' +
                 'from non-owner account');
+            monitoring.promMetrics('PUT', bucketName, 404, 'putObject');
             return callback(errors.NoSuchBucket);
         }
         return async.waterfall([
@@ -86,6 +91,8 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
             },
         ], (err, storingResult) => {
             if (err) {
+                monitoring.promMetrics('PUT', bucketName, err.code,
+                    'putObject');
                 return callback(err, responseHeaders);
             }
             const newByteLength = request.parsedContentLength;
@@ -118,6 +125,8 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
                 newByteLength,
                 oldByteLength: isVersionedObj ? null : oldByteLength,
             });
+            monitoring.promMetrics('PUT', bucketName, '200',
+                'putObject', newByteLength, oldByteLength, isVersionedObj);
             return callback(null, responseHeaders);
         });
     });

--- a/lib/api/objectPutACL.js
+++ b/lib/api/objectPutACL.js
@@ -10,6 +10,7 @@ const vault = require('../auth/vault');
 const { decodeVersionId, getVersionIdResHeader }
     = require('./apiUtils/object/versioning');
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
+const monitoring = require('../utilities/monitoringHandler');
 
 /*
    Format of xml request:
@@ -56,10 +57,12 @@ function objectPutACL(authInfo, request, log, cb) {
     ];
     if (newCannedACL && possibleCannedACL.indexOf(newCannedACL) === -1) {
         log.trace('invalid canned acl argument', { cannedAcl: newCannedACL });
+        monitoring.promMetrics('PUT', bucketName, 400, 'putObjectAcl');
         return cb(errors.InvalidArgument);
     }
     if (!aclUtils.checkGrantHeaderValidity(request.headers)) {
         log.trace('invalid acl header');
+        monitoring.promMetrics('PUT', bucketName, 400, 'putObjectAcl');
         return cb(errors.InvalidArgument);
     }
     const possibleGroups = [
@@ -288,6 +291,8 @@ function objectPutACL(authInfo, request, log, cb) {
                 error: err,
                 method: 'objectPutACL',
             });
+            monitoring.promMetrics(
+                'PUT', bucketName, err.code, 'putObjectAcl');
             return cb(err, resHeaders);
         }
 
@@ -301,6 +306,7 @@ function objectPutACL(authInfo, request, log, cb) {
             bucket: bucketName,
             keys: [objectKey],
         });
+        monitoring.promMetrics('PUT', bucketName, '200', 'putObjectAcl');
         return cb(null, resHeaders);
     });
 }

--- a/lib/api/objectPutCopyPart.js
+++ b/lib/api/objectPutCopyPart.js
@@ -10,6 +10,7 @@ const logger = require('../utilities/logger');
 const services = require('../services');
 const setUpCopyLocator = require('./apiUtils/object/setUpCopyLocator');
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
+const monitoring = require('../utilities/monitoringHandler');
 
 const versionIdUtils = versioning.VersionID;
 
@@ -45,6 +46,8 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
     const partNumber = Number.parseInt(request.query.partNumber, 10);
     // AWS caps partNumbers at 10,000
     if (partNumber > 10000 || !Number.isInteger(partNumber) || partNumber < 1) {
+        monitoring.promMetrics('PUT', destBucketName, 400,
+            'putObjectCopyPart');
         return callback(errors.InvalidArgument);
     }
     // We pad the partNumbers so that the parts will be sorted
@@ -312,6 +315,8 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
         if (err && err !== skipError) {
             log.trace('error from copy part waterfall',
             { error: err });
+            monitoring.promMetrics('PUT', destBucketName, err.code,
+                'putObjectCopyPart');
             return callback(err, null, corsHeaders);
         }
         const xml = [
@@ -338,6 +343,8 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
         //      bucket: destBucketName,
         //      keys: [objectKey],
         // });
+        monitoring.promMetrics(
+            'PUT', destBucketName, '200', 'putObjectCopyPart');
         return callback(null, xml, additionalHeaders);
     });
 }

--- a/lib/api/objectPutPart.js
+++ b/lib/api/objectPutPart.js
@@ -14,6 +14,7 @@ const { pushMetric } = require('../utapi/utilities');
 const logger = require('../utilities/logger');
 const { config } = require('../Config');
 const multipleBackendGateway = require('../data/multipleBackendGateway');
+const monitoring = require('../utilities/monitoringHandler');
 
 const skipError = new Error('skip');
 
@@ -55,6 +56,8 @@ function objectPutPart(authInfo, request, streamingV4Params, log,
 
     if (Number.parseInt(size, 10) > constants.maximumAllowedPartSize) {
         log.debug('put part size too large', { size });
+        monitoring.promMetrics('PUT', request.bucketName, 400,
+            'putObjectPart');
         return cb(errors.EntityTooLarge);
     }
 
@@ -67,9 +70,13 @@ function objectPutPart(authInfo, request, streamingV4Params, log,
     const partNumber = Number.parseInt(request.query.partNumber, 10);
     // AWS caps partNumbers at 10,000
     if (partNumber > 10000) {
+        monitoring.promMetrics('PUT', request.bucketName, 400,
+            'putObjectPart');
         return cb(errors.TooManyParts);
     }
     if (!Number.isInteger(partNumber) || partNumber < 1) {
+        monitoring.promMetrics('PUT', request.bucketName, 400,
+            'putObjectPart');
         return cb(errors.InvalidArgument);
     }
     const bucketName = request.bucketName;
@@ -336,6 +343,8 @@ function objectPutPart(authInfo, request, streamingV4Params, log,
                 error: err,
                 method: 'objectPutPart',
             });
+            monitoring.promMetrics('PUT', bucketName, err.code,
+                'putObjectPart');
             return cb(err, null, corsHeaders);
         }
         pushMetric('uploadPart', log, {
@@ -345,6 +354,8 @@ function objectPutPart(authInfo, request, streamingV4Params, log,
             newByteLength: size,
             oldByteLength: prevObjectSize,
         });
+        monitoring.promMetrics('PUT', bucketName,
+            '200', 'putObjectPart', size, prevObjectSize);
         return cb(null, hexDigest, corsHeaders);
     });
 }

--- a/lib/api/objectPutTagging.js
+++ b/lib/api/objectPutTagging.js
@@ -6,6 +6,7 @@ const { decodeVersionId, getVersionIdResHeader } =
 
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
+const monitoring = require('../utilities/monitoringHandler');
 const getReplicationInfo = require('./apiUtils/object/getReplicationInfo');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const metadata = require('../metadata/wrapper');
@@ -102,12 +103,16 @@ function objectPutTagging(authInfo, request, log, callback) {
         if (err) {
             log.trace('error processing request', { error: err,
                 method: 'objectPutTagging' });
+            monitoring.promMetrics('PUT', bucketName, err.code,
+                'putObjectTagging');
         } else {
             pushMetric('putObjectTagging', log, {
                 authInfo,
                 bucket: bucketName,
                 keys: [objectKey],
             });
+            monitoring.promMetrics(
+                'PUT', bucketName, '200', 'putObjectTagging');
             const verCfg = bucket.getVersioningConfiguration();
             additionalResHeaders['x-amz-version-id'] =
                 getVersionIdResHeader(verCfg, objectMD);

--- a/lib/api/serviceGet.js
+++ b/lib/api/serviceGet.js
@@ -2,6 +2,7 @@ const { errors } = require('arsenal');
 
 const constants = require('../../constants');
 const services = require('../services');
+const monitoring = require('../utilities/monitoringHandler');
 
 /*
  *  Format of xml response:
@@ -55,6 +56,8 @@ function serviceGet(authInfo, request, log, callback) {
 
     if (authInfo.isRequesterPublicUser()) {
         log.debug('operation not available for public user');
+        monitoring.promMetrics(
+            'GET', request.bucketName, 403, 'getService');
         return callback(errors.AccessDenied);
     }
     const xml = [];
@@ -73,12 +76,15 @@ function serviceGet(authInfo, request, log, callback) {
     return services.getService(authInfo, request, log, constants.splitter,
         (err, userBuckets, splitter) => {
             if (err) {
+                monitoring.promMetrics(
+                    'GET', userBuckets, err.code, 'getService');
                 return callback(err);
             }
             // TODO push metric for serviceGet
             // pushMetric('getService', log, {
             //      bucket: bucketName,
             // });
+            monitoring.promMetrics('GET', userBuckets, '200', 'getService');
             return callback(null, generateXml(xml, canonicalId, userBuckets,
                 splitter));
         });

--- a/lib/api/websiteGet.js
+++ b/lib/api/websiteGet.js
@@ -11,6 +11,7 @@ const { isObjAuthorized } = require('./apiUtils/authorization/aclChecks');
 const collectResponseHeaders = require('../utilities/collectResponseHeaders');
 const { pushMetric } = require('../utapi/utilities');
 const { isBucketAuthorized } = require('./apiUtils/authorization/aclChecks');
+const monitoring = require('../utilities/monitoringHandler');
 
 /**
  * _errorActions - take a number of actions once have error getting obj
@@ -32,6 +33,8 @@ function _errorActions(err, errorDocument, routingRules,
         objectKey, err.code);
     if (errRoutingRule) {
         // route will redirect
+        monitoring.promMetrics(
+            'GET', bucketName, err.code, 'getObject');
         return callback(err, false, null, corsHeaders, errRoutingRule,
             objectKey);
     }
@@ -42,6 +45,8 @@ function _errorActions(err, errorDocument, routingRules,
                     // error retrieving error document so return original error
                     // and set boolean of error retrieving user's error document
                     // to true
+                    monitoring.promMetrics(
+                        'GET', bucketName, err.code, 'getObject');
                     return callback(err, true, null, corsHeaders);
                 }
                 // return the default error message if the object is private
@@ -49,6 +54,8 @@ function _errorActions(err, errorDocument, routingRules,
                 if (!isObjAuthorized(bucket, errObjMD, 'objectGet',
                     constants.publicId)) {
                     log.trace('errorObj not authorized', { error: err });
+                    monitoring.promMetrics(
+                        'GET', bucketName, err.code, 'getObject');
                     return callback(err, true, null, corsHeaders);
                 }
                 const dataLocator = errObjMD.location;
@@ -67,9 +74,13 @@ function _errorActions(err, errorDocument, routingRules,
                     bucket: bucketName,
                     newByteLength: responseMetaHeaders['Content-Length'],
                 });
+                monitoring.promMetrics(
+                    'GET', bucketName, err.code, 'getObject');
                 return callback(err, false, dataLocator, responseMetaHeaders);
             });
     }
+    monitoring.promMetrics(
+        'GET', bucketName, err.code, 'getObject');
     return callback(err, false, null, corsHeaders);
 }
 
@@ -89,16 +100,22 @@ function websiteGet(request, log, callback) {
     return metadata.getBucket(bucketName, log, (err, bucket) => {
         if (err) {
             log.trace('error retrieving bucket metadata', { error: err });
+            monitoring.promMetrics(
+                'GET', bucketName, err.code, 'getObject');
             return callback(err, false);
         }
         if (bucketShield(bucket, 'objectGet')) {
             log.trace('bucket in transient/deleted state so shielding');
+            monitoring.promMetrics(
+                'GET', bucketName, 404, 'getObject');
             return callback(errors.NoSuchBucket, false);
         }
         const corsHeaders = collectCorsHeaders(request.headers.origin,
             request.method, bucket);
         const websiteConfig = bucket.getWebsiteConfiguration();
         if (!websiteConfig) {
+            monitoring.promMetrics(
+                'GET', bucketName, 404, 'getObject');
             return callback(errors.NoSuchWebsiteConfiguration, false, null,
             corsHeaders);
         }
@@ -142,6 +159,8 @@ function websiteGet(request, log, callback) {
                 if (err) {
                     log.trace('error retrieving object metadata',
                     { error: err });
+                    monitoring.promMetrics(
+                        'GET', bucketName, err.code, 'getObject');
                     let returnErr = err;
                     const bucketAuthorized = isBucketAuthorized(bucket,
                       'bucketGet', constants.publicId);
@@ -205,6 +224,8 @@ function websiteGet(request, log, callback) {
                     bucket: bucketName,
                     newByteLength: responseMetaHeaders['Content-Length'],
                 });
+                monitoring.promMetrics('GET', bucketName, '200',
+                    'getObject', responseMetaHeaders['Content-Length']);
                 return callback(null, false, dataLocator, responseMetaHeaders);
             });
     });

--- a/lib/api/websiteHead.js
+++ b/lib/api/websiteHead.js
@@ -11,6 +11,7 @@ const { isObjAuthorized } = require('./apiUtils/authorization/aclChecks');
 const collectResponseHeaders = require('../utilities/collectResponseHeaders');
 const { pushMetric } = require('../utapi/utilities');
 const { isBucketAuthorized } = require('./apiUtils/authorization/aclChecks');
+const monitoring = require('../utilities/monitoringHandler');
 
 
 /**
@@ -51,10 +52,14 @@ function websiteHead(request, log, callback) {
     return metadata.getBucket(bucketName, log, (err, bucket) => {
         if (err) {
             log.trace('error retrieving bucket metadata', { error: err });
+            monitoring.promMetrics(
+                'HEAD', bucketName, err.code, 'headObject');
             return callback(err);
         }
         if (bucketShield(bucket, 'objectHead')) {
             log.trace('bucket in transient/deleted state so shielding');
+            monitoring.promMetrics(
+                'HEAD', bucketName, 404, 'headObject');
             return callback(errors.NoSuchBucket);
         }
         const corsHeaders = collectCorsHeaders(request.headers.origin,
@@ -63,6 +68,8 @@ function websiteHead(request, log, callback) {
         // head of an object. object ACL's are what matter
         const websiteConfig = bucket.getWebsiteConfiguration();
         if (!websiteConfig) {
+            monitoring.promMetrics(
+                'HEAD', bucketName, 404, 'headObject');
             return callback(errors.NoSuchWebsiteConfiguration);
         }
         // any errors above would be generic header error response
@@ -151,6 +158,8 @@ function websiteHead(request, log, callback) {
                 pushMetric('headObject', log, {
                     bucket: bucketName,
                 });
+                monitoring.promMetrics(
+                    'HEAD', bucketName, '200', 'headObject');
                 return callback(null, responseMetaHeaders);
             });
     });

--- a/lib/server.js
+++ b/lib/server.js
@@ -3,6 +3,7 @@ const https = require('https');
 const cluster = require('cluster');
 const arsenal = require('arsenal');
 const { RedisClient, StatsClient } = require('arsenal').metrics;
+const monitoringClient = require('./utilities/monitoringHandler');
 
 const logger = require('./utilities/logger');
 const { internalHandlers } = require('./utilities/internalHandlers');
@@ -248,6 +249,7 @@ function main() {
         const server = new S3Server(cluster.worker);
         server.initiateStartup(logger.newRequestLogger());
     }
+    monitoringClient.collectDefaultMetrics({ timeout: 5000 });
 }
 
 module.exports = main;

--- a/lib/utilities/monitoringHandler.js
+++ b/lib/utilities/monitoringHandler.js
@@ -1,6 +1,108 @@
 const errors = require('arsenal');
 const client = require('prom-client');
 
+const collectDefaultMetrics = client.collectDefaultMetrics;
+let crrStatsPulled = false;
+const numberOfBuckets = new client.Gauge({
+    name: 'cloud_server_number_of_buckets',
+    help: 'Total number of buckets',
+});
+const numberOfObjects = new client.Gauge({
+    name: 'cloud_server_number_of_objects',
+    help: 'Total number of objects',
+});
+const dataDiskAvailable = new client.Gauge({
+    name: 'cloud_server_data_disk_available',
+    help: 'Available data disk storage in bytes',
+});
+const dataDiskFree = new client.Gauge({
+    name: 'cloud_server_data_disk_free',
+    help: 'Free data disk storage in bytes',
+});
+const dataDiskTotal = new client.Gauge({
+    name: 'cloud_server_data_disk_total',
+    help: 'Total data disk storage in bytes',
+});
+
+const labelNames = ['method', 'service', 'code'];
+const httpRequestsTotal = new client.Counter({
+    labelNames,
+    name: 'cloud_server_http_requests_total',
+    help: 'Total number of HTTP requests',
+});
+
+const httpRequestSizeBytes = new client.Summary({
+    labelNames,
+    name: 'cloud_server_http_request_size_bytes',
+    help: 'The HTTP request sizes in bytes.',
+});
+
+const httpResponseSizeBytes = new client.Summary({
+    labelNames,
+    name: 'cloud_server_http_response_size_bytes',
+    help: 'The HTTP response sizes in bytes.',
+});
+
+function promMetrics(requestType, bucketName, code, typeOfRequest,
+    newByteLength, oldByteLength, isVersionedObj,
+    numOfObjectsRemoved) {
+    let bytes;
+
+    httpRequestsTotal.labels(requestType, 'cloud_server', code).inc();
+    if ((typeOfRequest === 'putObject' ||
+    typeOfRequest === 'copyObject' ||
+    typeOfRequest === 'putOjectPart') &&
+    code === '200') {
+        bytes = newByteLength - (isVersionedObj ? 0 : oldByteLength);
+        httpRequestSizeBytes
+            .labels(requestType, 'cloud_server', code)
+            .observe(bytes);
+        dataDiskAvailable.dec(bytes);
+        dataDiskFree.dec(bytes);
+        numberOfObjects.inc();
+    }
+    if (typeOfRequest === 'createBucket' && code === '200') {
+        numberOfBuckets.inc();
+    }
+    if (typeOfRequest === 'getObject' && code === '200') {
+        httpResponseSizeBytes
+            .labels(requestType, 'cloud_server', code)
+            .observe(newByteLength);
+    }
+    if ((typeOfRequest === 'deleteBucket' ||
+    typeOfRequest === 'deleteBucketWebsite')
+    && (code === '200' || code === '204')) {
+        numberOfBuckets.dec();
+    }
+    if ((typeOfRequest === 'deleteObject' ||
+    typeOfRequest === 'abortMultipartUpload' ||
+    typeOfRequest === 'multiObjectDelete')
+    && code === '200') {
+        dataDiskAvailable.inc(newByteLength);
+        dataDiskFree.inc(newByteLength);
+        if (numOfObjectsRemoved) {
+            numberOfObjects.dec(numOfObjectsRemoved);
+        } else {
+            numberOfObjects.dec();
+        }
+    }
+}
+
+function crrCacheToProm(crrResults) {
+    if (!crrStatsPulled && crrResults) {
+        if (crrResults.getObjectCount) {
+            numberOfBuckets.set(crrResults.getObjectCount.buckets || 0);
+            numberOfObjects.set(crrResults.getObjectCount.objects || 0);
+        }
+        if (crrResults.getDataDiskUsage) {
+            dataDiskAvailable.set(crrResults.getDataDiskUsage.available || 0);
+            dataDiskFree.set(crrResults.getDataDiskUsage.free || 0);
+            dataDiskTotal.set(crrResults.getDataDiskUsage.total || 0);
+        }
+    }
+    crrStatsPulled = true;
+}
+
 function writeResponse(res, error, log, results, cb) {
     let statusCode = 200;
     if (error) {
@@ -22,7 +124,6 @@ function routeHandler(req, res, log, cb) {
     if (req.method !== 'GET') {
         return cb(errors.BadRequest, []);
     }
-    client.collectDefaultMetrics();
     const promMetrics = client.register.metrics();
     const contentLen = Buffer.byteLength(promMetrics, 'utf8');
     res.setHeader('content-length', contentLen);
@@ -62,4 +163,8 @@ function monitoringHandler(clientIP, req, res, log) {
 
 module.exports = {
     monitoringHandler,
+    client,
+    collectDefaultMetrics,
+    promMetrics,
+    crrCacheToProm,
 };

--- a/lib/utilities/reportHandler.js
+++ b/lib/utilities/reportHandler.js
@@ -7,6 +7,7 @@ const async = require('async');
 const config = require('../Config').config;
 const data = require('../data/wrapper');
 const metadata = require('../metadata/wrapper');
+const monitoring = require('../utilities/monitoringHandler');
 
 const REPORT_MODEL_VERSION = 1;
 
@@ -200,7 +201,7 @@ function reportHandler(clientIP, req, res, log) {
                 config: cleanup(config),
                 capabilities: getCapabilities(),
             };
-
+            monitoring.crrCacheToProm(results);
             res.writeHead(200, { 'Content-Type': 'application/json' });
             res.write(JSON.stringify(response));
             log.end().debug('report handler finished');


### PR DESCRIPTION
Signed-off-by: anurag4dsb <anurag.mittal@scality.com>

## Monitoring for Zenko using Prometheus

### This pull request provides metrics in the form of labels using counters, gauges, and summaries of prom-client

Why is this change required? What problem does it solve?
This change is required to successfully monitor S3 using Prometheus server

### Related issues: 
[ZENKO-171](https://scality.atlassian.net/browse/ZENKO-171)

## Metrics list:
- name: 'cloud_server_number_of_buckets',
    help: 'Total number of buckets'
- name: 'cloud_server_number_of_objects',
    help: 'Total number of objects'
- name: 'cloud_server_data_disk_available',
    help: 'Available data disk storage in bytes'
- name: 'cloud_server_data_disk_free',
    help: 'Free data disk storage in bytes'
- name: 'cloud_server_data_disk_total',
    help: 'Total data disk storage in bytes'

The following metrics are with the labels: 'method', 'bucketName', 'code'
- name: 'cloud_server_http_requests_total',
    help: 'Total number of HTTP requests'
- name: 'cloud_server_http_request_size_bytes',
    help: 'The HTTP request sizes in bytes.'
- name: 'cloud_server_http_response_size_bytes',
    help: 'The HTTP response sizes in bytes.'

## Labels Description:
- method: PUT, DELETE, HEAD, GET
- bucketName: Name of the bucket on which the request is made
- code: 1xx, 2xx, 3xx, 4xx, 5xx