### PR TITLE
improvement: ZENKO-762 read crr stats from Redis HA

### DIFF
--- a/lib/utilities/reportHandler.js
+++ b/lib/utilities/reportHandler.js
@@ -139,7 +139,7 @@ function _crrRequest(backbeatMetrics, rDetails, site, log, cb) {
 
 function getCRRStats(log, cb, _config) {
     log.debug('getting CRR stats', { method: 'getCRRStats' });
-    const { replicationEndpoints, localCache: redis } = _config || config;
+    const { replicationEndpoints, redis } = _config || config;
     if (!redis) {
         log.debug('redis connection not configured', { method: 'getCRRStats' });
         return process.nextTick(() => cb(null, {}));

--- a/tests/functional/utilities/reportHandler.js
+++ b/tests/functional/utilities/reportHandler.js
@@ -16,7 +16,7 @@ const testLocationConstraints = {
     noshow: { type: 'aws_s3' },
 };
 config.setReplicationEndpoints(testLocationConstraints);
-config.localCache = { host: 'localhost', port: 6379 };
+config.redis = { host: 'localhost', port: 6379 };
 
 const {
     _crrRequest,
@@ -137,7 +137,7 @@ describe('reportHandler::getCRRStats', function testSuite() {
     let redisClient;
 
     before(done => {
-        redisClient = new RedisClient(config.localCache, logger);
+        redisClient = new RedisClient(config.redis, logger);
         async.series([
             next => redisClient.clear(next),
             next => populateRedis(redisClient, next),


### PR DESCRIPTION
This changes the behavior of the report handler to use Redis HA to
read the metrics from instead of localCache.