### PR TITLE
ft: ZENKO-777 add pause/resume status reports

### DIFF
--- a/lib/utilities/reportHandler.js
+++ b/lib/utilities/reportHandler.js
@@ -3,6 +3,7 @@ const os = require('os');
 
 const { errors, ipCheck, backbeat } = require('arsenal');
 const async = require('async');
+const request = require('request');
 
 const config = require('../Config').config;
 const data = require('../data/wrapper');
@@ -213,6 +214,60 @@ function getCRRStats(log, cb, _config) {
     });
 }
 
+function getReplicationStates(log, cb, _testConfig) {
+    log.debug('requesting location replications states from backbeat api',
+        {
+            method: 'getReplicationStates',
+        });
+    const { host, port } = _testConfig || config.backbeat;
+    const makeRequest = (path, cb) => {
+        const endpoint = `http://${host}:${port}${path}`;
+        request({ url: endpoint, json: true }, (error, response, body) => {
+            if (error) {
+                return cb(error);
+            }
+            if (response.statusCode >= 400) {
+                return cb('responseError', body);
+            }
+            if (body) {
+                return cb(null, body);
+            }
+            return cb(null, {});
+        });
+    };
+    async.parallel({
+        states: done => makeRequest('/_/crr/status', done),
+        schedules: done => makeRequest('/_/crr/resume/all', done),
+    }, (err, res) => {
+        if (err) {
+            if (err === 'responseError') {
+                log.error('error response from backbeat api', {
+                    error: res,
+                    method: 'getReplicationStates',
+                });
+            } else {
+                log.error('unable to perform request to backbeat api', {
+                    error: err,
+                    method: 'getReplicationStates',
+                });
+            }
+            return cb(null, {});
+        }
+        const locationSchedules = {};
+        Object.keys(res.schedules).forEach(loc => {
+            const val = res.schedules[loc];
+            if (!isNaN(Date.parse(val))) {
+                locationSchedules[loc] = new Date(val);
+            }
+        });
+        const retObj = {
+            states: res.states || {},
+            schedules: locationSchedules,
+        };
+        return cb(null, retObj);
+    });
+}
+
 /**
  * Sends back a report
  *
@@ -239,6 +294,7 @@ function reportHandler(clientIP, req, res, log) {
         getVersion: cb => getGitVersion(cb),
         getObjectCount: cb => metadata.countItems(log, cb),
         getCRRStats: cb => getCRRStats(log, cb),
+        getReplicationStates: cb => getReplicationStates(log, cb),
     },
     (err, results) => {
         if (err) {
@@ -257,7 +313,7 @@ function reportHandler(clientIP, req, res, log) {
                 systemStats: getSystemStats(),
                 itemCounts: results.getObjectCount,
                 crrStats: results.getCRRStats,
-
+                repStatus: results.getReplicationStates,
                 config: cleanup(config),
                 capabilities: getCapabilities(),
             };
@@ -275,4 +331,5 @@ module.exports = {
     reportHandler,
     _crrRequest,
     getCRRStats,
+    getReplicationStates,
 };

--- a/tests/functional/utilities/reportHandler.js
+++ b/tests/functional/utilities/reportHandler.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const async = require('async');
+const http = require('http');
 const { backbeat } = require('arsenal');
 const { RedisClient } = require('arsenal').metrics;
 
@@ -20,6 +21,7 @@ config.localCache = { host: 'localhost', port: 6379 };
 const {
     _crrRequest,
     getCRRStats,
+    getReplicationStates,
 } = require('../../../lib/utilities/reportHandler');
 
 
@@ -178,5 +180,111 @@ describe('reportHandler::getCRRStats', function testSuite() {
             });
             return done();
         }, config);
+    });
+});
+
+describe('reportHandler::getReplicationStates', function testSuite() {
+    this.timeout(20000);
+    const testPort = '4242';
+    let httpServer;
+
+    const expectedStatusResults = {
+        location1: 'enabled',
+        location2: 'disabled',
+    };
+
+    const expectedScheduleResults = {
+        location1: 'none',
+        location2: new Date(),
+    };
+
+    function requestHandler(req, res) {
+        switch (req.url) {
+        case '/_/crr/status':
+            res.write(JSON.stringify(expectedStatusResults));
+            break;
+        case '/_/crr/resume/all':
+            res.write(JSON.stringify(expectedScheduleResults));
+            break;
+        default:
+            break;
+        }
+        res.end();
+    }
+
+
+    function requestFailHandler(req, res) {
+        const testError = {
+            code: 404,
+            description: 'reportHandler test error',
+        };
+        // eslint-disable-next-line no-param-reassign
+        res.statusCode = 404;
+        res.write(JSON.stringify(testError));
+        res.end();
+    }
+
+    describe('Test Request Failure Cases', () => {
+        before(done => {
+            httpServer = http.createServer(requestFailHandler).listen(testPort);
+            httpServer.on('listening', done);
+            httpServer.on('error', err => {
+                process.stdout.write(`https server: ${err.stack}\n`);
+                process.exit(1);
+            });
+        });
+
+        after('Terminating Server', () => {
+            httpServer.close();
+        });
+
+        it('should return empty object if a request error occurs', done => {
+            getReplicationStates(logger, (err, res) => {
+                assert.ifError(err, `Expected success, but got error ${err}`);
+                assert.deepStrictEqual(res, {});
+                done();
+            }, { host: 'nonexisthost', port: testPort });
+        });
+
+        it('should return empty object if response status code is >= 400',
+        done => {
+            getReplicationStates(logger, (err, res) => {
+                assert.ifError(err, `Expected success, but got error ${err}`);
+                assert.deepStrictEqual(res, {});
+                done();
+            }, { host: 'localhost', port: testPort });
+        });
+    });
+
+    describe('Test Request Success Cases', () => {
+        before(done => {
+            httpServer = http.createServer(requestHandler).listen(testPort);
+            httpServer.on('listening', done);
+            httpServer.on('error', err => {
+                process.stdout.write(`https server: ${err.stack}\n`);
+                process.exit(1);
+            });
+        });
+
+        after('Terminating Server', () => {
+            httpServer.close();
+        });
+
+        it('should return correct results', done => {
+            getReplicationStates(logger, (err, res) => {
+                const expectedResults = {
+                    states: {
+                        location1: 'enabled',
+                        location2: 'disabled',
+                    },
+                    schedules: {
+                        location2: expectedScheduleResults.location2,
+                    },
+                };
+                assert.ifError(err, `Expected success, but got error ${err}`);
+                assert.deepStrictEqual(res, expectedResults);
+                done();
+            }, { host: 'localhost', port: testPort });
+        });
     });
 });


### PR DESCRIPTION
Adds pause/resume status as part of the report to Orbit

reportHandler addition:
```
    {
        ...
        repStatus: {
            states: {
                location: 'enabled | disabled',
            },
            schedules: {
                location: 'timestamp',
            }
        }
    }
```