### PR TITLE
bf: ZENKO-835 do not replicate lifecycle actions

### DIFF
--- a/conf/authdata.json
+++ b/conf/authdata.json
@@ -41,5 +41,16 @@
             "access": "replicationKey1",
             "secret": "replicationSecretKey1"
         }]
+    },
+    {
+        "name": "Lifecycle",
+        "email": "inspector@lifecycle.info",
+        "arn": "arn:aws:iam::123456789016:root",
+        "canonicalID": "http://acs.zenko.io/accounts/service/lifecycle",
+        "shortid": "123456789016",
+        "keys": [{
+            "access": "lifecycleKey1",
+            "secret": "lifecycleSecretKey1"
+        }]
     }]
 }

--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -107,7 +107,8 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
         size,
         headers,
         isDeleteMarker,
-        replicationInfo: getReplicationInfo(objectKey, bucketMD, false, size),
+        replicationInfo: getReplicationInfo(
+            objectKey, bucketMD, false, size, null, null, authInfo),
         log,
     };
     if (!isDeleteMarker) {

--- a/lib/api/apiUtils/object/getReplicationInfo.js
+++ b/lib/api/apiUtils/object/getReplicationInfo.js
@@ -1,5 +1,6 @@
 const s3config = require('../../../Config').config;
 const constants = require('../../../../constants');
+const { isBackbeatUser } = require('../authorization/aclChecks');
 
 function _getBackend(objectMD, site) {
     const backends = objectMD ? objectMD.replicationInfo.backends : [];
@@ -68,14 +69,26 @@ function _getReplicationInfo(rule, replicationConfig, content, operationType,
  * @param {boolean} objSize - The size, in bytes, of the object being PUT
  * @param {string} operationType - The type of operation to replicate
  * @param {object} objectMD - The object metadata
+ * @param {AuthInfo} [authInfo] - authentication info of object owner
  * @return {undefined}
  */
 function getReplicationInfo(objKey, bucketMD, isMD, objSize, operationType,
-    objectMD) {
+    objectMD, authInfo) {
     const content = isMD || objSize === 0 ? ['METADATA'] : ['DATA', 'METADATA'];
     const config = bucketMD.getReplicationConfiguration();
-    // If bucket does not have a replication configuration, do not replicate.
-    if (config) {
+
+    // Do not replicate object in the following cases:
+    //
+    // - bucket does not have a replication configuration
+    //
+    // - replication configuration does not apply to the object
+    //   (i.e. no rule matches object prefix)
+    //
+    // - object owner is an internal service account like Lifecycle
+    //   (because we do not want to replicate objects created from
+    //   actions triggered by internal services, by design)
+
+    if (config && (!authInfo || !isBackbeatUser(authInfo.getCanonicalID()))) {
         const rule = config.rules.find(rule => objKey.startsWith(rule.prefix));
         if (rule) {
             return _getReplicationInfo(rule, config, content, operationType,

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -69,6 +69,7 @@ function makeAuthInfo(accessKey) {
             + 'cd47ef2be',
         accessKey2: '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7'
             + 'cd47ef2bf',
+        lifecycleKey1: '0123456789abcdef/lifecycle',
         default: crypto.randomBytes(32).toString('hex'),
     };
     canIdMap[constants.publicId] = constants.publicId;


### PR DESCRIPTION
All actions coming from lifecycle (or potentially any service account)
are not replicated anymore. This applies now to delete markers created
by lifecycle expiration rules.
