### PR TITLE
Improvement/zenko 1291 ext backends keep alive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ _build
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+yarn.lock

--- a/config.json
+++ b/config.json
@@ -90,7 +90,7 @@
     "externalBackends": {
         "aws_s3": {
             "httpAgent": {
-                "keepAlive": true,
+                "keepAlive": false,
                 "keepAliveMsecs": 1000,
                 "maxFreeSockets": 256,
                 "maxSockets": null

--- a/config.json
+++ b/config.json
@@ -86,5 +86,23 @@
        "replicaSet": "rs0",
        "readPreference": "primary",
        "database": "metadata"
+    },
+    "externalBackends": {
+        "aws_s3": {
+            "httpAgent": {
+                "keepAlive": true,
+                "keepAliveMsecs": 1000,
+                "maxFreeSockets": 256,
+                "maxSockets": null
+            }
+        },
+        "gcp": {
+            "httpAgent": {
+                "keepAlive": true,
+                "keepAliveMsecs": 1000,
+                "maxFreeSockets": 256,
+                "maxSockets": null
+            }
+        }
     }
 }

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -150,6 +150,41 @@ fi
 if test -v INITIAL_INSTANCE_ID && test -v S3METADATAPATH && ! test -f ${S3METADATAPATH}/uuid ; then
     echo -n ${INITIAL_INSTANCE_ID} > ${S3METADATAPATH}/uuid
 fi
+# external backends http(s) agent config
+
+# AWS
+if [[ "$AWS_S3_HTTPAGENT_KEEPALIVE" ]]; then
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .externalBackends.aws_s3.httpAgent.keepAlive=$AWS_S3_HTTPAGENT_KEEPALIVE"
+fi
+
+if [[ "$AWS_S3_HTTPAGENT_KEEPALIVE_MS" ]]; then
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .externalBackends.aws_s3.httpAgent.keepAliveMsecs=$AWS_S3_HTTPAGENT_KEEPALIVE_MS"
+fi
+
+if [[ "$AWS_S3_HTTPAGENT_KEEPALIVE_MAX_SOCKETS" ]]; then
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .externalBackends.aws_s3.httpAgent.maxSockets=$AWS_S3_HTTPAGENT_KEEPALIVE_MAX_SOCKETS"
+fi
+
+if [[ "$AWS_S3_HTTPAGENT_KEEPALIVE_MAX_FREE_SOCKETS" ]]; then
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .externalBackends.aws_s3.httpAgent.maxFreeSockets=$AWS_S3_HTTPAGENT_KEEPALIVE_MAX_FREE_SOCKETS"
+fi
+
+#GCP
+if [[ "$GCP_HTTPAGENT_KEEPALIVE" ]]; then
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .externalBackends.gcp.httpAgent.keepAlive=$GCP_HTTPAGENT_KEEPALIVE"
+fi
+
+if [[ "$GCP_HTTPAGENT_KEEPALIVE_MS" ]]; then
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .externalBackends.gcp.httpAgent.keepAliveMsecs=$GCP_HTTPAGENT_KEEPALIVE_MS"
+fi
+
+if [[ "$GCP_HTTPAGENT_KEEPALIVE_MAX_SOCKETS" ]]; then
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .externalBackends.gcp.httpAgent.maxSockets=$GCP_HTTPAGENT_KEEPALIVE_MAX_SOCKETS"
+fi
+
+if [[ "$GCP_HTTPAGENT_KEEPALIVE_MAX_FREE_SOCKETS" ]]; then
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .externalBackends.gcp.httpAgent.maxFreeSockets=$GCP_HTTPAGENT_KEEPALIVE_MAX_FREE_SOCKETS"
+fi
 
 # s3 secret credentials for Zenko
 if [ -r /run/secrets/s3-credentials ] ; then

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -20,7 +20,7 @@ const defaultExternalBackendsConfig = {
     // eslint-disable-next-line camelcase
     aws_s3: {
         httpAgent: {
-            keepAlive: true,
+            keepAlive: false,
             keepAliveMsecs: 1000,
             maxFreeSockets: 256,
             maxSockets: null,

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -9,13 +9,32 @@ const uuid = require('node-uuid');
 const { isValidBucketName } = require('arsenal').s3routes.routesUtils;
 const validateAuthConfig = require('arsenal').auth.inMemory.validateAuthConfig;
 const { buildAuthDataAccount } = require('./auth/in_memory/builder');
-const externalBackends = require('../constants').externalBackends;
+const validExternalBackends = require('../constants').externalBackends;
 const { azureAccountNameRegex, base64Regex } = require('../constants');
 
 // whitelist IP, CIDR for health checks
 const defaultHealthChecks = { allowFrom: ['127.0.0.1/8', '::1'] };
 
 const defaultLocalCache = { host: '127.0.0.1', port: 6379 };
+const defaultExternalBackendsConfig = {
+    // eslint-disable-next-line camelcase
+    aws_s3: {
+        httpAgent: {
+            keepAlive: true,
+            keepAliveMsecs: 1000,
+            maxFreeSockets: 256,
+            maxSockets: null,
+        },
+    },
+    gcp: {
+        httpAgent: {
+            keepAlive: true,
+            keepAliveMsecs: 1000,
+            maxFreeSockets: 256,
+            maxSockets: null,
+        },
+    },
+};
 
 function assertCertPaths(key, cert, ca, basePath) {
     const certObj = {};
@@ -148,7 +167,7 @@ function azureLocationConstraintAssert(location, locationObj) {
 function locationConstraintAssert(locationConstraints) {
     const supportedBackends =
           ['mem', 'file', 'scality',
-           'mongodb'].concat(Object.keys(externalBackends));
+           'mongodb'].concat(Object.keys(validExternalBackends));
     assert(typeof locationConstraints === 'object',
         'bad config: locationConstraints must be an object');
     Object.keys(locationConstraints).forEach(l => {
@@ -432,10 +451,10 @@ class Config extends EventEmitter {
                 assert.notStrictEqual(site, '', 'bad config: `site` property ' +
                     "of object in `replicationEndpoints` must not be ''");
                 if (type !== undefined) {
-                    assert(externalBackends[type], 'bad config: `type` ' +
+                    assert(validExternalBackends[type], 'bad config: `type` ' +
                         'property of `replicationEndpoints` object must be ' +
                         'a valid external backend (one of: "' +
-                        `${Object.keys(externalBackends).join('", "')})`);
+                        `${Object.keys(validExternalBackends).join('", "')})`);
                 } else {
                     assert.notStrictEqual(servers, undefined, 'bad config: ' +
                         'each object of `replicationEndpoints` array that is ' +
@@ -958,6 +977,40 @@ class Config extends EventEmitter {
             config.reportToken ||
             uuid.v4().toString();
         this.reportEndpoint = process.env.REPORT_ENDPOINT;
+
+        // External backends
+        // Currently supports configuring httpAgent(s) for keepAlive
+        this.externalBackends = defaultExternalBackendsConfig;
+        if (config.externalBackends) {
+            const extBackendsConfig = Object.keys(config.externalBackends);
+            extBackendsConfig.forEach(b => {
+                // assert that it's a valid backend
+                assert(validExternalBackends[b] !== undefined,
+                    `bad config: ${b} is not one of valid external backends: ` +
+                    `${Object.keys(validExternalBackends).join(', ')}`);
+
+                const { httpAgent } = config.externalBackends[b];
+                assert(typeof httpAgent === 'object',
+                    `bad config: ${b} must have httpAgent object defined`);
+                const { keepAlive, keepAliveMsecs, maxFreeSockets, maxSockets }
+                    = httpAgent;
+                assert(typeof keepAlive === 'boolean',
+                    `bad config: ${b}.httpAgent.keepAlive must be a boolean`);
+                assert(typeof keepAliveMsecs === 'number' &&
+                    httpAgent.keepAliveMsecs > 0,
+                    `bad config: ${b}.httpAgent.keepAliveMsecs must be` +
+                    ' a number > 0');
+                assert(typeof maxFreeSockets === 'number' &&
+                    httpAgent.maxFreeSockets >= 0,
+                    `bad config: ${b}.httpAgent.maxFreeSockets must be ` +
+                    'a number >= 0');
+                assert((typeof maxSockets === 'number' && maxSockets >= 0) ||
+                    maxSockets === null,
+                    `bad config: ${b}.httpAgent.maxFreeSockets must be ` +
+                    'null or a number >= 0');
+                Object.assign(this.externalBackends[b].httpAgent, httpAgent);
+            });
+        }
     }
 
     _configureBackends() {

--- a/lib/data/locationConstraintParser.js
+++ b/lib/data/locationConstraintParser.js
@@ -52,6 +52,13 @@ function parseLC() {
             const sslEnabled = locationObj.details.https === true;
             const signatureVersion = !sslEnabled ? 'v2' : 'v4';
             const pathStyle = locationObj.details.pathStyle;
+            // keepalive config
+            const httpAgentConfig =
+                config.externalBackends[locationObj.type].httpAgent;
+           //  max sockets is infinity by default and expressed as null
+            if (httpAgentConfig.maxSockets === null) {
+                httpAgentConfig.maxSockets = undefined;
+            }
             const proxyMatch = proxyCompareUrl(endpoint);
             if (config.outboundProxy.url && !proxyMatch) {
                 const options = url.parse(config.outboundProxy.url);
@@ -59,14 +66,14 @@ function parseLC() {
                     Object.assign(options, config.outboundProxy.certs);
                     options.secureProxy = true;
                 }
-                options.keepAlive = true;
+                options.keepAlive = httpAgentConfig.keepAlive;
                 // whether options.secureProxy is set to true determines
                 // https or http proxy
                 connectionAgent = new HttpsProxyAgent(options);
             } else {
                 connectionAgent = sslEnabled ?
-                    new https.Agent({ keepAlive: true }) :
-                    new http.Agent({ keepAlive: true });
+                    new https.Agent(httpAgentConfig) :
+                    new http.Agent(httpAgentConfig);
             }
             const httpOptions = { agent: connectionAgent, timeout: 0 };
             const s3Params = {

--- a/tests/unit/multipleBackend/locConstraintParse.js
+++ b/tests/unit/multipleBackend/locConstraintParse.js
@@ -28,7 +28,7 @@ describe('locationConstraintParser', () => {
         assert.strictEqual(client._s3Params.sslEnabled, true);
         assert.strictEqual(client._s3Params.httpOptions.agent.protocol,
             'https:');
-        assert.strictEqual(client._s3Params.httpOptions.agent.keepAlive, true);
+        assert.strictEqual(client._s3Params.httpOptions.agent.keepAlive, false);
         assert.strictEqual(client._s3Params.signatureVersion, 'v4');
     });
 
@@ -39,7 +39,7 @@ describe('locationConstraintParser', () => {
         assert.strictEqual(client._s3Params.sslEnabled, false);
         assert.strictEqual(client._s3Params.httpOptions.agent.protocol,
             'http:');
-        assert.strictEqual(client._s3Params.httpOptions.agent.keepAlive, true);
+        assert.strictEqual(client._s3Params.httpOptions.agent.keepAlive, false);
         assert.strictEqual(client._s3Params.signatureVersion, 'v2');
     });
 });


### PR DESCRIPTION
# Pull request template

## Description
Keep-Alive configuration for external backends

### Motivation and context

Socket hangups were observed when keepalive is enabled (especially to AWS). This PR makes keep alive configuration per backend tunable and set keep alive disabled for AWS.

#### Commits
- improvement: ZENKO-1291 configurable httpAgent options
> This commit adds the ability to configure httpAgent options for external backends.
Currently only AWS and GCP are suppored. Azure is not supported as there is no
straight forward way to set a custom httpAgent in the Azure SDK. The defaults are
expressed to be sensible and explicit.
The default maxSockets is inifinity which is expressed as `null` and other values
are inspired by node.js defaults.
This configuration is applied globally for all locations of the same type of external backend.

- improvement: ZENKO-1291 disable keepAlive for AWS
> This commit disables keep-alive on connections to AWS as connection
reuse showed intermittent socket hang ups.