### PR TITLE
INTEGRATION [PR#1683 > development/8.1] ci: S3C-1933 remove active deadline on ci workers

### DIFF
--- a/eve/workers/pod.yaml
+++ b/eve/workers/pod.yaml
@@ -4,7 +4,6 @@ kind: Pod
 metadata:
   name: "proxy-ci-test-pod"
 spec:
-  activeDeadlineSeconds: 3600
   restartPolicy: Never
   terminationGracePeriodSeconds: 10
   hostAliases:


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1683.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-1933-remove-pod-ttl`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-1933-remove-pod-ttl
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-1933-remove-pod-ttl
```

Please always comment pull request #1683 instead of this one.