### PR TITLE
feature: S3C-1903 allow public reads on buckets

### DIFF
--- a/lib/api/apiUtils/authorization/aclChecks.js
+++ b/lib/api/apiUtils/authorization/aclChecks.js
@@ -1,5 +1,9 @@
 const constants = require('../../../../constants');
 
+// whitelist buckets to allow public read on objects
+const publicReadBuckets = process.env.ALLOW_PUBLIC_READ_BUCKETS ?
+    process.env.ALLOW_PUBLIC_READ_BUCKETS.split(',') : [];
+
 function isBucketAuthorized(bucket, requestType, canonicalID) {
     // Check to see if user is authorized to perform a
     // particular action on bucket based on ACLs.
@@ -114,6 +118,16 @@ function isObjAuthorized(bucket, objectMD, requestType, canonicalID) {
             || objectMD.acl.READ_ACP.indexOf(canonicalID) > -1) {
             return true;
         }
+    }
+
+    // allow public reads on buckets that are whitelisted for anonymous reads
+    // TODO: remove this after bucket policies are implemented
+    const bucketAcl = bucket.getAcl();
+    const allowPublicReads = publicReadBuckets.includes(bucket.getName()) &&
+        bucketAcl.Canned === 'public-read' &&
+        (requestType === 'objectGet' || requestType === 'objectHead');
+    if (allowPublicReads) {
+        return true;
     }
     return false;
 }


### PR DESCRIPTION
This change supports proving a whitelist of buckets that have public-read
canned acl set, to allow reads from anonymous users on objects without
having to explicitly set public-read acl on them.

