### PR TITLE
bugfix: ZENKO-632 avoid process crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -223,8 +223,8 @@
       "dev": true
     },
     "arsenal": {
-      "version": "github:scality/Arsenal#c749725410abd62a4e90ef71ecded5d606f38adf",
-      "from": "github:scality/Arsenal#c749725",
+      "version": "github:scality/Arsenal#1b9242788ae334be6577dc4fbfcc1bc9a42df484",
+      "from": "github:scality/Arsenal#1b92427",
       "requires": {
         "JSONStream": "^1.0.0",
         "ajv": "4.10.0",
@@ -258,9 +258,9 @@
           }
         },
         "mongodb": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.0.tgz",
-          "integrity": "sha512-fSDZRq9FomRqeDSM7MpMTLa8sz+STs3nZ7Ib0+xvmaKZ6nquNDN4zGDsVhjto6UozFvHMDYJMAfJwhqUygXs9g==",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.1.tgz",
+          "integrity": "sha512-GU9oWK4pi8PC7NyGiwjFMwZyMqwGWoMEMvM0LZh7UKW/FFAqgmZKjjriD+5MEOCDUJE2dtHX93/K5UtDxO0otg==",
           "requires": {
             "mongodb-core": "3.1.0"
           }
@@ -670,14 +670,10 @@
     "bucketclient": {
       "version": "github:scality/bucketclient#5aa99d7b25fdfb5a42b787cce7710cdec8ac78f0",
       "from": "github:scality/bucketclient#5aa99d7",
-      "requires": {
-        "arsenal": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
-        "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2"
-      },
       "dependencies": {
         "arsenal": {
           "version": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
-          "from": "github:scality/Arsenal#7.4.0.3",
+          "from": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
           "requires": {
             "JSONStream": "^1.0.0",
             "ajv": "4.10.0",
@@ -719,7 +715,7 @@
         },
         "werelogs": {
           "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
-          "from": "github:scality/werelogs#7.4.0.3",
+          "from": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
           "requires": {
             "safe-json-stringify": "^1.0.3"
           }
@@ -871,13 +867,13 @@
       "resolved": "github:scality/cdmiclient#8f0c2e6331dfa905bfe269fb4e1558d65ca0b866",
       "optional": true,
       "requires": {
-        "arsenal": "github:scality/Arsenal#3d06ec62304cdfd4cf51eb2f8cf0b8e732728ed1",
+        "arsenal": "github:scality/Arsenal#1b9242788ae334be6577dc4fbfcc1bc9a42df484",
         "async": "~1.4.2",
         "werelogs": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46"
       },
       "dependencies": {
         "arsenal": {
-          "version": "github:scality/Arsenal#3d06ec62304cdfd4cf51eb2f8cf0b8e732728ed1",
+          "version": "github:scality/Arsenal#1b9242788ae334be6577dc4fbfcc1bc9a42df484",
           "from": "github:scality/Arsenal#development/8.0",
           "optional": true,
           "requires": {
@@ -930,9 +926,9 @@
           "optional": true
         },
         "mongodb": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.0.tgz",
-          "integrity": "sha512-fSDZRq9FomRqeDSM7MpMTLa8sz+STs3nZ7Ib0+xvmaKZ6nquNDN4zGDsVhjto6UozFvHMDYJMAfJwhqUygXs9g==",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.1.tgz",
+          "integrity": "sha512-GU9oWK4pi8PC7NyGiwjFMwZyMqwGWoMEMvM0LZh7UKW/FFAqgmZKjjriD+5MEOCDUJE2dtHX93/K5UtDxO0otg==",
           "optional": true,
           "requires": {
             "mongodb-core": "3.1.0"
@@ -4357,13 +4353,10 @@
     "sproxydclient": {
       "version": "github:scality/sproxydclient#45090b76b24ca1d05482bf151ba84ff6178423d1",
       "from": "github:scality/sproxydclient#45090b7",
-      "requires": {
-        "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2"
-      },
       "dependencies": {
         "werelogs": {
           "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
-          "from": "github:scality/werelogs#7.4.0.3",
+          "from": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
           "requires": {
             "safe-json-stringify": "^1.0.3"
           }
@@ -4800,17 +4793,14 @@
       "version": "github:scality/utapi#4b646285d2dc3648ae3b16da22dbfefc2816ff59",
       "from": "github:scality/utapi#4b64628",
       "requires": {
-        "arsenal": "github:scality/Arsenal#c749725410abd62a4e90ef71ecded5d606f38adf",
         "async": "^2.0.1",
         "ioredis": "^2.3.0",
-        "node-schedule": "1.2.0",
-        "vaultclient": "github:scality/vaultclient#ba81ffe0e1b7821aa5ef6a9ca000ebd63586d506",
-        "werelogs": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46"
+        "node-schedule": "1.2.0"
       },
       "dependencies": {
         "arsenal": {
           "version": "github:scality/Arsenal#c749725410abd62a4e90ef71ecded5d606f38adf",
-          "from": "github:scality/Arsenal#development/8.0",
+          "from": "github:scality/Arsenal#c749725410abd62a4e90ef71ecded5d606f38adf",
           "requires": {
             "JSONStream": "^1.0.0",
             "ajv": "4.10.0",
@@ -4861,16 +4851,16 @@
           }
         },
         "mongodb": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.0.tgz",
-          "integrity": "sha512-fSDZRq9FomRqeDSM7MpMTLa8sz+STs3nZ7Ib0+xvmaKZ6nquNDN4zGDsVhjto6UozFvHMDYJMAfJwhqUygXs9g==",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.1.tgz",
+          "integrity": "sha512-GU9oWK4pi8PC7NyGiwjFMwZyMqwGWoMEMvM0LZh7UKW/FFAqgmZKjjriD+5MEOCDUJE2dtHX93/K5UtDxO0otg==",
           "requires": {
             "mongodb-core": "3.1.0"
           }
         },
         "vaultclient": {
           "version": "github:scality/vaultclient#ba81ffe0e1b7821aa5ef6a9ca000ebd63586d506",
-          "from": "github:scality/vaultclient#development/8.0",
+          "from": "github:scality/vaultclient#ba81ffe0e1b7821aa5ef6a9ca000ebd63586d506",
           "requires": {
             "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
             "commander": "2.9.0",
@@ -4931,7 +4921,7 @@
         },
         "werelogs": {
           "version": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46",
-          "from": "github:scality/werelogs#development/8.0",
+          "from": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46",
           "requires": {
             "safe-json-stringify": "1.0.3"
           }
@@ -5013,15 +5003,13 @@
       "version": "github:scality/vaultclient#754b6e1e1121f44bc3719e35b836a9185d6d5e1a",
       "from": "github:scality/vaultclient#754b6e1",
       "requires": {
-        "arsenal": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
         "commander": "2.9.0",
-        "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
         "xml2js": "0.4.17"
       },
       "dependencies": {
         "arsenal": {
           "version": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
-          "from": "github:scality/Arsenal#7.4.0.3",
+          "from": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
           "requires": {
             "JSONStream": "^1.0.0",
             "ajv": "4.10.0",
@@ -5071,7 +5059,7 @@
         },
         "werelogs": {
           "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
-          "from": "github:scality/werelogs#7.4.0.3",
+          "from": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
           "requires": {
             "safe-json-stringify": "^1.0.3"
           }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "github:scality/Arsenal#c749725",
+    "arsenal": "github:scality/Arsenal#1b92427",
     "async": "~2.5.0",
     "aws-sdk": "2.28.0",
     "azure-storage": "^2.1.0",


### PR DESCRIPTION
This brings Arsenal check where it crashes CloudServer when Readable
stream's destroy method is accessed without checking if it is available