### PR TITLE
bugfix: filter NoSuchKey errors when deleting on AWS/GCP

### DIFF
--- a/lib/data/external/AwsClient.js
+++ b/lib/data/external/AwsClient.js
@@ -200,7 +200,7 @@ class AwsClient {
             if (err) {
                 logHelper(log, 'error', 'error deleting object from ' +
                 'datastore', err, this._dataStoreName, this.clientType);
-                if (err.code === 'NoSuchVersion') {
+                if (err.code === 'NoSuchVersion' || err.code === 'NoSuchKey') {
                     // data may have been deleted directly from the AWS backend
                     // don't want to retry the delete and errors are not
                     // sent back to client anyway, so no need to return err

--- a/tests/functional/aws-node-sdk/test/multipleBackend/delete/deleteGcp.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/delete/deleteGcp.js
@@ -102,5 +102,12 @@ describeSkipIfNotMultiple('Multiple backend delete', function testSuite() {
                 });
             }));
         });
+
+        it('should return success if the object does not exist',
+            done => s3.deleteObject({ Bucket: bucket, Key: 'noop' }, err => {
+                assert.strictEqual(err, null,
+                    `Expected success, got error ${JSON.stringify(err)}`);
+                done();
+            }));
     });
 });


### PR DESCRIPTION
This accounts for 404s when trying to delete something that doesn't exist
or hasn't been replicated yet. It returns no error to the client as the delete
is a no-op and is inline with S3 API compatibility.
The test has been updated as well to match the behavior change.