### PR TITLE
bugfix: versioningGeneral2 were not passing

### DIFF
--- a/tests/functional/aws-node-sdk/test/versioning/versioningGeneral2.js
+++ b/tests/functional/aws-node-sdk/test/versioning/versioningGeneral2.js
@@ -6,10 +6,7 @@ const getConfig = require('../support/config');
 
 const bucket = `versioning-bucket-${Date.now()}`;
 
-const skipIfMongo = process.env.S3METADATA === 'mongodb' ?
-    describe.skip : describe;
-
-skipIfMongo('aws-node-sdk test bucket versioning', function testSuite() {
+describe('aws-node-sdk test bucket versioning', function testSuite() {
     this.timeout(600000);
     let s3;
     const versionIds = [];


### PR DESCRIPTION
The bug has been fixed in Arsenal and was related
to some objects being created before the versioning
was enabled in the bucket and therefore did not
jave the versionId property

# Pull request template

## Description

### Motivation and context

Why is this change required? What problem does it solve?

### Related issues

Please use the following link syntaxes #600 to reference issues in the
current repository

## Checklist

### Add tests to cover the changes

New tests added or existing tests modified to cover all changes

### Code conforms with the [style guide](https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#coding-style-guidelines)

### Sign your work

In order to contribute to the project, you must sign your work
https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#sign-your-work

Thank you again for contributing! We will try to test and integrate the change
as soon as we can.
