### PR TITLE
bugfix: ZENKO-665 Only create version for replica

### DIFF
--- a/bin/create_bucket_with_NFS_enabled.js
+++ b/bin/create_bucket_with_NFS_enabled.js
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env node
 'use strict'; // eslint-disable-line strict
 
 require('../lib/nfs/utilities.js').createBucketWithNFSEnabled();

--- a/lib/nfs/utilities.js
+++ b/lib/nfs/utilities.js
@@ -5,7 +5,7 @@ const https = require('https');
 const logger = require('../utilities/logger');
 
 function _createBucketWithNFSEnabled(host, port, bucketName, accessKey,
-    secretKey, verbose, ssl) {
+    secretKey, verbose, ssl, locationConstraint) {
     const options = {
         host,
         port,
@@ -46,6 +46,13 @@ function _createBucketWithNFSEnabled(host, port, bucketName, accessKey,
     if (verbose) {
         logger.info('request headers', { headers: request._headers });
     }
+    if (locationConstraint) {
+        const createBucketConfiguration = '<CreateBucketConfiguration ' +
+        'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+        `<LocationConstraint>${locationConstraint}</LocationConstraint>` +
+        '</CreateBucketConfiguration >';
+        request.write(createBucketConfiguration);
+    }
     request.end();
 }
 
@@ -66,10 +73,12 @@ function createBucketWithNFSEnabled() {
         .option('-p, --port <port>', 'Port of the server')
         .option('-s', '--ssl', 'Enable ssl')
         .option('-v, --verbose')
+        .option('-l, --location-constraint <locationConstraint>',
+        'location Constraint')
         .parse(process.argv);
 
     const { host, port, accessKey, secretKey, bucket, verbose,
-        ssl } = commander;
+        ssl, locationConstraint } = commander;
 
     if (!host || !port || !accessKey || !secretKey || !bucket) {
         logger.error('missing parameter');
@@ -77,7 +86,7 @@ function createBucketWithNFSEnabled() {
         process.exit(1);
     }
     _createBucketWithNFSEnabled(host, port, bucket, accessKey, secretKey,
-        verbose, ssl);
+        verbose, ssl, locationConstraint);
 }
 
 module.exports = {

--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -310,10 +310,17 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
         // version (updating master as well) but with specified
         // versionId
         const options = {
-            versioning: omVal.versionId !== undefined ||
-                omVal.replicationInfo.isNFS === true,
+            versioning: true,
             versionId: omVal.versionId,
         };
+        // If the object is from a source bucket without versioning (i.e. NFS),
+        // then we want to create a version for the replica object even though
+        // none was provided in the object metadata value.
+        if (omVal.replicationInfo.isNFS) {
+            const isReplica = omVal.replicationInfo.status === 'REPLICA';
+            options.versioning = isReplica;
+            omVal.replicationInfo.isNFS = !isReplica;
+        }
         log.trace('putting object version', {
             objectKey: request.objectKey, omVal, options });
         return metadata.putObjectMD(bucketName, objectKey, omVal, options, log,


### PR DESCRIPTION
If the object is from a source bucket without versioning (i.e. NFS), then we want to create a version for the replica object even though none was provided in the object metadata value. This then leaves the source object without versioning.