### PR TITLE
Bugfix/zenko 1091 redirect payload

### DIFF
--- a/lib/data/external/AwsClient.js
+++ b/lib/data/external/AwsClient.js
@@ -1,5 +1,6 @@
-const { errors, s3middleware } = require('arsenal');
 const AWS = require('aws-sdk');
+const { errors, s3middleware } = require('arsenal');
+const werelogs = require('werelogs');
 const MD5Sum = s3middleware.MD5Sum;
 const getMetaHeaders = s3middleware.userMetadata.getMetaHeaders;
 const createLogger = require('../multipleBackendLogger');
@@ -23,6 +24,40 @@ class AwsClient {
         this._serverSideEncryption = config.serverSideEncryption;
         this._supportsVersioning = config.supportsVersioning;
         this._client = new AWS.S3(this._s3Params);
+        this._logger = new werelogs.Logger('AwsClient');
+    }
+
+    setup(cb) {
+        // this request implicitly updates the endpoint for the location
+        // the following code explcitly sets it to avoid surprises
+        this._client.getBucketLocation({ Bucket: this._awsBucketName },
+        (err, res) => {
+            if (err && err.code !== 'AuthorizationHeaderMalformed') {
+                this._logger.error('error during setup', {
+                    error: err,
+                    method: 'AwsClient.setup',
+                });
+                return cb(err);
+            }
+            let region;
+            if (err && err.code === 'AuthorizationHeaderMalformed') {
+                // set regional endpoint
+                region = err.region;
+            } else if (res) {
+                region = res.LocationConstraint;
+            }
+            const isAWS = this._s3Params.endpoint.endsWith('amazonaws.com');
+            if (region && isAWS) {
+                const endpoint = `s3.${region}.amazonaws.com`;
+                this._logger.debug('setting regional endpoint', {
+                    method: 'AwsClient.setup',
+                    region,
+                    endpoint,
+                });
+                this._client.endpoint = new AWS.Endpoint(endpoint);
+            }
+            return cb();
+        });
     }
 
     _createAwsKey(requestBucketName, requestObjectKey,

--- a/lib/data/external/AwsClient.js
+++ b/lib/data/external/AwsClient.js
@@ -1,4 +1,3 @@
-const { waterfall } = require('async');
 const { errors, s3middleware } = require('arsenal');
 const AWS = require('aws-sdk');
 const MD5Sum = s3middleware.MD5Sum;
@@ -32,49 +31,6 @@ class AwsClient {
             return requestObjectKey;
         }
         return `${requestBucketName}/${requestObjectKey}`;
-    }
-
-    _request(api, params, cb) {
-        let endpointCorrection = false;
-        waterfall([
-            // api call
-            next => this._client[api](params, (err, res) => {
-                if (err && err.name === 'AuthorizationHeaderMalformed') {
-                    endpointCorrection = true;
-                    return next(null, null);
-                }
-                if (err) {
-                    return next(err);
-                }
-                return next(null, res);
-            }),
-            // adjust endpoint if needed
-            (res, next) => {
-                if (endpointCorrection) {
-                    return this._client.getBucketLocation({
-                        Bucket: this._awsBucketName,
-                    }, (err, data) => {
-                        if (err) {
-                            return next(err);
-                        }
-                        const { LocationConstraint } = data;
-                        if (LocationConstraint) {
-                            this._client.endpoint = new AWS.Endpoint(
-                                `s3.${LocationConstraint}.amazonaws.com`);
-                        }
-                        return next(null, null);
-                    });
-                }
-                return next(null, res);
-            },
-            // retry api call with the correct endpoint
-            (res, next) => {
-                if (!endpointCorrection) {
-                    return next(null, res);
-                }
-                return this._client[api](params, next);
-            },
-        ], cb);
     }
 
     toObjectGetInfo(objectKey, bucketName) {
@@ -140,16 +96,16 @@ class AwsClient {
             uploadParams.ContentEncoding = keyContext.contentEncoding;
         }
         if (!stream) {
-            return this._request('putObject', uploadParams, putCb);
+            return this._client.putObject(uploadParams, putCb);
         }
 
         uploadParams.Body = stream;
-        return this._request('upload', uploadParams, putCb);
+        return this._client.upload(uploadParams, putCb);
     }
     head(objectGetInfo, reqUids, callback) {
         const log = createLogger(reqUids);
         const { key, dataStoreVersionId } = objectGetInfo;
-        return this._request('headObject', {
+        return this._client.headObject({
             Bucket: this._awsBucketName,
             Key: key,
             VersionId: dataStoreVersionId,
@@ -205,7 +161,7 @@ class AwsClient {
         if (deleteVersion) {
             params.VersionId = dataStoreVersionId;
         }
-        return this._request('deleteObject', params, err => {
+        return this._client.deleteObject(params, err => {
             if (err) {
                 logHelper(log, 'error', 'error deleting object from ' +
                 'datastore', err, this._dataStoreName, this.clientType);
@@ -239,7 +195,7 @@ class AwsClient {
                 };
                 return callback(null, awsResp);
             }
-            return this._request('getBucketVersioning', {
+            return this._client.getBucketVersioning({
                 Bucket: this._awsBucketName },
             (err, data) => {
                 if (err) {
@@ -283,7 +239,7 @@ class AwsClient {
             ContentDisposition: contentDisposition,
             ContentEncoding: contentEncoding,
         };
-        return this._request('createMultipartUpload', params, (err, res) => {
+        return this._client.createMultipartUpload(params, (err, mpuResObj) => {
             if (err) {
                 logHelper(log, 'error', 'err from data backend',
                   err, this._dataStoreName, this.clientType);
@@ -292,7 +248,7 @@ class AwsClient {
                   `${this.type}: ${err.message}`)
                 );
             }
-            return callback(null, res);
+            return callback(null, mpuResObj);
         });
     }
 
@@ -311,7 +267,7 @@ class AwsClient {
         const params = { Bucket: awsBucket, Key: awsKey, UploadId: uploadId,
             Body: hashedStream, ContentLength: size,
             PartNumber: partNumber };
-        return this._request('uploadPart', params, (err, partResObj) => {
+        return this._client.uploadPart(params, (err, partResObj) => {
             if (err) {
                 logHelper(log, 'error', 'err from data backend ' +
                   'on uploadPart', err, this._dataStoreName, this.clientType);
@@ -339,7 +295,7 @@ class AwsClient {
         const awsKey = this._createAwsKey(bucketName, key, this._bucketMatch);
         const params = { Bucket: awsBucket, Key: awsKey, UploadId: uploadId,
             PartNumberMarker: partNumberMarker, MaxParts: maxParts };
-        return this._request('listParts', params, (err, partList) => {
+        return this._client.listParts(params, (err, partList) => {
             if (err) {
                 logHelper(log, 'error', 'err from data backend on listPart',
                   err, this._dataStoreName, this.clientType);
@@ -405,7 +361,7 @@ class AwsClient {
             },
         };
         const completeObjData = { key: awsKey };
-        return this._request('completeMultipartUpload', mpuParams,
+        return this._client.completeMultipartUpload(mpuParams,
         (err, completeMpuRes) => {
             if (err) {
                 if (mpuError[err.code]) {
@@ -428,8 +384,7 @@ class AwsClient {
             }
             // need to get content length of new object to store
             // in our metadata
-            return this._request('headObject',
-            { Bucket: awsBucket, Key: awsKey },
+            return this._client.headObject({ Bucket: awsBucket, Key: awsKey },
             (err, objHeaders) => {
                 if (err) {
                     logHelper(log, 'trace', 'err from data backend on ' +
@@ -456,7 +411,7 @@ class AwsClient {
         const abortParams = {
             Bucket: awsBucket, Key: awsKey, UploadId: uploadId,
         };
-        return this._request('abortMultipartUpload', abortParams, err => {
+        return this._client.abortMultipartUpload(abortParams, err => {
             if (err) {
                 logHelper(log, 'error', 'There was an error aborting ' +
                 'the MPU on AWS S3. You should abort directly on AWS S3 ' +
@@ -486,7 +441,7 @@ class AwsClient {
             const value = objectMD.tags[key];
             return { Key: key, Value: value };
         });
-        return this._request('putObjectTagging', tagParams, err => {
+        return this._client.putObjectTagging(tagParams, err => {
             if (err) {
                 logHelper(log, 'error', 'error from data backend on ' +
                   'putObjectTagging', err,
@@ -509,7 +464,7 @@ class AwsClient {
             Key: awsKey,
             VersionId: dataStoreVersionId,
         };
-        return this._request('deleteObjectTagging', tagParams, err => {
+        return this._client.deleteObjectTagging(tagParams, err => {
             if (err) {
                 logHelper(log, 'error', 'error from data backend on ' +
                 'deleteObjectTagging', err,
@@ -545,7 +500,7 @@ class AwsClient {
         config.isAWSServerSideEncrytion(destLocationConstraintName)) {
             awsParams.ServerSideEncryption = 'AES256';
         }
-        this._request('copyObject', awsParams, (err, copyResult) => {
+        this._client.copyObject(awsParams, (err, copyResult) => {
             if (err) {
                 if (err.code === 'AccessDenied') {
                     logHelper(log, 'error', 'Unable to access ' +
@@ -594,7 +549,7 @@ class AwsClient {
             PartNumber: partNumber,
             UploadId: uploadId,
         };
-        return this._request('uploadPartCopy', params, (err, res) => {
+        return this._client.uploadPartCopy(params, (err, res) => {
             if (err) {
                 if (err.code === 'AccessDenied') {
                     logHelper(log, 'error', 'Unable to access ' +

--- a/lib/data/locationConstraintParser.js
+++ b/lib/data/locationConstraintParser.js
@@ -106,6 +106,9 @@ function parseLC() {
             }
             clients[location] = locationObj.type === 'gcp' ?
                 new GcpClient(clientConfig) : new AwsClient(clientConfig);
+            if (locationObj.type === 'aws_s3') {
+                clients[location].setup(() => {});
+            }
         }
         if (locationObj.type === 'azure') {
             const azureStorageEndpoint = config.getAzureEndpoint(location);


### PR DESCRIPTION
- improvement: revert ZENKO-819 regional endpoints
- bugfix: set region endpoint during location setup
This commit removes the current redirect code and adds a setup method
that makes a call to get the region of the destination bucket on AWS S3
and updates the endpoint to use the correct region specific endpoint.
This should avoid redirects from AWS which in turn messes up the payload
causing errors during PUTs. The setup call will be cleaned up to address
the technical debt of waiting for the callback.
