### PR TITLE
bugfix: ZENKO-1018 Disabled status for CRR config

### DIFF
--- a/lib/api/apiUtils/object/getReplicationInfo.js
+++ b/lib/api/apiUtils/object/getReplicationInfo.js
@@ -71,7 +71,8 @@ function getReplicationInfo(objKey, bucketMD, isMD, objSize, operationType,
     const config = bucketMD.getReplicationConfiguration();
     // If bucket does not have a replication configuration, do not replicate.
     if (config) {
-        const rule = config.rules.find(rule => objKey.startsWith(rule.prefix));
+        const rule = config.rules.find(rule =>
+            (objKey.startsWith(rule.prefix) && rule.enabled));
         if (rule) {
             return _getReplicationInfo(rule, config, content, operationType,
                 objectMD);

--- a/tests/unit/api/apiUtils/getReplicationInfo.js
+++ b/tests/unit/api/apiUtils/getReplicationInfo.js
@@ -1,0 +1,56 @@
+const assert = require('assert');
+
+const BucketInfo = require('arsenal').models.BucketInfo;
+const getReplicationInfo =
+      require('../../../../lib/api/apiUtils/object/getReplicationInfo');
+
+function _getObjectReplicationInfo(replicationConfig) {
+    const bucketInfo = new BucketInfo(
+        'testbucket', 'someCanonicalId', 'accountDisplayName',
+        new Date().toJSON(),
+        null, null, null, null, null, null, null, null, null,
+        replicationConfig);
+    return getReplicationInfo('fookey', bucketInfo, true, 123, null, null);
+}
+
+describe('getReplicationInfo helper', () => {
+    it('should get replication info when rules are enabled', () => {
+        const replicationConfig = {
+            role: 'arn:aws:iam::root:role/s3-replication-role',
+            rules: [{
+                prefix: '',
+                enabled: true,
+                storageClass: 'awsbackend',
+            }],
+            destination: 'tosomewhere',
+        };
+        const replicationInfo = _getObjectReplicationInfo(replicationConfig);
+        assert.deepStrictEqual(replicationInfo, {
+            status: 'PENDING',
+            backends: [{
+                site: 'awsbackend',
+                status: 'PENDING',
+                dataStoreVersionId: '',
+            }],
+            content: ['METADATA'],
+            destination: 'tosomewhere',
+            storageClass: 'awsbackend',
+            role: 'arn:aws:iam::root:role/s3-replication-role',
+            storageType: 'aws_s3',
+        });
+    });
+
+    it('should not get replication info when rules are disabled', () => {
+        const replicationConfig = {
+            role: 'arn:aws:iam::root:role/s3-replication-role',
+            rules: [{
+                prefix: '',
+                enabled: false,
+                storageClass: 'awsbackend',
+            }],
+            destination: 'tosomewhere',
+        };
+        const replicationInfo = _getObjectReplicationInfo(replicationConfig);
+        assert.deepStrictEqual(replicationInfo, undefined);
+    });
+});


### PR DESCRIPTION
Do not update the `replicationInfo` property for objects that match the replication config prefix but the rule's status is `Disabled`. This has the effect that the backbeat processor will not attempt CRR on objects that meet this condition.