### PR TITLE
feature: ZENKO-733 Lifecycle non-versioned buckets

### DIFF
--- a/lib/api/bucketPutVersioning.js
+++ b/lib/api/bucketPutVersioning.js
@@ -14,6 +14,10 @@ const monitoring = require('../utilities/monitoringHandler');
 const externalVersioningErrorMessage = 'We do not currently support putting ' +
 'a versioned object to a location-constraint of type Azure or GCP.';
 
+const replicationVersioningErrorMessage = 'A replication configuration is ' +
+'present on this bucket, so you cannot change the versioning state. To ' +
+'change the versioning state, first delete the replication configuration.';
+
 /**
  * Format of xml request:
 
@@ -75,6 +79,18 @@ function _checkBackendVersioningImplemented(bucket) {
     return true;
 }
 
+function _isValidReplicationVersioning(result, bucket) {
+    if (result.VersioningConfiguration &&
+        result.VersioningConfiguration.Status) {
+        // Is there a replication configuration set on the bucket and is the
+        // user attempting to suspend versioning?
+        if (bucket.getReplicationConfiguration()) {
+            return result.VersioningConfiguration.Status[0] !== 'Suspended';
+        }
+    }
+    return true;
+}
+
 /**
  * Bucket Put Versioning - Create or update bucket Versioning
  * @param {AuthInfo} authInfo - Instance of AuthInfo class with requester's info
@@ -115,6 +131,15 @@ function bucketPutVersioning(authInfo, request, log, callback) {
                     error: errors.NotImplemented });
                 const error = errors.NotImplemented.customizeDescription(
                     externalVersioningErrorMessage);
+                return next(error, bucket);
+            }
+            if (!_isValidReplicationVersioning(result, bucket)) {
+                log.debug(replicationVersioningErrorMessage, {
+                    method: 'bucketPutVersioning',
+                    error: errors.InvalidBucketState,
+                });
+                const error = errors.InvalidBucketState
+                    .customizeDescription(replicationVersioningErrorMessage);
                 return next(error, bucket);
             }
             const versioningConfiguration = {};

--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -856,15 +856,6 @@ function routeBackbeat(clientIP, request, response, log) {
                 return backbeatRoutes[request.method][request.resourceType]
                     [request.query.operation](request, response, log, next);
             }
-            if (!bucketInfo.isNFS() && !bucketInfo.isVersioningEnabled()) {
-                log.debug('bucket versioning is not enabled', {
-                    method: request.method,
-                    bucketName: request.bucketName,
-                    objectKey: request.objectKey,
-                    resourceType: request.resourceType,
-                });
-                return next(errors.InvalidBucketState);
-            }
             return backbeatRoutes[request.method][request.resourceType](
                 request, response, bucketInfo, objMd, log, next);
         }],

--- a/tests/multipleBackend/routes/routeBackbeat.js
+++ b/tests/multipleBackend/routes/routeBackbeat.js
@@ -302,35 +302,6 @@ describeSkipIfAWS('backbeat routes', () => {
             });
         });
 
-        it('should refuse PUT data if bucket is not versioned',
-        done => makeBackbeatRequest({
-            method: 'PUT', bucket: NONVERSIONED_BUCKET,
-            objectKey: testKey, resourceType: 'data',
-            headers: {
-                'content-length': testData.length,
-                'content-md5': testDataMd5,
-                'x-scal-canonical-id': testArn,
-            },
-            authCredentials: backbeatAuthCredentials,
-            requestBody: testData,
-        },
-        err => {
-            assert.strictEqual(err.code, 'InvalidBucketState');
-            done();
-        }));
-
-        it('should refuse PUT metadata if bucket is not versioned',
-        done => makeBackbeatRequest({
-            method: 'PUT', bucket: NONVERSIONED_BUCKET,
-            objectKey: testKey, resourceType: 'metadata',
-            authCredentials: backbeatAuthCredentials,
-            requestBody: JSON.stringify(testMd),
-        },
-        err => {
-            assert.strictEqual(err.code, 'InvalidBucketState');
-            done();
-        }));
-
         it('should refuse PUT data if no x-scal-canonical-id header ' +
            'is provided', done => makeBackbeatRequest({
                method: 'PUT', bucket: TEST_BUCKET,


### PR DESCRIPTION
Lifecycle transitions requires fetching object metadata through the backbeat routes such that the replication of data can be performed. Transitions can occur on non-versioned buckets, so we do not want to return an `InvalidBucket` error in that case.