### PR TITLE
improvement: ZENKO-749 removed crr s3 to s3 object test from aws-node-sdk

### DIFF
--- a/tests/functional/aws-node-sdk/test/object/objectHead_replication.js
+++ b/tests/functional/aws-node-sdk/test/object/objectHead_replication.js
@@ -48,11 +48,11 @@ describe("Head object 'ReplicationStatus' value", () => {
             beforeEach(done => s3.putBucketReplication({
                 Bucket: sourceBucket,
                 ReplicationConfiguration: {
-                    Role: 'arn:aws:iam::123456789012:role/src-resource,' +
-                        'arn:aws:iam::123456789012:role/dest-resource',
+                    Role: 'arn:aws:iam::123456789012:role/src-resource',
                     Rules: [
                         {
-                            Destination: { Bucket: 'arn:aws:s3:::dest-bucket' },
+                            Destination: { StorageClass: 'us-east-2',
+                            Bucket: 'arn:aws:s3:::dest-bucket' },
                             Prefix: keyPrefix,
                             Status: 'Enabled',
                         },

--- a/tests/locationConfig/locationConfigLegacy.json
+++ b/tests/locationConfig/locationConfigLegacy.json
@@ -11,6 +11,11 @@
 
         "details": {}
     },
+    "us-east-2": {
+        "type": "file",
+        "legacyAwsBehavior": true,
+        "details": {}
+    },
     "scality-internal-file": {
         "type": "file",
         "legacyAwsBehavior": false,

--- a/tests/locationConfig/locationConfigTests.json
+++ b/tests/locationConfig/locationConfigTests.json
@@ -4,6 +4,11 @@
         "legacyAwsBehavior": true,
         "details": {}
     },
+    "us-east-2": {
+        "type": "file",
+        "legacyAwsBehavior": true,
+        "details": {}
+    },
     "scality-internal-file": {
         "type": "file",
         "legacyAwsBehavior": false,


### PR DESCRIPTION
### Remove CRR s3 to s3 from aws-sdk-node object test
This needs to be done so that we can add E2E tests for zenko. Currently, we do not support s3 to s3 with zenko.