### PR TITLE
bf: ZENKO 676 - only location metric

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -747,8 +747,10 @@ class Config extends EventEmitter {
         }
         if (Object.keys(this.locationConstraints).some(
         loc => this.locationConstraints[loc].details.sizeLimitGB)) {
-            assert(this.utapi, 'bad config: if storage size limit set on a ' +
-                'location constraint, Utapi must also be configured');
+            assert(this.utapi && this.utapi.metrics &&
+                this.utapi.metrics.includes('location'),
+                'bad config: if storage size limit set on a location ' +
+                'constraint, Utapi must also be configured correctly');
         }
 
         this.log = { logLevel: 'debug', dumpLevel: 'error' };


### PR DESCRIPTION
In order to use the location storage limit feature, config.utapi needs to be configured as follows:
`"utapi": {
    "metrics": ["location"]
}
`

Depends on https://github.com/scality/utapi/pull/185