### PR TITLE
improvement: ZENKO-760 prepare setup to work without cluster

### DIFF
--- a/lib/metadata/wrapper.js
+++ b/lib/metadata/wrapper.js
@@ -40,7 +40,4 @@ if (clientName === 'mem') {
 
 const metadata = new MetadataWrapper(config.backends.metadata, params,
     bucketclient, logger);
-// call setup
-metadata.setup(() => {});
-
 module.exports = metadata;

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,7 @@
 const http = require('http');
 const https = require('https');
 const cluster = require('cluster');
+const { series } = require('async');
 const arsenal = require('arsenal');
 const { RedisClient, StatsClient } = require('arsenal').metrics;
 const monitoringClient = require('./utilities/monitoringHandler');
@@ -12,6 +13,7 @@ const _config = require('./Config').config;
 const { blacklistedPrefixes } = require('../constants');
 const api = require('./api/api');
 const data = require('./data/wrapper');
+const metadata = require('./metadata/wrapper');
 const { initManagement } = require('./management');
 
 const routes = arsenal.s3routes.routes;
@@ -48,6 +50,7 @@ class S3Server {
      */
     constructor(worker) {
         this.worker = worker;
+        this.cluster = true;
         http.globalAgent.keepAlive = true;
 
         process.on('SIGINT', this.cleanUp.bind(this));
@@ -67,6 +70,7 @@ class S3Server {
             });
             this.caughtExceptionShutdown();
         });
+        this.started = false;
     }
 
     routeRequest(req, res) {
@@ -165,47 +169,62 @@ class S3Server {
     }
 
     caughtExceptionShutdown() {
+        if (!this.cluster) {
+            process.exit(1);
+        }
         logger.error('shutdown of worker due to exception', {
             workerId: this.worker ? this.worker.id : undefined,
             workerPid: this.worker ? this.worker.process.pid : undefined,
         });
         // Will close all servers, cause disconnect event on master and kill
         // worker process with 'SIGTERM'.
-        this.worker.kill();
+        if (this.worker) {
+            this.worker.kill();
+        }
     }
 
     initiateStartup(log) {
-        clientCheck(true, log, (err, results) => {
+        series([
+            next => metadata.setup(next),
+            next => clientCheck(true, log, next),
+        ], (err, results) => {
             if (err) {
                 log.info('initial health check failed, delaying startup', {
                     error: err,
                     healthStatus: results,
                 });
                 setTimeout(() => this.initiateStartup(log), 2000);
-            } else {
-                log.debug('initial health check succeeded');
-                if (_config.listenOn.length > 0) {
-                    _config.listenOn.forEach(item => {
-                        this.startup(item.port, item.ip);
-                    });
-                } else {
-                    this.startup(_config.port);
-                }
+                return;
+            }
+            log.debug('initial health check succeeded');
+            if (_config.listenOn.length > 0) {
+                _config.listenOn.forEach(item => {
+                    this.startup(item.port, item.ip);
+                });
+                return;
+            }
+            if (!this.started) {
+                this.startup(_config.port);
+                this.started = true;
             }
         });
     }
 }
 
 function main() {
-    let clusters = _config.clusters || 1;
+    // TODO: change config to use workers prop. name for clarity
+    let workers = _config.clusters || 1;
     if (process.env.S3BACKEND === 'mem') {
-        clusters = 1;
+        workers = 1;
     }
-    if (cluster.isMaster) {
-        // Make sure all workers use the same report token
+    this.cluster = workers > 1;
+    if (!this.cluster) {
         process.env.REPORT_TOKEN = _config.reportToken;
-
-        for (let n = 0; n < clusters; n++) {
+        const server = new S3Server();
+        server.initiateStartup(logger.newRequestLogger());
+    }
+    if (this.cluster && cluster.isMaster) {
+        for (let n = 0; n < workers; n++) {
             const worker = cluster.fork();
             logger.info('new worker forked', {
                 workerId: worker.id,
@@ -214,8 +233,8 @@ function main() {
         }
         setInterval(() => {
             const len = Object.keys(cluster.workers).length;
-            if (len < clusters) {
-                for (let i = len; i < clusters; i++) {
+            if (len < workers) {
+                for (let i = len; i < workers; i++) {
                     const newWorker = cluster.fork();
                     logger.info('new worker forked', {
                         workerId: newWorker.id,
@@ -245,7 +264,8 @@ function main() {
                 workerPid: worker.process.pid,
             });
         });
-    } else {
+    }
+    if (this.cluster && cluster.isWorker) {
         const server = new S3Server(cluster.worker);
         server.initiateStartup(logger.newRequestLogger());
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -223,8 +223,8 @@
       "dev": true
     },
     "arsenal": {
-      "version": "github:scality/Arsenal#241338bcfaf779ee0e4ce1e4a131baa71499e8e5",
-      "from": "github:scality/Arsenal#241338b",
+      "version": "github:scality/Arsenal#fdbeed1c4eb5bff95662ad07470afcb05b077d38",
+      "from": "github:scality/Arsenal#fdbeed1",
       "requires": {
         "JSONStream": "^1.0.0",
         "ajv": "4.10.0",
@@ -867,13 +867,13 @@
       "resolved": "github:scality/cdmiclient#8f0c2e6331dfa905bfe269fb4e1558d65ca0b866",
       "optional": true,
       "requires": {
-        "arsenal": "github:scality/Arsenal#6db80e9411286e2641c3d145cade480ba2acc650",
+        "arsenal": "github:scality/Arsenal#91fbc3fd23df04198e751bdadd9a68a58fff2f82",
         "async": "~1.4.2",
         "werelogs": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46"
       },
       "dependencies": {
         "arsenal": {
-          "version": "github:scality/Arsenal#6db80e9411286e2641c3d145cade480ba2acc650",
+          "version": "github:scality/Arsenal#91fbc3fd23df04198e751bdadd9a68a58fff2f82",
           "from": "github:scality/Arsenal#development/8.0",
           "optional": true,
           "requires": {
@@ -4123,9 +4123,9 @@
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
     },
     "saslprep": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.0.tgz",
-      "integrity": "sha512-5lvKUEQ7lAN5/vPl5d3k8FQeDbEamu9kizfATfLLWV5h6Mkh1xcieR1FSsJkcSRUk49lF2tAW8gzXWVwtwZVhw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.1.tgz",
+      "integrity": "sha512-ntN6SbE3hRqd45PKKadRPgA+xHPWg5lPSj2JWJdJvjTwXDDfkPVtXWvP8jJojvnm+rAsZ2b299C5NwZqq818EA==",
       "optional": true
     },
     "sax": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "github:scality/Arsenal#241338b",
+    "arsenal": "github:scality/Arsenal#dfcdea4",
     "async": "~2.5.0",
     "aws-sdk": "2.28.0",
     "azure-storage": "^2.1.0",


### PR DESCRIPTION
## Description
improvement: ZENKO-760 prepare setup to work without cluster

### Motivation and context

To be inline with Kubernetes pods sentiment of running one process per pod, the cluster
module usage is removed when workers are configured to be 1. Another change is to move
the metadata setup to make sure connection to MongoDB is in place before accepting any
requests
