### PR TITLE
bugfix: ZENKO-315 Only create version for replica

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -304,12 +304,15 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
             // use original data locations
             omVal.location = objMd.location;
         }
-        // specify both 'versioning' and 'versionId' to create a "new"
-        // version (updating master as well) but with specified
-        // versionId
+        // Specify both 'versioning' and 'versionId' to create a "new" version
+        // (updating master as well) but with specified versionId. If the object
+        // is from a source bucket without versioning (i.e. NFS), then we want
+        // to create a version for the replica object even though none was
+        // provided in the object metadata value.
         const options = {
             versioning: omVal.versionId !== undefined ||
-                omVal.replicationInfo.isNFS === true,
+                (omVal.replicationInfo.isNFS === true &&
+                omVal.replicationInfo.status === 'REPLICA'),
             versionId: omVal.versionId,
         };
         log.trace('putting object version', {


### PR DESCRIPTION
If the object is from a source bucket without versioning (i.e. NFS), then we want to create a version for the replica object even though none was provided in the object metadata value. This then leaves the source object without versioning.