### PR TITLE
bf: ZENKO-1013 use backbeat api metrics routes for stats

### DIFF
--- a/lib/utilities/reportHandler.js
+++ b/lib/utilities/reportHandler.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const os = require('os');
 
-const { errors, ipCheck, backbeat } = require('arsenal');
+const { errors, ipCheck } = require('arsenal');
 const async = require('async');
 const request = require('request');
 
@@ -11,7 +11,13 @@ const metadata = require('../metadata/wrapper');
 const monitoring = require('../utilities/monitoringHandler');
 
 const REPORT_MODEL_VERSION = 1;
-const CRR_METRIC_EXPIRY = 86400;
+const ASYNCLIMIT = 5;
+
+const REQ_PATHS = {
+    crrSchedules: '/_/crr/resume/all',
+    crrStatus: '/_/crr/status',
+    crrMetricPrefix: '/_/metrics/crr',
+};
 
 function hasWSOptionalDependencies() {
     try {
@@ -97,16 +103,37 @@ function getSystemStats() {
     };
 }
 
-function _crrRequest(backbeatMetrics, rDetails, site, log, cb) {
-    const details = JSON.parse(JSON.stringify(rDetails));
-    // Add `site` as we're not using Backbeat's request parser for the API's URI
-    details.site = site;
-    return backbeatMetrics.getAllMetrics(details, (err, res) => {
+const _makeRequest = (endpoint, path, cb) => {
+    const url = `${endpoint}${path}`;
+    request({ url, json: true }, (error, response, body) => {
+        if (error) {
+            return cb(error);
+        }
+        if (response.statusCode >= 400) {
+            return cb('responseError', body);
+        }
+        if (body) {
+            return cb(null, body);
+        }
+        return cb(null, {});
+    });
+};
+
+function _crrRequest(endpoint, site, log, cb) {
+    const path = `${REQ_PATHS.crrMetricPrefix}/${site}`;
+    return _makeRequest(endpoint, path, (err, res) => {
         if (err) {
-            log.error('error occured when retrieving metrics', {
-                method: '_crrRequest',
-                error: err,
-            });
+            if (err === 'responseError') {
+                log.error('error response from backbeat api', {
+                    error: res,
+                    method: '_crrRequest',
+                });
+            } else {
+                log.error('unable to perform request to backbeat api', {
+                    error: err,
+                    method: '_crrRequest',
+                });
+            }
             return cb(null, {});
         }
         const { completions, failures, backlog, throughput } = res;
@@ -138,47 +165,28 @@ function _crrRequest(backbeatMetrics, rDetails, site, log, cb) {
     });
 }
 
-function getCRRStats(log, cb, _config) {
-    log.debug('getting CRR stats', { method: 'getCRRStats' });
-    const { replicationEndpoints, redis } = _config || config;
-    if (!redis) {
-        log.debug('redis connection not configured', { method: 'getCRRStats' });
-        return process.nextTick(() => cb(null, {}));
-    }
+function getCRRStats(log, cb, _testConfig) {
+    log.debug('request CRR metrics from backbeat api', {
+        method: 'getCRRStats',
+    });
+    const { replicationEndpoints, backbeat } = _testConfig || config;
+    const { host, port } = backbeat;
+    const endpoint = `http://${host}:${port}`;
     const sites = replicationEndpoints.map(endpoint => endpoint.site);
-    const backbeatMetrics = new backbeat.Metrics({
-        redisConfig: redis,
-        validSites: sites,
-        internalStart: Date.now() - (CRR_METRIC_EXPIRY * 1000), // 24 hours ago
-    }, log);
-    const redisKeys = {
-        ops: 'bb:crr:ops',
-        bytes: 'bb:crr:bytes',
-        opsDone: 'bb:crr:opsdone',
-        bytesDone: 'bb:crr:bytesdone',
-        opsFail: 'bb:crr:opsfail',
-        bytesFail: 'bb:crr:bytesfail',
-        failedCRR: 'bb:crr:failed',
-    };
-    const routes = backbeat.routes(redisKeys, sites);
-    const details = routes.find(route =>
-        route.category === 'metrics' && route.type === 'all');
     return async.parallel({
-        total: done => _crrRequest(backbeatMetrics, details, 'all', log, done),
-        byLocation: done => async.map(sites,
-            (site, next) => _crrRequest(backbeatMetrics, details, site, log,
-                (err, res) => {
-                    if (err) {
-                        log.debug('Error in retrieving site metrics', {
-                            method: 'getCRRStats',
-                            error: err,
-                            site,
-                        });
-                        return next(null, { site, stats: {} });
-                    }
-                    return next(null, { site, stats: res });
+        all: done => _crrRequest(endpoint, 'all', log, done),
+        byLocation: done => async.mapLimit(sites, ASYNCLIMIT,
+            (site, next) => _crrRequest(endpoint, site, log, (err, res) => {
+                if (err) {
+                    log.debug('Error in retrieving site metrics', {
+                        method: 'getCRRStats',
+                        error: err,
+                        site,
+                    });
+                    return next(null, { site, stats: {} });
                 }
-            ),
+                return next(null, { site, stats: res });
+            }),
             (err, locStats) => {
                 if (err) {
                     log.error('failed to get CRR stats for site', {
@@ -192,14 +200,7 @@ function getCRRStats(log, cb, _config) {
                     retObj[locStat.site] = locStat.stats;
                 });
                 return done(null, retObj);
-            }
-        ),
-        retrieveRedisClients: done => {
-            if (process.env.CI === 'true') {
-                return backbeatMetrics.listClients(done);
-            }
-            return done(null, []);
-        },
+            }),
     }, (err, res) => {
         if (err) {
             log.error('failed to get CRR stats', {
@@ -208,28 +209,16 @@ function getCRRStats(log, cb, _config) {
             });
             return cb(null, {});
         }
-        return backbeatMetrics.disconnect(err => {
-            if (err) {
-                log.error('failed to close redis client', {
-                    method: 'getCRRStats',
-                    error: err,
-                });
-                return cb(null, {});
-            }
-            const total = (res && res.total) || {};
-            const byLocation = (res && res.byLocation) || {};
-            const retObj = {
-                completions: total.completions,
-                failures: total.failures,
-                backlog: total.backlog,
-                throughput: total.throughput,
-                byLocation,
-            };
-            if (process.env.CI === 'true') {
-                retObj.clients = res.retrieveRedisClients;
-            }
-            return cb(null, retObj);
-        });
+        const all = (res && res.all) || {};
+        const byLocation = (res && res.byLocation) || {};
+        const retObj = {
+            completions: all.completions,
+            failures: all.failures,
+            backlog: all.backlog,
+            throughput: all.throughput,
+            byLocation,
+        };
+        return cb(null, retObj);
     });
 }
 
@@ -239,24 +228,10 @@ function getReplicationStates(log, cb, _testConfig) {
             method: 'getReplicationStates',
         });
     const { host, port } = _testConfig || config.backbeat;
-    const makeRequest = (path, cb) => {
-        const endpoint = `http://${host}:${port}${path}`;
-        request({ url: endpoint, json: true }, (error, response, body) => {
-            if (error) {
-                return cb(error);
-            }
-            if (response.statusCode >= 400) {
-                return cb('responseError', body);
-            }
-            if (body) {
-                return cb(null, body);
-            }
-            return cb(null, {});
-        });
-    };
+    const endpoint = `http://${host}:${port}`;
     async.parallel({
-        states: done => makeRequest('/_/crr/status', done),
-        schedules: done => makeRequest('/_/crr/resume/all', done),
+        states: done => _makeRequest(endpoint, REQ_PATHS.crrStatus, done),
+        schedules: done => _makeRequest(endpoint, REQ_PATHS.crrSchedules, done),
     }, (err, res) => {
         if (err) {
             if (err === 'responseError') {


### PR DESCRIPTION
made changes to `reportHandler` to retrieve CRR metrics through BackbeatAPI as opposed to reading from redis directly