### PR TITLE
Implementing buildbot logfiles configuration

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -87,9 +87,15 @@ models:
       name: install modules
       command: npm install
       haltOnFailure: True
-  - ShellCommand: &s3-log
-      name: s3 logs
-      command: cat /artifacts/s3.log || exit 0
+  - Upload: &upload-artifacts
+      source: /artifacts
+      urls:
+        - "*"
+  - ShellCommand: &follow-s3-log
+      logfiles:
+        s3:
+          filename: /artifacts/s3.log
+          follow: true
 
 stages:
   pre-merge:
@@ -165,6 +171,7 @@ stages:
             set -ex
             bash wait_for_local_port.bash 8000 40
             npm run multiple_backend_test"
+          <<: *follow-s3-log
           env:
             <<: *multiple-backend-vars
             <<: *global-env
@@ -172,14 +179,16 @@ stages:
       - ShellCommand:
           command: mvn test
           workdir: build/tests/functional/jaws
+          <<: *follow-s3-log
           env:
             <<: *multiple-backend-vars
       - ShellCommand:
           command: rspec tests.rb
           workdir: build/tests/functional/fog
+          <<: *follow-s3-log
           env:
             <<: *multiple-backend-vars
-      - ShellCommand: *s3-log
+      - Upload: *upload-artifacts
 
   mongo-ft-tests:
     worker: &s3-pod
@@ -204,10 +213,11 @@ stages:
             set -ex
             bash wait_for_local_port.bash 8000 40
             npm run ft_test
+          <<: *follow-s3-log
           env:
             <<: *mongo-vars
             <<: *global-env
-      - ShellCommand: *s3-log
+      - Upload: *upload-artifacts
 
   file-ft-tests:
     worker:
@@ -232,10 +242,11 @@ stages:
             set -ex
             bash wait_for_local_port.bash 8000 40
             npm run ft_test
+          <<: *follow-s3-log
           env:
             <<: *file-mem-mpu
             <<: *global-env
-      - ShellCommand: *s3-log
+      - Upload: *upload-artifacts
 
   post-merge:
     worker:


### PR DESCRIPTION
# Improving debug of containers logs

While trying to help @tmacro on a issue this morning I found the option of `logfiles` in buildbot documentation and thought that it could be a nice to have in S3 CI.

## documentation
You can checkout the full documentation about it [here](http://docs.buildbot.net/latest/manual/cfg-buildsteps.html#shellcommand). But here's what you need to know:

`logfiles`

Sometimes commands will log interesting data to a local file, rather than emitting everything to stdout or stderr. For example, Twisted’s trial command (which runs unit tests) only presents summary information to stdout, and puts the rest into a file named _trial_temp/test.log. It is often useful to watch these files as the command runs, rather than using /bin/cat to dump their contents afterwards.

## Personal thoughts
Checkout how this change affect the [UI](https://eve.devsca.com/github/scality/s3/#/builders/9/builds/1715)! You can see that you have your stdio field and now also have S3 and you will be able to follow up the logs while the command is running! Which could be useful.

IMHO this should be implemented implicitly eve side. But while the development is not done yet, we could have this working now.