### PR TITLE
INTEGRATION [PR#1526 > development/8.1] feature: ZENKO-1108 Set region for AWS locations

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -198,6 +198,7 @@ function locationConstraintAssert(locationConstraints) {
             'awsEndpoint',
             'bucketName',
             'credentialsProfile',
+            'region',
         ];
         stringFields.forEach(field => {
             if (details[field] !== undefined) {

--- a/lib/data/locationConstraintParser.js
+++ b/lib/data/locationConstraintParser.js
@@ -46,6 +46,7 @@ function parseLC() {
             const endpoint = locationObj.type === 'gcp' ?
                 locationObj.details.gcpEndpoint :
                 locationObj.details.awsEndpoint;
+            const region = locationObj.details.region;
             const protocol = locationObj.details.https ? 'https' : 'http';
             const sslEnabled = locationObj.details.https === true;
             const signatureVersion = !sslEnabled ? 'v2' : 'v4';
@@ -69,6 +70,7 @@ function parseLC() {
             const httpOptions = { agent: connectionAgent, timeout: 0 };
             const s3Params = {
                 endpoint: `${protocol}://${endpoint}`,
+                region,
                 debug: false,
                 // Not implemented yet for streams in node sdk,
                 // and has no negative impact if stream, so let's

--- a/lib/management/configuration.js
+++ b/lib/management/configuration.js
@@ -140,6 +140,7 @@ function patchConfiguration(newConf, log, cb) {
                             bucketMatch: l.details.bucketMatch,
                             serverSideEncryption:
                                 Boolean(l.details.serverSideEncryption),
+                            region: l.details.region,
                             awsEndpoint,
                             supportsVersioning,
                             pathStyle,

--- a/tests/unit/management/configuration.js
+++ b/tests/unit/management/configuration.js
@@ -122,6 +122,7 @@ describe('patchConfiguration', () => {
                         accessKey: 'awsaccesskey',
                         secretKey,
                         bucketName: 'awsbucketname',
+                        region: 'us-west-1',
                     },
                 },
                 'gcpbackendtest': {
@@ -233,6 +234,7 @@ describe('patchConfiguration', () => {
                             },
                             https: true,
                             pathStyle: false,
+                            region: 'us-west-1',
                             serverSideEncryption: false,
                             supportsVersioning: true,
                         },

--- a/tests/unit/testConfigs/locConstraintAssert.js
+++ b/tests/unit/testConfigs/locConstraintAssert.js
@@ -11,6 +11,7 @@ class LocationConstraint {
             awsEndpoint: 's3.amazonaws.com',
             bucketName: 'tester',
             credentialsProfile: 'default',
+            region: 'us-west-1',
         }, details || {});
     }
 }
@@ -117,6 +118,20 @@ describe('locationConstraintAssert', () => {
             locationConstraintAssert({ 'scality-east': locationConstraint });
         },
         /bad config: credentialsProfile must be a string/);
+    });
+    it('should throw error if region is not a string', () => {
+        const locationConstraint = new LocationConstraint(
+            'scality', 'locId', false,
+            {
+                awsEndpoint: 's3.amazonaws.com',
+                bucketName: 'premadebucket',
+                credentialsProfile: 'zenko',
+                region: 42,
+            });
+        assert.throws(() => {
+            locationConstraintAssert({ 'scality-east': locationConstraint });
+        },
+        /bad config: region must be a string/);
     });
     it('should throw error if us-east-1 not specified', () => {
         const locationConstraint = new LocationConstraint();


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1526.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/feature/ZENKO-1108/set-region-for-AWS-locations`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/feature/ZENKO-1108/set-region-for-AWS-locations
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/feature/ZENKO-1108/set-region-for-AWS-locations
```

Please always comment pull request #1526 instead of this one.