### PR TITLE
improvement: ZENKO-819 use regional endpoints

### DIFF
--- a/lib/data/external/AwsClient.js
+++ b/lib/data/external/AwsClient.js
@@ -1,3 +1,4 @@
+const { waterfall } = require('async');
 const { errors, s3middleware } = require('arsenal');
 const AWS = require('aws-sdk');
 const MD5Sum = s3middleware.MD5Sum;
@@ -31,6 +32,49 @@ class AwsClient {
             return requestObjectKey;
         }
         return `${requestBucketName}/${requestObjectKey}`;
+    }
+
+    _request(api, params, cb) {
+        let endpointCorrection = false;
+        waterfall([
+            // api call
+            next => this._client[api](params, (err, res) => {
+                if (err && err.name === 'AuthorizationHeaderMalformed') {
+                    endpointCorrection = true;
+                    return next(null, null);
+                }
+                if (err) {
+                    return next(err);
+                }
+                return next(null, res);
+            }),
+            // adjust endpoint if needed
+            (res, next) => {
+                if (endpointCorrection) {
+                    return this._client.getBucketLocation({
+                        Bucket: this._awsBucketName,
+                    }, (err, data) => {
+                        if (err) {
+                            return next(err);
+                        }
+                        const { LocationConstraint } = data;
+                        if (LocationConstraint) {
+                            this._client.endpoint = new AWS.Endpoint(
+                                `s3.${LocationConstraint}.amazonaws.com`);
+                        }
+                        return next(null, null);
+                    });
+                }
+                return next(null, res);
+            },
+            // retry api call with the correct endpoint
+            (res, next) => {
+                if (!endpointCorrection) {
+                    return next(null, res);
+                }
+                return this._client[api](params, next);
+            },
+        ], cb);
     }
 
     toObjectGetInfo(objectKey, bucketName) {
@@ -96,16 +140,16 @@ class AwsClient {
             uploadParams.ContentEncoding = keyContext.contentEncoding;
         }
         if (!stream) {
-            return this._client.putObject(uploadParams, putCb);
+            return this._request('putObject', uploadParams, putCb);
         }
 
         uploadParams.Body = stream;
-        return this._client.upload(uploadParams, putCb);
+        return this._request('upload', uploadParams, putCb);
     }
     head(objectGetInfo, reqUids, callback) {
         const log = createLogger(reqUids);
         const { key, dataStoreVersionId } = objectGetInfo;
-        return this._client.headObject({
+        return this._request('headObject', {
             Bucket: this._awsBucketName,
             Key: key,
             VersionId: dataStoreVersionId,
@@ -161,7 +205,7 @@ class AwsClient {
         if (deleteVersion) {
             params.VersionId = dataStoreVersionId;
         }
-        return this._client.deleteObject(params, err => {
+        return this._request('deleteObject', params, err => {
             if (err) {
                 logHelper(log, 'error', 'error deleting object from ' +
                 'datastore', err, this._dataStoreName, this.clientType);
@@ -195,7 +239,7 @@ class AwsClient {
                 };
                 return callback(null, awsResp);
             }
-            return this._client.getBucketVersioning({
+            return this._request('getBucketVersioning', {
                 Bucket: this._awsBucketName },
             (err, data) => {
                 if (err) {
@@ -239,7 +283,7 @@ class AwsClient {
             ContentDisposition: contentDisposition,
             ContentEncoding: contentEncoding,
         };
-        return this._client.createMultipartUpload(params, (err, mpuResObj) => {
+        return this._request('createMultipartUpload', params, (err, res) => {
             if (err) {
                 logHelper(log, 'error', 'err from data backend',
                   err, this._dataStoreName, this.clientType);
@@ -248,7 +292,7 @@ class AwsClient {
                   `${this.type}: ${err.message}`)
                 );
             }
-            return callback(null, mpuResObj);
+            return callback(null, res);
         });
     }
 
@@ -267,7 +311,7 @@ class AwsClient {
         const params = { Bucket: awsBucket, Key: awsKey, UploadId: uploadId,
             Body: hashedStream, ContentLength: size,
             PartNumber: partNumber };
-        return this._client.uploadPart(params, (err, partResObj) => {
+        return this._request('uploadPart', params, (err, partResObj) => {
             if (err) {
                 logHelper(log, 'error', 'err from data backend ' +
                   'on uploadPart', err, this._dataStoreName, this.clientType);
@@ -295,7 +339,7 @@ class AwsClient {
         const awsKey = this._createAwsKey(bucketName, key, this._bucketMatch);
         const params = { Bucket: awsBucket, Key: awsKey, UploadId: uploadId,
             PartNumberMarker: partNumberMarker, MaxParts: maxParts };
-        return this._client.listParts(params, (err, partList) => {
+        return this._request('listParts', params, (err, partList) => {
             if (err) {
                 logHelper(log, 'error', 'err from data backend on listPart',
                   err, this._dataStoreName, this.clientType);
@@ -361,7 +405,7 @@ class AwsClient {
             },
         };
         const completeObjData = { key: awsKey };
-        return this._client.completeMultipartUpload(mpuParams,
+        return this._request('completeMultipartUpload', mpuParams,
         (err, completeMpuRes) => {
             if (err) {
                 if (mpuError[err.code]) {
@@ -384,7 +428,8 @@ class AwsClient {
             }
             // need to get content length of new object to store
             // in our metadata
-            return this._client.headObject({ Bucket: awsBucket, Key: awsKey },
+            return this._request('headObject',
+            { Bucket: awsBucket, Key: awsKey },
             (err, objHeaders) => {
                 if (err) {
                     logHelper(log, 'trace', 'err from data backend on ' +
@@ -411,7 +456,7 @@ class AwsClient {
         const abortParams = {
             Bucket: awsBucket, Key: awsKey, UploadId: uploadId,
         };
-        return this._client.abortMultipartUpload(abortParams, err => {
+        return this._request('abortMultipartUpload', abortParams, err => {
             if (err) {
                 logHelper(log, 'error', 'There was an error aborting ' +
                 'the MPU on AWS S3. You should abort directly on AWS S3 ' +
@@ -441,7 +486,7 @@ class AwsClient {
             const value = objectMD.tags[key];
             return { Key: key, Value: value };
         });
-        return this._client.putObjectTagging(tagParams, err => {
+        return this._request('putObjectTagging', tagParams, err => {
             if (err) {
                 logHelper(log, 'error', 'error from data backend on ' +
                   'putObjectTagging', err,
@@ -464,7 +509,7 @@ class AwsClient {
             Key: awsKey,
             VersionId: dataStoreVersionId,
         };
-        return this._client.deleteObjectTagging(tagParams, err => {
+        return this._request('deleteObjectTagging', tagParams, err => {
             if (err) {
                 logHelper(log, 'error', 'error from data backend on ' +
                 'deleteObjectTagging', err,
@@ -500,7 +545,7 @@ class AwsClient {
         config.isAWSServerSideEncrytion(destLocationConstraintName)) {
             awsParams.ServerSideEncryption = 'AES256';
         }
-        this._client.copyObject(awsParams, (err, copyResult) => {
+        this._request('copyObject', awsParams, (err, copyResult) => {
             if (err) {
                 if (err.code === 'AccessDenied') {
                     logHelper(log, 'error', 'Unable to access ' +
@@ -549,7 +594,7 @@ class AwsClient {
             PartNumber: partNumber,
             UploadId: uploadId,
         };
-        return this._client.uploadPartCopy(params, (err, res) => {
+        return this._request('uploadPartCopy', params, (err, res) => {
             if (err) {
                 if (err.code === 'AccessDenied') {
                     logHelper(log, 'error', 'Unable to access ' +


### PR DESCRIPTION
This commit adds a retry for requests to AWS where the api call fails as the common endpoint
s3.amazonaws.com is not redirected to the regional endpoints anymore. If the original call
recives AuthorizationHeaderMalformed, a GET Bucket location call is made and the endpoint is
updated to use the correct region in it's hostname.