### PR TITLE
improvement: ZENKO-1371 Upgrade AWS SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "arsenal": "github:scality/arsenal#699890d",
     "async": "~2.5.0",
-    "aws-sdk": "2.28.0",
+    "aws-sdk": "2.60.0",
     "azure-storage": "^2.1.0",
     "backo": "^1.1.0",
     "bucketclient": "scality/bucketclient#5aa99d7",

--- a/tests/functional/aws-node-sdk/test/bucket/putBucketLifecycle.js
+++ b/tests/functional/aws-node-sdk/test/bucket/putBucketLifecycle.js
@@ -411,8 +411,7 @@ describe('aws-sdk test put bucket lifecycle', () => {
                 });
             });
 
-            // TODO: Upgrade to aws-sdk >= 2.60.0 for correct Date field support
-            it.skip('should allow Date', done => {
+            it('should allow Date', done => {
                 const transitions = [{
                     Date: '2016-01-01T00:00:00.000Z',
                     StorageClass: 'us-east-2',
@@ -424,9 +423,7 @@ describe('aws-sdk test put bucket lifecycle', () => {
                 });
             });
 
-            // TODO: Upgrade to aws-sdk >= 2.60.0 for correct Date field support
-            it.skip('should not allow speficying both Days and Date value',
-            done => {
+            it('should not allow speficying both Days and Date value', done => {
                 const transitions = [{
                     Date: '2016-01-01T00:00:00.000Z',
                     Days: 1,
@@ -439,8 +436,7 @@ describe('aws-sdk test put bucket lifecycle', () => {
                 });
             });
 
-            // TODO: Upgrade to aws-sdk >= 2.60.0 for correct Date field support
-            it.skip('should not allow speficying both Days and Date value ' +
+            it('should not allow speficying both Days and Date value ' +
             'across transitions', done => {
                 const transitions = [{
                     Date: '2016-01-01T00:00:00.000Z',
@@ -459,8 +455,7 @@ describe('aws-sdk test put bucket lifecycle', () => {
                 });
             });
 
-            // TODO: Upgrade to aws-sdk >= 2.60.0 for correct Date field support
-            it.skip('should not allow speficying both Days and Date value ' +
+            it('should not allow speficying both Days and Date value ' +
             'across transitions and expiration', done => {
                 const transitions = [{
                     Days: 1,


### PR DESCRIPTION
AWS-SDK versions below 2.60.0 do not correctly support the `Date` field when setting transition policies. See bugfix https://github.com/aws/aws-sdk-js/blob/HEAD/CHANGELOG.md#2600.