### PR TITLE
bf: ZENKO-916 do not replicate ACL change

### DIFF
--- a/lib/metadata/acl.js
+++ b/lib/metadata/acl.js
@@ -1,6 +1,5 @@
 const { errors } = require('arsenal');
 
-const getReplicationInfo = require('../api/apiUtils/object/getReplicationInfo');
 const aclUtils = require('../utilities/aclUtils');
 const constants = require('../../constants');
 const metadata = require('../metadata/wrapper');
@@ -17,12 +16,6 @@ const acl = {
         log.trace('updating object acl in metadata');
         // eslint-disable-next-line no-param-reassign
         objectMD.acl = addACLParams;
-        const replicationInfo = getReplicationInfo(objectKey, bucket, true);
-        if (replicationInfo) {
-            // eslint-disable-next-line no-param-reassign
-            objectMD.replicationInfo = Object.assign({},
-                objectMD.replicationInfo, replicationInfo);
-        }
         metadata.putObjectMD(bucket.getName(), objectKey, objectMD, params, log,
             cb);
     },


### PR DESCRIPTION
We should not reset the replication status to PENDING when changing
ACLs of an object. This because we choose not to replicate ACLs to
replication targets. Later on we may see this as a feature but not
now.

As per description in ZENKO-916, it fixes because putting ACLs is the
only known problematic case where it breaks with a transient source
location. E.g. object tags get replicated correctly because we only
replicate tags specifically in such case.

Note that https://scality.atlassian.net/browse/ZENKO-932 may look like a similar issue from a user standpoint but will be treated separately as the root cause is different.
