### PR TITLE
improvement: use simpler unit test script

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -137,8 +137,8 @@ stages:
           name: Unit Coverage
           command: |
             mkdir -p $CIRCLE_TEST_REPORTS/unit
-            npm run unit_coverage
-            npm run unit_coverage_legacy_location
+            npm run test
+            npm run test_legacy_location
           env: &shared-vars
             CIRCLE_TEST_REPORTS: /tmp
             CIRCLE_ARTIFACTS: /tmp


### PR DESCRIPTION
The `unit_coverage` and `unit_coverage_legacy_location` scripts were used for circle ci, but do not provide detailed logs when tests fail.
running `test` and `test_legacy_location` will show more detailed output.
