### PR TITLE
ZENKO-1337

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -281,9 +281,15 @@ stages:
           name: Build docker image
           command: >-
             docker build
+            --no-cache
             -t %(prop:docker_image_name)s
-            -t zenko/cloudserver:latest-%(prop:product_version)s
             .
+      - ShellCommand:
+          name: Tag images
+          command: |
+            docker tag %(prop:docker_image_name)s zenko/cloudserver:$TAG
+          env:
+            TAG: "latest-%(prop:product_version)s"
       - ShellCommand:
           name: Push image
           command: |


### PR DESCRIPTION
## Description

### Motivation and context

Why is this change required? What problem does it solve?

Fixes a silent issue where the docker tags need escape characters to properly build.