### PR TITLE
bugfix: ZENKO-567 location header check exception

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -178,17 +178,15 @@ function locationConstraintAssert(locationConstraints) {
             === 'boolean',
             'bad config: locationConstraints[region]' +
             '.legacyAwsBehavior is mandatory and must be a boolean');
-        if (locationConstraints[l].details.serverSideEncryption !== undefined) {
-            assert(typeof locationConstraints[l].details.serverSideEncryption
-              === 'boolean',
+        const details = locationConstraints[l].details;
+        assert(typeof details === 'object',
+            'bad config: locationConstraints[region].details is ' +
+            'mandatory and must be an object');
+        if (details.serverSideEncryption !== undefined) {
+            assert(typeof details.serverSideEncryption === 'boolean',
               'bad config: locationConstraints[region]' +
               '.details.serverSideEncryption must be a boolean');
         }
-        assert(typeof locationConstraints[l].details
-            === 'object',
-            'bad config: locationConstraints[region].details is ' +
-            'mandatory and must be an object');
-        const details = locationConstraints[l].details;
         const stringFields = [
             'awsEndpoint',
             'bucketName',

--- a/lib/management/configuration.js
+++ b/lib/management/configuration.js
@@ -84,7 +84,9 @@ function patchConfiguration(newConf, log, cb) {
             // Object.values() is apparently too recent
             Object.keys(newConf.locations || {}).forEach(k => {
                 const l = newConf.locations[k];
-                const location = {};
+                const location = {
+                    details: {},
+                };
                 let supportsVersioning = false;
                 let pathStyle = false;
 

--- a/tests/unit/management/configuration.js
+++ b/tests/unit/management/configuration.js
@@ -90,11 +90,13 @@ describe('patchConfiguration', () => {
                 'legacy': {
                     name: 'legacy',
                     locationType: 'location-mem-v1',
+                    details: {},
                 },
                 'us-east-1': {
                     name: 'us-east-1',
                     locationType: 'location-file-v1',
                     legacyAwsBehavior: true,
+                    details: {},
                 },
                 'azurebackendtest': {
                     name: 'azurebackendtest',
@@ -142,16 +144,19 @@ describe('patchConfiguration', () => {
                     name: 'transienttest',
                     locationType: 'location-file-v1',
                     isTransient: true,
+                    details: {},
                 },
                 'sizelimitedtest': {
                     name: 'sizelimitedtest',
                     locationType: 'location-file-v1',
                     sizeLimitGB: 1024,
+                    details: {},
                 },
                 'sizezerotest': {
                     name: 'sizezerotest',
                     locationType: 'location-file-v1',
                     sizeLimitGB: 0,
+                    details: {},
                 },
             },
             browserAccess: {
@@ -183,12 +188,14 @@ describe('patchConfiguration', () => {
                         legacyAwsBehavior: false,
                         isTransient: false,
                         sizeLimitGB: null,
+                        details: {},
                     },
                     'us-east-1': {
                         type: 'file',
                         legacyAwsBehavior: true,
                         isTransient: false,
                         sizeLimitGB: null,
+                        details: {},
                     },
                     'azurebackendtest': {
                         details: {
@@ -261,18 +268,21 @@ describe('patchConfiguration', () => {
                         legacyAwsBehavior: false,
                         isTransient: true,
                         sizeLimitGB: null,
+                        details: {},
                     },
                     'sizelimitedtest': {
                         type: 'file',
                         legacyAwsBehavior: false,
                         isTransient: false,
                         sizeLimitGB: 1024,
+                        details: {},
                     },
                     'sizezerotest': {
                         type: 'file',
                         legacyAwsBehavior: false,
                         isTransient: false,
                         sizeLimitGB: null,
+                        details: {},
                     },
                 },
             };

--- a/tests/unit/testConfigs/locConstraintAssert.js
+++ b/tests/unit/testConfigs/locConstraintAssert.js
@@ -23,6 +23,11 @@ function getAzureDetails(replaceParams) {
     }, replaceParams);
 }
 
+// FIXME: most of tests using a line-wrapped regexp are broken,
+// because such regexp is converted to a string which does not enforce
+// the check of the message. A more durable solution would be use
+// 'joi' for config parsing.
+
 describe('locationConstraintAssert', () => {
     it('should throw error if locationConstraints is not an object', () => {
         assert.throws(() => {


### PR DESCRIPTION
  * bf: ZENKO-567 config validation may crash
    
    Config validation may crash if locationConstraint[x].details is not
    set because of a reversed check.

  * bf: ZENKO-567 enforce "details" in location constraint
    
    Make sure when Orbit configuration is applied, a "details" attribute
    is always present in the locations config.
