### PR TITLE
bf: ZENKO-308 remove versioningGeneral1 test skiping with mongoDB

### DIFF
--- a/tests/functional/aws-node-sdk/test/versioning/versioningGeneral1.js
+++ b/tests/functional/aws-node-sdk/test/versioning/versioningGeneral1.js
@@ -6,9 +6,6 @@ const getConfig = require('../support/config');
 
 const bucket = `versioning-bucket-${Date.now()}`;
 
-const skipIfMongo = process.env.S3METADATA === 'mongodb' ?
-    describe.skip : describe;
-
 function comp(v1, v2) {
     if (v1.Key > v2.Key) {
         return 1;
@@ -26,8 +23,7 @@ function comp(v1, v2) {
 }
 
 
-skipIfMongo('aws-node-sdk test bucket versioning listing',
-function testSuite() {
+describe('aws-node-sdk test bucket versioning listing', function testSuite() {
     this.timeout(600000);
     let s3;
     const masterVersions = [];


### PR DESCRIPTION
Now the listing bug has been fixed in Arsenal, it is time to make the
versioningGeneral1 test run with mongoDB back-end.

# Pull request template

## Description

### Motivation and context

Why is this change required? What problem does it solve?

### Related issues

Please use the following link syntaxes #600 to reference issues in the
current repository

## Checklist

### Add tests to cover the changes

New tests added or existing tests modified to cover all changes

### Code conforms with the [style guide](https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#coding-style-guidelines)

### Sign your work

In order to contribute to the project, you must sign your work
https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#sign-your-work

Thank you again for contributing! We will try to test and integrate the change
as soon as we can.
