### PR TITLE
bumping cloudserver version to 8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "8.0.0-beta",
+  "version": "8.1.0-beta",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
# Updating cloudserver version

Updating cloudserver version on `package.json` for development/8.1

This commit is required to fixup Bert-E's workflow and allowing all PR to be automatically forward ported.
