### PR TITLE
chore: bump arsenal

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "github:scality/arsenal#0a75792",
+    "arsenal": "github:scality/arsenal#d6fdd15",
     "async": "~2.5.0",
     "aws-sdk": "2.28.0",
     "azure-storage": "^2.1.0",


### PR DESCRIPTION
Bump arsenal commit hash to `d6fdd15` in order to allow encoding on PFSD requests (`ZENKO-1362`) 