### PR TITLE
Improvement/zenko 1045 ceph e2 e tests

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -237,16 +237,23 @@ function locationConstraintAssert(locationConstraints) {
             assert(typeof details.credentials.secretKey === 'string',
                 'bad config: credentials must include secretKey as string');
         }
-        if (details.https !== undefined) {
+        if (process.env.CI === 'true') {
+            // eslint-disable-next-line no-param-reassign
+            locationConstraints[l].details.https = false;
+        } else if (details.https !== undefined) {
             assert(typeof details.https === 'boolean', 'bad config: ' +
                 'locationConstraints[region].details https must be a boolean');
         } else {
             // eslint-disable-next-line no-param-reassign
             locationConstraints[l].details.https = true;
         }
+
         if (details.pathStyle !== undefined) {
             assert(typeof details.pathStyle === 'boolean', 'bad config: ' +
                 'locationConstraints[region].pathStyle must be a boolean');
+        } else if (process.env.CI === 'true') {
+            // eslint-disable-next-line no-param-reassign
+            locationConstraints[l].details.pathStyle = true;
         } else {
             // eslint-disable-next-line no-param-reassign
             locationConstraints[l].details.pathStyle = false;

--- a/lib/management/configuration.js
+++ b/lib/management/configuration.js
@@ -90,7 +90,7 @@ function patchConfiguration(newConf, log, cb) {
                     details: {},
                 };
                 let supportsVersioning = false;
-                let pathStyle = false;
+                let pathStyle = process.env.CI !== undefined;
 
                 switch (l.locationType) {
                 case 'location-mem-v1':


### PR DESCRIPTION
## Description
Allow forcing path-style buckets, and http for AWS locations using the pre-existing `CI` environment variable.


### Motivation and context
Required for Ceph in Zenko's CI. At present there is no way for a backend to be added as AWS and to also use path-style bucket, and http if configured through Orbit (or in our case orbit-simulator). Currently, Barring running our own DNS server, or resorting to kube-dns hacks, we are forced to use path-style buckets for "mocked" backends in our CI. For https we would need either external access for ACME (LetsEncrypt), external hosted DNS with an API for ACMEv2 DNS challenges, or to add a self-signed cert to our cloudserver docker images.