### PR TITLE
Improvement/s3 c 1745 bucket deletion

### DIFF
--- a/lib/api/apiUtils/bucket/bucketDeletion.js
+++ b/lib/api/apiUtils/bucket/bucketDeletion.js
@@ -3,51 +3,12 @@ const async = require('async');
 const { errors } = require('arsenal');
 
 const abortMultipartUpload = require('../object/abortMultipartUpload');
-const logger = require('../../../utilities/logger');
 
-const { usersBucket, oldUsersBucket, splitter, oldSplitter, mpuBucketPrefix } =
+const { splitter, oldSplitter, mpuBucketPrefix } =
     require('../../../../constants');
-const createKeyForUserBucket = require('./createKeyForUserBucket');
 const metadata = require('../../../metadata/wrapper');
 const kms = require('../../../kms/wrapper');
-
-function _deleteUserBucketEntry(bucketName, canonicalID, log, cb) {
-    log.trace('deleting bucket name from users bucket', { method:
-        '_deleteUserBucketEntry' });
-    const keyForUserBucket = createKeyForUserBucket(canonicalID, splitter,
-        bucketName);
-    metadata.deleteObjectMD(usersBucket, keyForUserBucket, {}, log, error => {
-        // If the object representing the bucket is not in the
-        // users bucket just continue
-        if (error && error.NoSuchKey) {
-            return cb(null);
-        // BACKWARDS COMPATIBILITY: Remove this once no longer
-        // have old user bucket format
-        } else if (error && error.NoSuchBucket) {
-            const keyForUserBucket2 = createKeyForUserBucket(canonicalID,
-                oldSplitter, bucketName);
-            return metadata.deleteObjectMD(oldUsersBucket, keyForUserBucket2,
-                {}, log, error => {
-                    if (error && !error.NoSuchKey) {
-                        log.error('from metadata while deleting user bucket',
-                            { error });
-                        return cb(error);
-                    }
-                    log.trace('deleted bucket from user bucket',
-                    { method: '_deleteUserBucketEntry' });
-                    return cb(null);
-                });
-        } else if (error) {
-            log.error('from metadata while deleting user bucket', { error,
-                method: '_deleteUserBucketEntry' });
-            return cb(error);
-        }
-        log.trace('deleted bucket from user bucket', {
-            method: '_deleteUserBucketEntry' });
-        return cb(null);
-    });
-}
-
+const deleteUserBucketEntry = require('./deleteUserBucketEntry');
 
 function _deleteMPUbucket(destinationBucketName, log, cb) {
     const mpuBucketName =
@@ -58,38 +19,6 @@ function _deleteMPUbucket(destinationBucketName, log, cb) {
             return cb();
         }
         return cb(err);
-    });
-}
-
-/**
- * Invisibly finishes deleting a bucket that already has a deleted flag
- * by deleting the object in the users bucket representing the created bucket
- * and then deleting the bucket in metadata
- * @param {string} bucketName - name of bucket
- * @param {string} canonicalID - bucket owner's canonicalID
- * @return {undefined}
- */
-function invisiblyDelete(bucketName, canonicalID) {
-    const log = logger.newRequestLogger();
-    log.trace('deleting bucket with deleted flag invisibly', { bucketName });
-    return _deleteUserBucketEntry(bucketName, canonicalID, log, err => {
-        if (err) {
-            log.error('error invisibly deleting bucket name from user bucket',
-            { error: err });
-            return log.end();
-        }
-        log.trace('deleted bucket name from user bucket');
-        return metadata.deleteBucket(bucketName, log, error => {
-            log.trace('deleting bucket from metadata',
-            { method: 'invisiblyDelete' });
-            if (error) {
-                log.error('error deleting bucket from metadata', { error });
-                return log.end();
-            }
-            log.trace('invisible deletion of bucket succeeded',
-            { method: 'invisiblyDelete' });
-            return log.end();
-        });
     });
 }
 
@@ -182,7 +111,7 @@ function deleteBucket(authInfo, bucketMD, bucketName, canonicalID, log, cb) {
         },
         function deleteUserBucketEntryStep(next) {
             log.trace('deleting bucket name from user bucket');
-            return _deleteUserBucketEntry(bucketName, canonicalID, log, next);
+            return deleteUserBucketEntry(bucketName, canonicalID, log, next);
         },
     ],
     // eslint-disable-next-line prefer-arrow-callback
@@ -206,7 +135,4 @@ function deleteBucket(authInfo, bucketMD, bucketName, canonicalID, log, cb) {
     });
 }
 
-module.exports = {
-    invisiblyDelete,
-    deleteBucket,
-};
+module.exports = deleteBucket;

--- a/lib/api/apiUtils/bucket/bucketDeletion.js
+++ b/lib/api/apiUtils/bucket/bucketDeletion.js
@@ -2,22 +2,20 @@ const assert = require('assert');
 const async = require('async');
 const { errors } = require('arsenal');
 
+const abortMultipartUpload = require('../object/abortMultipartUpload');
 const logger = require('../../../utilities/logger');
 
-const constants = require('../../../../constants');
+const { usersBucket, oldUsersBucket, splitter, oldSplitter, mpuBucketPrefix } =
+    require('../../../../constants');
 const createKeyForUserBucket = require('./createKeyForUserBucket');
 const metadata = require('../../../metadata/wrapper');
 const kms = require('../../../kms/wrapper');
 
-const usersBucket = constants.usersBucket;
-const oldUsersBucket = constants.oldUsersBucket;
-
-
 function _deleteUserBucketEntry(bucketName, canonicalID, log, cb) {
     log.trace('deleting bucket name from users bucket', { method:
         '_deleteUserBucketEntry' });
-    const keyForUserBucket = createKeyForUserBucket(canonicalID,
-        constants.splitter, bucketName);
+    const keyForUserBucket = createKeyForUserBucket(canonicalID, splitter,
+        bucketName);
     metadata.deleteObjectMD(usersBucket, keyForUserBucket, {}, log, error => {
         // If the object representing the bucket is not in the
         // users bucket just continue
@@ -27,7 +25,7 @@ function _deleteUserBucketEntry(bucketName, canonicalID, log, cb) {
         // have old user bucket format
         } else if (error && error.NoSuchBucket) {
             const keyForUserBucket2 = createKeyForUserBucket(canonicalID,
-                constants.oldSplitter, bucketName);
+                oldSplitter, bucketName);
             return metadata.deleteObjectMD(oldUsersBucket, keyForUserBucket2,
                 {}, log, error => {
                     if (error && !error.NoSuchKey) {
@@ -53,7 +51,7 @@ function _deleteUserBucketEntry(bucketName, canonicalID, log, cb) {
 
 function _deleteMPUbucket(destinationBucketName, log, cb) {
     const mpuBucketName =
-        `${constants.mpuBucketPrefix}${destinationBucketName}`;
+        `${mpuBucketPrefix}${destinationBucketName}`;
     return metadata.deleteBucket(mpuBucketName, log, err => {
         // If the mpu bucket does not exist, just move on
         if (err && err.NoSuchBucket) {
@@ -95,8 +93,19 @@ function invisiblyDelete(bucketName, canonicalID) {
     });
 }
 
+function _deleteOngoingMPUs(authInfo, bucketName, mpus, log, cb) {
+    async.mapLimit(mpus, 1, (mpu, next) => {
+        const splitterChar = mpu.key.includes(oldSplitter) ?
+            oldSplitter : splitter;
+        // `overview${splitter}${objectKey}${splitter}${uploadId}
+        const [, objectKey, uploadId] = mpu.key.split(splitterChar);
+        abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
+            next);
+    }, cb);
+}
 /**
  * deleteBucket - Delete bucket from namespace
+ * @param {object} authInfo - authentication info
  * @param {object} bucketMD - bucket attributes/metadata
  * @param {string} bucketName - bucket in which objectMetadata is stored
  * @param {string} canonicalID - account canonicalID of requester
@@ -104,7 +113,7 @@ function invisiblyDelete(bucketName, canonicalID) {
  * @param {function} cb - callback from async.waterfall in bucketDelete
  * @return {undefined}
  */
-function deleteBucket(bucketMD, bucketName, canonicalID, log, cb) {
+function deleteBucket(authInfo, bucketMD, bucketName, canonicalID, log, cb) {
     log.trace('deleting bucket from metadata');
     assert.strictEqual(typeof bucketName, 'string');
     assert.strictEqual(typeof canonicalID, 'string');
@@ -133,15 +142,13 @@ function deleteBucket(bucketMD, bucketName, canonicalID, log, cb) {
                     return next();
                 });
         },
-        // Note: This does not mirror AWS behavior.  AWS will allow a user to
-        // delete a bucket even if there are ongoing multipart uploads.
+
         function deleteMPUbucketStep(next) {
-            const MPUBucketName = `${constants.mpuBucketPrefix}${bucketName}`;
+            const MPUBucketName = `${mpuBucketPrefix}${bucketName}`;
             // check to see if there are any mpu overview objects (so ignore
             // any orphaned part objects)
-            return metadata.listObject(MPUBucketName,
-                { maxKeys: 1, prefix: 'overview' }, log,
-                (err, objectsListRes) => {
+            return metadata.listObject(MPUBucketName, { prefix: 'overview' },
+                log, (err, objectsListRes) => {
                     // If no shadow bucket ever created, no ongoing MPU's, so
                     // continue with deletion
                     if (err && err.NoSuchBucket) {
@@ -152,12 +159,14 @@ function deleteBucket(bucketMD, bucketName, canonicalID, log, cb) {
                         return next(err);
                     }
                     if (objectsListRes.Contents.length) {
-                        log.debug('bucket delete failed',
-                            { error: errors.MPUinProgress });
-                        // Return non-AWS standard error
-                        // regarding ongoing MPUs so user
-                        // understands what is occurring
-                        return next(errors.MPUinProgress);
+                        return _deleteOngoingMPUs(authInfo, bucketName,
+                            objectsListRes.Contents, log, err => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                log.trace('deleting shadow MPU bucket');
+                                return _deleteMPUbucket(bucketName, log, next);
+                            });
                     }
                     log.trace('deleting shadow MPU bucket');
                     return _deleteMPUbucket(bucketName, log, next);

--- a/lib/api/apiUtils/bucket/bucketShield.js
+++ b/lib/api/apiUtils/bucket/bucketShield.js
@@ -1,4 +1,4 @@
-const { invisiblyDelete } = require('./bucketDeletion');
+const invisiblyDelete = require('./invisiblyDelete');
 
 /**
  * Checks whether to proceed with a request based on the bucket flags

--- a/lib/api/apiUtils/bucket/deleteUserBucketEntry.js
+++ b/lib/api/apiUtils/bucket/deleteUserBucketEntry.js
@@ -1,0 +1,43 @@
+const createKeyForUserBucket = require('./createKeyForUserBucket');
+const { usersBucket, oldUsersBucket, splitter, oldSplitter } =
+    require('../../../../constants');
+const metadata = require('../../../metadata/wrapper');
+
+function deleteUserBucketEntry(bucketName, canonicalID, log, cb) {
+    log.trace('deleting bucket name from users bucket', { method:
+        '_deleteUserBucketEntry' });
+    const keyForUserBucket = createKeyForUserBucket(canonicalID, splitter,
+        bucketName);
+    metadata.deleteObjectMD(usersBucket, keyForUserBucket, {}, log, error => {
+        // If the object representing the bucket is not in the
+        // users bucket just continue
+        if (error && error.NoSuchKey) {
+            return cb(null);
+        // BACKWARDS COMPATIBILITY: Remove this once no longer
+        // have old user bucket format
+        } else if (error && error.NoSuchBucket) {
+            const keyForUserBucket2 = createKeyForUserBucket(canonicalID,
+                oldSplitter, bucketName);
+            return metadata.deleteObjectMD(oldUsersBucket, keyForUserBucket2,
+                {}, log, error => {
+                    if (error && !error.NoSuchKey) {
+                        log.error('from metadata while deleting user bucket',
+                            { error });
+                        return cb(error);
+                    }
+                    log.trace('deleted bucket from user bucket',
+                    { method: '_deleteUserBucketEntry' });
+                    return cb(null);
+                });
+        } else if (error) {
+            log.error('from metadata while deleting user bucket', { error,
+                method: '_deleteUserBucketEntry' });
+            return cb(error);
+        }
+        log.trace('deleted bucket from user bucket', {
+            method: '_deleteUserBucketEntry' });
+        return cb(null);
+    });
+}
+
+module.exports = deleteUserBucketEntry;

--- a/lib/api/apiUtils/bucket/invisiblyDelete.js
+++ b/lib/api/apiUtils/bucket/invisiblyDelete.js
@@ -1,0 +1,37 @@
+const logger = require('../../../utilities/logger');
+const deleteUserBucketEntry = require('./deleteUserBucketEntry');
+const metadata = require('../../../metadata/wrapper');
+
+/**
+ * Invisibly finishes deleting a bucket that already has a deleted flag
+ * by deleting the object in the users bucket representing the created bucket
+ * and then deleting the bucket in metadata
+ * @param {string} bucketName - name of bucket
+ * @param {string} canonicalID - bucket owner's canonicalID
+ * @return {undefined}
+ */
+function invisiblyDelete(bucketName, canonicalID) {
+    const log = logger.newRequestLogger();
+    log.trace('deleting bucket with deleted flag invisibly', { bucketName });
+    return deleteUserBucketEntry(bucketName, canonicalID, log, err => {
+        if (err) {
+            log.error('error invisibly deleting bucket name from user bucket',
+            { error: err });
+            return log.end();
+        }
+        log.trace('deleted bucket name from user bucket');
+        return metadata.deleteBucket(bucketName, log, error => {
+            log.trace('deleting bucket from metadata',
+            { method: 'invisiblyDelete' });
+            if (error) {
+                log.error('error deleting bucket from metadata', { error });
+                return log.end();
+            }
+            log.trace('invisible deletion of bucket succeeded',
+            { method: 'invisiblyDelete' });
+            return log.end();
+        });
+    });
+}
+
+module.exports = invisiblyDelete;

--- a/lib/api/apiUtils/object/abortMultipartUpload.js
+++ b/lib/api/apiUtils/object/abortMultipartUpload.js
@@ -1,0 +1,128 @@
+const async = require('async');
+
+const { config } = require('../../../Config');
+const constants = require('../../../../constants');
+const data = require('../../../data/wrapper');
+const { metadataValidateBucketAndObj } =
+    require('../../../metadata/metadataUtils');
+const multipleBackendGateway = require('../../../data/multipleBackendGateway');
+const services = require('../../../services');
+
+function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
+    callback) {
+    const metadataValMPUparams = {
+        authInfo,
+        bucketName,
+        objectKey,
+        uploadId,
+        requestType: 'deleteMPU',
+    };
+    // For validating the request at the destinationBucket level
+    // params are the same as validating at the MPU level
+    // but the requestType is the more general 'objectDelete'
+    const metadataValParams = Object.assign({}, metadataValMPUparams);
+    metadataValParams.requestType = 'objectPut';
+
+    async.waterfall([
+        function checkDestBucketVal(next) {
+            metadataValidateBucketAndObj(metadataValParams, log,
+                (err, destinationBucket) => {
+                    if (err) {
+                        return next(err, destinationBucket);
+                    }
+                    if (destinationBucket.policies) {
+                        // TODO: Check bucket policies to see if user is granted
+                        // permission or forbidden permission to take
+                        // given action.
+                        // If permitted, add 'bucketPolicyGoAhead'
+                        // attribute to params for validating at MPU level.
+                        // This is GH Issue#76
+                        metadataValMPUparams.requestType =
+                            'bucketPolicyGoAhead';
+                    }
+                    return next(null, destinationBucket);
+                });
+        },
+        function checkMPUval(destBucket, next) {
+            metadataValParams.log = log;
+            services.metadataValidateMultipart(metadataValParams,
+                (err, mpuBucket, mpuOverviewObj) => {
+                    if (err) {
+                        return next(err, destBucket);
+                    }
+                    return next(err, mpuBucket, mpuOverviewObj, destBucket);
+                });
+        },
+        function ifMultipleBackend(mpuBucket, mpuOverviewObj, destBucket,
+        next) {
+            if (config.backends.data === 'multiple') {
+                const location = mpuOverviewObj.
+                    controllingLocationConstraint;
+                return multipleBackendGateway.abortMPU(objectKey, uploadId,
+                location, bucketName, log, (err, skipDataDelete) => {
+                    if (err) {
+                        return next(err, destBucket);
+                    }
+                    return next(null, mpuBucket, destBucket,
+                    skipDataDelete);
+                });
+            }
+            return next(null, mpuBucket, destBucket, false);
+        },
+        function getPartLocations(mpuBucket, destBucket, skipDataDelete,
+        next) {
+            services.getMPUparts(mpuBucket.getName(), uploadId, log,
+                (err, result) => {
+                    if (err) {
+                        return next(err, destBucket);
+                    }
+                    const storedParts = result.Contents;
+                    return next(null, mpuBucket, storedParts, destBucket,
+                    skipDataDelete);
+                });
+        },
+        function deleteData(mpuBucket, storedParts, destBucket,
+        skipDataDelete, next) {
+            // for Azure we do not need to delete data
+            if (skipDataDelete) {
+                return next(null, mpuBucket, storedParts, destBucket);
+            }
+            // The locations were sent to metadata as an array
+            // under partLocations.  Pull the partLocations.
+            let locations = storedParts.map(item => item.value.partLocations);
+            if (locations.length === 0) {
+                return next(null, mpuBucket, storedParts, destBucket);
+            }
+            // flatten the array
+            locations = [].concat(...locations);
+            return async.eachLimit(locations, 5, (loc, cb) => {
+                data.delete(loc, log, err => {
+                    if (err) {
+                        log.fatal('delete ObjectPart failed', { err });
+                    }
+                    cb();
+                });
+            }, () => next(null, mpuBucket, storedParts, destBucket));
+        },
+        function deleteMetadata(mpuBucket, storedParts, destBucket, next) {
+            let splitter = constants.splitter;
+            // BACKWARD: Remove to remove the old splitter
+            if (mpuBucket.getMdBucketModelVersion() < 2) {
+                splitter = constants.oldSplitter;
+            }
+            // Reconstruct mpuOverviewKey
+            const mpuOverviewKey =
+                `overview${splitter}${objectKey}${splitter}${uploadId}`;
+
+            // Get the sum of all part sizes to include in pushMetric object
+            const partSizeSum = storedParts.map(item => item.value.Size)
+                .reduce((currPart, nextPart) => currPart + nextPart, 0);
+            const keysToDelete = storedParts.map(item => item.key);
+            keysToDelete.push(mpuOverviewKey);
+            services.batchDeleteObjectMetadata(mpuBucket.getName(),
+                keysToDelete, log, err => next(err, destBucket, partSizeSum));
+        },
+    ], callback);
+}
+
+module.exports = abortMultipartUpload;

--- a/lib/api/bucketDelete.js
+++ b/lib/api/bucketDelete.js
@@ -41,8 +41,8 @@ function bucketDelete(authInfo, request, log, cb) {
             }
             log.trace('passed checks',
                 { method: 'metadataValidateBucket' });
-            return deleteBucket(bucketMD, bucketName, authInfo.getCanonicalID(),
-                log, err => {
+            return deleteBucket(authInfo, bucketMD, bucketName,
+                authInfo.getCanonicalID(), log, err => {
                     if (err) {
                         return cb(err, corsHeaders);
                     }

--- a/lib/api/bucketDelete.js
+++ b/lib/api/bucketDelete.js
@@ -1,7 +1,7 @@
 const { errors } = require('arsenal');
 
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
-const { deleteBucket } = require('./apiUtils/bucket/bucketDeletion');
+const deleteBucket = require('./apiUtils/bucket/bucketDeletion');
 const { metadataValidateBucket } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
 

--- a/lib/api/multipartDelete.js
+++ b/lib/api/multipartDelete.js
@@ -1,15 +1,9 @@
-const async = require('async');
 const { errors } = require('arsenal');
 
+const abortMultipartUpload = require('./apiUtils/object/abortMultipartUpload');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
-const constants = require('../../constants');
-const data = require('../data/wrapper');
-const services = require('../services');
-const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
-const { pushMetric } = require('../utapi/utilities');
 const isLegacyAWSBehavior = require('../utilities/legacyAWSBehavior');
-const { config } = require('../Config');
-const multipleBackendGateway = require('../data/multipleBackendGateway');
+const { pushMetric } = require('../utapi/utilities');
 
 /**
  * multipartDelete - DELETE an open multipart upload from a bucket
@@ -28,148 +22,40 @@ function multipartDelete(authInfo, request, log, callback) {
     const bucketName = request.bucketName;
     const objectKey = request.objectKey;
     const uploadId = request.query.uploadId;
-    const metadataValMPUparams = {
-        authInfo,
-        bucketName,
-        objectKey,
-        uploadId,
-        requestType: 'deleteMPU',
-    };
-    // For validating the request at the destinationBucket level
-    // params are the same as validating at the MPU level
-    // but the requestType is the more general 'objectDelete'
-    const metadataValParams = Object.assign({}, metadataValMPUparams);
-    metadataValParams.requestType = 'objectPut';
 
-    async.waterfall([
-        function checkDestBucketVal(next) {
-            metadataValidateBucketAndObj(metadataValParams, log,
-                (err, destinationBucket) => {
-                    if (err) {
-                        return next(err, destinationBucket);
-                    }
-                    if (destinationBucket.policies) {
-                        // TODO: Check bucket policies to see if user is granted
-                        // permission or forbidden permission to take
-                        // given action.
-                        // If permitted, add 'bucketPolicyGoAhead'
-                        // attribute to params for validating at MPU level.
-                        // This is GH Issue#76
-                        metadataValMPUparams.requestType =
-                            'bucketPolicyGoAhead';
-                    }
-                    return next(null, destinationBucket);
-                });
-        },
-        function checkMPUval(destBucket, next) {
-            metadataValParams.log = log;
-            services.metadataValidateMultipart(metadataValParams,
-                (err, mpuBucket, mpuOverviewObj) => {
-                    if (err) {
-                        return next(err, destBucket);
-                    }
-                    return next(err, mpuBucket, mpuOverviewObj, destBucket);
-                });
-        },
-        function ifMultipleBackend(mpuBucket, mpuOverviewObj, destBucket,
-        next) {
-            if (config.backends.data === 'multiple') {
-                const location = mpuOverviewObj.
-                    controllingLocationConstraint;
-                return multipleBackendGateway.abortMPU(objectKey, uploadId,
-                location, bucketName, log, (err, skipDataDelete) => {
-                    if (err) {
-                        return next(err, destBucket);
-                    }
-                    return next(null, mpuBucket, destBucket,
-                    skipDataDelete);
-                });
-            }
-            return next(null, mpuBucket, destBucket, false);
-        },
-        function getPartLocations(mpuBucket, destBucket, skipDataDelete,
-        next) {
-            services.getMPUparts(mpuBucket.getName(), uploadId, log,
-                (err, result) => {
-                    if (err) {
-                        return next(err, destBucket);
-                    }
-                    const storedParts = result.Contents;
-                    return next(null, mpuBucket, storedParts, destBucket,
-                    skipDataDelete);
-                });
-        },
-        function deleteData(mpuBucket, storedParts, destBucket,
-        skipDataDelete, next) {
-            // for Azure we do not need to delete data
-            if (skipDataDelete) {
-                return next(null, mpuBucket, storedParts, destBucket);
-            }
-            // The locations were sent to metadata as an array
-            // under partLocations.  Pull the partLocations.
-            let locations = storedParts.map(item => item.value.partLocations);
-            if (locations.length === 0) {
-                return next(null, mpuBucket, storedParts, destBucket);
-            }
-            // flatten the array
-            locations = [].concat(...locations);
-            return async.eachLimit(locations, 5, (loc, cb) => {
-                data.delete(loc, log, err => {
-                    if (err) {
-                        log.fatal('delete ObjectPart failed', { err });
-                    }
-                    cb();
-                });
-            }, () => next(null, mpuBucket, storedParts, destBucket));
-        },
-        function deleteMetadata(mpuBucket, storedParts, destBucket, next) {
-            let splitter = constants.splitter;
-            // BACKWARD: Remove to remove the old splitter
-            if (mpuBucket.getMdBucketModelVersion() < 2) {
-                splitter = constants.oldSplitter;
-            }
-            // Reconstruct mpuOverviewKey
-            const mpuOverviewKey =
-                `overview${splitter}${objectKey}${splitter}${uploadId}`;
-
-            // Get the sum of all part sizes to include in pushMetric object
-            const partSizeSum = storedParts.map(item => item.value.Size)
-                .reduce((currPart, nextPart) => currPart + nextPart, 0);
-            const keysToDelete = storedParts.map(item => item.key);
-            keysToDelete.push(mpuOverviewKey);
-            services.batchDeleteObjectMetadata(mpuBucket.getName(),
-                keysToDelete, log, err => {
-                    if (err) {
-                        return next(err, destBucket);
-                    }
-                    pushMetric('abortMultipartUpload', log, {
-                        authInfo,
-                        bucket: bucketName,
-                        keys: [objectKey],
-                        byteLength: partSizeSum,
-                    });
-                    return next(null, destBucket);
-                });
-        },
-    ], (err, destinationBucket) => {
-        const corsHeaders = collectCorsHeaders(request.headers.origin,
-            request.method, destinationBucket);
-        const locationConstraint = destinationBucket ?
-            destinationBucket.getLocationConstraint() : null;
-        if (err === errors.NoSuchUpload) {
-            log.trace('did not find valid mpu with uploadId' +
-            `${uploadId}`, { method: 'multipartDelete' });
-            // if legacy behavior is enabled for 'us-east-1' and
-            // request is from 'us-east-1', return 404 instead of
-            // 204
-            if (isLegacyAWSBehavior(locationConstraint)) {
+    abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
+        (err, destinationBucket, partSizeSum) => {
+            const corsHeaders = collectCorsHeaders(request.headers.origin,
+                request.method, destinationBucket);
+            const location = destinationBucket ?
+                destinationBucket.getLocationConstraint() : null;
+            if (err && err !== errors.NoSuchUpload) {
                 return callback(err, corsHeaders);
             }
-            // otherwise ignore error and return 204 status code
+            if (err === errors.NoSuchUpload && isLegacyAWSBehavior(location)) {
+                log.trace('did not find valid mpu with uploadId', {
+                    method: 'multipartDelete',
+                    uploadId,
+                });
+                pushMetric('abortMultipartUpload', log, {
+                    authInfo,
+                    bucket: bucketName,
+                    keys: [objectKey],
+                    byteLength: partSizeSum,
+                });
+                // if legacy behavior is enabled for 'us-east-1' and
+                // request is from 'us-east-1', return 404 instead of
+                // 204
+                return callback(err, corsHeaders);
+            }
+            pushMetric('abortMultipartUpload', log, {
+                authInfo,
+                bucket: bucketName,
+                keys: [objectKey],
+                byteLength: partSizeSum,
+            });
             return callback(null, corsHeaders);
-        }
-        return callback(err, corsHeaders);
-    });
+        });
 }
 
 module.exports = multipartDelete;


### PR DESCRIPTION
## Description
Delete bucket even if the bucket has ongoing multipart uploads.
### Motivation and context

This makes Cloudserver compatible with AWS S3 behavior of deleting buckets even when there are ongoing multipart uploads in a bucket

New test added to confirm the behavior and one test has been changed indicating change of behavior

### Review notes
Easy way to review this PR is to review commit by commit. The refactors are plain movement of code and turning them into modules. The improvement commit is the one that changes the behavior.