### PR TITLE
feat(PfsClient): add delete functionality

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -669,6 +669,8 @@ class Config extends EventEmitter {
             this.pfsDaemon.dataPath =
                 process.env.PFSD_MOUNT_PATH ?
                 process.env.PFSD_MOUNT_PATH : `${__dirname}/../localPfs`;
+            this.pfsDaemon.isReadOnly =
+                process.env.PFSD_READONLY === 'true';
         }
 
         if (config.metadataDaemon) {

--- a/lib/data/external/PfsClient.js
+++ b/lib/data/external/PfsClient.js
@@ -8,13 +8,8 @@ class PfsClient {
         const { host, port } = config.endpoint;
 
         this.clientType = 'pfs';
-        this.type = 'PFS';
-        this._bucketName = config.bucketName;
         this._bucketMatch = config.bucketMatch;
-        this._serverSideEncryption = config.serverSideEncryption;
         this._dataStoreName = config.dataStoreName;
-        this._supportsVersioning = config.supportsVersioning;
-        this._mountPath = config.mountPath;
         this._restClient = new arsenal.network.rest.RESTClient({
             host,
             port,
@@ -72,9 +67,16 @@ class PfsClient {
 
     delete(objectGetInfo, reqUids, callback) {
         const log = createLogger(reqUids);
-        logHelper(log, 'error', 'Not implemented', errors.NotImplemented,
+        const key = typeof objectGetInfo === 'string' ? objectGetInfo :
+            objectGetInfo.key;
+        this._restClient.delete(key, reqUids, err => {
+            if (err) {
+                logHelper(log, 'error', 'err from data backend', err,
                 this._dataStoreName, this.clientType);
-        return callback(errors.NotImplemented);
+                return callback(err);
+            }
+            return callback();
+        });
     }
 
     // TODO: Implement a healthcheck

--- a/lib/data/locationConstraintParser.js
+++ b/lib/data/locationConstraintParser.js
@@ -141,13 +141,9 @@ function parseLC() {
         if (locationObj.type === 'pfs') {
             const pfsDaemonEndpoint = config.getPfsDaemonEndpoint(location);
             clients[location] = new PfsClient({
-                bucketName: locationObj.details.bucketName,
                 bucketMatch: locationObj.details.bucketMatch,
-                serverSideEncryption: locationObj.details.serverSideEncryption,
                 dataStoreName: location,
-                supportsVersioning: locationObj.details.supportsVersioning,
                 endpoint: pfsDaemonEndpoint,
-                mountPath: locationObj.details.mountPath,
             });
             clients[location].clientType = 'pfs';
         }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "github:scality/arsenal#3e08bad",
+    "arsenal": "github:scality/arsenal#ea1a7d4",
     "async": "~2.5.0",
     "aws-sdk": "2.28.0",
     "azure-storage": "^2.1.0",

--- a/pfsserver.js
+++ b/pfsserver.js
@@ -11,6 +11,7 @@ const pfsServer = new arsenal.network.rest.RESTServer({
         dataPath: config.pfsDaemon.dataPath,
         log: config.log,
         isPassthrough: true,
+        isReadOnly: config.pfsDaemon.isReadOnly,
     }),
     log: config.log,
 });


### PR DESCRIPTION
This PR:
- Adds delete support for the PfsClient.
- Allows you to configure the PfsDaemon for ReadOnly mode.
- Deletes unnecessary and unused properties.

Depends on https://github.com/scality/Arsenal/pull/609.