### PR TITLE
ci: S3C-1933 remove active deadline on ci workers

### DIFF
--- a/eve/workers/pod.yaml
+++ b/eve/workers/pod.yaml
@@ -4,7 +4,6 @@ kind: Pod
 metadata:
   name: "proxy-ci-test-pod"
 spec:
-  activeDeadlineSeconds: 3600
   restartPolicy: Never
   terminationGracePeriodSeconds: 10
   hostAliases:


### PR DESCRIPTION
# Remove Activedeadline on CI workers

Ressources were getting killed if they lived longer than 1 hour.

Removing this option as it will cause some trouble/flakiness.
