### PR TITLE
bf: ZENKO 646 allow mdsearch by replication status

### DIFF
--- a/lib/api/apiUtils/bucket/validateSearch.js
+++ b/lib/api/apiUtils/bucket/validateSearch.js
@@ -41,6 +41,7 @@ function _validateTree(whereClause, possibleAttributes) {
                 const field = node[operator][0];
                 if (!field.startsWith('tags.') &&
                     !possibleAttributes[field] &&
+                    !field.startsWith('replicationInfo.') &&
                     !field.startsWith('x-amz-meta-')) {
                     invalidAttribute = field;
                 }
@@ -57,12 +58,18 @@ function _validateTree(whereClause, possibleAttributes) {
  *  which should be jsu sql where clause
  * For metadata: x-amz-meta-color=\"blue\"
  * For tags: tags.x-amz-meta-color=\"blue\"
+ * For replication status : replication-status=\"PENDING\"
  * For any other attribute: `content-length`=5
  * @return {undefined | error} undefined if validates or arsenal error if not
  */
 function validateSearchParams(searchParams) {
     let ast;
     try {
+        // allow using 'replicationStatus' as search param to increase
+        // ease of use, pending metadata search rework
+        // eslint-disable-next-line no-param-reassign
+        searchParams = searchParams.replace(
+            'replication-status', 'replicationInfo.status');
         ast = parser.parse(searchParams);
     } catch (e) {
         if (e) {

--- a/tests/unit/utils/validateSearch.js
+++ b/tests/unit/utils/validateSearch.js
@@ -112,6 +112,16 @@ describe('validate search where clause', () => {
             result: errors.InvalidArgument.customizeDescription(
                 'Invalid sql where clause sent as search query'),
         },
+        {
+            it: 'should allow a simple search with tag query',
+            searchParams: 'tags.x-amz-meta-color="blue"',
+            result: undefined,
+        },
+        {
+            it: 'should allow a simple search with replicationStatus query',
+            searchParams: 'replication-status="PENDING"',
+            result: undefined,
+        },
     ];
 
     tests.forEach(test => {


### PR DESCRIPTION
As discussed with team leads, deep metadata search is going to require a rework of our search method.
This PR is a quick-fix to enable md search by 'replicationStatus', as that is the most pressing use-case atm.