### PR TITLE
feature: ZENKO-1570 enable versioning for ingestion

### DIFF
--- a/lib/api/apiUtils/bucket/bucketCreation.js
+++ b/lib/api/apiUtils/bucket/bucketCreation.js
@@ -187,6 +187,8 @@ function createBucket(authInfo, bucketName, headers,
         }
         if (ingestion === 'ingest') {
             bucket.enableIngestion();
+            //automatically enable versioning for ingestion buckets
+            bucket.setVersioningConfiguration({ Status: 'Enabled' });
         }
     }
     const parseAclParams = {

--- a/lib/api/bucketPutVersioning.js
+++ b/lib/api/bucketPutVersioning.js
@@ -18,6 +18,8 @@ const replicationVersioningErrorMessage = 'A replication configuration is ' +
 'present on this bucket, so you cannot change the versioning state. To ' +
 'change the versioning state, first delete the replication configuration.';
 
+const ingestionVersioningErrorMessage = 'Versioning cannot be suspended for '
++ 'buckets setup with Out of Band updates from a location';
 /**
  * Format of xml request:
 
@@ -79,12 +81,15 @@ function _checkBackendVersioningImplemented(bucket) {
     return true;
 }
 
-function _isValidReplicationVersioning(result, bucket) {
+function _isValidVersioningRequest(result, bucket) {
     if (result.VersioningConfiguration &&
         result.VersioningConfiguration.Status) {
-        // Is there a replication configuration set on the bucket and is the
-        // user attempting to suspend versioning?
-        if (bucket.getReplicationConfiguration()) {
+        const restricted = bucket.getReplicationConfiguration()
+            || (bucket.isIngestionBucket && bucket.isIngestionBucket());
+        // Is there a replication configuration set on the bucket or the bucket
+        // is an ingestion bucket and is the user attempting to suspend
+        // versioning?
+        if (restricted) {
             return result.VersioningConfiguration.Status[0] !== 'Suspended';
         }
     }
@@ -133,13 +138,17 @@ function bucketPutVersioning(authInfo, request, log, callback) {
                     externalVersioningErrorMessage);
                 return next(error, bucket);
             }
-            if (!_isValidReplicationVersioning(result, bucket)) {
-                log.debug(replicationVersioningErrorMessage, {
+            if (!_isValidVersioningRequest(result, bucket)) {
+                const errorMsg =
+                (bucket.isIngestionBucket && bucket.isIngestionBucket()) ?
+                    ingestionVersioningErrorMessage :
+                    replicationVersioningErrorMessage;
+                log.debug(errorMsg, {
                     method: 'bucketPutVersioning',
                     error: errors.InvalidBucketState,
                 });
                 const error = errors.InvalidBucketState
-                    .customizeDescription(replicationVersioningErrorMessage);
+                    .customizeDescription(errorMsg);
                 return next(error, bucket);
             }
             const versioningConfiguration = {};

--- a/tests/functional/aws-node-sdk/test/bucket/put.js
+++ b/tests/functional/aws-node-sdk/test/bucket/put.js
@@ -250,6 +250,12 @@ describe('PUT Bucket - AWS.S3.createBucket', () => {
                         assert.strictEqual(res.LocationConstraint, 'us-east-2');
                         return next();
                     }),
+                    next => bucketUtil.s3.getBucketVersioning(
+                        { Bucket: bucketName }, (err, res) => {
+                            assert.ifError(err);
+                            assert.strictEqual(res.Status, 'Enabled');
+                            return next();
+                    }),
                 ], done);
             });
         });

--- a/tests/functional/aws-node-sdk/test/bucket/testBucketVersioning.js
+++ b/tests/functional/aws-node-sdk/test/bucket/testBucketVersioning.js
@@ -4,18 +4,16 @@ const { S3 } = require('aws-sdk');
 const getConfig = require('../support/config');
 
 const bucket = `versioning-bucket-${Date.now()}`;
-
+const config = getConfig('default', { signatureVersion: 'v4' });
+const configReplication = getConfig('replication',
+    { signatureVersion: 'v4' });
+const s3 = new S3(config);
 describe('aws-node-sdk test bucket versioning', function testSuite() {
     this.timeout(60000);
-    let s3;
     let replicationAccountS3;
 
     // setup test
     before(done => {
-        const config = getConfig('default', { signatureVersion: 'v4' });
-        const configReplication = getConfig('replication',
-            { signatureVersion: 'v4' });
-        s3 = new S3(config);
         replicationAccountS3 = new S3(configReplication);
         s3.createBucket({ Bucket: bucket }, done);
     });
@@ -165,6 +163,29 @@ describe('aws-node-sdk test bucket versioning', function testSuite() {
         s3.getBucketVersioning(params, (error, data) => {
             assert.strictEqual(error, null);
             assert.deepStrictEqual(data, { Status: 'Enabled' });
+            done();
+        });
+    });
+});
+
+
+describe('bucket versioning for ingestion buckets', () => {
+    const Bucket = `ingestion-bucket-${Date.now()}`;
+    before(done => s3.createBucket({
+            Bucket,
+            CreateBucketConfiguration: {
+                LocationConstraint: 'us-east-2:ingest',
+            },
+        }, done));
+
+    after(done => s3.deleteBucket({ Bucket }, done));
+
+    it('should not allow suspending versioning for ingestion buckets', done => {
+        s3.putBucketVersioning({ Bucket, VersioningConfiguration: {
+            Status: 'Suspended'
+        } }, err => {
+            assert(err, 'Expected error but got success');
+            assert.strictEqual(err.code, 'InvalidBucketState');
             done();
         });
     });

--- a/tests/functional/utilities/countItems.js
+++ b/tests/functional/utilities/countItems.js
@@ -53,7 +53,7 @@ function populateDB(s3Client, cb) {
                     CreateBucketConfiguration: { LocationConstraint:
                     `us-east-1:${ingestion}` } }, done),
             putBucketVersioning: done => {
-                if (!versioning) {
+                if (!versioning || ingestion) {
                     return done();
                 }
                 return s3Client.putBucketVersioning({
@@ -96,7 +96,7 @@ const refResults = {
     bucketList: testBuckets.map(b => ({
         name: b.bucketName,
         location: 'us-east-1',
-        isVersioned: b.versioning,
+        isVersioned: b.ingestion ? true : b.versioning,
         ownerCanonicalId,
         ingestion: b.ingestion ? b.ingestion === 'ingest' : false,
     })),


### PR DESCRIPTION


## Description
feature: ZENKO-1570 enable versioning for ingestion
### Motivation and context

This commit ensures that versioning is automatically enabled for ingestion
buckets upon creation. It satisfies the requirement that all ingestion buckets
must be versioning enabled.
