### PR TITLE
bf: ZENKO-659 fix "storageType" in object replicationInfo

### DIFF
--- a/lib/api/apiUtils/object/getReplicationInfo.js
+++ b/lib/api/apiUtils/object/getReplicationInfo.js
@@ -35,11 +35,14 @@ function _getReplicationInfo(rule, replicationConfig, content, operationType,
     const backends = [];
     const storageClasses = _getStorageClasses(rule);
     storageClasses.forEach(storageClass => {
-        const location = s3config.locationConstraints[storageClass];
+        const storageClassName =
+              storageClass.endsWith(':preferred_read') ?
+              storageClass.split(':')[0] : storageClass;
+        const location = s3config.locationConstraints[storageClassName];
         if (location && constants.replicationBackends[location.type]) {
             storageTypes.push(location.type);
         }
-        backends.push(_getBackend(objectMD, storageClass));
+        backends.push(_getBackend(objectMD, storageClassName));
     });
     if (storageTypes.length > 0 && operationType) {
         content.push(operationType);

--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -140,7 +140,9 @@ function _checkMultipleBackendRequest(request, log) {
         return errors.BadRequest.customizeDescription(errMessage);
     }
     const location = locationConstraints[headers['x-scal-storage-class']];
-    const isValidLocation = location && storageType.includes(location.type);
+    const storageTypeList = storageType.split(',');
+    const isValidLocation = location &&
+          storageTypeList.includes(location.type);
     if (!isValidLocation) {
         errMessage = 'invalid request: invalid location constraint in request';
         log.debug(errMessage, {

--- a/tests/unit/api/apiUtils/getReplicationInfo.js
+++ b/tests/unit/api/apiUtils/getReplicationInfo.js
@@ -1,0 +1,107 @@
+const assert = require('assert');
+
+const BucketInfo = require('arsenal').models.BucketInfo;
+const getReplicationInfo =
+      require('../../../../lib/api/apiUtils/object/getReplicationInfo');
+
+function _getObjectReplicationInfo(replicationConfig) {
+    const bucketInfo = new BucketInfo(
+        'testbucket', 'someCanonicalId', 'accountDisplayName',
+        new Date().toJSON(),
+        null, null, null, null, null, null, null, null, null,
+        replicationConfig);
+    return getReplicationInfo('fookey', bucketInfo, true, 123, null, null);
+}
+
+describe('getReplicationInfo helper', () => {
+    it('should get replication info with single cloud target', () => {
+        const replicationConfig = {
+            role: 'arn:aws:iam::root:role/s3-replication-role',
+            rules: [{
+                prefix: '',
+                enabled: true,
+                storageClass: 'awsbackend',
+            }],
+            destination: 'tosomewhere',
+        };
+        const replicationInfo = _getObjectReplicationInfo(replicationConfig);
+        assert.deepStrictEqual(replicationInfo, {
+            status: 'PENDING',
+            backends: [{
+                site: 'awsbackend',
+                status: 'PENDING',
+                dataStoreVersionId: '',
+            }],
+            content: ['METADATA'],
+            destination: 'tosomewhere',
+            storageClass: 'awsbackend',
+            role: 'arn:aws:iam::root:role/s3-replication-role',
+            storageType: 'aws_s3',
+            isNFS: null,
+        });
+    });
+
+    it('should get replication info with multiple cloud targets', () => {
+        const replicationConfig = {
+            role: 'arn:aws:iam::root:role/s3-replication-role',
+            rules: [{
+                prefix: '',
+                enabled: true,
+                storageClass: 'awsbackend,azurebackend',
+            }],
+            destination: 'tosomewhere',
+        };
+        const replicationInfo = _getObjectReplicationInfo(replicationConfig);
+        assert.deepStrictEqual(replicationInfo, {
+            status: 'PENDING',
+            backends: [{
+                site: 'awsbackend',
+                status: 'PENDING',
+                dataStoreVersionId: '',
+            }, {
+                site: 'azurebackend',
+                status: 'PENDING',
+                dataStoreVersionId: '',
+            }],
+            content: ['METADATA'],
+            destination: 'tosomewhere',
+            storageClass: 'awsbackend,azurebackend',
+            role: 'arn:aws:iam::root:role/s3-replication-role',
+            storageType: 'aws_s3,azure',
+            isNFS: null,
+        });
+    });
+
+    it('should get replication info with multiple cloud targets and ' +
+    'preferred read location', () => {
+        const replicationConfig = {
+            role: 'arn:aws:iam::root:role/s3-replication-role',
+            rules: [{
+                prefix: '',
+                enabled: true,
+                storageClass: 'awsbackend:preferred_read,azurebackend',
+            }],
+            destination: 'tosomewhere',
+            preferredReadLocation: 'awsbackend',
+        };
+        const replicationInfo = _getObjectReplicationInfo(replicationConfig);
+        assert.deepStrictEqual(replicationInfo, {
+            status: 'PENDING',
+            backends: [{
+                site: 'awsbackend',
+                status: 'PENDING',
+                dataStoreVersionId: '',
+            }, {
+                site: 'azurebackend',
+                status: 'PENDING',
+                dataStoreVersionId: '',
+            }],
+            content: ['METADATA'],
+            destination: 'tosomewhere',
+            storageClass: 'awsbackend:preferred_read,azurebackend',
+            role: 'arn:aws:iam::root:role/s3-replication-role',
+            storageType: 'aws_s3,azure',
+            isNFS: null,
+        });
+    });
+});


### PR DESCRIPTION
When a preferred read location is defined, the storageType attribute
did not contain that location.

Also fix the lookup of the location type in "x-scal-storage-type" in
backbeat routes: create the array of location types first instead of
looking for a substring directly.
