### PR TITLE
ft: ZENKO-717: replicationBackends constant moved to Arsenal

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -118,7 +118,6 @@ const constants = {
     legacyLocations: ['sproxyd', 'legacy'],
     /* eslint-disable camelcase */
     externalBackends: { aws_s3: true, azure: true, gcp: true, pfs: true },
-    replicationBackends: { aws_s3: true, azure: true, gcp: true, pfs: false },
     // some of the available data backends  (if called directly rather
     // than through the multiple backend gateway) need a key provided
     // as a string as first parameter of the get/delete methods.

--- a/lib/api/apiUtils/object/getReplicationInfo.js
+++ b/lib/api/apiUtils/object/getReplicationInfo.js
@@ -1,6 +1,6 @@
 const s3config = require('../../../Config').config;
-const constants = require('../../../../constants');
 const { isBackbeatUser } = require('../authorization/aclChecks');
+const { replicationBackends } = require('arsenal').constants;
 
 function _getBackend(objectMD, site) {
     const backends = objectMD ? objectMD.replicationInfo.backends : [];
@@ -40,7 +40,7 @@ function _getReplicationInfo(rule, replicationConfig, content, operationType,
               storageClass.endsWith(':preferred_read') ?
               storageClass.split(':')[0] : storageClass;
         const location = s3config.locationConstraints[storageClassName];
-        if (location && constants.replicationBackends[location.type]) {
+        if (location && replicationBackends[location.type]) {
             storageTypes.push(location.type);
         }
         backends.push(_getBackend(objectMD, storageClassName));

--- a/lib/management/configuration.js
+++ b/lib/management/configuration.js
@@ -3,7 +3,6 @@ const arsenal = require('arsenal');
 
 const { buildAuthDataAccount } = require('../auth/in_memory/builder');
 const _config = require('../Config').config;
-const constants = require('../../constants');
 const metadata = require('../metadata/wrapper');
 
 const { getStoredCredentials } = require('./credentials');
@@ -13,6 +12,7 @@ const managementDatabaseName = 'PENSIEVE';
 const replicatorEndpoint = 'zenko-cloudserver-replicator';
 const { decryptSecret } = arsenal.pensieve.credentialUtils;
 const { reshapeExceptionError } = arsenal.errorUtils;
+const { replicationBackends } = require('arsenal').constants;
 
 function overlayHasVersion(overlay) {
     return overlay && overlay.version !== undefined;
@@ -207,7 +207,7 @@ function patchConfiguration(newConf, log, cb) {
                 // NOTE: In Orbit, we don't need to have Scality location in our
                 // replication endpoind config, since we do not replicate to
                 // any Scality Instance yet.
-                .filter(key => constants.replicationBackends
+                .filter(key => replicationBackends
                   [locations[key].type])
                 .reduce((obj, key) => {
                     /* eslint no-param-reassign:0 */

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "github:scality/arsenal#07f655c",
+    "arsenal": "github:scality/arsenal#3e08bad",
     "async": "~2.5.0",
     "aws-sdk": "2.28.0",
     "azure-storage": "^2.1.0",


### PR DESCRIPTION
With the management code moved from cloud server to its own repository,
this constant should be shared in Arsenal constants.

# Pull request template

## Description

### Motivation and context

Why is this change required? What problem does it solve?

### Related issues

Please use the following link syntaxes #600 to reference issues in the
current repository

## Checklist

### Add tests to cover the changes

New tests added or existing tests modified to cover all changes

### Code conforms with the [style guide](https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#coding-style-guidelines)

### Sign your work

In order to contribute to the project, you must sign your work
https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#sign-your-work

Thank you again for contributing! We will try to test and integrate the change
as soon as we can.
