### PR TITLE
Improving secret handling in CI

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -9,19 +9,39 @@ branches:
 
 models:
   - env: &global-env
-      b2backend_B2_ACCOUNT_ID: '%(secret:b2backend_b2_account_id)s'
-      b2backend_B2_STORAGE_ACCESS_KEY: >
-        '%(secret:b2backend_b2_storage_access_key)s'
-      b2backend_B2_STORAGE_ENDPOINT: '%(secret:b2backend_b2_storage_endpoint)s'
-      gcpbackend2_GCP_SERVICE_EMAIL: '%(secret:gcp2_service_email)s'
-      gcpbackend2_GCP_SERVICE_KEY: '%(secret:gcp2_service_key)s'
+      azurebackend_AZURE_STORAGE_ACCESS_KEY: "%(secret:azure_storage_access_key)s"
+      azurebackend_AZURE_STORAGE_ACCOUNT_NAME: "%(secret:azure_storage_account_name)s"
+      azurebackend_AZURE_STORAGE_ENDPOINT: "%(secret:azure_storage_endpoint)s"
+      azurebackend2_AZURE_STORAGE_ACCESS_KEY: "%(secret:azure_storage_access_key_2)s"
+      azurebackend2_AZURE_STORAGE_ACCOUNT_NAME: "%(secret:azure_storage_account_name_2)s"
+      azurebackend2_AZURE_STORAGE_ENDPOINT: "%(secret:azure_storage_endpoint_2)s"
+      azurebackendmismatch_AZURE_STORAGE_ACCESS_KEY: "%(secret:azure_storage_access_key)s"
+      azurebackendmismatch_AZURE_STORAGE_ACCOUNT_NAME: "%(secret:azure_storage_account_name)s"
+      azurebackendmismatch_AZURE_STORAGE_ENDPOINT: "%(secret:azure_storage_endpoint)s"
+      azurenonexistcontainer_AZURE_STORAGE_ACCESS_KEY: "%(secret:azure_storage_access_key)s"
+      azurenonexistcontainer_AZURE_STORAGE_ACCOUNT_NAME: "%(secret:azure_storage_account_name)s"
+      azurenonexistcontainer_AZURE_STORAGE_ENDPOINT: "%(secret:azure_storage_endpoint)s"
+      azuretest_AZURE_BLOB_ENDPOINT: "%(secret:azure_storage_endpoint)s"
+      b2backend_B2_ACCOUNT_ID: "%(secret:b2backend_b2_account_id)s"
+      b2backend_B2_STORAGE_ACCESS_KEY: "%(secret:b2backend_b2_storage_access_key)s"
+      GOOGLE_SERVICE_EMAIL: "%(secret:gcp_service_email)s"
+      GOOGLE_SERVICE_KEY: "%(secret:gcp_service_key)s"
+      AWS_S3_BACKEND_ACCESS_KEY: "%(secret:aws_s3_backend_access_key)s"
+      AWS_S3_BACKEND_SECRET_KEY: "%(secret:aws_s3_backend_secret_key)s"
+      AWS_S3_BACKEND_ACCESS_KEY_2: "%(secret:aws_s3_backend_access_key_2)s"
+      AWS_S3_BACKEND_SECRET_KEY_2: "%(secret:aws_s3_backend_secret_key_2)s"
+      AWS_GCP_BACKEND_ACCESS_KEY: "%(secret:aws_gcp_backend_access_key)s"
+      AWS_GCP_BACKEND_SECRET_KEY: "%(secret:aws_gcp_backend_secret_key)s"
+      AWS_GCP_BACKEND_ACCESS_KEY_2: "%(secret:aws_gcp_backend_access_key_2)s"
+      AWS_GCP_BACKEND_SECRET_KEY_2: "%(secret:aws_gcp_backend_secret_key_2)s"
+      b2backend_B2_STORAGE_ENDPOINT: "%(secret:b2backend_b2_storage_endpoint)s"
+      gcpbackend2_GCP_SERVICE_EMAIL: "%(secret:gcp2_service_email)s"
+      gcpbackend2_GCP_SERVICE_KEY: "%(secret:gcp2_service_key)s"
       gcpbackend2_GCP_SERVICE_KEYFILE: /root/.gcp/servicekey
-      gcpbackend_GCP_SERVICE_EMAIL: '%(secret:gcp_service_email)s'
-      gcpbackend_GCP_SERVICE_KEY: '%(secret:gcp_service_key)s'
-      gcpbackendmismatch_GCP_SERVICE_EMAIL: >
-        '%(secret:gcpbackendmismatch_gcp_service_email)s'
-      gcpbackendmismatch_GCP_SERVICE_KEY: >
-        '%(secret:gcpbackendmismatch_gcp_service_key)s'
+      gcpbackend_GCP_SERVICE_EMAIL: "%(secret:gcp_service_email)s"
+      gcpbackend_GCP_SERVICE_KEY: "%(secret:gcp_service_key)s"
+      gcpbackendmismatch_GCP_SERVICE_EMAIL: "%(secret:gcpbackendmismatch_gcp_service_email)s"
+      gcpbackendmismatch_GCP_SERVICE_KEY: "%(secret:gcpbackendmismatch_gcp_service_key)s"
       gcpbackend_GCP_SERVICE_KEYFILE: /root/.gcp/servicekey
       gcpbackendmismatch_GCP_SERVICE_KEYFILE: /root/.gcp/servicekey
       gcpbackendnoproxy_GCP_SERVICE_KEYFILE: /root/.gcp/servicekey
@@ -43,11 +63,12 @@ models:
       shallow: True
       retryFetch: True
       haltOnFailure: True
-  - ShellCommandWthSecrets: &credentials
+  - ShellCommand: &credentials
       name: Setup Credentials
       command: bash eve/workers/build/credentials.bash
       haltOnFailure: True
-  - ShellCommandWithSecrets: &npm-install
+      env: *global-env
+  - ShellCommand: &npm-install
       name: install modules
       command: npm install
       haltOnFailure: True
@@ -120,9 +141,9 @@ stages:
           <<: *global-env
     steps:
       - Git: *clone
-      - ShellCommandWithSecrets: *credentials
+      - ShellCommand: *credentials
       - ShellCommand: *npm-install
-      - ShellCommandWithSecrets:
+      - ShellCommand:
           command: |
             bash -c "
             source /root/.aws/exports &> /dev/null
@@ -161,11 +182,10 @@ stages:
           <<: *global-env
     steps:
       - Git: *clone
-      - ShellCommandWithSecrets: *credentials
+      - ShellCommand: *credentials
       - ShellCommand: *npm-install
-      - ShellCommandWithSecrets:
+      - ShellCommand:
           command: |
-            . /root/.aws/exports &> /dev/null
             set -ex
             bash wait_for_local_port.bash 8000 40
             npm run ft_test
@@ -190,11 +210,10 @@ stages:
           <<: *global-env
     steps:
       - Git: *clone
-      - ShellCommandWithSecrets: *credentials
+      - ShellCommand: *credentials
       - ShellCommand: *npm-install
-      - ShellCommandWithSecrets:
+      - ShellCommand:
           command: |
-            . /root/.aws/exports &> /dev/null
             set -ex
             bash wait_for_local_port.bash 8000 40
             npm run ft_test

--- a/eve/workers/build/credentials.bash
+++ b/eve/workers/build/credentials.bash
@@ -3,27 +3,7 @@ set -x #echo on
 set -e #exit at the first error
 
 mkdir -p ~/.aws
-cat >>/root/.aws/exports <<EOF
-export AWS_ACCESS_KEY_ID=
-export AWS_SECRET_ACCESS_KEY=
-export GOOGLE_SERVICE_EMAIL="$GCP_BACKEND_SERVICE_EMAIL"
-export GOOGLE_SERVICE_KEY="$GCP_BACKEND_SERVICE_KEY"
-export azurebackend2_AZURE_STORAGE_ACCESS_KEY="$AZURE_BACKEND_ACCESS_KEY_2"
-export azurebackend2_AZURE_STORAGE_ACCOUNT_NAME="$AZURE_BACKEND_ACCOUNT_NAME_2"
-export azurebackend2_AZURE_STORAGE_ENDPOINT="$AZURE_BACKEND_ENDPOINT_2"
-export azurebackend_AZURE_STORAGE_ACCESS_KEY="$AZURE_BACKEND_ACCESS_KEY"
-export azurebackend_AZURE_STORAGE_ACCOUNT_NAME="$AZURE_BACKEND_ACCOUNT_NAME"
-export azurebackend_AZURE_STORAGE_ENDPOINT="$AZURE_BACKEND_ENDPOINT"
-export azurebackendmismatch_AZURE_STORAGE_ACCESS_KEY="$AZURE_BACKEND_ACCESS_KEY"
-export azurebackendmismatch_AZURE_STORAGE_ACCOUNT_NAME="$AZURE_BACKEND_ACCOUNT_NAME"
-export azurebackendmismatch_AZURE_STORAGE_ENDPOINT="$AZURE_BACKEND_ENDPOINT"
-export azurenonexistcontainer_AZURE_STORAGE_ACCESS_KEY="$AZURE_BACKEND_ACCESS_KEY"
-export azurenonexistcontainer_AZURE_STORAGE_ACCOUNT_NAME="$AZURE_BACKEND_ACCOUNT_NAME"
-export azurenonexistcontainer_AZURE_STORAGE_ENDPOINT="$AZURE_BACKEND_ENDPOINT"
-export azuretest_AZURE_BLOB_ENDPOINT="$AZURE_BACKEND_ENDPOINT"
-EOF
 
-source /root/.aws/exports &> /dev/null
 cat >>/root/.aws/credentials <<EOF
 [default]
 aws_access_key_id = $AWS_S3_BACKEND_ACCESS_KEY

--- a/eve/workers/pod.yaml
+++ b/eve/workers/pod.yaml
@@ -72,9 +72,6 @@ spec:
         - bash
         - -ec
         - |
-          # wait for exports to be created
-          sleep 15 
-          source /root/.aws/exports || exit 1
           /usr/src/app/docker-entrypoint.sh npm start | tee -a /artifacts/s3.log
       env:
         {% if vars.env.S3DATA is defined and vars.env.S3DATA == "multiple" -%}


### PR DESCRIPTION
# Intro

Sorry for the wait, but here it is!

Up for an early review until we upgrade eve in production. Works on my dev environment (link). Need your review to see if everything looks good for you. Feel free to ask any change from your point of view.

I'll merge this PR once we've upgraded Eve (which should be on Wednesday morning if everything goes fine on our side).

# Description

Made the migration of using only Vault to provide all the secrets for S3. They can be used with the syntax `%(secret:my_secret)s`.

`ShellCommandWithSecrets` will be deprecated in the future. Keep that in mind when writing CI code.

Also using a new feature in Eve [EVE-962](https://scality.atlassian.net/browse/EVE-962) that allows to interpolate those variables inside a kubernetes pod.

