### PR TITLE
fs type location

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -118,8 +118,8 @@ const constants = {
     objectLocationConstraintHeader: 'x-amz-meta-scal-location-constraint',
     legacyLocations: ['sproxyd', 'legacy'],
     /* eslint-disable camelcase */
-    externalBackends: { aws_s3: true, azure: true, gcp: true },
-    replicationBackends: { aws_s3: true, azure: true, gcp: true },
+    externalBackends: { aws_s3: true, azure: true, gcp: true, fs: true },
+    replicationBackends: { aws_s3: true, azure: true, gcp: true, fs: true },
     // some of the available data backends  (if called directly rather
     // than through the multiple backend gateway) need a key provided
     // as a string as first parameter of the get/delete methods.

--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -181,7 +181,8 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
             // regular puts are stored in the same data structure,
             // place the retrieval info here into a single element array
             const { key, dataStoreName, dataStoreType, dataStoreETag,
-                dataStoreVersionId } = dataGetInfo;
+                    dataStoreVersionId, dataStoreSize,
+                    dataStoreMd5 } = dataGetInfo;
             const prefixedDataStoreETag = dataStoreETag
                       ? `1:${dataStoreETag}`
                       : `1:${calculatedHash}`;
@@ -194,6 +195,12 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
                     cipherBundle.cipheredDataKey;
             }
             metadataStoreParams.contentMD5 = calculatedHash;
+            if (dataStoreSize !== undefined) {
+                metadataStoreParams.size = dataStoreSize;
+            }
+            if (dataStoreMd5 !== undefined) {
+                metadataStoreParams.contentMD5 = dataStoreMd5;
+            }
             return next(null, dataGetInfoArr);
         },
         function getVersioningInfo(infoArr, next) {

--- a/lib/data/external/FsClient.js
+++ b/lib/data/external/FsClient.js
@@ -1,0 +1,156 @@
+const { errors, s3middleware } = require('arsenal');
+const werelogs = require('werelogs');
+const MD5Sum = s3middleware.MD5Sum;
+const getMetaHeaders = s3middleware.userMetadata.getMetaHeaders;
+const createLogger = require('../multipleBackendLogger');
+const { logHelper } = require('./utils');
+const { config } = require('../../Config');
+const fs = require('fs');
+
+class FsClient {
+    constructor(config) {
+        this.clientType = 'fs';
+        this.type = 'FS';
+        this._bucketName = config.bucketName;
+        this._bucketMatch = config.bucketMatch;
+        this._serverSideEncryption = config.serverSideEncryption;
+        this._dataStoreName = config.dataStoreName;
+        this._supportsVersioning = config.supportsVersioning;
+        this._mountPath = config.mountPath;
+        this._logger = new werelogs.Logger('FsClient');
+    }
+
+    setup(cb) {
+        return cb();
+    }
+
+    _createFsKey(requestBucketName, requestObjectKey,
+        bucketMatch) {
+        if (bucketMatch) {
+            return requestObjectKey;
+        }
+        return `${requestBucketName}/${requestObjectKey}`;
+    }
+
+    toObjectGetInfo(objectKey, bucketName) {
+        return {
+            key: this._createFsKey(bucketName, objectKey, this._bucketMatch),
+            dataStoreName: this._dataStoreName,
+        };
+    }
+
+    put(stream, size, keyContext, reqUids, callback) {
+        const log = createLogger(reqUids);
+
+        if (size === 0) {
+            const b64 = keyContext.metaHeaders['x-amz-meta-md5chksum'];
+            let md5 = null;
+            if (b64 !== null) {
+                md5 = new Buffer(b64, 'base64').toString('hex');
+            }
+            return callback(null, keyContext.objectKey, '',
+                            keyContext.metaHeaders['x-amz-meta-size'],
+                            md5,
+                           );
+        }
+        logHelper(log, 'error', 'Not implemented', errors.NotImplemented,
+                 this._dataStoreName, this.clientType);
+        return callback(errors.NotImplemented);
+    }
+
+    get(objectGetInfo, range, reqUids, callback) {
+        const log = createLogger(reqUids);
+
+        const filePath = this._mountPath + '/' + objectGetInfo.key;
+        const readStreamOptions = {
+            flags: 'r',
+            encoding: null,
+            fd: null,
+            autoClose: false,
+        };
+        const rs = fs.createReadStream(filePath, readStreamOptions)
+              .on('error', err => {
+                  logHelper(log, 'error', 'Error reading file', err,
+                            this._dataStoreName, this.clientType);
+                  console.log('err', err);
+              })
+              .on('open', () => {
+                  return callback(null, rs);
+              });
+    }
+
+    delete(objectGetInfo, reqUids, callback) {
+        const log = createLogger(reqUids);
+
+        logHelper(log, 'error', 'Not implemented', errors.NotImplemented,
+                  this._dataStoreName, this.clientType);
+        return callback(errors.NotImplemented);
+    }
+
+    healthcheck(location, callback) {
+        const fsResp = {};
+        return callback(null, fsResp);
+    }
+
+    createMPU(key, metaHeaders, bucketName, websiteRedirectHeader, contentType,
+              cacheControl, contentDisposition, contentEncoding, log, callback) {
+
+        logHelper(log, 'error', 'Not implemented', errors.NotImplemented,
+                  this._dataStoreName, this.clientType);
+        return callback(errors.NotImplemented);
+    }
+
+    uploadPart(request, streamingV4Params, stream, size, key, uploadId,
+               partNumber, bucketName, log, callback) {
+        logHelper(log, 'error', 'Not implemented', errors.NotImplemented,
+                  this._dataStoreName, this.clientType);
+        return callback(errors.NotImplemented);
+    }
+
+    listParts(key, uploadId, bucketName, partNumberMarker, maxParts, log,
+              callback) {
+        logHelper(log, 'error', 'Not implemented', errors.NotImplemented,
+                  this._dataStoreName, this.clientType);
+        return callback(errors.NotImplemented);
+    }
+
+    completeMPU(jsonList, mdInfo, key, uploadId, bucketName, log, callback) {
+        logHelper(log, 'error', 'Not implemented', errors.NotImplemented,
+                  this._dataStoreName, this.clientType);
+        return callback(errors.NotImplemented);
+    }
+
+    abortMPU(key, uploadId, bucketName, log, callback) {
+        logHelper(log, 'error', 'Not implemented', errors.NotImplemented,
+                  this._dataStoreName, this.clientType);
+        return callback(errors.NotImplemented);
+    }
+
+    objectPutTagging(key, bucket, objectMD, log, callback) {
+        logHelper(log, 'error', 'Not implemented', errors.NotImplemented,
+                  this._dataStoreName, this.clientType);
+        return callback(errors.NotImplemented);
+    }
+
+    objectDeleteTagging(key, bucket, objectMD, log, callback) {
+        logHelper(log, 'error', 'Not implemented', errors.NotImplemented,
+                  this._dataStoreName, this.clientType);
+        return callback(errors.NotImplemented);
+    }
+    
+    copyObject(request, destLocationConstraintName, sourceKey,
+               sourceLocationConstraintName, storeMetadataParams, log, callback) {
+        logHelper(log, 'error', 'Not implemented', errors.NotImplemented,
+                  this._dataStoreName, this.clientType);
+        return callback(errors.NotImplemented);
+    }
+    
+    uploadPartCopy(request, awsSourceKey, sourceLocationConstraintName,
+                   log, callback) {
+        logHelper(log, 'error', 'Not implemented', errors.NotImplemented,
+                  this._dataStoreName, this.clientType);
+        return callback(errors.NotImplemented);
+    }
+}
+
+module.exports = FsClient;

--- a/lib/data/external/FsClient.js
+++ b/lib/data/external/FsClient.js
@@ -50,7 +50,7 @@ class FsClient {
             }
             return callback(null, keyContext.objectKey, '',
                             keyContext.metaHeaders['x-amz-meta-size'],
-                            md5,
+                            md5
                            );
         }
         logHelper(log, 'error', 'Not implemented', errors.NotImplemented,

--- a/lib/data/locationConstraintParser.js
+++ b/lib/data/locationConstraintParser.js
@@ -11,6 +11,7 @@ const inMemory = require('./in_memory/backend').backend;
 const AwsClient = require('./external/AwsClient');
 const GcpClient = require('./external/GcpClient');
 const AzureClient = require('./external/AzureClient');
+const FsClient = require('./external/FsClient');
 const proxyCompareUrl = require('./proxyCompareUrl');
 
 const { config } = require('../Config');
@@ -127,6 +128,17 @@ function parseLC() {
                 proxy: proxyParams,
             });
             clients[location].clientType = 'azure';
+        }
+        if (locationObj.type === 'fs') {
+            clients[location] = new FsClient({
+                bucketName: locationObj.details.bucketName,
+                bucketMatch: locationObj.details.bucketMatch,
+                serverSideEncryption: locationObj.details.serverSideEncryption,
+                dataStoreName: location,
+                supportsVersioning: locationObj.details.supportsVersioning,
+                mountPath: locationObj.details.mountPath,
+            });
+            clients[location].clientType = 'fs';
         }
     });
     return clients;

--- a/lib/data/multipleBackendGateway.js
+++ b/lib/data/multipleBackendGateway.js
@@ -60,7 +60,8 @@ const multipleBackendGateway = {
             }
         }
         return client.put(writeStream, size, keyContext,
-            reqUids, (err, key, dataStoreVersionId) => {
+                          reqUids, (err, key, dataStoreVersionId,
+                                    dataStoreSize, dataStoreMd5) => {
                 const log = createLogger(reqUids);
                 log.debug('put to location', { controllingLocationConstraint });
                 if (err) {
@@ -73,6 +74,8 @@ const multipleBackendGateway = {
                     dataStoreName: controllingLocationConstraint,
                     dataStoreType: client.clientType,
                     dataStoreVersionId,
+                    dataStoreSize,
+                    dataStoreMd5
                 };
                 return callback(null, dataRetrievalInfo);
             });

--- a/locationConfig.json
+++ b/locationConfig.json
@@ -94,5 +94,13 @@
         "objectId": "sa-east-1",
         "legacyAwsBehavior": false,
         "details": {}
+    },
+    "fs1": {
+        "type": "fs",
+        "objectId": "fs",
+        "legacyAwsBehavior": false,
+        "details": {
+            "mountPath": "/home/vr/local-fs"
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "cdmiclient": "scality/cdmiclient#8f0c2e6"
   },
   "scripts": {
-    "cloudserver": "S3METADATA=mongodb npm-run-all --parallel start_dataserver start_s3server",
+    "cloudserver": "npm-run-all --parallel start_dataserver start_s3server",
     "ft_awssdk": "cd tests/functional/aws-node-sdk && mocha test/",
     "ft_awssdk_aws": "cd tests/functional/aws-node-sdk && AWS_ON_AIR=true mocha test/",
     "ft_awssdk_buckets": "cd tests/functional/aws-node-sdk && mocha test/bucket",


### PR DESCRIPTION


## Description
This PR add a new type of location called "fs".

### Motivation and context
Recently some Zenko users have expressed the need of being able to read
local FS objects from Zenko, as "symlinks" (see https://forum.zenko.io/t/using-existing-file-data/355/5).

Also we want to be able to support ingestion of metadata from existing filesystems (e.g. NFS).

### Why is this change required? What problem does it solve?

This change allows a location to put 0-byte objects with consistent size and MD5. The files
can be re-read in a pass-through data backend. 

The new "fs" type location supports a mountPath configuration that typically points on a
local folder or mount point that contains the file (e.g. a Kubernetes NFS PV).

Note that the data backend does not try to list or read the metadata from the mountPath,
because:
- The hierarchical filesystem structure is not compatible with the prefix and delimiter type of queries of a filesystem.
- File system entries are not lexicographically ordered.

As a result, the listing will be slow and impracticable for large filesystems, and not necessarily strictly compatible with S3.

But also:
- The MD5 of files is not available in file systems (but needed for doing S3 read requests). It would be too intense to compute at e.g. every HEAD query.

Instead it relies on a external tool, called periodically that checks for updates in the filesystem (see https://github.com/scality/rclone/pull/1).

The modified rclone tool make sure that the whole structure of the FS is properly mirrored in an S3 bucket. De facto being 100% compatible with all S3 LIST requests. Moreover the MD5 and size are properly set when creating the 0-byte file, therefore properly serving HEAD and GET S3 requests.

The mirroring is done in a way that existing entries are not populated twice. The tool can also track ctime changes and mirror attribute changes in the local filesystem.

### Caveats
With this design, changes are not mirrored in real-time. Anyways, being notified of real-time changes e.g. via inotify() is not possible on NFS. The alternative is to have access the the operation log of the filesystem which is not always the case.

## Checklist

### Add tests to cover the changes

Need to add tests.

### Code conforms with the [style guide]

(https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#coding-style-guidelines)

