### PR TITLE
bf: S3C-1602 log end message in backbeat routes

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -51,7 +51,13 @@ function _respond(response, payload, log, callback) {
         'content-length': Buffer.byteLength(body),
     };
     response.writeHead(200, httpHeaders);
-    response.end(body, 'utf8', callback);
+    response.end(body, 'utf8', () => {
+        log.end().info('responded with payload', {
+            httpCode: 200,
+            contentLength: Buffer.byteLength(body),
+        });
+        callback();
+    });
 }
 
 function _getRequestPayload(req, cb) {


### PR DESCRIPTION
Add an info log when the response has been sent back to the client
of backbeat routes.
