### PR TITLE
bf: ZENKO 790 redis limit return

### DIFF
--- a/lib/api/apiUtils/object/locationStorageCheck.js
+++ b/lib/api/apiUtils/object/locationStorageCheck.js
@@ -34,7 +34,7 @@ function locationStorageCheck(location, updateSize, log, cb) {
             log.error(`Error listing metrics from Utapi: ${err.message}`);
             return cb(err);
         }
-        const newStorageSize = bytesStored + updateSize;
+        const newStorageSize = parseInt(bytesStored, 10) + updateSize;
         const sizeLimitBytes = _gbToBytes(sizeLimitGB);
         if (sizeLimitBytes < newStorageSize) {
             return cb(errors.AccessDenied.customizeDescription(


### PR DESCRIPTION
Redis suddenly decided to return key values as strings, so new put sizes were being concatenated instead of added to the existing location value