### PR TITLE
INTEGRATION [PR#1475 > development/8.1] ft: ZENKO-925 increase metrics expiry to 24hrs

### DIFF
--- a/lib/utilities/reportHandler.js
+++ b/lib/utilities/reportHandler.js
@@ -148,7 +148,7 @@ function getCRRStats(log, cb, _config) {
     const backbeatMetrics = new backbeat.Metrics({
         redisConfig: redis,
         validSites: sites,
-        internalStart: Date.now() - 900000, // 15 minutes ago.
+        internalStart: Date.now() - (86400 * 1000), // 24 hours ago.
     }, log);
     const redisKeys = {
         ops: 'bb:crr:ops',

--- a/package-lock.json
+++ b/package-lock.json
@@ -223,8 +223,8 @@
       "dev": true
     },
     "arsenal": {
-      "version": "github:scality/Arsenal#6413c92fbcee700230cfec8c4984fa8e9aa4d833",
-      "from": "github:scality/Arsenal#6413c92",
+      "version": "github:scality/Arsenal#782c2e9a4ef149bf37bd098e35d43886d03d98c4",
+      "from": "github:scality/Arsenal#782c2e9",
       "requires": {
         "JSONStream": "^1.0.0",
         "ajv": "4.10.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "github:scality/Arsenal#b8ad86a",
+    "arsenal": "github:scality/Arsenal#782c2e9",
     "async": "~2.5.0",
     "aws-sdk": "2.28.0",
     "azure-storage": "^2.1.0",

--- a/tests/functional/utilities/reportHandler.js
+++ b/tests/functional/utilities/reportHandler.js
@@ -54,6 +54,7 @@ const testCRRKeys = [
 ];
 
 const INTERVAL = 300;
+const EXPIRY = 86400;
 
 function _normalizeTimestamp(d) {
     const m = d.getMinutes();
@@ -88,7 +89,7 @@ describe('reportHandler::_crrRequest', function testSuite() {
             backbeatMetrics = new backbeat.Metrics({
                 redisConfig: config.redis,
                 validSites: sites,
-                internalStart: Date.now() - 900000,
+                internalStart: Date.now() - (EXPIRY * 1000),
             }, logger);
             return done();
         });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1475.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/feature/ZENKO-925-increaseMetricsExpiry`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/feature/ZENKO-925-increaseMetricsExpiry
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/feature/ZENKO-925-increaseMetricsExpiry
```

Please always comment pull request #1475 instead of this one.