### PR TITLE
Bugfix/zenko 903/get bucket list on report

### DIFF
--- a/lib/utilities/reportHandler.js
+++ b/lib/utilities/reportHandler.js
@@ -193,6 +193,12 @@ function getCRRStats(log, cb, _config) {
                 return done(null, retObj);
             }
         ),
+        retrieveRedisClients: done => {
+            if (process.env.CI === 'true') {
+                return backbeatMetrics.listClients(done);
+            }
+            return done(null, []);
+        },
     }, (err, res) => {
         if (err) {
             log.error('failed to get CRR stats', {
@@ -201,16 +207,28 @@ function getCRRStats(log, cb, _config) {
             });
             return cb(null, {});
         }
-        const total = (res && res.total) || {};
-        const byLocation = (res && res.byLocation) || {};
-        const retObj = {
-            completions: total.completions,
-            failures: total.failures,
-            backlog: total.backlog,
-            throughput: total.throughput,
-            byLocation,
-        };
-        return cb(null, retObj);
+        return backbeatMetrics.disconnect(err => {
+            if (err) {
+                log.error('failed to close redis client', {
+                    method: 'getCRRStats',
+                    error: err,
+                });
+                return cb(null, {});
+            }
+            const total = (res && res.total) || {};
+            const byLocation = (res && res.byLocation) || {};
+            const retObj = {
+                completions: total.completions,
+                failures: total.failures,
+                backlog: total.backlog,
+                throughput: total.throughput,
+                byLocation,
+            };
+            if (process.env.CI === 'true') {
+                retObj.clients = res.retrieveRedisClients;
+            }
+            return cb(null, retObj);
+        });
     });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -223,8 +223,8 @@
       "dev": true
     },
     "arsenal": {
-      "version": "github:scality/Arsenal#a2311bb69cef9bca2e861fef217ccd56fac71619",
-      "from": "github:scality/Arsenal#a2311bb",
+      "version": "github:scality/Arsenal#db743f82695357cbd6461331d0eec92894229dea",
+      "from": "github:scality/Arsenal#db743f8",
       "requires": {
         "JSONStream": "^1.0.0",
         "ajv": "4.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -223,8 +223,8 @@
       "dev": true
     },
     "arsenal": {
-      "version": "github:scality/Arsenal#6413c92fbcee700230cfec8c4984fa8e9aa4d833",
-      "from": "github:scality/Arsenal#6413c92",
+      "version": "github:scality/Arsenal#a2311bb69cef9bca2e861fef217ccd56fac71619",
+      "from": "github:scality/Arsenal#a2311bb",
       "requires": {
         "JSONStream": "^1.0.0",
         "ajv": "4.10.0",
@@ -232,6 +232,7 @@
         "bson": "2.0.4",
         "debug": "~2.3.3",
         "diskusage": "^0.2.2",
+        "fcntl": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
         "ioctl": "2.0.0",
         "ioredis": "2.4.0",
         "ipaddr.js": "1.2.0",
@@ -670,10 +671,14 @@
     "bucketclient": {
       "version": "github:scality/bucketclient#5aa99d7b25fdfb5a42b787cce7710cdec8ac78f0",
       "from": "github:scality/bucketclient#5aa99d7",
+      "requires": {
+        "arsenal": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
+        "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2"
+      },
       "dependencies": {
         "arsenal": {
           "version": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
-          "from": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
+          "from": "github:scality/Arsenal#7.4.0.3",
           "requires": {
             "JSONStream": "^1.0.0",
             "ajv": "4.10.0",
@@ -715,7 +720,7 @@
         },
         "werelogs": {
           "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
-          "from": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+          "from": "github:scality/werelogs#7.4.0.3",
           "requires": {
             "safe-json-stringify": "^1.0.3"
           }
@@ -867,13 +872,13 @@
       "resolved": "github:scality/cdmiclient#8f0c2e6331dfa905bfe269fb4e1558d65ca0b866",
       "optional": true,
       "requires": {
-        "arsenal": "github:scality/Arsenal#91fbc3fd23df04198e751bdadd9a68a58fff2f82",
+        "arsenal": "github:scality/Arsenal#5cf55fcb68ee46b58e0500daf2eb102a62f76334",
         "async": "~1.4.2",
         "werelogs": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46"
       },
       "dependencies": {
         "arsenal": {
-          "version": "github:scality/Arsenal#91fbc3fd23df04198e751bdadd9a68a58fff2f82",
+          "version": "github:scality/Arsenal#5cf55fcb68ee46b58e0500daf2eb102a62f76334",
           "from": "github:scality/Arsenal#development/8.0",
           "optional": true,
           "requires": {
@@ -883,6 +888,7 @@
             "bson": "2.0.4",
             "debug": "~2.3.3",
             "diskusage": "^0.2.2",
+            "fcntl": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
             "ioctl": "2.0.0",
             "ioredis": "2.4.0",
             "ipaddr.js": "1.2.0",
@@ -1790,6 +1796,14 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fcntl": {
+      "version": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
+      "from": "github:scality/node-fcntl",
+      "requires": {
+        "bindings": "^1.1.1",
+        "nan": "^2.3.2"
+      }
     },
     "figures": {
       "version": "1.7.0",
@@ -4353,10 +4367,13 @@
     "sproxydclient": {
       "version": "github:scality/sproxydclient#45090b76b24ca1d05482bf151ba84ff6178423d1",
       "from": "github:scality/sproxydclient#45090b7",
+      "requires": {
+        "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2"
+      },
       "dependencies": {
         "werelogs": {
           "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
-          "from": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+          "from": "github:scality/werelogs#7.4.0.3",
           "requires": {
             "safe-json-stringify": "^1.0.3"
           }
@@ -4739,7 +4756,7 @@
     "uc.micro": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.5.tgz",
-      "integrity": "sha1-DGXxX4FaoItWCmHOi023/8P0U3Y=",
+      "integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg==",
       "dev": true
     },
     "uglify-js": {
@@ -4793,19 +4810,21 @@
       "version": "github:scality/utapi#6d0c8dd1c0cd28e40a3534758fcf80216f023690",
       "from": "github:scality/utapi#6d0c8dd",
       "requires": {
+        "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
         "async": "^2.0.1",
         "ioredis": "^2.3.0",
-        "node-schedule": "1.2.0"
+        "node-schedule": "1.2.0",
+        "vaultclient": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
+        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61"
       },
       "dependencies": {
         "arsenal": {
-          "version": "github:scality/Arsenal#c749725410abd62a4e90ef71ecded5d606f38adf",
-          "from": "github:scality/Arsenal#c749725410abd62a4e90ef71ecded5d606f38adf",
+          "version": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
+          "from": "github:scality/Arsenal#67365083",
           "requires": {
             "JSONStream": "^1.0.0",
             "ajv": "4.10.0",
             "async": "~2.1.5",
-            "bson": "2.0.4",
             "debug": "~2.3.3",
             "diskusage": "^0.2.2",
             "ioctl": "2.0.0",
@@ -4814,7 +4833,6 @@
             "joi": "^10.6",
             "level": "~1.6.0",
             "level-sublevel": "~6.6.1",
-            "mongodb": "^3.0.1",
             "node-forge": "^0.7.1",
             "simple-glob": "^0.1",
             "socket.io": "~1.7.3",
@@ -4832,13 +4850,6 @@
               "requires": {
                 "lodash": "^4.14.0"
               }
-            },
-            "werelogs": {
-              "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-              "from": "github:scality/werelogs#0ff7ec82",
-              "requires": {
-                "safe-json-stringify": "1.0.3"
-              }
             }
           }
         },
@@ -4850,17 +4861,9 @@
             "graceful-readlink": ">= 1.0.0"
           }
         },
-        "mongodb": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.1.tgz",
-          "integrity": "sha512-GU9oWK4pi8PC7NyGiwjFMwZyMqwGWoMEMvM0LZh7UKW/FFAqgmZKjjriD+5MEOCDUJE2dtHX93/K5UtDxO0otg==",
-          "requires": {
-            "mongodb-core": "3.1.0"
-          }
-        },
         "vaultclient": {
-          "version": "github:scality/vaultclient#ba81ffe0e1b7821aa5ef6a9ca000ebd63586d506",
-          "from": "github:scality/vaultclient#ba81ffe0e1b7821aa5ef6a9ca000ebd63586d506",
+          "version": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
+          "from": "github:scality/vaultclient#fbd9988d",
           "requires": {
             "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
             "commander": "2.9.0",
@@ -4868,46 +4871,6 @@
             "xml2js": "0.4.17"
           },
           "dependencies": {
-            "arsenal": {
-              "version": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
-              "from": "github:scality/Arsenal#67365083",
-              "requires": {
-                "JSONStream": "^1.0.0",
-                "ajv": "4.10.0",
-                "async": "~2.1.5",
-                "debug": "~2.3.3",
-                "diskusage": "^0.2.2",
-                "ioctl": "2.0.0",
-                "ioredis": "2.4.0",
-                "ipaddr.js": "1.2.0",
-                "joi": "^10.6",
-                "level": "~1.6.0",
-                "level-sublevel": "~6.6.1",
-                "node-forge": "^0.7.1",
-                "simple-glob": "^0.1",
-                "socket.io": "~1.7.3",
-                "socket.io-client": "~1.7.3",
-                "utf8": "2.1.2",
-                "uuid": "^3.0.1",
-                "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-                "xml2js": "~0.4.16"
-              }
-            },
-            "async": {
-              "version": "2.1.5",
-              "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
-              "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
-              "requires": {
-                "lodash": "^4.14.0"
-              }
-            },
-            "werelogs": {
-              "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-              "from": "github:scality/werelogs#0ff7ec82",
-              "requires": {
-                "safe-json-stringify": "1.0.3"
-              }
-            },
             "xml2js": {
               "version": "0.4.17",
               "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
@@ -4920,8 +4883,8 @@
           }
         },
         "werelogs": {
-          "version": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46",
-          "from": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46",
+          "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+          "from": "github:scality/werelogs#0ff7ec82",
           "requires": {
             "safe-json-stringify": "1.0.3"
           }
@@ -5003,13 +4966,15 @@
       "version": "github:scality/vaultclient#754b6e1e1121f44bc3719e35b836a9185d6d5e1a",
       "from": "github:scality/vaultclient#754b6e1",
       "requires": {
+        "arsenal": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
         "commander": "2.9.0",
+        "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
         "xml2js": "0.4.17"
       },
       "dependencies": {
         "arsenal": {
           "version": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
-          "from": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
+          "from": "github:scality/Arsenal#7.4.0.3",
           "requires": {
             "JSONStream": "^1.0.0",
             "ajv": "4.10.0",
@@ -5059,7 +5024,7 @@
         },
         "werelogs": {
           "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
-          "from": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+          "from": "github:scality/werelogs#7.4.0.3",
           "requires": {
             "safe-json-stringify": "^1.0.3"
           }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "github:scality/Arsenal#b8ad86a",
+    "arsenal": "github:scality/Arsenal#a2311bb",
     "async": "~2.5.0",
     "aws-sdk": "2.28.0",
     "azure-storage": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "github:scality/Arsenal#a2311bb",
+    "arsenal": "github:scality/Arsenal#db743f8",
     "async": "~2.5.0",
     "aws-sdk": "2.28.0",
     "azure-storage": "^2.1.0",

--- a/tests/functional/utilities/countItems.js
+++ b/tests/functional/utilities/countItems.js
@@ -1,0 +1,192 @@
+const assert = require('assert');
+const async = require('async');
+const uuid = require('uuid/v4');
+
+const BucketUtility =
+    require('../aws-node-sdk/lib/utility/bucket-util');
+const metadata = require('../../../lib/metadata/wrapper');
+const { DummyRequestLogger } = require('../../unit/helpers');
+const { mongoClient } = require('./mongoClient');
+
+const runIfMongo = process.env.S3METADATA === 'mongodb' ?
+    describe : describe.skip;
+
+const logger = new DummyRequestLogger();
+
+const objCnt = Math.floor(Math.random() * 10) + 10;
+const bodySize = Math.floor(Math.random() * 100) + 10;
+const outBucketCnt = Math.floor(Math.random() * 5) + 1;
+const body = Buffer.alloc(bodySize);
+
+const genUniqID = () => uuid().replace(/-/g, '');
+const testBuckets = [
+    {
+        bucketName: `non-version-bucket-${genUniqID()}`,
+        versioning: false,
+    },
+    {
+        bucketName: `version-bucket-${genUniqID()}`,
+        versioning: true,
+    },
+];
+
+function populateDB(s3Client, cb) {
+    const put = (bucketName, cb) => {
+        async.timesLimit(objCnt, 5,
+        (n, next) => s3Client.putObject({
+            Bucket: bucketName,
+            Key: `key-${n}`,
+            Body: body },
+        next), cb);
+    };
+
+    async.eachLimit(testBuckets, 1, (b, next) => {
+        const { bucketName, versioning } = b;
+        async.series({
+            createBucket: done =>
+                s3Client.createBucket({ Bucket: bucketName }, done),
+            putBucketVersioning: done => {
+                if (!versioning) {
+                    return done();
+                }
+                return s3Client.putBucketVersioning({
+                    Bucket: b.bucketName,
+                    VersioningConfiguration: { Status: 'Enabled' },
+                }, done);
+            },
+            putObjects: done => put(bucketName, done),
+            putVersions: done => {
+                if (!versioning) {
+                    return done();
+                }
+                return put(bucketName, done);
+            },
+        }, next);
+    }, cb);
+}
+
+function cleanDB(bucketUtil, cb) {
+    async.eachLimit(testBuckets, 1, (b, next) => {
+        const { bucketName } = b;
+        const emptyBucket =
+            async.asyncify(bucketUtil.empty.bind(bucketUtil));
+        const deleteBucket =
+            async.asyncify(bucketUtil.deleteOne.bind(bucketUtil));
+        async.series([
+            done => emptyBucket(bucketName, done),
+            done => deleteBucket(bucketName, done),
+        ], next);
+    }, cb);
+}
+
+const ownerCanonicalId =
+    '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be';
+
+const refResults = {
+    objects: 2 * objCnt,
+    versions: objCnt,
+    buckets: 2,
+    bucketList: testBuckets.map(b => ({
+        name: b.bucketName,
+        location: 'us-east-1',
+        isVersioned: b.versioning,
+        ownerCanonicalId,
+    })),
+    dataManaged: {
+        total: { curr: 2 * objCnt * bodySize, prev: objCnt * bodySize },
+        byLocation: {
+            'us-east-1':
+                { curr: 2 * objCnt * bodySize, prev: objCnt * bodySize },
+        },
+    },
+};
+
+const sortFn = (a, b) => {
+    if (a.name < b.name) {
+        return -1;
+    }
+    if (a.name > b.name) {
+        return 1;
+    }
+    return 0;
+};
+
+function assertResults(res, expRes) {
+    Object.keys(expRes).forEach(key => {
+        if (Array.isArray(expRes[key]) && Array.isArray(res[key])) {
+            assert.deepStrictEqual(
+                res[key].sort(sortFn), expRes[key].sort(sortFn));
+        } else {
+            assert.deepStrictEqual(res[key], expRes[key]);
+        }
+    });
+}
+
+function createOutBuckets(buckets, cb) {
+    async.eachLimit(buckets, 5, (b, next) => {
+        mongoClient.createBucket(b, 'us-east-1', next);
+    }, cb);
+}
+
+function deleteOutBuckets(buckets, cb) {
+    async.eachLimit(buckets, 5, (b, next) => {
+        mongoClient.deleteBucket(b, next);
+    }, cb);
+}
+
+runIfMongo('reportHandler::countItems', function testSuite() {
+    this.timeout(200000);
+    const bucketUtil = new BucketUtility('default', {});
+
+    before(done => populateDB(bucketUtil.s3, done));
+    after(done => cleanDB(bucketUtil, done));
+
+    it('should return correct countItems report', done => {
+        async.series([
+            next => metadata.setup(next),
+            next => metadata.countItems(logger, (err, res) => {
+                assertResults(res, refResults);
+                next();
+            }),
+        ], done);
+    });
+
+    describe('with "out-of-band" bucket updates', () => {
+        const outBuckets = Array.from(Array(outBucketCnt).keys()).map(
+            () => `out-of-band-bucket${genUniqID()}`);
+
+        before(done => {
+            async.series([
+                next => mongoClient.connectClient(next),
+                next => createOutBuckets(outBuckets, next),
+            ], done);
+        });
+
+        after(done => {
+            async.series([
+                next => deleteOutBuckets(outBuckets, next),
+                next => mongoClient.disconnectClient(next),
+            ], done);
+        });
+
+        it('should retrieve update bucket list', done => {
+            async.series([
+                next => metadata.setup(next),
+                next => metadata.countItems(logger, (err, res) => {
+                    const expResults = JSON.parse(JSON.stringify(refResults));
+                    expResults.buckets = 2 + outBucketCnt;
+                    outBuckets.forEach(b => {
+                        expResults.bucketList.push({
+                            name: b,
+                            location: 'us-east-1',
+                            isVersioned: false,
+                            ownerCanonicalId,
+                        });
+                    });
+                    assertResults(res, expResults);
+                    next();
+                }),
+            ], done);
+        });
+    });
+});

--- a/tests/functional/utilities/mongoClient.js
+++ b/tests/functional/utilities/mongoClient.js
@@ -1,0 +1,111 @@
+const async = require('async');
+const { models, errors } = require('arsenal');
+const BucketInfo = models.BucketInfo;
+const { MongoClient } = require('mongodb');
+
+const replicaSetHosts = 'localhost:27018,localhost:27019,localhost:27020';
+const writeConcern = 'majority';
+const replicaSet = 'rs0';
+const readPreference = 'primary';
+const database = 'metadata';
+
+const METASTORE = '__metastore';
+
+const mongoUrl = `mongodb://${replicaSetHosts}/?w=${writeConcern}&` +
+    `replicaSet=${replicaSet}&readPreference=${readPreference}`;
+
+const ownerCanonicalId =
+    '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be';
+
+class MongoTestClient {
+    constructor(config) {
+        this.mongoUrl = config.mongoUrl;
+        this.options = config.options;
+        this.database = config.database;
+        this.client = null;
+        this.db = null;
+    }
+
+    isConnected() {
+        return !!this.client;
+    }
+
+    disconnectClient(cb) {
+        return this.client.close(true, cb);
+    }
+
+    connectClient(cb) {
+        return MongoClient.connect(this.mongoUrl, this.options,
+        (err, client) => {
+            if (err) {
+                return cb(err);
+            }
+            this.client = client;
+            this.db = client.db(this.database, {
+                ignoreUndefined: true,
+            });
+            return cb();
+        });
+    }
+
+    createBucket(bucketName, location, cb) {
+        const creationDate = new Date().toJSON();
+        const bucketMD = new BucketInfo(bucketName,
+            ownerCanonicalId, ownerCanonicalId, creationDate,
+            BucketInfo.currentModelVersion());
+        bucketMD.setLocationConstraint(location);
+        const bucketInfo = BucketInfo.fromObj(bucketMD);
+        const bucketMDStr = bucketInfo.serialize();
+        const mdValue = JSON.parse(bucketMDStr);
+        const m = this.db.collection(METASTORE);
+        m.update({
+            _id: bucketName,
+        }, {
+            _id: bucketName,
+            value: mdValue,
+        }, {
+            upsert: true,
+        }, err => {
+            if (err) {
+                return cb(errors.InternalError);
+            }
+            return this.db.createCollection(bucketName, {}, cb);
+        });
+    }
+
+    deleteBucket(bucketName, cb) {
+        return async.series({
+            deleteCollection: next => {
+                const c = this.db.collection(bucketName);
+                c.drop({}, err => {
+                    if (err && err.codeName !== 'NameSpaceNodeFound') {
+                        return next(err);
+                    }
+                    return next();
+                });
+            },
+            deleteMetastoreEntry: next => {
+                const m = this.db.collection(METASTORE);
+                m.findOneAndDelete({
+                    _id: bucketName,
+                }, {}, (err, res) => {
+                    if (err || res.ok !== 1) {
+                        return next(errors.InternalError);
+                    }
+                    return next();
+                });
+            },
+        }, cb);
+    }
+}
+
+const mongoClient = new MongoTestClient({
+    mongoUrl,
+    options: {},
+    database,
+});
+
+module.exports = {
+    MongoTestClient,
+    mongoClient,
+};

--- a/tests/functional/utilities/reportHandler.js
+++ b/tests/functional/utilities/reportHandler.js
@@ -126,7 +126,7 @@ describe('reportHandler::_crrRequest', function testSuite() {
                 redisClient.clear(next),
             disconnectRedisPopulator: next =>
                 redisClient.disconnect(next),
-            disconnectBackcbeatMetrics: next =>
+            disconnectBackbeatMetrics: next =>
                 backbeatMetrics.disconnect(next),
         }, done);
     });

--- a/tests/functional/utilities/reportHandler.js
+++ b/tests/functional/utilities/reportHandler.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const async = require('async');
 const http = require('http');
+const Redis = require('ioredis');
 const { backbeat } = require('arsenal');
 const { RedisClient } = require('arsenal').metrics;
 
@@ -73,6 +74,31 @@ function populateRedis(redisClient, cb) {
     return redisClient.batch(cmdKeys, cb);
 }
 
+function assertResults(res) {
+    const testRes = res;
+    delete testRes.clients;
+    assert.deepStrictEqual(testRes, {
+        completions: { count: 10000, size: 10000 },
+        failures: { count: 2000, size: 2000 },
+        backlog: { count: 10000, size: 10000 },
+        throughput: { count: 11, size: 11 },
+        byLocation: {
+            test: {
+                completions: { count: 5000, size: 5000 },
+                failures: { count: 1000, size: 1000 },
+                backlog: { count: 5000, size: 5000 },
+                throughput: { count: 5, size: 5 },
+            },
+            noshow: {
+                completions: { count: 5000, size: 5000 },
+                failures: { count: 1000, size: 1000 },
+                backlog: { count: 5000, size: 5000 },
+                throughput: { count: 5, size: 5 },
+            },
+        },
+    });
+}
+
 describe('reportHandler::_crrRequest', function testSuite() {
     this.timeout(20000);
     let redisClient;
@@ -84,7 +110,7 @@ describe('reportHandler::_crrRequest', function testSuite() {
             next => redisClient.clear(next),
             next => populateRedis(redisClient, next),
         ], err => {
-            assert.ifError(err, `Expected success, but got error ${err}`);
+            assert.ifError(err);
             backbeatMetrics = new backbeat.Metrics({
                 redisConfig: config.redis,
                 validSites: sites,
@@ -95,18 +121,20 @@ describe('reportHandler::_crrRequest', function testSuite() {
     });
 
     after(done => {
-        redisClient.clear(err => {
-            assert.ifError(err, `Expected success, but got error ${err}`);
-            redisClient._client.disconnect();
-            backbeatMetrics._redisClient._client.disconnect();
-            return done();
-        });
+        async.series({
+            clearRedis: next =>
+                redisClient.clear(next),
+            disconnectRedisPopulator: next =>
+                redisClient.disconnect(next),
+            disconnectBackcbeatMetrics: next =>
+                backbeatMetrics.disconnect(next),
+        }, done);
     });
 
     it('should retrieve CRR metrics for all sites', done => {
         _crrRequest(backbeatMetrics, testDetails, 'all', logger,
         (err, res) => {
-            assert.ifError(err, `Expected success, but got error ${err}`);
+            assert.ifError(err);
             assert.deepStrictEqual(res, {
                 completions: { count: 10000, size: 10000 },
                 failures: { count: 2000, size: 2000 },
@@ -120,7 +148,7 @@ describe('reportHandler::_crrRequest', function testSuite() {
     it('should retrieve CRR metrics for specific site', done => {
         _crrRequest(backbeatMetrics, testDetails, 'test', logger,
         (err, res) => {
-            assert.ifError(err, `Expected success, but got error ${err}`);
+            assert.ifError(err);
             assert.deepStrictEqual(res, {
                 completions: { count: 5000, size: 5000 },
                 failures: { count: 1000, size: 1000 },
@@ -136,48 +164,69 @@ describe('reportHandler::getCRRStats', function testSuite() {
     this.timeout(20000);
     let redisClient;
 
-    before(done => {
+    beforeEach(done => {
         redisClient = new RedisClient(config.redis, logger);
         async.series([
             next => redisClient.clear(next),
             next => populateRedis(redisClient, next),
         ], err => {
-            assert.ifError(err, `Expected success, but got error ${err}`);
+            assert.ifError(err);
             return done();
         });
     });
 
-    after(done => {
-        redisClient.clear(err => {
-            assert.ifError(err, `Expected success, but got error ${err}`);
-            redisClient._client.disconnect();
-            return done();
+    afterEach(done => {
+        async.series({
+            clearRedis: next =>
+                redisClient.clear(next),
+            disconnectRedisPopulator: next =>
+                redisClient.disconnect(next),
+        }, done);
+    });
+
+    it('should disconnect backbeat.metrics client on report completion',
+    done => {
+        const redisChecker = new Redis({ host: 'localhost', port: 6379 });
+        redisChecker.once('error', err => {
+            redisClient.disconnect();
+            done(err);
         });
+        let preCheckCount;
+        async.series({
+            preCheck: next => {
+                redisChecker.client('list', (err, res) => {
+                    assert.ifError(err);
+                    const clients = res.split('\n').filter(c => !!c);
+                    preCheckCount = clients.length;
+                    next();
+                });
+            },
+            checkResults: next => {
+                getCRRStats(logger, (err, res) => {
+                    assert.ifError(err);
+                    assert(res.clients);
+                    const clients = res.clients.split('\n').filter(c => !!c);
+                    assert.strictEqual(clients.length, preCheckCount + 1);
+                    assertResults(res);
+                    next();
+                }, config);
+            },
+            postCheck: next => {
+                redisChecker.client('list', (err, res) => {
+                    assert.ifError(err);
+                    const clients = res.split('\n').filter(c => !!c);
+                    assert.strictEqual(clients.length, preCheckCount);
+                    next();
+                });
+            },
+            disconnectTestClient: next => redisChecker.quit(next),
+        }, done);
     });
 
     it('should retrieve CRR metrics', done => {
         getCRRStats(logger, (err, res) => {
-            assert.ifError(err, `Expected success, but got error ${err}`);
-            assert.deepStrictEqual(res, {
-                completions: { count: 10000, size: 10000 },
-                failures: { count: 2000, size: 2000 },
-                backlog: { count: 10000, size: 10000 },
-                throughput: { count: 11, size: 11 },
-                byLocation: {
-                    test: {
-                        completions: { count: 5000, size: 5000 },
-                        failures: { count: 1000, size: 1000 },
-                        backlog: { count: 5000, size: 5000 },
-                        throughput: { count: 5, size: 5 },
-                    },
-                    noshow: {
-                        completions: { count: 5000, size: 5000 },
-                        failures: { count: 1000, size: 1000 },
-                        backlog: { count: 5000, size: 5000 },
-                        throughput: { count: 5, size: 5 },
-                    },
-                },
-            });
+            assert.ifError(err);
+            assertResults(res);
             return done();
         }, config);
     });
@@ -240,7 +289,7 @@ describe('reportHandler::getReplicationStates', function testSuite() {
 
         it('should return empty object if a request error occurs', done => {
             getReplicationStates(logger, (err, res) => {
-                assert.ifError(err, `Expected success, but got error ${err}`);
+                assert.ifError(err);
                 assert.deepStrictEqual(res, {});
                 done();
             }, { host: 'nonexisthost', port: testPort });
@@ -249,7 +298,7 @@ describe('reportHandler::getReplicationStates', function testSuite() {
         it('should return empty object if response status code is >= 400',
         done => {
             getReplicationStates(logger, (err, res) => {
-                assert.ifError(err, `Expected success, but got error ${err}`);
+                assert.ifError(err);
                 assert.deepStrictEqual(res, {});
                 done();
             }, { host: 'localhost', port: testPort });
@@ -281,7 +330,7 @@ describe('reportHandler::getReplicationStates', function testSuite() {
                         location2: expectedScheduleResults.location2,
                     },
                 };
-                assert.ifError(err, `Expected success, but got error ${err}`);
+                assert.ifError(err);
                 assert.deepStrictEqual(res, expectedResults);
                 done();
             }, { host: 'localhost', port: testPort });


### PR DESCRIPTION
Adds tests for verifying that the mongo-counter is able to retrieve the updated bucket list when new buckets have been added by out-of-band means. This will simulate the scenario in which cloudserver worker pods will create the buckets whereby not triggering the counter on the manager pod. The manager should still perform a report with the up-to-date bucket list.