### PR TITLE
bugfix: Fix data server regression

### DIFF
--- a/dataserver.js
+++ b/dataserver.js
@@ -6,9 +6,7 @@ const logger = require('./lib/utilities/logger');
 
 if (config.backends.data === 'file' ||
     (config.backends.data === 'multiple' &&
-     config.backends.metadata !== 'scality') &&
-     (config.backends.auth !== 'scality' &&
-      config.backends.metadata !== 'mongodb')) {
+     config.backends.metadata !== 'scality')) {
     const dataServer = new arsenal.network.rest.RESTServer(
         { bindAddress: config.dataDaemon.bindAddress,
             port: config.dataDaemon.port,

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "cdmiclient": "scality/cdmiclient#development/8.0"
   },
   "scripts": {
+    "cloudserver": "S3METADATA=mongodb npm-run-all --parallel start_dataserver start_s3server",
     "ft_awssdk": "cd tests/functional/aws-node-sdk && mocha test/",
     "ft_awssdk_aws": "cd tests/functional/aws-node-sdk && AWS_ON_AIR=true mocha test/",
     "ft_awssdk_buckets": "cd tests/functional/aws-node-sdk && mocha test/bucket",
@@ -84,7 +85,6 @@
     "mem_backend": "S3BACKEND=mem node index.js",
     "perf": "mocha tests/performance/s3standard.js",
     "start": "npm-run-all --parallel start_dmd start_s3server",
-    "start_mongo": "S3METADATA=mongodb npm-run-all --parallel start_dataserver start_s3server",
     "start_mdserver": "node mdserver.js",
     "start_dataserver": "node dataserver.js",
     "start_s3server": "node index.js",


### PR DESCRIPTION
ZENKO-464 Fixes regression that prevented s3 from starting properly
and renames the start_mongo script to cloudserver for clear definition.
