### PR TITLE
improvement:S3C-1561- update vaultclient version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -200,7 +200,6 @@
         "socket.io-client": "~1.7.3",
         "utf8": "2.1.2",
         "uuid": "^3.0.1",
-        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
         "xml2js": "~0.4.16"
       },
       "dependencies": {
@@ -210,6 +209,13 @@
           "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
           "requires": {
             "lodash": "^4.14.0"
+          }
+        },
+        "werelogs": {
+          "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+          "from": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+          "requires": {
+            "safe-json-stringify": "1.0.3"
           }
         }
       }
@@ -620,14 +626,10 @@
     "bucketclient": {
       "version": "github:scality/bucketclient#b74165ac27ca46117c7f42e65fe4499ec94cc0a5",
       "from": "github:scality/bucketclient#b74165ac",
-      "requires": {
-        "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
-        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61"
-      },
       "dependencies": {
         "arsenal": {
           "version": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
-          "from": "github:scality/Arsenal#67365083",
+          "from": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
           "requires": {
             "JSONStream": "^1.0.0",
             "ajv": "4.10.0",
@@ -648,6 +650,15 @@
             "uuid": "^3.0.1",
             "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
             "xml2js": "~0.4.16"
+          },
+          "dependencies": {
+            "werelogs": {
+              "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+              "from": "github:scality/werelogs#0ff7ec82",
+              "requires": {
+                "safe-json-stringify": "1.0.3"
+              }
+            }
           }
         },
         "async": {
@@ -656,6 +667,13 @@
           "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
           "requires": {
             "lodash": "^4.14.0"
+          }
+        },
+        "werelogs": {
+          "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+          "from": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+          "requires": {
+            "safe-json-stringify": "1.0.3"
           }
         }
       }
@@ -808,7 +826,7 @@
         },
         "async": {
           "version": "1.4.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
           "integrity": "sha1-bJ7csRztTw3S8tQNsNSaEJwIiqs=",
           "optional": true
         }
@@ -3965,8 +3983,14 @@
     "sproxydclient": {
       "version": "github:scality/sproxydclient#6a391f8db104df72651824659151a020c2242cd1",
       "from": "github:scality/sproxydclient#6a391f8d",
-      "requires": {
-        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61"
+      "dependencies": {
+        "werelogs": {
+          "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+          "from": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+          "requires": {
+            "safe-json-stringify": "1.0.3"
+          }
+        }
       }
     },
     "ssh2": {
@@ -4422,17 +4446,14 @@
       "version": "github:scality/utapi#cd3324df87e15b24912c58bd7712b48f6fc356cb",
       "from": "github:scality/utapi#cd3324df",
       "requires": {
-        "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
         "async": "^2.0.1",
         "ioredis": "^2.3.0",
-        "node-schedule": "1.2.0",
-        "vaultclient": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
-        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61"
+        "node-schedule": "1.2.0"
       },
       "dependencies": {
         "arsenal": {
           "version": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
-          "from": "github:scality/Arsenal#67365083",
+          "from": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
           "requires": {
             "JSONStream": "^1.0.0",
             "ajv": "4.10.0",
@@ -4462,7 +4483,98 @@
               "requires": {
                 "lodash": "^4.14.0"
               }
+            },
+            "werelogs": {
+              "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+              "from": "github:scality/werelogs#0ff7ec82",
+              "requires": {
+                "safe-json-stringify": "1.0.3"
+              }
             }
+          }
+        },
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
+        },
+        "vaultclient": {
+          "version": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
+          "from": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
+          "requires": {
+            "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
+            "commander": "2.9.0",
+            "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+            "xml2js": "0.4.17"
+          },
+          "dependencies": {
+            "arsenal": {
+              "version": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
+              "from": "github:scality/Arsenal#67365083",
+              "requires": {
+                "JSONStream": "^1.0.0",
+                "ajv": "4.10.0",
+                "async": "~2.1.5",
+                "debug": "~2.3.3",
+                "diskusage": "^0.2.2",
+                "ioctl": "2.0.0",
+                "ioredis": "2.4.0",
+                "ipaddr.js": "1.2.0",
+                "joi": "^10.6",
+                "level": "~1.6.0",
+                "level-sublevel": "~6.6.1",
+                "node-forge": "^0.7.1",
+                "simple-glob": "^0.1",
+                "socket.io": "~1.7.3",
+                "socket.io-client": "~1.7.3",
+                "utf8": "2.1.2",
+                "uuid": "^3.0.1",
+                "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+                "xml2js": "~0.4.16"
+              }
+            },
+            "async": {
+              "version": "2.1.5",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+              "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+              "requires": {
+                "lodash": "^4.14.0"
+              }
+            },
+            "werelogs": {
+              "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+              "from": "github:scality/werelogs#0ff7ec82",
+              "requires": {
+                "safe-json-stringify": "1.0.3"
+              }
+            },
+            "xml2js": {
+              "version": "0.4.17",
+              "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+              "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+              "requires": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "^4.1.0"
+              }
+            }
+          }
+        },
+        "werelogs": {
+          "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+          "from": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+          "requires": {
+            "safe-json-stringify": "1.0.3"
+          }
+        },
+        "xmlbuilder": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+          "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+          "requires": {
+            "lodash": "^4.0.0"
           }
         }
       }
@@ -4497,18 +4609,16 @@
       "integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA=="
     },
     "vaultclient": {
-      "version": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
-      "from": "github:scality/vaultclient#fbd9988d",
+      "version": "github:scality/vaultclient#1a19aa4aff9a95af2414d648070b6f924ab7df0d",
+      "from": "github:scality/vaultclient#1a19aa4",
       "requires": {
-        "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
         "commander": "2.9.0",
-        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
         "xml2js": "0.4.17"
       },
       "dependencies": {
         "arsenal": {
           "version": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
-          "from": "github:scality/Arsenal#67365083",
+          "from": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
           "requires": {
             "JSONStream": "^1.0.0",
             "ajv": "4.10.0",
@@ -4529,6 +4639,15 @@
             "uuid": "^3.0.1",
             "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
             "xml2js": "~0.4.16"
+          },
+          "dependencies": {
+            "werelogs": {
+              "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+              "from": "github:scality/werelogs#0ff7ec82",
+              "requires": {
+                "safe-json-stringify": "1.0.3"
+              }
+            }
           }
         },
         "async": {
@@ -4541,10 +4660,17 @@
         },
         "commander": {
           "version": "2.9.0",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "requires": {
             "graceful-readlink": ">= 1.0.0"
+          }
+        },
+        "werelogs": {
+          "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+          "from": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+          "requires": {
+            "safe-json-stringify": "1.0.3"
           }
         },
         "xml2js": {
@@ -4558,7 +4684,7 @@
         },
         "xmlbuilder": {
           "version": "4.2.1",
-          "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
           "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
           "requires": {
             "lodash": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "utapi": "scality/utapi#cd3324df",
     "utf8": "~2.1.1",
     "uuid": "^3.0.1",
-    "vaultclient": "scality/vaultclient#fbd9988d",
+    "vaultclient": "scality/vaultclient#1a19aa4",
     "werelogs": "scality/werelogs#0ff7ec82",
     "xml2js": "~0.4.16"
   },


### PR DESCRIPTION
## Description
Update VaultClient version for having Quotas feature

### Motivation and context
End-users are encouraged to use vaultclient from Scality-s3 container. So cloudserver/s3 needs to have the updated version of vaultclient with quota options.

Why is this change required? What problem does it solve?
[S3C-2005](https://scality.atlassian.net/browse/S3C-2005)

### Related issues
[S3C-1561](https://scality.atlassian.net/browse/S3C-1561)