### PR TITLE
feature: ZENKO-1585 configure replication group id

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -75,6 +75,10 @@ if [[ "$LISTEN_ADDR" ]]; then
     JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .listenOn=[\"$LISTEN_ADDR:8000\"]"
 fi
 
+if [[ "$REPLICATION_GROUP_ID" ]] ; then
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .replicationGroupId=\"$REPLICATION_GROUP_ID\""
+fi
+
 if [[ "$DATA_HOST" ]]; then
     JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .dataClient.host=\"$DATA_HOST\""
 fi


### PR DESCRIPTION



## Description
feature: ZENKO-1585 configure replication group id
### Motivation and context

Replication group id is used in the calculation of version ids for objects
on buckets that have versioning enabled. It has many benefits including avoiding
collisions in an active-active scenario, identifying distinct entries from an
instance etc.
This allows commit allows configuring a custom replication group id for an instance,
ensuring that the version ids generated by the instance are unique.
