### PR TITLE
bf: ZENKO-660 api proxy fixes

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -721,7 +721,7 @@ function routeBackbeat(clientIP, request, response, log) {
         const path = request.url.replace('/_/backbeat/api', '/_/');
         const { host, port } = config.backbeat;
         const target = `http://${host}:${port}${path}`;
-        return auth.server.doAuth(request, log, err => {
+        return auth.server.doAuth(request, log, (err, userInfo) => {
             if (err) {
                 log.debug('authentication error', {
                     error: err,
@@ -731,7 +731,25 @@ function routeBackbeat(clientIP, request, response, log) {
                 });
                 return responseJSONBody(err, null, response, log);
             }
-            return backbeatProxy.web(request, response, { target });
+            // FIXME for now, any authenticated user can access API
+            // routes. We should introduce admin accounts or accounts
+            // with admin privileges, and restrict access to those
+            // only.
+            if (userInfo.getCanonicalID() === constants.publicId) {
+                log.debug('unauthenticated access to API routes', {
+                    method: request.method,
+                    bucketName: request.bucketName,
+                    objectKey: request.objectKey,
+                });
+                return responseJSONBody(
+                    errors.AccessDenied, null, response, log);
+            }
+            return backbeatProxy.web(request, response, { target }, err => {
+                log.error('error proxying request to api server',
+                          { error: err.message });
+                return responseJSONBody(errors.ServiceUnavailable, null,
+                                        response, log);
+            });
         }, 's3', requestContexts);
     }
 

--- a/tests/functional/raw-node/test/routes/routeBackbeat.js
+++ b/tests/functional/raw-node/test/routes/routeBackbeat.js
@@ -395,6 +395,44 @@ describeSkipIfAWS('backbeat routes', () => {
                     });
                 });
          });
+        it('GET  /_/backbeat/api/... should respond with ' +
+           '503 on authenticated requests (API server down)',
+           done => {
+               const options = {
+                   authCredentials: {
+                       accessKey: 'accessKey2',
+                       secretKey: 'verySecretKey2',
+                   },
+                   hostname: ipAddress,
+                   port: 8000,
+                   method: 'GET',
+                   path: '/_/backbeat/api/crr/failed',
+                   jsonResponse: true,
+               };
+               makeRequest(options, err => {
+                   assert(err);
+                   assert.strictEqual(err.statusCode, 503);
+                   assert.strictEqual(err.code, 'ServiceUnavailable');
+                   done();
+               });
+           });
+        it('GET  /_/backbeat/api/... should respond with ' +
+           '403 Forbidden if the request is unauthenticated',
+           done => {
+               const options = {
+                   hostname: ipAddress,
+                   port: 8000,
+                   method: 'GET',
+                   path: '/_/backbeat/api/crr/failed',
+                   jsonResponse: true,
+               };
+               makeRequest(options, err => {
+                   assert(err);
+                   assert.strictEqual(err.statusCode, 403);
+                   assert.strictEqual(err.code, 'AccessDenied');
+                   done();
+               });
+           });
     });
 
     describe('GET Metadata route', () => {


### PR DESCRIPTION
- reject unauthenticated requests on /_/backbeat/api routes:

  - don't allow access to `/_/backbeat/api` passthrough routes for
    public users. It's a temporary option until we have support for
    admin accounts or accounts with admin privileges.

- fix error handling by catching errors raised by http-proxy module
