### PR TITLE
Add capabilities in Orbit reporting

### DIFF
--- a/lib/utilities/reportHandler.js
+++ b/lib/utilities/reportHandler.js
@@ -10,6 +10,27 @@ const metadata = require('../metadata/wrapper');
 
 const REPORT_MODEL_VERSION = 1;
 
+function hasWSOptionalDependencies() {
+    try {
+        const b = require('bufferutil');
+        const u = require('utf-8-validate');
+        return !!(b && u);
+    } catch (_) {
+        return false;
+    }
+}
+
+function getCapabilities() {
+    return {
+        locationTypeDigitalOcean: true,
+        locationTypeS3Custom: true,
+        locationTypeSproxyd: true,
+        preferredReadLocation: true,
+        managedLifecycle: true,
+        secureChannelOptimizedPath: hasWSOptionalDependencies(),
+    };
+}
+
 function cleanup(obj) {
     return {
         overlayVersion: obj.overlayVersion,
@@ -177,6 +198,7 @@ function reportHandler(clientIP, req, res, log) {
                 crrStats: results.getCRRStats,
 
                 config: cleanup(config),
+                capabilities: getCapabilities(),
             };
 
             res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -188,5 +210,6 @@ function reportHandler(clientIP, req, res, log) {
 }
 
 module.exports = {
+    getCapabilities,
     reportHandler,
 };

--- a/tests/functional/report/checkRoutes.js
+++ b/tests/functional/report/checkRoutes.js
@@ -14,6 +14,7 @@ const reportAttributes = [
     'serverVersion',
     'systemStats',
     'itemCounts',
+    'capabilities',
 ];
 
 function options(token = 'report-token-1') {

--- a/tests/unit/management/secureChannel.js
+++ b/tests/unit/management/secureChannel.js
@@ -1,0 +1,17 @@
+const assert = require('assert');
+
+const { getCapabilities } = require('../../../lib/utilities/reportHandler');
+
+// Ensures that expected features are enabled even if they
+// rely on optional dependencies (such as secureChannelOptimizedPath)
+describe('report handler', () => {
+    it('should report current capabilities', () => {
+        const c = getCapabilities();
+        assert.strictEqual(c.locationTypeDigitalOcean, true);
+        assert.strictEqual(c.locationTypeS3Custom, true);
+        assert.strictEqual(c.locationTypeSproxyd, true);
+        assert.strictEqual(c.preferredReadLocation, true);
+        assert.strictEqual(c.managedLifecycle, true);
+        assert.strictEqual(c.secureChannelOptimizedPath, true);
+    });
+});


### PR DESCRIPTION
Adds capabilities to orbit reports (in addition to the implicit `secureChannel`) to be able to show features depending on what the instance actually supports.