### PR TITLE
ft: ZENKO-448 Move to alpine based image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
 node_modules
 localData/*
 localMetadata/*
+tests/
+**.md
+examples/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,28 @@
-FROM node:6-slim
+FROM node:6-alpine
 MAINTAINER Giorgio Regni <gr@scality.com>
+
+EXPOSE 8000
+
+COPY ./package.json ./package-lock.json /usr/src/app/
 
 WORKDIR /usr/src/app
 
-# Keep the .git directory in order to properly report version
-COPY ./package.json .
-
-RUN apt-get update \
-    && apt-get install -y jq python git build-essential --no-install-recommends \
+RUN apk add --update jq bash\
+    && apk add --virtual build-deps \
+                         python \
+                         build-base \
+                         git \
     && npm install --production \
-    && apt-get autoremove --purge -y python git build-essential \
-    && rm -rf /var/lib/apt/lists/* \
+    && apk del build-deps \
     && npm cache clear \
     && rm -rf ~/.node-gyp \
-    && rm -rf /tmp/npm-*
+    && rm -rf /tmp/npm-* \
+    && rm -rf /var/cache/apk/*
 
-COPY ./ ./
+COPY . /usr/src/app
 
 VOLUME ["/usr/src/app/localData","/usr/src/app/localMetadata"]
 
 ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"]
-CMD [ "npm", "start" ]
 
-EXPOSE 8000
+CMD [ "npm", "start" ]


### PR DESCRIPTION
Moving to alpine saves about ~100MB of space.

zenko/cloudserver:0.2.1 269MB
with alpine                      165MB


