### PR TITLE
INTEGRATION [PR#1475 > development/8.1] ft: ZENKO-925 increase metrics expiry to 24hrs

### DIFF
--- a/lib/utilities/reportHandler.js
+++ b/lib/utilities/reportHandler.js
@@ -11,6 +11,7 @@ const metadata = require('../metadata/wrapper');
 const monitoring = require('../utilities/monitoringHandler');
 
 const REPORT_MODEL_VERSION = 1;
+const CRR_METRIC_EXPIRY = 86400;
 
 function hasWSOptionalDependencies() {
     try {
@@ -148,7 +149,7 @@ function getCRRStats(log, cb, _config) {
     const backbeatMetrics = new backbeat.Metrics({
         redisConfig: redis,
         validSites: sites,
-        internalStart: Date.now() - 900000, // 15 minutes ago.
+        internalStart: Date.now() - (CRR_METRIC_EXPIRY * 1000), // 24 hours ago
     }, log);
     const redisKeys = {
         ops: 'bb:crr:ops',

--- a/package-lock.json
+++ b/package-lock.json
@@ -223,8 +223,8 @@
       "dev": true
     },
     "arsenal": {
-      "version": "github:scality/Arsenal#db743f82695357cbd6461331d0eec92894229dea",
-      "from": "github:scality/Arsenal#db743f8",
+      "version": "github:scality/Arsenal#06dfdd96126618170888fe0a10826db93fd45042",
+      "from": "github:scality/Arsenal#06dfdd9",
       "requires": {
         "JSONStream": "^1.0.0",
         "ajv": "4.10.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "github:scality/Arsenal#db743f8",
+    "arsenal": "github:scality/Arsenal#06dfdd9",
     "async": "~2.5.0",
     "aws-sdk": "2.28.0",
     "azure-storage": "^2.1.0",

--- a/tests/functional/utilities/reportHandler.js
+++ b/tests/functional/utilities/reportHandler.js
@@ -55,6 +55,7 @@ const testCRRKeys = [
 ];
 
 const INTERVAL = 300;
+const EXPIRY = 86400;
 
 function _normalizeTimestamp(d) {
     const m = d.getMinutes();
@@ -114,7 +115,7 @@ describe('reportHandler::_crrRequest', function testSuite() {
             backbeatMetrics = new backbeat.Metrics({
                 redisConfig: config.redis,
                 validSites: sites,
-                internalStart: Date.now() - 900000,
+                internalStart: Date.now() - (EXPIRY * 1000),
             }, logger);
             return done();
         });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1475.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/feature/ZENKO-925-increaseMetricsExpiry`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/feature/ZENKO-925-increaseMetricsExpiry
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/feature/ZENKO-925-increaseMetricsExpiry
```

Please always comment pull request #1475 instead of this one.