### PR TITLE
bugfix(s3-data): add noCache and noSync option

### DIFF
--- a/dataserver.js
+++ b/dataserver.js
@@ -7,13 +7,17 @@ const logger = require('./lib/utilities/logger');
 if (config.backends.data === 'file' ||
     (config.backends.data === 'multiple' &&
      config.backends.metadata !== 'scality')) {
-    const dataServer = new arsenal.network.rest.RESTServer(
-        { bindAddress: config.dataDaemon.bindAddress,
-            port: config.dataDaemon.port,
-            dataStore: new arsenal.storage.data.file.DataFileStore(
-                { dataPath: config.dataDaemon.dataPath,
-                    log: config.log }),
-            log: config.log });
+    const dataServer = new arsenal.network.rest.RESTServer({
+        bindAddress: config.dataDaemon.bindAddress,
+        port: config.dataDaemon.port,
+        dataStore: new arsenal.storage.data.file.DataFileStore({
+            dataPath: config.dataDaemon.dataPath,
+            log: config.log,
+            noSync: config.dataDaemon.noSync,
+            noCache: config.dataDaemon.noCache,
+        }),
+        log: config.log,
+    });
     dataServer.setup(err => {
         if (err) {
             logger.error('Error initializing REST data server',

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -628,6 +628,8 @@ class Config extends EventEmitter {
             this.dataDaemon.dataPath =
                 process.env.S3DATAPATH ?
                 process.env.S3DATAPATH : `${__dirname}/../localData`;
+            this.dataDaemon.noSync = process.env.S3DATA_NOSYNC === 'true';
+            this.dataDaemon.noCache = process.env.S3DATA_NOCACHE === 'true';
         }
 
         if (config.metadataDaemon) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -185,8 +185,8 @@
       "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco="
     },
     "arsenal": {
-      "version": "github:scality/Arsenal#9fe16c64fa3ba3d1b78aad5a777b86fafb98a779",
-      "from": "github:scality/Arsenal#9fe16c6",
+      "version": "github:scality/Arsenal#b5fa54ec1132b8be4615360ff5950c54a588bc0d",
+      "from": "github:scality/Arsenal#b5fa54e",
       "requires": {
         "JSONStream": "^1.0.0",
         "ajv": "4.10.0",
@@ -222,7 +222,7 @@
         },
         "bson": {
           "version": "2.0.4",
-          "resolved": "http://registry.npmjs.org/bson/-/bson-2.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-2.0.4.tgz",
           "integrity": "sha512-e/GPy6CE0xL7MOYYRMIEwPGKF21WNaQdPIpV0YvaQDoR7oc47KUZ8c2P/TlRJVQP8RZ4CEsArGBC1NbkCRvl1w=="
         },
         "mongodb": {
@@ -651,7 +651,7 @@
     },
     "blob": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
     },
     "bluebird": {
@@ -681,14 +681,10 @@
     "bucketclient": {
       "version": "github:scality/bucketclient#5aa99d7b25fdfb5a42b787cce7710cdec8ac78f0",
       "from": "github:scality/bucketclient#5aa99d7",
-      "requires": {
-        "arsenal": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
-        "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2"
-      },
       "dependencies": {
         "arsenal": {
           "version": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
-          "from": "github:scality/Arsenal#7.4.0.3",
+          "from": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
           "requires": {
             "JSONStream": "^1.0.0",
             "ajv": "4.10.0",
@@ -730,7 +726,7 @@
         },
         "werelogs": {
           "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
-          "from": "github:scality/werelogs#7.4.0.3",
+          "from": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
           "requires": {
             "safe-json-stringify": "^1.0.3"
           }
@@ -880,13 +876,13 @@
       "resolved": "github:scality/cdmiclient#8f0c2e6331dfa905bfe269fb4e1558d65ca0b866",
       "optional": true,
       "requires": {
-        "arsenal": "github:scality/Arsenal#9a009746be40ee68f5f1d774731f336d27b8a7e3",
+        "arsenal": "github:scality/Arsenal#b5fa54ec1132b8be4615360ff5950c54a588bc0d",
         "async": "~1.4.2",
         "werelogs": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46"
       },
       "dependencies": {
         "arsenal": {
-          "version": "github:scality/Arsenal#9a009746be40ee68f5f1d774731f336d27b8a7e3",
+          "version": "github:scality/Arsenal#b5fa54ec1132b8be4615360ff5950c54a588bc0d",
           "from": "github:scality/Arsenal#development/8.0",
           "optional": true,
           "requires": {
@@ -935,13 +931,13 @@
         },
         "async": {
           "version": "1.4.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
           "integrity": "sha1-bJ7csRztTw3S8tQNsNSaEJwIiqs=",
           "optional": true
         },
         "bson": {
           "version": "2.0.4",
-          "resolved": "http://registry.npmjs.org/bson/-/bson-2.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-2.0.4.tgz",
           "integrity": "sha512-e/GPy6CE0xL7MOYYRMIEwPGKF21WNaQdPIpV0YvaQDoR7oc47KUZ8c2P/TlRJVQP8RZ4CEsArGBC1NbkCRvl1w==",
           "optional": true
         },
@@ -1410,7 +1406,7 @@
     },
     "engine.io-parser": {
       "version": "1.3.2",
-      "resolved": "http://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
       "integrity": "sha1-k3sHnwAH0Ik+xW1GyyILjLQ1Igo=",
       "requires": {
         "after": "0.8.2",
@@ -2197,7 +2193,7 @@
     },
     "hoek": {
       "version": "4.2.1",
-      "resolved": "http://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
       "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "hosted-git-info": {
@@ -2488,7 +2484,7 @@
     },
     "isemail": {
       "version": "2.2.1",
-      "resolved": "http://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
       "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
     },
     "isexe": {
@@ -2841,7 +2837,7 @@
     },
     "level-iterator-stream": {
       "version": "1.3.1",
-      "resolved": "http://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
       "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
       "requires": {
         "inherits": "^2.0.1",
@@ -2883,7 +2879,7 @@
       "dependencies": {
         "abstract-leveldown": {
           "version": "0.12.4",
-          "resolved": "http://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
           "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
           "requires": {
             "xtend": "~3.0.0"
@@ -2898,7 +2894,7 @@
         },
         "bl": {
           "version": "0.8.2",
-          "resolved": "http://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
           "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
           "requires": {
             "readable-stream": "~1.0.26"
@@ -2940,7 +2936,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -2951,7 +2947,7 @@
         },
         "semver": {
           "version": "5.1.1",
-          "resolved": "http://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
           "integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk="
         }
       }
@@ -2970,7 +2966,7 @@
       "dependencies": {
         "bindings": {
           "version": "1.2.1",
-          "resolved": "http://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
           "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
         },
         "nan": {
@@ -3142,9 +3138,9 @@
       "dev": true
     },
     "memory-pager": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.1.0.tgz",
-      "integrity": "sha512-Mf9OHV/Y7h6YWDxTzX/b4ZZ4oh9NSXblQL8dtPCOomOtZciEHxePR78+uHFLLlsk01A6jVHhHsQZZ/WcIPpnzg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.4.0.tgz",
+      "integrity": "sha512-ycuyV5gKpZln7HB/A11wCpAxEY9VQ2EhYU1F56pUAxvmj6OyOHtB9tkLLjAyFsPdghSP2S3Ujk3aYJCusgiMZg==",
       "optional": true
     },
     "mime": {
@@ -3793,7 +3789,7 @@
     },
     "readable-stream": {
       "version": "1.1.14",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -4102,7 +4098,7 @@
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
         }
       }
@@ -4170,7 +4166,7 @@
     },
     "socket.io-parser": {
       "version": "2.3.1",
-      "resolved": "http://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
       "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
       "requires": {
         "component-emitter": "1.1.2",
@@ -4181,7 +4177,7 @@
       "dependencies": {
         "debug": {
           "version": "2.2.0",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "requires": {
             "ms": "0.7.1"
@@ -4189,7 +4185,7 @@
         },
         "ms": {
           "version": "0.7.1",
-          "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
         }
       }
@@ -4577,7 +4573,7 @@
     },
     "topo": {
       "version": "2.0.2",
-      "resolved": "http://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
       "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
       "requires": {
         "hoek": "4.x.x"
@@ -4747,17 +4743,14 @@
       "version": "github:scality/utapi#f2f1d0c7423ffdec2ad175e3c0e8bcd7aa2ba867",
       "from": "github:scality/utapi#f2f1d0c",
       "requires": {
-        "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
         "async": "^2.0.1",
         "ioredis": "^2.3.0",
-        "node-schedule": "1.2.0",
-        "vaultclient": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
-        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61"
+        "node-schedule": "1.2.0"
       },
       "dependencies": {
         "arsenal": {
           "version": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
-          "from": "github:scality/Arsenal#67365083",
+          "from": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
           "requires": {
             "JSONStream": "^1.0.0",
             "ajv": "4.10.0",
@@ -4787,12 +4780,19 @@
               "requires": {
                 "lodash": "^4.14.0"
               }
+            },
+            "werelogs": {
+              "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+              "from": "github:scality/werelogs#0ff7ec82",
+              "requires": {
+                "safe-json-stringify": "1.0.3"
+              }
             }
           }
         },
         "commander": {
           "version": "2.9.0",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "requires": {
             "graceful-readlink": ">= 1.0.0"
@@ -4800,7 +4800,7 @@
         },
         "vaultclient": {
           "version": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
-          "from": "github:scality/vaultclient#fbd9988d",
+          "from": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
           "requires": {
             "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
             "commander": "2.9.0",
@@ -4808,6 +4808,46 @@
             "xml2js": "0.4.17"
           },
           "dependencies": {
+            "arsenal": {
+              "version": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
+              "from": "github:scality/Arsenal#67365083",
+              "requires": {
+                "JSONStream": "^1.0.0",
+                "ajv": "4.10.0",
+                "async": "~2.1.5",
+                "debug": "~2.3.3",
+                "diskusage": "^0.2.2",
+                "ioctl": "2.0.0",
+                "ioredis": "2.4.0",
+                "ipaddr.js": "1.2.0",
+                "joi": "^10.6",
+                "level": "~1.6.0",
+                "level-sublevel": "~6.6.1",
+                "node-forge": "^0.7.1",
+                "simple-glob": "^0.1",
+                "socket.io": "~1.7.3",
+                "socket.io-client": "~1.7.3",
+                "utf8": "2.1.2",
+                "uuid": "^3.0.1",
+                "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+                "xml2js": "~0.4.16"
+              }
+            },
+            "async": {
+              "version": "2.1.5",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+              "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+              "requires": {
+                "lodash": "^4.14.0"
+              }
+            },
+            "werelogs": {
+              "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+              "from": "github:scality/werelogs#0ff7ec82",
+              "requires": {
+                "safe-json-stringify": "1.0.3"
+              }
+            },
             "xml2js": {
               "version": "0.4.17",
               "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
@@ -4821,14 +4861,14 @@
         },
         "werelogs": {
           "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-          "from": "github:scality/werelogs#0ff7ec82",
+          "from": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
           "requires": {
             "safe-json-stringify": "1.0.3"
           }
         },
         "xmlbuilder": {
           "version": "4.2.1",
-          "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
           "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
           "requires": {
             "lodash": "^4.0.0"
@@ -4908,15 +4948,13 @@
       "version": "github:scality/vaultclient#754b6e1e1121f44bc3719e35b836a9185d6d5e1a",
       "from": "github:scality/vaultclient#754b6e1",
       "requires": {
-        "arsenal": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
         "commander": "2.9.0",
-        "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
         "xml2js": "0.4.17"
       },
       "dependencies": {
         "arsenal": {
           "version": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
-          "from": "github:scality/Arsenal#7.4.0.3",
+          "from": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
           "requires": {
             "JSONStream": "^1.0.0",
             "ajv": "4.10.0",
@@ -4966,7 +5004,7 @@
         },
         "werelogs": {
           "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
-          "from": "github:scality/werelogs#7.4.0.3",
+          "from": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
           "requires": {
             "safe-json-stringify": "^1.0.3"
           }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "scality/Arsenal#9fe16c6",
+    "arsenal": "scality/Arsenal#b5fa54e",
     "async": "~2.5.0",
     "aws-sdk": "2.28.0",
     "azure-storage": "^2.1.0",


### PR DESCRIPTION
This PR allows you to configure the `noCache` and `noSync` options for both `s3-data` and `pfsd` (`pfsd` change is on the integration branch).

See scality/Arsenal#635 for reference.