### PR TITLE
INTEGRATION [PR#1656 > development/8.1] bugfix: ZENKO-1365 Orbit set https for RING+S3C

### DIFF
--- a/lib/management/configuration.js
+++ b/lib/management/configuration.js
@@ -128,7 +128,7 @@ function patchConfiguration(newConf, log, cb) {
                         if (awsEndpoint.includes('://')) {
                             const url = new URL(awsEndpoint);
                             awsEndpoint = url.host;
-                            https = url.scheme === 'https';
+                            https = url.protocol.includes('https');
                         }
 
                         location.details = {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1656.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/ZENKO-1365-orbit-ring-s3-https`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/ZENKO-1365-orbit-ring-s3-https
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/ZENKO-1365-orbit-ring-s3-https
```

Please always comment pull request #1656 instead of this one.