### PR TITLE
bugfix: restrict metadata proxy routes to policy

### DIFF
--- a/lib/routes/routeMetadata.js
+++ b/lib/routes/routeMetadata.js
@@ -1,13 +1,12 @@
 const url = require('url');
 const { waterfall } = require('async');
 const httpProxy = require('http-proxy');
-const { auth, errors, s3routes } = require('arsenal');
+const { auth, errors, s3routes, policies } = require('arsenal');
 const { config } = require('../Config');
 const constants = require('../../constants');
 const vault = require('../auth/vault');
-const prepareRequestContexts = require(
-    '../api/apiUtils/authorization/prepareRequestContexts');
 
+const RequestContext = policies.RequestContext;
 const { responseJSONBody } = s3routes.routesUtils;
 const metadataProxy = httpProxy.createProxyServer({ ignorePath: true });
 auth.setHandler(vault);
@@ -18,11 +17,12 @@ function _normalizeMetadataRequest(req) {
     req.path = parsedUrl.pathname;
     req.query = parsedUrl.query;
     const pathArr = req.path.split('/');
-    req.resourceType = pathArr[3];
-    req.bucketName = pathArr[4];
+    req.resourceType = pathArr[3]; // admin, default
+    req.generalResource = pathArr[4]; // raft_sessions, buckets
     if (pathArr[5]) {
-        req.objectKey = pathArr.slice(5).join('/');
+        req.specificResource = pathArr[5]; // raft session ids, bucket names
     }
+    req.subResource = pathArr[6];
     /* eslint-enable no-param-reassign */
 }
 
@@ -37,9 +37,20 @@ function routeMetadata(clientIP, request, response, log) {
     log.debug('routing request', { method: 'routeMetadata' });
     log.addDefaultFields({ clientIP, httpMethod: request.method });
     _normalizeMetadataRequest(request);
-    const requestContexts = prepareRequestContexts('objectReplicate', request);
+
+    // restrict access to only routes ending in bucket, log or id
+    const { resourceType, subResource } = request;
+    if (resourceType === 'admin'
+        && !['bucket', 'log', 'id'].includes(subResource)) {
+        return responseJSONBody(errors.NotImplemented, null, response, log);
+    }
+    const ip = request.headers['x-forwarded-for'] ||
+    request.socket.remoteAddress;
+    const requestContexts = [new RequestContext(request.headers, request.query,
+        request.generalResource, request.specificResource, ip,
+        request.connection.encrypted, request.resourceType, 'metadata')];
     return waterfall([
-        next => auth.server.doAuth(request, log, (err, userInfo) => {
+        next => auth.server.doAuth(request, log, (err, userInfo, authRes) => {
             if (err) {
                 log.debug('authentication error', {
                     error: err,
@@ -47,11 +58,15 @@ function routeMetadata(clientIP, request, response, log) {
                     bucketName: request.bucketName,
                     objectKey: request.objectKey,
                 });
+                return next(err);
             }
-            return next(err, userInfo);
+            // authRes is not defined for account credentials
+            if (authRes && !authRes[0].isAllowed) {
+                return next(errors.AccessDenied);
+            }
+            return next(null, userInfo);
         }, 's3', requestContexts),
         (userInfo, next) => {
-            // TODO: refactor this for code-reuse in development/8.0
             if (userInfo.getCanonicalID() === constants.publicId) {
                 log.debug('unauthenticated access to API routes', {
                     method: request.method,
@@ -66,7 +81,6 @@ function routeMetadata(clientIP, request, response, log) {
                 url.replace('/_/metadata/', '/');
             // bucketd is always configured on the loopback interface in s3c
             const endpoint = bootstrap[0];
-            // TODO: support https bucketd
             const target = `http://${endpoint}${path}`;
             return metadataProxy.web(request, response, { target }, err => {
                 if (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -128,7 +128,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -142,7 +142,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -180,8 +180,8 @@
       "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco="
     },
     "arsenal": {
-      "version": "github:scality/Arsenal#879823c4283c455b49dbf38f977064093fc32ec0",
-      "from": "github:scality/Arsenal#879823c4",
+      "version": "github:scality/Arsenal#0eaae2bb2ad36f6e053a4da7c49bad8020072ce7",
+      "from": "github:scality/Arsenal#0eaae2b",
       "requires": {
         "JSONStream": "^1.0.0",
         "ajv": "4.10.0",
@@ -200,7 +200,7 @@
         "socket.io-client": "~1.7.3",
         "utf8": "2.1.2",
         "uuid": "^3.0.1",
-        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+        "werelogs": "github:scality/werelogs#0ff7ec82",
         "xml2js": "~0.4.16"
       },
       "dependencies": {
@@ -545,14 +545,17 @@
       }
     },
     "bindings": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
-      "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew==",
-      "optional": true
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
         "readable-stream": "^2.3.5",
@@ -566,7 +569,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -580,7 +583,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -590,7 +593,7 @@
     },
     "blob": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
     },
     "bluebird": {
@@ -621,8 +624,8 @@
       "version": "github:scality/bucketclient#b74165ac27ca46117c7f42e65fe4499ec94cc0a5",
       "from": "github:scality/bucketclient#b74165ac",
       "requires": {
-        "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
-        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61"
+        "arsenal": "github:scality/Arsenal#67365083",
+        "werelogs": "github:scality/werelogs#0ff7ec82"
       },
       "dependencies": {
         "arsenal": {
@@ -646,7 +649,7 @@
             "socket.io-client": "~1.7.3",
             "utf8": "2.1.2",
             "uuid": "^3.0.1",
-            "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+            "werelogs": "github:scality/werelogs#0ff7ec82",
             "xml2js": "~0.4.16"
           }
         },
@@ -656,6 +659,13 @@
           "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
           "requires": {
             "lodash": "^4.14.0"
+          }
+        },
+        "werelogs": {
+          "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+          "from": "github:scality/werelogs#0ff7ec82",
+          "requires": {
+            "safe-json-stringify": "1.0.3"
           }
         }
       }
@@ -764,9 +774,9 @@
       "resolved": "github:scality/cdmiclient#9ff12c180b71b5d6a7b98a0a0e7eb926a0fbad54",
       "optional": true,
       "requires": {
-        "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
+        "arsenal": "github:scality/Arsenal#67365083",
         "async": "~1.4.2",
-        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61"
+        "werelogs": "github:scality/werelogs#0ff7ec82"
       },
       "dependencies": {
         "arsenal": {
@@ -791,7 +801,7 @@
             "socket.io-client": "~1.7.3",
             "utf8": "2.1.2",
             "uuid": "^3.0.1",
-            "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+            "werelogs": "github:scality/werelogs#0ff7ec82",
             "xml2js": "~0.4.16"
           },
           "dependencies": {
@@ -808,7 +818,7 @@
         },
         "async": {
           "version": "1.4.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
           "integrity": "sha1-bJ7csRztTw3S8tQNsNSaEJwIiqs=",
           "optional": true
         }
@@ -1224,7 +1234,7 @@
     },
     "engine.io-parser": {
       "version": "1.3.2",
-      "resolved": "http://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
       "integrity": "sha1-k3sHnwAH0Ik+xW1GyyILjLQ1Igo=",
       "requires": {
         "after": "0.8.2",
@@ -1609,6 +1619,12 @@
         "object-assign": "^4.0.1"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "fileset": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
@@ -1978,7 +1994,7 @@
     },
     "hoek": {
       "version": "4.2.1",
-      "resolved": "http://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
       "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "hosted-git-info": {
@@ -2245,7 +2261,7 @@
     },
     "isemail": {
       "version": "2.2.1",
-      "resolved": "http://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
       "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
     },
     "isexe": {
@@ -2603,7 +2619,7 @@
     },
     "level-iterator-stream": {
       "version": "1.3.1",
-      "resolved": "http://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
       "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
       "requires": {
         "inherits": "^2.0.1",
@@ -2645,7 +2661,7 @@
       "dependencies": {
         "abstract-leveldown": {
           "version": "0.12.4",
-          "resolved": "http://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
           "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
           "requires": {
             "xtend": "~3.0.0"
@@ -2660,7 +2676,7 @@
         },
         "bl": {
           "version": "0.8.2",
-          "resolved": "http://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
           "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
           "requires": {
             "readable-stream": "~1.0.26"
@@ -2702,7 +2718,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -2713,7 +2729,7 @@
         },
         "semver": {
           "version": "5.1.1",
-          "resolved": "http://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
           "integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk="
         }
       }
@@ -2732,7 +2748,7 @@
       "dependencies": {
         "bindings": {
           "version": "1.2.1",
-          "resolved": "http://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
           "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
         },
         "nan": {
@@ -2930,7 +2946,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mkdirp": {
@@ -3099,9 +3115,9 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node-abi": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.5.0.tgz",
-      "integrity": "sha512-9g2twBGSP6wIR5PW7tXvAWnEWKJDH/VskdXp168xsw9VVxpEGov8K4jsP4/VeoC7b2ZAyzckvMCuQuQlw44lXg==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.7.1.tgz",
+      "integrity": "sha512-OV8Bq1OrPh6z+Y4dqwo05HqrRL9YNF7QVMRfq1/pguwKLG+q9UB/Lk0x5qXjO23JjJg+/jqCHSTaG1P3tfKfuw==",
       "requires": {
         "semver": "^5.4.1"
       }
@@ -3530,7 +3546,7 @@
     },
     "readable-stream": {
       "version": "1.1.14",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -3830,7 +3846,7 @@
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
         }
       }
@@ -3898,7 +3914,7 @@
     },
     "socket.io-parser": {
       "version": "2.3.1",
-      "resolved": "http://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
       "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
       "requires": {
         "component-emitter": "1.1.2",
@@ -3909,7 +3925,7 @@
       "dependencies": {
         "debug": {
           "version": "2.2.0",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "requires": {
             "ms": "0.7.1"
@@ -3917,7 +3933,7 @@
         },
         "ms": {
           "version": "0.7.1",
-          "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
         }
       }
@@ -3966,7 +3982,16 @@
       "version": "github:scality/sproxydclient#6a391f8db104df72651824659151a020c2242cd1",
       "from": "github:scality/sproxydclient#6a391f8d",
       "requires": {
-        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61"
+        "werelogs": "github:scality/werelogs#0ff7ec82"
+      },
+      "dependencies": {
+        "werelogs": {
+          "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+          "from": "github:scality/werelogs#0ff7ec82",
+          "requires": {
+            "safe-json-stringify": "1.0.3"
+          }
+        }
       }
     },
     "ssh2": {
@@ -4195,7 +4220,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -4209,7 +4234,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -4252,7 +4277,7 @@
     },
     "topo": {
       "version": "2.0.2",
-      "resolved": "http://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
       "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
       "requires": {
         "hoek": "4.x.x"
@@ -4422,12 +4447,12 @@
       "version": "github:scality/utapi#cd3324df87e15b24912c58bd7712b48f6fc356cb",
       "from": "github:scality/utapi#cd3324df",
       "requires": {
-        "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
+        "arsenal": "github:scality/Arsenal#67365083",
         "async": "^2.0.1",
         "ioredis": "^2.3.0",
         "node-schedule": "1.2.0",
-        "vaultclient": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
-        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61"
+        "vaultclient": "github:scality/vaultclient#fbd9988d",
+        "werelogs": "github:scality/werelogs#0ff7ec82"
       },
       "dependencies": {
         "arsenal": {
@@ -4451,7 +4476,7 @@
             "socket.io-client": "~1.7.3",
             "utf8": "2.1.2",
             "uuid": "^3.0.1",
-            "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+            "werelogs": "github:scality/werelogs#0ff7ec82",
             "xml2js": "~0.4.16"
           },
           "dependencies": {
@@ -4463,6 +4488,50 @@
                 "lodash": "^4.14.0"
               }
             }
+          }
+        },
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
+        },
+        "vaultclient": {
+          "version": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
+          "from": "github:scality/vaultclient#fbd9988d",
+          "requires": {
+            "arsenal": "github:scality/Arsenal#67365083",
+            "commander": "2.9.0",
+            "werelogs": "github:scality/werelogs#0ff7ec82",
+            "xml2js": "0.4.17"
+          },
+          "dependencies": {
+            "xml2js": {
+              "version": "0.4.17",
+              "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+              "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+              "requires": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "^4.1.0"
+              }
+            }
+          }
+        },
+        "werelogs": {
+          "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+          "from": "github:scality/werelogs#0ff7ec82",
+          "requires": {
+            "safe-json-stringify": "1.0.3"
+          }
+        },
+        "xmlbuilder": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+          "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+          "requires": {
+            "lodash": "^4.0.0"
           }
         }
       }
@@ -4500,9 +4569,9 @@
       "version": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
       "from": "github:scality/vaultclient#fbd9988d",
       "requires": {
-        "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
+        "arsenal": "github:scality/Arsenal#67365083",
         "commander": "2.9.0",
-        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+        "werelogs": "github:scality/werelogs#0ff7ec82",
         "xml2js": "0.4.17"
       },
       "dependencies": {
@@ -4527,7 +4596,7 @@
             "socket.io-client": "~1.7.3",
             "utf8": "2.1.2",
             "uuid": "^3.0.1",
-            "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+            "werelogs": "github:scality/werelogs#0ff7ec82",
             "xml2js": "~0.4.16"
           }
         },
@@ -4545,6 +4614,13 @@
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "requires": {
             "graceful-readlink": ">= 1.0.0"
+          }
+        },
+        "werelogs": {
+          "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+          "from": "github:scality/werelogs#0ff7ec82",
+          "requires": {
+            "safe-json-stringify": "1.0.3"
           }
         },
         "xml2js": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "scality/Arsenal#879823c4",
+    "arsenal": "github:scality/Arsenal#0eaae2b",
     "async": "~2.5.0",
     "aws-sdk": "2.28.0",
     "azure-storage": "^2.1.0",

--- a/tests/functional/raw-node/test/routes/routeMetadata.js
+++ b/tests/functional/raw-node/test/routes/routeMetadata.js
@@ -95,4 +95,15 @@ describe('metadata routes with metadata mock backend', () => {
             return done();
         });
     });
+
+    it('should get an error for accessing invalid routes', done => {
+        makeMetadataRequest({
+            method: 'GET',
+            authCredentials: metadataAuthCredentials,
+            path: '/_/metadata/admin/raft_sessions',
+        }, err => {
+            assert.strictEqual(err.code, 'NotImplemented');
+            return done();
+        });
+    });
 });


### PR DESCRIPTION
## Description
bugfix: restrict metadata proxy routes to policy
### Motivation and context

These changes ensure that the routes are available only to account credentials
or credentials of users who are assigned metadata:admin policy


