### PR TITLE
feature: ZENKO-1359 add ingestion capability

### DIFF
--- a/lib/utilities/reportHandler.js
+++ b/lib/utilities/reportHandler.js
@@ -37,6 +37,7 @@ function getCapabilities() {
         preferredReadLocation: true,
         managedLifecycle: true,
         secureChannelOptimizedPath: hasWSOptionalDependencies(),
+        s3cIngestLocation: true,
     };
 }
 

--- a/tests/unit/management/secureChannel.js
+++ b/tests/unit/management/secureChannel.js
@@ -13,5 +13,6 @@ describe('report handler', () => {
         assert.strictEqual(c.preferredReadLocation, true);
         assert.strictEqual(c.managedLifecycle, true);
         assert.strictEqual(c.secureChannelOptimizedPath, true);
+        assert.strictEqual(c.s3cIngestLocation, true);
     });
 });


### PR DESCRIPTION
## Description
ZENKO-1359 add ingestion capability
### Motivation and context

This flag allows Orbit to identify Zenko instances which have Ingestion
feature capabilities.