### PR TITLE
bf: ZENKO-1146 read from source until replicated to preferred read

### DIFF
--- a/lib/api/apiUtils/object/getReplicationBackendDataLocator.js
+++ b/lib/api/apiUtils/object/getReplicationBackendDataLocator.js
@@ -15,8 +15,14 @@ const { errors } = require('arsenal');
  * @param {string} replicationInfo.backends[].status - status of replication
  * @param {string} replicationInfo.backends[].dataStoreVersionId - version id
  * of object at replication location
- * @return {object} contains error if no replication backend matches or
- * dataLocator object
+ * @return {object} res - response object
+ *     {array} [res.dataLocator] - if COMPLETED status: array
+ *                                 containing the cloud location,
+ *                                 undefined otherwise
+ *     {string} [res.status] - replication status if no error
+ *     {string} [res.reason] - reason message if PENDING/FAILED
+ *     {Error} [res.error] - defined if object is not replicated to
+ *                           location passed in locationObj
  */
 function getReplicationBackendDataLocator(locationObj, replicationInfo) {
     const repBackendResult = {};
@@ -28,10 +34,10 @@ function getReplicationBackendDataLocator(locationObj, replicationInfo) {
             'passed in location header');
         return repBackendResult;
     }
+    repBackendResult.status = locMatch.status;
     if (['PENDING', 'FAILED'].includes(locMatch.status)) {
-        repBackendResult.error = errors.NoSuchKey.customizeDescription(
-            `Object replication to specified backend is ${locMatch.status}`);
-        repBackendResult.status = locMatch.status;
+        repBackendResult.reason =
+            `Object replication to specified backend is ${locMatch.status}`;
         return repBackendResult;
     }
     repBackendResult.dataLocator = [{

--- a/lib/api/objectGet.js
+++ b/lib/api/objectGet.js
@@ -156,12 +156,22 @@ function objectGet(authInfo, request, returnTagCount, log, callback) {
                     targetLocation, objMD.replicationInfo);
                 if (repBackendResult.error) {
                     log.error('Error with location constraint header', {
+                        bucketName, objectKey, versionId,
                         error: repBackendResult.error,
                         status: repBackendResult.status,
                     });
                     return callback(repBackendResult.error, null, corsHeaders);
                 }
-                dataLocator = repBackendResult.dataLocator;
+                const targetDataLocator = repBackendResult.dataLocator;
+                if (targetDataLocator) {
+                    dataLocator = targetDataLocator;
+                } else {
+                    log.debug('using source location as preferred read ' +
+                              'is unavailable', {
+                                  bucketName, objectKey, versionId,
+                                  reason: repBackendResult.reason,
+                              });
+                }
             }
             // if the data backend is azure, there will only ever be at
             // most one item in the dataLocator array

--- a/tests/unit/multipleBackend/getReplicationBackendDataLocator.js
+++ b/tests/unit/multipleBackend/getReplicationBackendDataLocator.js
@@ -15,7 +15,7 @@ const repMatchFailed = { backends:
     [{ site: 'spoofbackend', status: 'FAILED', dataVersionId: '' }] };
 const repMatch = { backends: [{
     site: 'spoofbackend',
-    status: 'COMPLETE',
+    status: 'COMPLETED',
     dataStoreVersionId: 'spoofid' }],
 };
 const expDataLocator = [{
@@ -32,22 +32,25 @@ describe('Replication Backend Compare', () => {
             getReplicationBackendDataLocator(locCheckResult, repNoMatch);
         assert(repBackendResult.error.InvalidLocationConstraint);
     });
-    it('should return error if backend status is PENDING', () => {
+    it('should return a status and reason if backend status is PENDING', () => {
         const repBackendResult =
             getReplicationBackendDataLocator(locCheckResult, repMatchPending);
-        assert(repBackendResult.error.NoSuchKey);
+        assert.strictEqual(repBackendResult.dataLocator, undefined);
         assert.strictEqual(repBackendResult.status, 'PENDING');
+        assert.notStrictEqual(repBackendResult.reason, undefined);
     });
-    it('should return error if backend status is FAILED', () => {
+    it('should return a status and reason if backend status is FAILED', () => {
         const repBackendResult =
             getReplicationBackendDataLocator(locCheckResult, repMatchFailed);
-        assert(repBackendResult.error.NoSuchKey);
+        assert.strictEqual(repBackendResult.dataLocator, undefined);
         assert.strictEqual(repBackendResult.status, 'FAILED');
+        assert.notStrictEqual(repBackendResult.reason, undefined);
     });
-    it('should return dataLocator obj if backend matches and rep is complete',
+    it('should return dataLocator obj if backend matches and rep is COMPLETED',
     () => {
         const repBackendResult =
             getReplicationBackendDataLocator(locCheckResult, repMatch);
+        assert.strictEqual(repBackendResult.status, 'COMPLETED');
         assert.deepStrictEqual(repBackendResult.dataLocator, expDataLocator);
     });
 });


### PR DESCRIPTION
When a preferred read location is defined for an object, and when
status of replication to this location is PENDING or FAILED, read
object from the source location instead of returning an error.

Note that reads are not guaranteed to succeed if the source location
is a transient source, because of a race condition with the garbage
collector. This will be addressed in a future change.
