### PR TITLE
bf: ZENKO-635 delete marker not replicated correctly

### DIFF
--- a/lib/data/external/AwsClient.js
+++ b/lib/data/external/AwsClient.js
@@ -32,6 +32,14 @@ class AwsClient {
         }
         return `${requestBucketName}/${requestObjectKey}`;
     }
+
+    toObjectGetInfo(objectKey, bucketName) {
+        return {
+            key: this._createAwsKey(bucketName, objectKey, this._bucketMatch),
+            dataStoreName: this._dataStoreName,
+        };
+    }
+
     put(stream, size, keyContext, reqUids, callback) {
         const awsKey = this._createAwsKey(keyContext.bucketName,
            keyContext.objectKey, this._bucketMatch);

--- a/lib/data/external/AzureClient.js
+++ b/lib/data/external/AzureClient.js
@@ -106,6 +106,13 @@ class AzureClient {
         });
     }
 
+    toObjectGetInfo(objectKey, bucketName) {
+        return {
+            key: this._createAzureKey(bucketName, objectKey, this._bucketMatch),
+            dataStoreName: this._dataStoreName,
+        };
+    }
+
     put(stream, size, keyContext, reqUids, callback) {
         const log = createLogger(reqUids);
         // before blob is put, make sure there is no ongoing MPU with same key

--- a/lib/data/external/GcpClient.js
+++ b/lib/data/external/GcpClient.js
@@ -48,6 +48,13 @@ class GcpClient extends AwsClient {
         this.listParts = undefined;
     }
 
+    toObjectGetInfo(objectKey, bucketName) {
+        return {
+            key: this._createGcpKey(bucketName, objectKey, this._bucketMatch),
+            dataStoreName: this._dataStoreName,
+        };
+    }
+
     /**
      * healthcheck - the gcp health requires checking multiple buckets:
      * main and mpu buckets

--- a/lib/data/file/backend.js
+++ b/lib/data/file/backend.js
@@ -9,6 +9,10 @@ class DataFileInterface {
             { host, port });
     }
 
+    toObjectGetInfo(objectKey) {
+        return { key: objectKey };
+    }
+
     put(stream, size, keyContext, reqUids, callback) {
         // ignore keyContext
         this.restClient.put(stream, size, reqUids, callback);

--- a/lib/data/in_memory/backend.js
+++ b/lib/data/in_memory/backend.js
@@ -18,6 +18,10 @@ function resetCount() {
 }
 
 const backend = {
+    toObjectGetInfo: function toObjectGetInfo(objectKey) {
+        return { key: objectKey };
+    },
+
     put: function putMem(request, size, keyContext, reqUids, callback) {
         const log = createLogger(reqUids);
         const value = Buffer.alloc(size);

--- a/lib/data/multipleBackendGateway.js
+++ b/lib/data/multipleBackendGateway.js
@@ -20,6 +20,13 @@ config.on('location-constraints-update', () => {
 
 
 const multipleBackendGateway = {
+    toObjectGetInfo: (objectKey, bucketName, location) => {
+        const client = clients[location];
+        if (!client || !client.toObjectGetInfo) {
+            return null;
+        }
+        return client.toObjectGetInfo(objectKey, bucketName);
+    },
 
     put: (hashedStream, size, keyContext,
      backendInfo, reqUids, callback) => {

--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -396,10 +396,15 @@ function deleteObject(request, response, log, callback) {
         return callback(err);
     }
     const storageLocation = request.headers['x-scal-storage-class'];
-    const objectGetInfo = {
-        key: request.objectKey,
-        dataStoreName: storageLocation,
-    };
+    const objectGetInfo = multipleBackendGateway.toObjectGetInfo(
+        request.objectKey, request.bucketName, storageLocation);
+    if (!objectGetInfo) {
+        log.error('error deleting object in multiple backend', {
+            error: 'cannot create objectGetInfo',
+            method: 'deleteObject',
+        });
+        return callback(errors.InternalError);
+    }
     const reqUids = log.getSerializedUids();
     return multipleBackendGateway.delete(objectGetInfo, reqUids, err => {
         if (err) {

--- a/tests/unit/multipleBackend/ExternalBackendClient.js
+++ b/tests/unit/multipleBackend/ExternalBackendClient.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 
 const AwsClient = require('../../../lib/data/external/AwsClient');
 const GcpClient = require('../../../lib/data/external/GcpClient');
+const AzureClient = require('../../../lib/data/external/AzureClient');
 const DummyService = require('../DummyService');
 const { DummyRequestLogger } = require('../helpers');
 
@@ -28,47 +29,78 @@ const backendClients = [
             type: 'gcp',
         },
     },
+    {
+        Class: AzureClient,
+        name: 'AzureClient',
+        config: {
+            azureStorageEndpoint: '',
+            azureStorageCredentials: {
+                storageAccountName: 'scality',
+                storageAccessKey: 'Zm9vCg==',
+            },
+            azureContainerName: 'azureTestBucketName',
+            dataStoreName: 'azureDataStore',
+            type: 'azure',
+        },
+    },
 ];
 const log = new DummyRequestLogger();
 
-backendClients.forEach(backend => {
-    let testClient;
+describe('external backend clients', () => {
+    backendClients.forEach(backend => {
+        let testClient;
 
-    before(() => {
-        testClient = new backend.Class(backend.config);
-        testClient._client = new DummyService({ versioning: true });
-    });
+        before(() => {
+            testClient = new backend.Class(backend.config);
+            testClient._client = new DummyService({ versioning: true });
+        });
 
-    describe(`${backend.name} completeMPU:`, () => {
-        it('should return correctly typed mpu results', done => {
-            const jsonList = {
-                Part: [
-                    {
-                        PartNumber: [1],
-                        ETag: ['testpart0001etag'],
-                    },
-                    {
-                        PartNumber: [2],
-                        ETag: ['testpart0002etag'],
-                    },
-                    {
-                        PartNumber: [3],
-                        ETag: ['testpart0003etag'],
-                    },
-                ],
-            };
+        if (backend.config.type !== 'azure') {
+            it(`${backend.name} completeMPU should return correctly ` +
+            'typed mpu results', done => {
+                const jsonList = {
+                    Part: [
+                        {
+                            PartNumber: [1],
+                            ETag: ['testpart0001etag'],
+                        },
+                        {
+                            PartNumber: [2],
+                            ETag: ['testpart0002etag'],
+                        },
+                        {
+                            PartNumber: [3],
+                            ETag: ['testpart0003etag'],
+                        },
+                    ],
+                };
+                const key = 'externalBackendTestKey';
+                const bucketName = 'externalBackendTestBucket';
+                const uploadId = 'externalBackendTestUploadId';
+                testClient.completeMPU(jsonList, null, key,
+                uploadId, bucketName, log, (err, res) => {
+                    assert.strictEqual(typeof res.key, 'string');
+                    assert.strictEqual(typeof res.eTag, 'string');
+                    assert.strictEqual(typeof res.dataStoreVersionId,
+                                       'string');
+                    assert.strictEqual(typeof res.contentLength, 'number');
+                    return done();
+                });
+            });
+        }
+
+        it(`${backend.name} toObjectGetInfo should return correct ` +
+        'objectGetInfo object', () => {
             const key = 'externalBackendTestKey';
             const bucketName = 'externalBackendTestBucket';
-            const uploadId = 'externalBackendTestUploadId';
-            testClient.completeMPU(jsonList, null, key, uploadId, bucketName,
-            log, (err, res) => {
-                assert.strictEqual(typeof res.key, 'string');
-                assert.strictEqual(typeof res.eTag, 'string');
-                assert.strictEqual(typeof res.dataStoreVersionId, 'string');
-                assert.strictEqual(typeof res.contentLength, 'number');
-                return done();
+            const objectGetInfo = testClient.toObjectGetInfo(key, bucketName);
+            assert.deepStrictEqual(objectGetInfo, {
+                // bucketMatch === false => expect bucket name to be
+                // prefixed to the backend key
+                key: 'externalBackendTestBucket/externalBackendTestKey',
+                dataStoreName: backend.config.dataStoreName,
             });
         });
+        // To-Do: test the other external client methods
     });
-    // To-Do: test the other external client methods
 });


### PR DESCRIPTION
Delete markers were lacking the bucket prefix on the backend keys for
cloud targets, which means they were ineffective in making the actual
objects appearing deleted. Fix this by adding a new "toObjectGetInfo"
method in multiple backends gateway, because right now the
responsibility of generating the key is per backend (IMO should be
reworked to make it global to all backends, but not the time to
refactor this).
