### PR TITLE
bf: ZENKO 726 storage limit config level

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -168,6 +168,11 @@ function locationConstraintAssert(locationConstraints) {
             typeof locationConstraints[l].isTransient),
                'bad config: locationConstraints[region]' +
                '.isTransient must be a boolean');
+        assert(['undefined', 'number'].includes(
+            typeof locationConstraints[l].sizeLimitGB),
+                'bad config: locationConstraints[region].sizeLimitGB ' +
+                'must be a number (in gigabytes)');
+
         const details = locationConstraints[l].details;
         assert(typeof details === 'object',
             'bad config: locationConstraints[region].details is ' +
@@ -223,11 +228,6 @@ function locationConstraintAssert(locationConstraints) {
             // default to true
             // eslint-disable-next-line no-param-reassign
             locationConstraints[l].details.supportsVersioning = true;
-        }
-        if (details.sizeLimitGB !== undefined) {
-            assert(typeof details.sizeLimitGB === 'number',
-                'bad config: locationConstraints[region].details.sizeLimitGB ' +
-                'must be a number (in gigabytes)');
         }
 
         if (locationConstraints[l].type === 'azure') {
@@ -760,7 +760,7 @@ class Config extends EventEmitter {
             }
         }
         if (Object.keys(this.locationConstraints).some(
-        loc => this.locationConstraints[loc].details.sizeLimitGB)) {
+        loc => this.locationConstraints[loc].sizeLimitGB)) {
             assert(this.utapi && this.utapi.metrics &&
                 this.utapi.metrics.includes('location'),
                 'bad config: if storage size limit set on a location ' +

--- a/lib/api/apiUtils/object/locationStorageCheck.js
+++ b/lib/api/apiUtils/object/locationStorageCheck.js
@@ -21,8 +21,7 @@ function _gbToBytes(gb) {
  */
 function locationStorageCheck(location, updateSize, log, cb) {
     const lc = config.locationConstraints;
-    const sizeLimitGB = lc[location] && lc[location].details ?
-        lc[location].details.sizeLimitGB : undefined;
+    const sizeLimitGB = lc[location] ? lc[location].sizeLimitGB : undefined;
     if (updateSize === 0 || sizeLimitGB === undefined) {
         return cb();
     }

--- a/tests/unit/testConfigs/locConstraintAssert.js
+++ b/tests/unit/testConfigs/locConstraintAssert.js
@@ -2,9 +2,10 @@ const assert = require('assert');
 const { locationConstraintAssert } = require('../../../lib/Config');
 
 class LocationConstraint {
-    constructor(type, legacyAwsBehavior, details) {
+    constructor(type, legacyAwsBehavior, details, sizeLimit) {
         this.type = type || 'scality';
         this.legacyAwsBehavior = legacyAwsBehavior || false;
+        this.sizeLimitGB = sizeLimit || undefined;
         this.details = Object.assign({}, {
             awsEndpoint: 's3.amazonaws.com',
             bucketName: 'tester',
@@ -290,14 +291,14 @@ describe('locationConstraintAssert', () => {
     it('should throw error if sizeLimitGB is not a number', () => {
         const usEast1 = new LocationConstraint();
         const locationConstraint = new LocationConstraint('aws_s3', true,
-            { sizeLimitGB: true });
+            null, true);
         assert.throws(() => {
             locationConstraintAssert({
                 'us-east-1': usEast1,
                 'awsstoragesizelimit': locationConstraint,
             });
         },
-        '/bad config: locationConstraints[region].details.sizeLimitGB ' +
+        '/bad config: locationConstraints[region].sizeLimitGB ' +
         'must be a number (in gigabytes)');
     });
 });


### PR DESCRIPTION
Small misunderstanding between Orbit and Cloudserver config left the sizeLimitGB property being set at different config levels.