### PR TITLE
INTEGRATION [PR#1380 > development/8.1] improment: ZENKO-749 removed stretch from aws-node-sdk object test

### DIFF
--- a/tests/functional/aws-node-sdk/test/object/objectHead_replication.js
+++ b/tests/functional/aws-node-sdk/test/object/objectHead_replication.js
@@ -51,7 +51,8 @@ describe("Head object 'ReplicationStatus' value", () => {
                     Role: 'arn:aws:iam::123456789012:role/src-resource',
                     Rules: [
                         {
-                            Destination: { Bucket: 'arn:aws:s3:::dest-bucket' },
+                            Destination: { StorageClass: 'us-east-2',
+                            Bucket: 'arn:aws:s3:::dest-bucket' },
                             Prefix: keyPrefix,
                             Status: 'Enabled',
                         },

--- a/tests/functional/aws-node-sdk/test/object/objectHead_replication.js
+++ b/tests/functional/aws-node-sdk/test/object/objectHead_replication.js
@@ -48,8 +48,7 @@ describe("Head object 'ReplicationStatus' value", () => {
             beforeEach(done => s3.putBucketReplication({
                 Bucket: sourceBucket,
                 ReplicationConfiguration: {
-                    Role: 'arn:aws:iam::123456789012:role/src-resource,' +
-                        'arn:aws:iam::123456789012:role/dest-resource',
+                    Role: 'arn:aws:iam::123456789012:role/src-resource',
                     Rules: [
                         {
                             Destination: { Bucket: 'arn:aws:s3:::dest-bucket' },


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1380.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/improvement/ZENKO-749-remove-stretch-from-aws-node-sdk-tests`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/improvement/ZENKO-749-remove-stretch-from-aws-node-sdk-tests
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/improvement/ZENKO-749-remove-stretch-from-aws-node-sdk-tests
```

Please always comment pull request #1380 instead of this one.