### PR TITLE
INTEGRATION [PR#1656 > development/8.1] bugfix: ZENKO-1365 Orbit set https for RING+S3C

### DIFF
--- a/lib/management/configuration.js
+++ b/lib/management/configuration.js
@@ -116,6 +116,19 @@ function patchConfiguration(newConf, log, cb) {
                     break;
                 case 'location-scality-ring-s3-v1':
                     pathStyle = true; // fallthrough
+                    let https = false;
+                    let ringEndpoint = l.details.endpoint ||
+                        's3.amazonaws.com';
+                    if (ringEndpoint.includes('://')) {
+                        const url = new URL(awsEndpoint);
+                        ringEndpoint = url.host;
+                        https = url.scheme === 'https';
+                    }
+                    location.details = {
+                        awsEndpoint: ringEndpoint,
+                        https,
+                    };
+                    break;
                 case 'location-aws-s3-v1':
                 case 'location-wasabi-v1':
                     supportsVersioning = true; // fallthrough


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1656.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/ZENKO-1365-orbit-ring-s3-https`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/ZENKO-1365-orbit-ring-s3-https
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/ZENKO-1365-orbit-ring-s3-https
```

Please always comment pull request #1656 instead of this one.