### PR TITLE
bugfix: ZENKO-1365 Orbit set https for RING+S3C

### DIFF
--- a/lib/management/configuration.js
+++ b/lib/management/configuration.js
@@ -128,7 +128,7 @@ function patchConfiguration(newConf, log, cb) {
                         if (awsEndpoint.includes('://')) {
                             const url = new URL(awsEndpoint);
                             awsEndpoint = url.host;
-                            https = url.scheme === 'https';
+                            https = url.protocol.includes('https');
                         }
 
                         location.details = {

--- a/tests/unit/management/configuration.js
+++ b/tests/unit/management/configuration.js
@@ -168,6 +168,19 @@ describe('patchConfiguration', () => {
                     sizeLimitGB: 0,
                     details: {},
                 },
+                'httpsawsbackendtest': {
+                    name: 'httpsawsbackendtest',
+                    objectId: 'httpsawsbackendtest',
+                    locationType: 'location-scality-ring-s3-v1',
+                    details: {
+                        bucketMatch: 'rings3bucketmatch',
+                        endpoint: 'https://secure.ring.end.point',
+                        accessKey: 'rings3accesskey',
+                        secretKey,
+                        bucketName: 'rings3bucketname',
+                        region: 'us-west-1',
+                    },
+                },
             },
             browserAccess: {
                 enabled: true,
@@ -305,6 +318,27 @@ describe('patchConfiguration', () => {
                         isTransient: false,
                         sizeLimitGB: null,
                         details: { supportsVersioning: true },
+                    },
+                    'httpsawsbackendtest': {
+                        details: {
+                            awsEndpoint: 'secure.ring.end.point',
+                            bucketMatch: 'rings3bucketmatch',
+                            bucketName: 'rings3bucketname',
+                            credentials: {
+                                accessKey: 'rings3accesskey',
+                                secretKey: decryptedSecretKey,
+                            },
+                            https: true,
+                            pathStyle: true,
+                            region: 'us-west-1',
+                            serverSideEncryption: false,
+                            supportsVersioning: true,
+                        },
+                        legacyAwsBehavior: false,
+                        isTransient: false,
+                        sizeLimitGB: null,
+                        type: 'aws_s3',
+                        objectId: 'httpsawsbackendtest',
                     },
                 },
             };


### PR DESCRIPTION
Add HTTPS support for RING+S3C endpoints added through Orbit.