### PR TITLE
INTEGRATION [PR#1534 > development/8.1] bugfix: filter NoSuchKey errors when deleting on AWS/GCP

### DIFF
--- a/lib/data/external/AwsClient.js
+++ b/lib/data/external/AwsClient.js
@@ -200,7 +200,7 @@ class AwsClient {
             if (err) {
                 logHelper(log, 'error', 'error deleting object from ' +
                 'datastore', err, this._dataStoreName, this.clientType);
-                if (err.code === 'NoSuchVersion') {
+                if (err.code === 'NoSuchVersion' || err.code === 'NoSuchKey') {
                     // data may have been deleted directly from the AWS backend
                     // don't want to retry the delete and errors are not
                     // sent back to client anyway, so no need to return err

--- a/tests/functional/aws-node-sdk/test/multipleBackend/delete/deleteGcp.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/delete/deleteGcp.js
@@ -102,5 +102,12 @@ describeSkipIfNotMultiple('Multiple backend delete', function testSuite() {
                 });
             }));
         });
+
+        it('should return success if the object does not exist',
+            done => s3.deleteObject({ Bucket: bucket, Key: 'noop' }, err => {
+                assert.strictEqual(err, null,
+                    `Expected success, got error ${JSON.stringify(err)}`);
+                done();
+            }));
     });
 });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1534.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/ZENKO-1113-gcp-del-204`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/ZENKO-1113-gcp-del-204
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/ZENKO-1113-gcp-del-204
```

Please always comment pull request #1534 instead of this one.