### PR TITLE
Feature/zenko 142 location quota

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -238,6 +238,11 @@ function locationConstraintAssert(locationConstraints) {
             // eslint-disable-next-line no-param-reassign
             locationConstraints[l].details.supportsVersioning = true;
         }
+        if (details.sizeLimitGB !== undefined) {
+            assert(typeof details.sizeLimitGB === 'number',
+                'bad config: locationConstraints[region].details.sizeLimitGB ' +
+                'must be a number (in gigabytes)');
+        }
 
         if (locationConstraints[l].type === 'azure') {
             azureLocationConstraintAssert(l, locationConstraints[l]);
@@ -754,6 +759,11 @@ class Config extends EventEmitter {
                     'bad config: utapi.expireMetricsTTL must be a number');
                 this.utapi.expireMetricsTTL = config.utapi.expireMetricsTTL;
             }
+        }
+        if (Object.keys(this.locationConstraints).some(
+        loc => this.locationConstraints[loc].details.sizeLimitGB)) {
+            assert(this.utapi, 'bad config: if storage size limit set on a ' +
+                'location constraint, Utapi must also be configured');
         }
 
         this.log = { logLevel: 'debug', dumpLevel: 'error' };

--- a/lib/api/apiUtils/object/locationStorageCheck.js
+++ b/lib/api/apiUtils/object/locationStorageCheck.js
@@ -1,0 +1,49 @@
+const { errors } = require('arsenal');
+
+const { config } = require('../../../Config');
+const { getLocationMetric, pushLocationMetric } =
+    require('../../../utapi/utilities');
+
+function _gbToBytes(gb) {
+    return gb * 1024 * 1024 * 1024;
+}
+
+/**
+ * locationStorageCheck - will ensure there is enough space left for object on
+ * PUT operations, or will update metric on DELETE
+ * NOTE: storage limit may not be exactly enforced in the case of concurrent
+ * requests when near limit
+ * @param {string} location - name of location to check quota
+ * @param {number} updateSize - new size to check against quota in bytes
+ * @param {object} log - werelogs logger
+ * @param {function} cb - callback function
+ * @return {undefined}
+ */
+function locationStorageCheck(location, updateSize, log, cb) {
+    const lc = config.locationConstraints;
+    const sizeLimitGB = lc[location] && lc[location].details ?
+        lc[location].details.sizeLimitGB : undefined;
+    if (updateSize === 0 || sizeLimitGB === undefined) {
+        return cb();
+    }
+    // no need to list location metric, since it should be decreased
+    if (updateSize < 0) {
+        return pushLocationMetric(location, updateSize, log, cb);
+    }
+    return getLocationMetric(location, log, (err, bytesStored) => {
+        if (err) {
+            log.error(`Error listing metrics from Utapi: ${err.message}`);
+            return cb(err);
+        }
+        const newStorageSize = bytesStored + updateSize;
+        const sizeLimitBytes = _gbToBytes(sizeLimitGB);
+        if (sizeLimitBytes < newStorageSize) {
+            return cb(errors.AccessDenied.customizeDescription(
+                `The assigned storage space limit for location ${location} ` +
+                'will be exceeded'));
+        }
+        return pushLocationMetric(location, updateSize, log, cb);
+    });
+}
+
+module.exports = locationStorageCheck;

--- a/lib/api/multipartDelete.js
+++ b/lib/api/multipartDelete.js
@@ -106,6 +106,13 @@ function multipartDelete(authInfo, request, log, callback) {
             if (skipDataDelete) {
                 return next(null, mpuBucket, storedParts, destBucket);
             }
+            for (let i = 0; i < storedParts.length; i++) {
+                if (storedParts[i].value.partLocations.length > 0) {
+                    // eslint-disable-next-line no-param-reassign
+                    storedParts[i].value.partLocations[0].size =
+                        storedParts[i].value.Size;
+                }
+            }
             // The locations were sent to metadata as an array
             // under partLocations.  Pull the partLocations.
             let locations = storedParts.map(item => item.value.partLocations);

--- a/lib/data/multipleBackendGateway.js
+++ b/lib/data/multipleBackendGateway.js
@@ -10,6 +10,8 @@ const DataFileBackend = require('./file/backend');
 
 const { checkExternalBackend } = require('./external/utils');
 const { externalBackendHealthCheckInterval } = require('../../constants');
+const locationStorageCheck =
+    require('../api/apiUtils/object/locationStorageCheck');
 
 let clients = parseLC(config);
 config.on('location-constraints-update', () => {
@@ -187,8 +189,13 @@ const multipleBackendGateway = {
         const client = clients[location];
 
         if (client.uploadPart) {
-            return client.uploadPart(request, streamingV4Params, stream, size,
-            key, uploadId, partNumber, bucketName, log, cb);
+            return locationStorageCheck(location, size, log, err => {
+                if (err) {
+                    return cb(err);
+                }
+                return client.uploadPart(request, streamingV4Params, stream,
+                    size, key, uploadId, partNumber, bucketName, log, cb);
+            });
         }
         return cb();
     },
@@ -259,16 +266,22 @@ const multipleBackendGateway = {
     sourceLocationConstraintName, storeMetadataParams, log, cb) => {
         const client = clients[destLocationConstraintName];
         if (client.copyObject) {
-            return client.copyObject(request, destLocationConstraintName,
-            externalSourceKey, sourceLocationConstraintName,
-            storeMetadataParams, log, (err, key, dataStoreVersionId) => {
-                const dataRetrievalInfo = {
-                    key,
-                    dataStoreName: destLocationConstraintName,
-                    dataStoreType: client.clientType,
-                    dataStoreVersionId,
-                };
-                cb(err, dataRetrievalInfo);
+            return locationStorageCheck(destLocationConstraintName,
+            storeMetadataParams.size, log, err => {
+                if (err) {
+                    cb(err);
+                }
+                return client.copyObject(request, destLocationConstraintName,
+                externalSourceKey, sourceLocationConstraintName,
+                storeMetadataParams, log, (err, key, dataStoreVersionId) => {
+                    const dataRetrievalInfo = {
+                        key,
+                        dataStoreName: destLocationConstraintName,
+                        dataStoreType: client.clientType,
+                        dataStoreVersionId,
+                    };
+                    cb(err, dataRetrievalInfo);
+                });
             });
         }
         return cb(errors.NotImplemented

--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -14,6 +14,8 @@ const kms = require('../kms/wrapper');
 const externalBackends = require('../../constants').externalBackends;
 const constants = require('../../constants');
 const { BackendInfo } = require('../api/apiUtils/object/BackendInfo');
+const locationStorageCheck =
+    require('../api/apiUtils/object/locationStorageCheck');
 const RelayMD5Sum = require('../utilities/RelayMD5Sum');
 const skipError = new Error('skip');
 
@@ -50,15 +52,6 @@ if (config.backends.data === 'mem') {
     implName = 'cdmi';
 }
 
-/**
- * _retryDelete - Attempt to delete key again if it failed previously
- * @param { string | object } objectGetInfo - either string location of object
- *      to delete or object containing info of object to delete
- * @param {object} log - Werelogs request logger
- * @param {number} count - keeps count of number of times function has been run
- * @param {function} cb - callback
- * @returns undefined and calls callback
- */
 const MAX_RETRY = 2;
 
 // This check is done because on a put, complete mpu or copy request to
@@ -77,6 +70,15 @@ function _shouldSkipDelete(locations, requestMethod, newObjDataStoreName) {
     return (isSkipBackend && isMatchingBackends && isSkipMethod);
 }
 
+/**
+ * _retryDelete - Attempt to delete key again if it failed previously
+ * @param { string | object } objectGetInfo - either string location of object
+ *      to delete or object containing info of object to delete
+ * @param {object} log - Werelogs request logger
+ * @param {number} count - keeps count of number of times function has been run
+ * @param {function} cb - callback
+ * @return {undefined} calls callback
+ */
 function _retryDelete(objectGetInfo, log, count, cb) {
     if (count > MAX_RETRY) {
         return cb(errors.InternalError);
@@ -114,15 +116,15 @@ function _put(cipherBundle, value, valueSize,
         /* eslint-disable no-param-reassign */
         keyContext.cipherBundle = cipherBundle;
         return client.put(hashedStream,
-               valueSize, keyContext, backendInfo, log.getSerializedUids(),
-               (err, dataRetrievalInfo) => {
-                   if (err) {
-                       log.error('put error from datastore',
-                                 { error: err, implName });
-                       return cb(errors.ServiceUnavailable);
-                   }
-                   return cb(null, dataRetrievalInfo, hashedStream);
-               });
+        valueSize, keyContext, backendInfo, log.getSerializedUids(),
+        (err, dataRetrievalInfo) => {
+            if (err) {
+                log.error('put error from datastore',
+                            { error: err, implName });
+                return cb(errors.ServiceUnavailable);
+            }
+            return cb(null, dataRetrievalInfo, hashedStream);
+        });
     }
     /* eslint-enable no-param-reassign */
 
@@ -149,23 +151,29 @@ function _put(cipherBundle, value, valueSize,
 
 const data = {
     put: (cipherBundle, value, valueSize, keyContext, backendInfo, log, cb) => {
-        _put(cipherBundle, value, valueSize, keyContext, backendInfo, log,
-             (err, dataRetrievalInfo, hashedStream) => {
-                 if (err) {
-                     return cb(err);
-                 }
-                 if (hashedStream) {
-                     if (hashedStream.completedHash) {
-                         return cb(null, dataRetrievalInfo, hashedStream);
-                     }
-                     hashedStream.on('hashed', () => {
-                         hashedStream.removeAllListeners('hashed');
-                         return cb(null, dataRetrievalInfo, hashedStream);
-                     });
-                     return undefined;
-                 }
-                 return cb(null, dataRetrievalInfo);
-             });
+        const location = backendInfo.getControllingLocationConstraint();
+        return locationStorageCheck(location, valueSize, log, err => {
+            if (err) {
+                return cb(err);
+            }
+            return _put(cipherBundle, value, valueSize, keyContext, backendInfo,
+            log, (err, dataRetrievalInfo, hashedStream) => {
+                if (err) {
+                    return cb(err);
+                }
+                if (hashedStream) {
+                    if (hashedStream.completedHash) {
+                        return cb(null, dataRetrievalInfo, hashedStream);
+                    }
+                    hashedStream.on('hashed', () => {
+                        hashedStream.removeAllListeners('hashed');
+                        return cb(null, dataRetrievalInfo, hashedStream);
+                    });
+                    return undefined;
+                }
+                return cb(null, dataRetrievalInfo);
+            });
+        });
     },
 
     head: (objectGetInfo, log, cb) => {
@@ -255,6 +263,19 @@ const data = {
             if (err && !err.ObjNotFound) {
                 log.error('delete error from datastore',
                     { error: err, key: objectGetInfo.key, moreRetries: 'no' });
+            }
+            if (!err) {
+                // pass size as negative so location metric is decremented
+                return locationStorageCheck(objectGetInfo.dataStoreName,
+                -objectGetInfo.size, log, err => {
+                    if (err) {
+                        log.error('Utapi error pushing location metric', {
+                            error: err,
+                            key: objectGetInfo.key,
+                            method: 'locationStorageCheck' });
+                    }
+                    return callback(err);
+                });
             }
             return callback(err);
         });

--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -216,7 +216,35 @@ function pushMetric(action, log, metricObj) {
     return utapi.pushMetric(action, log.getSerializedUids(), utapiObj);
 }
 
+/**
+ * Call the Utapi Client 'getLocationMetric' method with the
+ * associated parameters
+ * @param {string} location - name of data backend to list metric for
+ * @param {object} log - werelogs logger
+ * @param {function} cb - callback to call
+ * @return {function} - `utapi.getLocationMetric`
+ */
+function getLocationMetric(location, log, cb) {
+    return utapi.getLocationMetric(location, log.getSerializedUids(), cb);
+}
+
+/**
+ * Call the Utapi Client 'pushLocationMetric' method with the
+ * associated parameters
+ * @param {string} location - name of data backend
+ * @param {number} byteLength - number of bytes
+ * @param {object} log - werelogs logger
+ * @param {function} cb - callback to call
+ * @return {function} - `utapi.pushLocationMetric`
+ */
+function pushLocationMetric(location, byteLength, log, cb) {
+    return utapi.pushLocationMetric(location, byteLength,
+        log.getSerializedUids(), cb);
+}
+
 module.exports = {
     listMetrics,
     pushMetric,
+    getLocationMetric,
+    pushLocationMetric,
 };

--- a/tests/unit/testConfigs/locConstraintAssert.js
+++ b/tests/unit/testConfigs/locConstraintAssert.js
@@ -286,4 +286,18 @@ describe('locationConstraintAssert', () => {
         assert.strictEqual(locationConstraint.details.pathStyle, true,
             'pathstyle config should be true');
     });
+
+    it('should throw error if sizeLimitGB is not a number', () => {
+        const usEast1 = new LocationConstraint();
+        const locationConstraint = new LocationConstraint('aws_s3', true,
+            { sizeLimitGB: true });
+        assert.throws(() => {
+            locationConstraintAssert({
+                'us-east-1': usEast1,
+                'awsstoragesizelimit': locationConstraint,
+            });
+        },
+        '/bad config: locationConstraints[region].details.sizeLimitGB ' +
+        'must be a number (in gigabytes)');
+    });
 });


### PR DESCRIPTION
Add a storage quota size per location! Make sure you never put more data than you want!
APIs affected:
ObjectPut
ObjectDelete
ObjectCopy
ObjectPutPart
ObjectPutCopyPart
AbortMPU

The storage limit check is done at the wrapper level, so is found in `data.wrapper` put and delete, and in `multipleBackendGateway` as needed.