### PR TITLE
improvement: log errors to avoid ws throwing exceptions

### DIFF
--- a/lib/management/push.js
+++ b/lib/management/push.js
@@ -77,6 +77,11 @@ function createWSAgent(pushEndpoint, env, log) {
  */
 function startWSManagementClient(pushEndpoint, instanceId, token) {
     logger.info('connecting to push server');
+    function _logError(error) {
+        if (error) {
+            logger.error('management client error', { error });
+        }
+    }
 
     const socketsByChannelId = [];
     const headers = {
@@ -90,7 +95,7 @@ function startWSManagementClient(pushEndpoint, instanceId, token) {
 
     function sendPing() {
         if (ws.readyState === ws.OPEN) {
-            ws.ping();
+            ws.ping(_logError);
         }
         pingTimeout = setTimeout(() => ws.terminate(), PING_INTERVAL_MS);
     }
@@ -109,7 +114,8 @@ function startWSManagementClient(pushEndpoint, instanceId, token) {
             },
         };
         request(fromURL, fromOptions, (err, response, body) => {
-            ws.send(ChannelMessageV0.encodeMetricsReportMessage(body));
+            ws.send(ChannelMessageV0.encodeMetricsReportMessage(body),
+                _logError);
         }).json();
     }
 
@@ -131,7 +137,7 @@ function startWSManagementClient(pushEndpoint, instanceId, token) {
 
             socket.on('data', data => {
                 ws.send(ChannelMessageV0.
-                    encodeChannelDataMessage(channelId, data));
+                    encodeChannelDataMessage(channelId, data), _logError);
             });
 
             socket.on('connect', () => {
@@ -143,7 +149,8 @@ function startWSManagementClient(pushEndpoint, instanceId, token) {
             socket.on('end', () => {
                 socket.destroy();
                 socketsByChannelId[channelId] = null;
-                ws.send(ChannelMessageV0.encodeChannelCloseMessage(channelId));
+                ws.send(ChannelMessageV0.encodeChannelCloseMessage(channelId),
+                    _logError);
             });
 
             socketsByChannelId[channelId] = socket;
@@ -205,7 +212,7 @@ function startWSManagementClient(pushEndpoint, instanceId, token) {
     });
 
     ws.on('ping', () => {
-        ws.pong();
+        ws.pong(_logError);
     });
 
     ws.on('pong', () => {


### PR DESCRIPTION
websocket npm module throws errors in its methods where callbacks are
optional but not passed as a param. To avoid this a logger helper method
is passed a callback so that if an error is raised, it gets logged.