### PR TITLE
feat: check metadata in non-deep healthchecks

### DIFF
--- a/lib/utilities/healthcheckHandler.js
+++ b/lib/utilities/healthcheckHandler.js
@@ -82,7 +82,12 @@ function routeHandler(deep, req, res, log, statsClient, cb) {
         return cb(errors.BadRequest, []);
     }
     if (!deep) {
-        return statsClient.getStats(log, 's3', cb);
+        return metadata.checkHealth(log, err => {
+            if (err) {
+                return cb(errors.InternalError, []);
+            }
+            return statsClient.getStats(log, 's3', cb);
+        });
     }
     return clientCheck(false, log, cb);
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "github:scality/Arsenal#6413c92",
+    "arsenal": "github:scality/Arsenal#b8ad86a",
     "async": "~2.5.0",
     "aws-sdk": "2.28.0",
     "azure-storage": "^2.1.0",


### PR DESCRIPTION
This adds metadata health checks to the route `/_/healthcheck`.