### PR TITLE
bf: ZENKO-576 fix 'supportsVersioning' flag in locations

### DIFF
--- a/lib/management/configuration.js
+++ b/lib/management/configuration.js
@@ -91,9 +91,11 @@ function patchConfiguration(newConf, log, cb) {
                 switch (l.locationType) {
                 case 'location-mem-v1':
                     location.type = 'mem';
+                    supportsVersioning = true;
                     break;
                 case 'location-file-v1':
                     location.type = 'file';
+                    supportsVersioning = true;
                     break;
                 case 'location-azure-v1':
                     location.type = 'azure';


### PR DESCRIPTION
Orbit management layer now relies on
constants.versioningNotImplBackends to set the 'supportsVersioning'
flag on locations.
