### PR TITLE
bf(zenko-473): Handle a unspecified storage quota correctly

### DIFF
--- a/lib/api/apiUtils/object/locationStorageCheck.js
+++ b/lib/api/apiUtils/object/locationStorageCheck.js
@@ -22,7 +22,7 @@ function _gbToBytes(gb) {
 function locationStorageCheck(location, updateSize, log, cb) {
     const lc = config.locationConstraints;
     const sizeLimitGB = lc[location] ? lc[location].sizeLimitGB : undefined;
-    if (updateSize === 0 || sizeLimitGB === undefined) {
+    if (updateSize === 0 || sizeLimitGB === undefined || sizeLimitGB === null) {
         return cb();
     }
     // no need to list location metric, since it should be decreased


### PR DESCRIPTION
# Pull request template

## Description

### Motivation and context

in configuration.js location.sizeLimitGB is set as follows 

```
location.sizeLimitGB = l.sizeLimitGB || null;
```

where `l` is the location read from the overlay config

later when checking the quota when uploading an object the value is tested as follows

```
    const sizeLimitGB = lc[location] ? lc[location].sizeLimitGB : undefined;
    if (updateSize === 0 || sizeLimitGB === undefined) {
        return cb();
    }
```

This incorrectly lets a sizeLimitGB of null pass through for checking which causes all PUTs to fail with the error `The assigned storage space limit for location awsbackend will be exceeded` on the client.

The fix for this bug is adding an additional check for  `sizeLimitGB === null`
