### PR TITLE
feature: ZENKO-1388 Versioning for MD updates

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -319,7 +319,7 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
         // version (updating master as well) but with specified
         // versionId
         const options = {
-            versioning: true,
+            versioning: bucketInfo.isVersioningEnabled(),
             versionId: omVal.versionId,
         };
         // If the object is from a source bucket without versioning (i.e. NFS),


### PR DESCRIPTION
When putting metadata for a lifecycle operation, we sometimes update objects that are not versioned. This allows such flexibility.