### PR TITLE
ft: ZENKO-143 main location in loc constraint header

### DIFF
--- a/lib/api/objectGet.js
+++ b/lib/api/objectGet.js
@@ -142,7 +142,8 @@ function objectGet(authInfo, request, returnTagCount, log, callback) {
                 targetLocation = targetLocation || defReadDataLocator || null;
             }
 
-            if (targetLocation) {
+            if (targetLocation &&
+                targetLocation.location !== objMD.dataStoreName) {
                 const repBackendResult = getReplicationBackendDataLocator(
                     targetLocation, objMD.replicationInfo);
                 if (repBackendResult.error) {


### PR DESCRIPTION
Allow setting the main object location name in the
x-amz-location-constraint header, not only replication targets.

Backbeat will make use of this header to read locally next (and it will be tested as part of existing multiple backend E2E tests).
