### PR TITLE
feature: ZENKO-732 Lifecycle transition policies

### DIFF
--- a/lib/api/bucketPutLifecycle.js
+++ b/lib/api/bucketPutLifecycle.js
@@ -2,6 +2,7 @@ const { waterfall } = require('async');
 const LifecycleConfiguration =
     require('arsenal').models.LifecycleConfiguration;
 
+const config = require('../Config').config;
 const parseXML = require('../utilities/parseXML');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const metadata = require('../metadata/wrapper');
@@ -30,7 +31,8 @@ function bucketPutLifecycle(authInfo, request, log, callback) {
     return waterfall([
         next => parseXML(request.post, log, next),
         (parsedXml, next) => {
-            const lcConfigClass = new LifecycleConfiguration(parsedXml);
+            const lcConfigClass =
+                new LifecycleConfiguration(parsedXml, config);
             // if there was an error getting lifecycle configuration,
             // returned configObj will contain 'error' key
             process.nextTick(() => {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "github:scality/arsenal#ea1a7d4",
+    "arsenal": "github:scality/arsenal#699890d",
     "async": "~2.5.0",
     "aws-sdk": "2.28.0",
     "azure-storage": "^2.1.0",

--- a/tests/functional/aws-node-sdk/test/bucket/getBucketLifecycle.js
+++ b/tests/functional/aws-node-sdk/test/bucket/getBucketLifecycle.js
@@ -14,6 +14,14 @@ const lifecycleConfig = {
         Expiration: {
             Days: 1,
         },
+        NoncurrentVersionTransitions: [{
+            NoncurrentDays: 0,
+            StorageClass: 'us-east-2',
+        }],
+        Transitions: [{
+            Days: 0,
+            StorageClass: 'us-east-2',
+        }],
     }],
 };
 const expectedConfig = {
@@ -21,8 +29,14 @@ const expectedConfig = {
     ID: 'test-id',
     Filter: {},
     Status: 'Enabled',
-    Transitions: [],
-    NoncurrentVersionTransitions: [],
+    NoncurrentVersionTransitions: [{
+        NoncurrentDays: 0,
+        StorageClass: 'us-east-2',
+    }],
+    Transitions: [{
+        Days: 0,
+        StorageClass: 'us-east-2',
+    }],
 };
 
 // Check for the expected error response code and status code.

--- a/tests/functional/aws-node-sdk/test/bucket/putBucketLifecycle.js
+++ b/tests/functional/aws-node-sdk/test/bucket/putBucketLifecycle.js
@@ -5,8 +5,10 @@ const { S3 } = require('aws-sdk');
 const getConfig = require('../support/config');
 const BucketUtility = require('../../lib/utility/bucket-util');
 
+const MAX_DAYS = 2147483647; // Max 32-bit signed binary integer.
+
 const bucket = 'lifecycleputtestbucket';
-const basicRule = {
+const expirationRule = {
     ID: 'test-id',
     Status: 'Enabled',
     Prefix: '',
@@ -32,11 +34,11 @@ function assertError(err, expectedErr, cb) {
 function getLifecycleParams(paramToChange) {
     const newParam = {};
     const lifecycleConfig = {
-        Rules: [basicRule],
+        Rules: [expirationRule],
     };
     if (paramToChange) {
         newParam[paramToChange.key] = paramToChange.value;
-        lifecycleConfig.Rules[0] = Object.assign({}, basicRule, newParam);
+        lifecycleConfig.Rules[0] = Object.assign({}, expirationRule, newParam);
     }
     return {
         Bucket: bucket,
@@ -130,7 +132,7 @@ describe('aws-sdk test put bucket lifecycle', () => {
 
         describe('with Rule.Filter not Rule.Prefix', () => {
             before(done => {
-                basicRule.Prefix = null;
+                expirationRule.Prefix = null;
                 done();
             });
 
@@ -222,6 +224,284 @@ describe('aws-sdk test put bucket lifecycle', () => {
                 });
                 s3.putBucketLifecycleConfiguration(params, err =>
                     assertError(err, null, done));
+            });
+        });
+
+        describe('with NoncurrentVersionTransitions', () => {
+            // Get lifecycle request params with NoncurrentVersionTransitions.
+            function getParams(noncurrentVersionTransitions) {
+                const rule = {
+                    ID: 'test',
+                    Status: 'Enabled',
+                    Prefix: '',
+                    NoncurrentVersionTransitions: noncurrentVersionTransitions,
+                };
+                return {
+                    Bucket: bucket,
+                    LifecycleConfiguration: { Rules: [rule] },
+                };
+            }
+
+            it('should allow NoncurrentDays and StorageClass', done => {
+                const noncurrentVersionTransitions = [{
+                    NoncurrentDays: 0,
+                    StorageClass: 'us-east-2',
+                }];
+                const params = getParams(noncurrentVersionTransitions);
+                s3.putBucketLifecycleConfiguration(params, err => {
+                    assert.ifError(err);
+                    done();
+                });
+            });
+
+            it('should not allow duplicate StorageClass', done => {
+                const noncurrentVersionTransitions = [{
+                    NoncurrentDays: 1,
+                    StorageClass: 'us-east-2',
+                }, {
+                    NoncurrentDays: 2,
+                    StorageClass: 'us-east-2',
+                }];
+                const params = getParams(noncurrentVersionTransitions);
+                s3.putBucketLifecycleConfiguration(params, err => {
+                    assert.strictEqual(err.code, 'InvalidRequest');
+                    assert.strictEqual(err.message,
+                    "'StorageClass' must be different for " +
+                    "'NoncurrentVersionTransition' actions in same " +
+                    "'Rule' with prefix ''");
+                    done();
+                });
+            });
+
+            it('should not allow unknown StorageClass',
+            done => {
+                const noncurrentVersionTransitions = [{
+                    NoncurrentDays: 1,
+                    StorageClass: 'unknown',
+                }];
+                const params = getParams(noncurrentVersionTransitions);
+                s3.putBucketLifecycleConfiguration(params, err => {
+                    assert.strictEqual(err.code, 'MalformedXML');
+                    done();
+                });
+            });
+
+            it(`should not allow NoncurrentDays value exceeding ${MAX_DAYS}`,
+            done => {
+                const noncurrentVersionTransitions = [{
+                    NoncurrentDays: MAX_DAYS + 1,
+                    StorageClass: 'us-east-2',
+                }];
+                const params = getParams(noncurrentVersionTransitions);
+                s3.putBucketLifecycleConfiguration(params, err => {
+                    assert.strictEqual(err.code, 'MalformedXML');
+                    done();
+                });
+            });
+
+            it('should not allow negative NoncurrentDays',
+            done => {
+                const noncurrentVersionTransitions = [{
+                    NoncurrentDays: -1,
+                    StorageClass: 'us-east-2',
+                }];
+                const params = getParams(noncurrentVersionTransitions);
+                s3.putBucketLifecycleConfiguration(params, err => {
+                    assert.strictEqual(err.code, 'InvalidArgument');
+                    assert.strictEqual(err.message,
+                    "'NoncurrentDays' in NoncurrentVersionTransition " +
+                    'action must be nonnegative');
+                    done();
+                });
+            });
+
+            it('should not allow config missing NoncurrentDays',
+            done => {
+                const noncurrentVersionTransitions = [{
+                    StorageClass: 'us-east-2',
+                }];
+                const params = getParams(noncurrentVersionTransitions);
+                s3.putBucketLifecycleConfiguration(params, err => {
+                    assert.strictEqual(err.code, 'MalformedXML');
+                    done();
+                });
+            });
+
+            it('should not allow config missing StorageClass',
+            done => {
+                const noncurrentVersionTransitions = [{
+                    NoncurrentDays: 1,
+                }];
+                const params = getParams(noncurrentVersionTransitions);
+                s3.putBucketLifecycleConfiguration(params, err => {
+                    assert.strictEqual(err.code, 'MalformedXML');
+                    done();
+                });
+            });
+        });
+
+        describe('with Transitions', () => {
+            // Get lifecycle request params with Transitions.
+            function getParams(transitions) {
+                const rule = {
+                    ID: 'test',
+                    Status: 'Enabled',
+                    Prefix: '',
+                    Transitions: transitions,
+                };
+                return {
+                    Bucket: bucket,
+                    LifecycleConfiguration: { Rules: [rule] },
+                };
+            }
+
+            it('should allow Days', done => {
+                const transitions = [{
+                    Days: 0,
+                    StorageClass: 'us-east-2',
+                }];
+                const params = getParams(transitions);
+                s3.putBucketLifecycleConfiguration(params, err => {
+                    assert.ifError(err);
+                    done();
+                });
+            });
+
+            it(`should not allow Days value exceeding ${MAX_DAYS}`, done => {
+                const transitions = [{
+                    Days: MAX_DAYS + 1,
+                    StorageClass: 'us-east-2',
+                }];
+                const params = getParams(transitions);
+                s3.putBucketLifecycleConfiguration(params, err => {
+                    assert.strictEqual(err.code, 'MalformedXML');
+                    done();
+                });
+            });
+
+            it('should not allow negative Days value', done => {
+                const transitions = [{
+                    Days: -1,
+                    StorageClass: 'us-east-2',
+                }];
+                const params = getParams(transitions);
+                s3.putBucketLifecycleConfiguration(params, err => {
+                    assert.strictEqual(err.code, 'InvalidArgument');
+                    assert.strictEqual(err.message,
+                        "'Days' in Transition action must be nonnegative");
+                    done();
+                });
+            });
+
+            it('should not allow duplicate StorageClass', done => {
+                const transitions = [{
+                    Days: 1,
+                    StorageClass: 'us-east-2',
+                }, {
+                    Days: 2,
+                    StorageClass: 'us-east-2',
+                }];
+                const params = getParams(transitions);
+                s3.putBucketLifecycleConfiguration(params, err => {
+                    assert.strictEqual(err.code, 'InvalidRequest');
+                    assert.strictEqual(err.message,
+                        "'StorageClass' must be different for 'Transition' " +
+                        "actions in same 'Rule' with prefix ''");
+                    done();
+                });
+            });
+
+            // TODO: Upgrade to aws-sdk >= 2.60.0 for correct Date field support
+            it.skip('should allow Date', done => {
+                const transitions = [{
+                    Date: '2016-01-01T00:00:00.000Z',
+                    StorageClass: 'us-east-2',
+                }];
+                const params = getParams(transitions);
+                s3.putBucketLifecycleConfiguration(params, err => {
+                    assert.ifError(err);
+                    done();
+                });
+            });
+
+            // TODO: Upgrade to aws-sdk >= 2.60.0 for correct Date field support
+            it.skip('should not allow speficying both Days and Date value',
+            done => {
+                const transitions = [{
+                    Date: '2016-01-01T00:00:00.000Z',
+                    Days: 1,
+                    StorageClass: 'us-east-2',
+                }];
+                const params = getParams(transitions);
+                s3.putBucketLifecycleConfiguration(params, err => {
+                    assert.strictEqual(err.code, 'MalformedXML');
+                    done();
+                });
+            });
+
+            // TODO: Upgrade to aws-sdk >= 2.60.0 for correct Date field support
+            it.skip('should not allow speficying both Days and Date value ' +
+            'across transitions', done => {
+                const transitions = [{
+                    Date: '2016-01-01T00:00:00.000Z',
+                    StorageClass: 'us-east-2',
+                }, {
+                    Days: 1,
+                    StorageClass: 'zenko',
+                }];
+                const params = getParams(transitions);
+                s3.putBucketLifecycleConfiguration(params, err => {
+                    assert.strictEqual(err.code, 'InvalidRequest');
+                    assert.strictEqual(err.message,
+                        "Found mixed 'Date' and 'Days' based Transition " +
+                        "actions in lifecycle rule for prefix ''");
+                    done();
+                });
+            });
+
+            // TODO: Upgrade to aws-sdk >= 2.60.0 for correct Date field support
+            it.skip('should not allow speficying both Days and Date value ' +
+            'across transitions and expiration', done => {
+                const transitions = [{
+                    Days: 1,
+                    StorageClass: 'us-east-2',
+                }];
+                const params = getParams(transitions);
+                params.LifecycleConfiguration.Rules[0].Expiration = { Date: 0 };
+                s3.putBucketLifecycleConfiguration(params, err => {
+                    assert.strictEqual(err.code, 'InvalidRequest');
+                    assert.strictEqual(err.message,
+                        "Found mixed 'Date' and 'Days' based Expiration and " +
+                        "Transition actions in lifecycle rule for prefix ''");
+                    done();
+                });
+            });
+        });
+
+        describe('with NoncurrentVersionTransitions and Transitions', () => {
+            it('should allow config', done => {
+                const params = {
+                    Bucket: bucket,
+                    LifecycleConfiguration: {
+                        Rules: [{
+                            ID: 'test',
+                            Status: 'Enabled',
+                            Prefix: '',
+                            NoncurrentVersionTransitions: [{
+                                NoncurrentDays: 1,
+                                StorageClass: 'us-east-2',
+                            }],
+                            Transitions: [{
+                                Days: 1,
+                                StorageClass: 'us-east-2',
+                            }],
+                        }],
+                    },
+                };
+                s3.putBucketLifecycleConfiguration(params, err => {
+                    assert.ifError(err);
+                    done();
+                });
             });
         });
     });


### PR DESCRIPTION
Add functional tests for lifecycle transition policies.

Will follow up with an upgrade to aws-sdk version >= 2.60.0, such that any other affected tests can be altered accordingly.