### PR TITLE
Update Mongo in CI to 3.6

### DIFF
--- a/eve/workers/pod.yaml
+++ b/eve/workers/pod.yaml
@@ -14,7 +14,7 @@ spec:
   containers:
     {% if vars.env.S3METADATA is defined and vars.env.S3METADATA == "mongodb" -%}
     - name: mongo
-      image: scality/ci-mongo:3.4
+      image: scality/ci-mongo:3.6.8
       imagePullPolicy: IfNotPresent
       resources:
         requests:


### PR DESCRIPTION
Updates MongoDB version used in CI to match the one used by Zenko