### PR TITLE
Bugfix/zenko 1435 pathstyle https

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -229,7 +229,7 @@ stages:
         env:
           <<: *multiple-backend-vars
           <<: *global-env
-          CI_CEPH: enabled
+          CI_CEPH: "true"
           MPU_TESTING: "yes"
           S3_LOCATION_FILE: tests/locationConfig/locationConfigCeph.json
     steps:

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -159,8 +159,8 @@ stages:
           command: |
             set -ex
             mkdir -p $CIRCLE_TEST_REPORTS/unit
-            npm run unit_coverage
-            npm run unit_coverage_legacy_location
+            npm test
+            npm run test_legacy_location
           env: &shared-vars
             <<: *global-env
             S3_LOCATION_FILE: tests/locationConfig/locationConfigTests.json

--- a/eve/workers/pod.yaml
+++ b/eve/workers/pod.yaml
@@ -92,7 +92,7 @@ spec:
         - name: S3_LOCATION_FILE
           value: "/usr/src/app/tests/locationConfig/locationConfigTests.json"
         {%- endif %}
-        {% if vars.env.S3DATA is defined and vars.env.S3DATA == "multiple" and vars.env.CI_CEPH is defined and vars.env.CI_CEPH == "enabled" -%}
+        {% if vars.env.S3DATA is defined and vars.env.S3DATA == "multiple" and vars.env.CI_CEPH is defined and vars.env.CI_CEPH == "true" -%}
         - name: S3_LOCATION_FILE
           value: "/usr/src/app/tests/locationConfig/locationConfigCeph.json"
         {%- endif %}
@@ -157,7 +157,7 @@ spec:
           squid -f /etc/squid/squid.conf -N -z
           squid -f /etc/squid/squid.conf -NYCd 1
     {%- endif %}
-    {% if vars.env.CI_CEPH is defined and vars.env.CI_CEPH == "enabled" -%}
+    {% if vars.env.CI_CEPH is defined and vars.env.CI_CEPH == "true" -%}
     - name: ceph
       image: {{ images.ceph }}
       imagePullPolicy: IfNotPresent

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -237,7 +237,7 @@ function locationConstraintAssert(locationConstraints) {
             assert(typeof details.credentials.secretKey === 'string',
                 'bad config: credentials must include secretKey as string');
         }
-        if (process.env.CI === 'true') {
+        if (process.env.CI_CEPH === 'true') {
             // eslint-disable-next-line no-param-reassign
             locationConstraints[l].details.https = false;
         } else if (details.https !== undefined) {
@@ -251,7 +251,7 @@ function locationConstraintAssert(locationConstraints) {
         if (details.pathStyle !== undefined) {
             assert(typeof details.pathStyle === 'boolean', 'bad config: ' +
                 'locationConstraints[region].pathStyle must be a boolean');
-        } else if (process.env.CI === 'true') {
+        } else if (process.env.CI_CEPH === 'true') {
             // eslint-disable-next-line no-param-reassign
             locationConstraints[l].details.pathStyle = true;
         } else {

--- a/lib/management/configuration.js
+++ b/lib/management/configuration.js
@@ -90,7 +90,7 @@ function patchConfiguration(newConf, log, cb) {
                     details: {},
                 };
                 let supportsVersioning = false;
-                let pathStyle = process.env.CI !== undefined;
+                let pathStyle = process.env.CI_CEPH !== undefined;
 
                 switch (l.locationType) {
                 case 'location-mem-v1':


### PR DESCRIPTION
- bugfix: ZENKO-1435 remove coverage commands
> This switches up the coverage cmds of istanbul in favor of vanilla
mocha output for test results accuracy.

- bugfix: ZENKO-1435 use CI_CEPH has test flag
> The usage of CI env as a test flag for configuring https, pathStyle
options breaks other tests, so the env is being changed to be CI_CEPH
confining the scope to only CEPH backend tests.