### PR TITLE
Bugfix/zenko 791 quota update on put fail

### DIFF
--- a/lib/data/multipleBackendGateway.js
+++ b/lib/data/multipleBackendGateway.js
@@ -201,7 +201,22 @@ const multipleBackendGateway = {
                     return cb(err);
                 }
                 return client.uploadPart(request, streamingV4Params, stream,
-                    size, key, uploadId, partNumber, bucketName, log, cb);
+                size, key, uploadId, partNumber, bucketName, log,
+                (err, partInfo) => {
+                    if (err) {
+                        // if error putting part, counter should be decremented
+                        return locationStorageCheck(location, -size, log,
+                        error => {
+                            if (error) {
+                                log.error('Error decrementing location ' +
+                                    'metric following object PUT failure',
+                                    { error: error.message });
+                            }
+                            return cb(err);
+                        });
+                    }
+                    return cb(null, partInfo);
+                });
             });
         }
         return cb();
@@ -287,7 +302,19 @@ const multipleBackendGateway = {
                         dataStoreType: client.clientType,
                         dataStoreVersionId,
                     };
-                    cb(err, dataRetrievalInfo);
+                    if (err) {
+                        // if error copying obj, counter should be decremented
+                        return locationStorageCheck(destLocationConstraintName,
+                        -storeMetadataParams.size, log, error => {
+                            if (error) {
+                                log.error('Error decrementing location ' +
+                                    'metric following object PUT failure',
+                                    { error: error.message });
+                            }
+                            return cb(err);
+                        });
+                    }
+                    return cb(null, dataRetrievalInfo);
                 });
             });
         }

--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -159,7 +159,16 @@ const data = {
             return _put(cipherBundle, value, valueSize, keyContext, backendInfo,
             log, (err, dataRetrievalInfo, hashedStream) => {
                 if (err) {
-                    return cb(err);
+                    // if error putting object, counter should be decremented
+                    return locationStorageCheck(location, -valueSize, log,
+                    error => {
+                        if (error) {
+                            log.error('Error decrementing location metric ' +
+                                'following object PUT failure',
+                                { error: error.message });
+                        }
+                        return cb(err);
+                    });
                 }
                 if (hashedStream) {
                     if (hashedStream.completedHash) {


### PR DESCRIPTION
Location metric is updated before a data is actually put. If put fails, metric should be decremented appropriately.