### PR TITLE
ft: ZENKO-143 batchDelete backbeat route

### DIFF
--- a/lib/api/apiUtils/authorization/aclChecks.js
+++ b/lib/api/apiUtils/authorization/aclChecks.js
@@ -3,7 +3,7 @@ const constants = require('../../../../constants');
 function isBackbeatUser(canonicalID) {
     const canonicalIDArray = canonicalID.split('/');
     const serviceName = canonicalIDArray[canonicalIDArray.length - 1];
-    return ['replication', 'lifecycle'].includes(serviceName);
+    return ['replication', 'lifecycle', 'gc'].includes(serviceName);
 }
 
 function isBucketAuthorized(bucket, requestType, canonicalID) {

--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -83,6 +83,11 @@ function _retryDelete(objectGetInfo, log, count, cb) {
     }
     return client.delete(objectGetInfo, log.getSerializedUids(), err => {
         if (err) {
+            if (err.ObjNotFound) {
+                log.info('no such key in datastore',
+                         { objectGetInfo, implName, moreRetries: 'no' });
+                return cb(err);
+            }
             log.error('delete error from datastore',
                       { error: err, implName, moreRetries: 'yes' });
             return _retryDelete(objectGetInfo, log, count + 1, cb);
@@ -247,7 +252,7 @@ const data = {
             return;
         }
         _retryDelete(clientGetInfo, log, 0, err => {
-            if (err) {
+            if (err && !err.ObjNotFound) {
                 log.error('delete error from datastore',
                     { error: err, key: objectGetInfo.key, moreRetries: 'no' });
             }

--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -5,6 +5,7 @@ const { auth, errors, s3middleware } = require('arsenal');
 const { responseJSONBody } = require('arsenal').s3routes.routesUtils;
 const { getSubPartIds } = s3middleware.azureHelper.mpuUtils;
 const vault = require('../auth/vault');
+const data = require('../data/wrapper');
 const metadata = require('../metadata/wrapper');
 const locationConstraintCheck = require(
     '../api/apiUtils/object/locationConstraintCheck');
@@ -34,7 +35,7 @@ function _decodeURI(uri) {
     return decodeURIComponent(uri.replace(/\+/g, ' '));
 }
 
-function normalizeBackbeatRequest(req) {
+function _normalizeBackbeatRequest(req) {
     /* eslint-disable no-param-reassign */
     const parsedUrl = url.parse(req.url, true);
     req.path = _decodeURI(parsedUrl.pathname);
@@ -44,6 +45,11 @@ function normalizeBackbeatRequest(req) {
     req.bucketName = pathArr[4];
     req.objectKey = pathArr.slice(5).join('/');
     /* eslint-enable no-param-reassign */
+}
+
+function _isObjectRequest(req) {
+    return ['data', 'metadata', 'multiplebackenddata']
+        .includes(req.resourceType);
 }
 
 function _respond(response, payload, log, callback) {
@@ -215,10 +221,17 @@ PUT /_/backbeat/multiplebackenddata/<bucket name>/<object key>
     ?operation=putobject
 PUT /_/backbeat/multiplebackenddata/<bucket name>/<object key>
     ?operation=putpart
+DELETE /_/backbeat/multiplebackenddata/<bucket name>/<object key>
+    ?operation=deleteobject
+DELETE /_/backbeat/multiplebackenddata/<bucket name>/<object key>
+    ?operation=deleteobjecttagging
 POST /_/backbeat/multiplebackenddata/<bucket name>/<object key>
     ?operation=initiatempu
 POST /_/backbeat/multiplebackenddata/<bucket name>/<object key>
     ?operation=completempu
+POST /_/backbeat/multiplebackenddata/<bucket name>/<object key>
+    ?operation=puttagging
+POST /_/backbeat/batchdelete
 */
 
 function putData(request, response, bucketInfo, objMd, log, callback) {
@@ -609,6 +622,49 @@ function deleteObjectTagging(request, response, log, callback) {
         dataStoreVersionId, log, callback);
 }
 
+function batchDelete(request, response, log, callback) {
+    return _getRequestPayload(request, (err, payload) => {
+        if (err) {
+            return callback(err);
+        }
+        let request;
+        try {
+            request = JSON.parse(payload);
+        } catch (e) {
+            // FIXME: add error type MalformedJSON
+            return callback(errors.MalformedPOSTRequest);
+        }
+        if (!request || !Array.isArray(request.Locations)) {
+            return callback(errors.MalformedPOSTRequest);
+        }
+        const locations = request.Locations;
+        log.trace('batch delete locations', { locations });
+        return async.eachLimit(locations, 5, (loc, next) => {
+            data.delete(loc, log, err => {
+                if (err && err.ObjNotFound) {
+                    log.info('batch delete: data location do not exist', {
+                        method: 'batchDelete',
+                        location: loc,
+                    });
+                    return next();
+                }
+                return next(err);
+            });
+        }, err => {
+            if (err) {
+                log.error('batch delete failed', {
+                    method: 'batchDelete',
+                    locations,
+                    error: err,
+                });
+                return callback(err);
+            }
+            log.debug('batch delete successful', { locations });
+            return _respond(response, null, log, callback);
+        });
+    });
+}
+
 const backbeatRoutes = {
     PUT: {
         data: putData,
@@ -624,6 +680,7 @@ const backbeatRoutes = {
             completempu: completeMultipartUpload,
             puttagging: putObjectTagging,
         },
+        batchdelete: batchDelete,
     },
     DELETE: {
         multiplebackenddata: {
@@ -637,20 +694,40 @@ const backbeatRoutes = {
 };
 
 function routeBackbeat(clientIP, request, response, log) {
-    log.debug('routing request', { method: 'routeBackbeat' });
-    normalizeBackbeatRequest(request);
+    log.debug('routing request', {
+        method: 'routeBackbeat',
+        url: request.url,
+    });
+    _normalizeBackbeatRequest(request);
     const useMultipleBackend = request.resourceType === 'multiplebackenddata';
-    const invalidRequest = (!request.bucketName ||
-                            !request.objectKey ||
-                            !request.resourceType ||
-                            (!request.query.operation && useMultipleBackend));
-    if (invalidRequest) {
-        log.debug('invalid request', {
+    const invalidRequest =
+          (!request.resourceType ||
+           (_isObjectRequest(request) &&
+            (!request.bucketName || !request.objectKey)) ||
+           (!request.query.operation && useMultipleBackend));
+    const invalidRoute =
+          (backbeatRoutes[request.method] === undefined ||
+           backbeatRoutes[request.method][request.resourceType] === undefined ||
+           (backbeatRoutes[request.method][request.resourceType]
+            [request.query.operation] === undefined &&
+            useMultipleBackend));
+    if (invalidRequest || invalidRoute) {
+        log.debug(invalidRequest ? 'invalid request' : 'no such route', {
             method: request.method, bucketName: request.bucketName,
             objectKey: request.objectKey, resourceType: request.resourceType,
             query: request.query,
         });
         return responseJSONBody(errors.MethodNotAllowed, null, response, log);
+    }
+
+    if (!_isObjectRequest(request)) {
+        const route = backbeatRoutes[request.method][request.resourceType];
+        return route(request, response, log, err => {
+            if (err) {
+                return responseJSONBody(err, null, response, log);
+            }
+            return undefined;
+        });
     }
     const requestContexts = prepareRequestContexts('objectReplicate', request);
     const decodedVidResult = decodeVersionId(request.query);
@@ -687,21 +764,6 @@ function routeBackbeat(clientIP, request, response, log) {
             return metadataValidateBucketAndObj(mdValParams, log, next);
         },
         (bucketInfo, objMd, next) => {
-            const invalidRoute = backbeatRoutes[request.method] === undefined ||
-                backbeatRoutes[request.method][request.resourceType] ===
-                    undefined ||
-                (backbeatRoutes[request.method][request.resourceType]
-                    [request.query.operation] === undefined &&
-                    useMultipleBackend);
-            if (invalidRoute) {
-                log.debug('no such route', { method: request.method,
-                    bucketName: request.bucketName,
-                    objectKey: request.objectKey,
-                    resourceType: request.resourceType,
-                    query: request.query,
-                });
-                return next(errors.MethodNotAllowed);
-            }
             if (useMultipleBackend) {
                 return backbeatRoutes[request.method][request.resourceType]
                     [request.query.operation](request, response, log, next);

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "ft_awssdk_external_backends": "cd tests/functional/aws-node-sdk && mocha test/multipleBackend",
     "ft_management": "cd tests/functional/report && npm test",
     "ft_node": "cd tests/functional/raw-node && npm test",
+    "ft_node_routes": "cd tests/functional/raw-node && npm run test-routes",
     "ft_gcp": "cd tests/functional/raw-node && npm run test-gcp",
     "ft_healthchecks": "cd tests/functional/healthchecks && npm test",
     "ft_s3cmd": "cd tests/functional/s3cmd && mocha -t 40000 *.js",

--- a/tests/functional/raw-node/package.json
+++ b/tests/functional/raw-node/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "test-aws": "AWS_ON_AIR=true mocha -t 40000 test/",
     "test-gcp": "mocha -t 40000 test/GCP/",
+    "test-routes": "mocha -t 40000 test/routes/",
     "test": "mocha -t 40000 test/",
     "test-debug": "_mocha -t 40000 test/"
   },


### PR DESCRIPTION
- Implement 'POST /_/backbeat/batchdelete' backbeat route to get rid
  of an array of data locations. The route will be used by the garbage
  collector service.

  * This includes some reorganization of backbeat routes sanity checks

- Handle gracefully 404 errors from datastore backend:

  * no need to retry 404 errors as they are permanent

  * batch delete can also gracefully handle missing data locations and
    still delete other existing locations (may happen if a retry
    occurs, when replaying a kafka message among other cases).

- Support service-gc service account with account owner access rights.
