### PR TITLE
ft: ZENKO-1661 add ingestion data to reporthandler

### DIFF
--- a/lib/utilities/reportHandler.js
+++ b/lib/utilities/reportHandler.js
@@ -17,6 +17,9 @@ const REQ_PATHS = {
     crrSchedules: '/_/crr/resume/all',
     crrStatus: '/_/crr/status',
     crrMetricPrefix: '/_/metrics/crr',
+    ingestionSchedules: '/_/ingestion/resume/all',
+    ingestionStatus: '/_/ingestion/status',
+    ingestionMetricPrefix: '/_/metrics/ingestion',
 };
 
 function hasWSOptionalDependencies() {
@@ -123,19 +126,19 @@ const _makeRequest = (endpoint, path, cb) => {
     });
 };
 
-function _crrRequest(endpoint, site, log, cb) {
+function _crrMetricRequest(endpoint, site, log, cb) {
     const path = `${REQ_PATHS.crrMetricPrefix}/${site}`;
     return _makeRequest(endpoint, path, (err, res) => {
         if (err) {
             if (err === 'responseError') {
                 log.error('error response from backbeat api', {
                     error: res,
-                    method: '_crrRequest',
+                    method: '_crrMetricRequest',
                 });
             } else {
                 log.error('unable to perform request to backbeat api', {
                     error: err,
-                    method: '_crrRequest',
+                    method: '_crrMetricRequest',
                 });
             }
             return cb(null, {});
@@ -143,7 +146,7 @@ function _crrRequest(endpoint, site, log, cb) {
         const { completions, failures, backlog, throughput, pending } = res;
         if (!completions || !failures || !backlog || !throughput || !pending) {
             log.error('could not get metrics from backbeat', {
-                method: 'getCRRStats',
+                method: '_crrMetricRequest',
             });
             return cb(null, {});
         }
@@ -173,88 +176,142 @@ function _crrRequest(endpoint, site, log, cb) {
     });
 }
 
-function getCRRStats(log, cb, _testConfig) {
-    log.debug('request CRR metrics from backbeat api', {
-        method: 'getCRRStats',
-    });
-    const { replicationEndpoints, backbeat } = _testConfig || config;
-    const { host, port } = backbeat;
-    const endpoint = `http://${host}:${port}`;
-    const sites = replicationEndpoints.map(endpoint => endpoint.site);
-    return async.parallel({
-        all: done => _crrRequest(endpoint, 'all', log, done),
-        byLocation: done => async.mapLimit(sites, ASYNCLIMIT,
-            (site, next) => _crrRequest(endpoint, site, log, (err, res) => {
-                if (err) {
-                    log.debug('Error in retrieving site metrics', {
-                        method: 'getCRRStats',
-                        error: err,
-                        site,
-                    });
-                    return next(null, { site, stats: {} });
-                }
-                return next(null, { site, stats: res });
-            }),
-            (err, locStats) => {
-                if (err) {
-                    log.error('failed to get CRR stats for site', {
-                        method: 'getCRRStats',
-                        error: err,
-                    });
-                    return done(null, {});
-                }
-                const retObj = {};
-                locStats.forEach(locStat => {
-                    retObj[locStat.site] = locStat.stats;
-                });
-                return done(null, retObj);
-            }),
-    }, (err, res) => {
-        if (err) {
-            log.error('failed to get CRR stats', {
-                method: 'getCRRStats',
-                error: err,
-            });
-            return cb(null, {});
-        }
-        const all = (res && res.all) || {};
-        const byLocation = (res && res.byLocation) || {};
-        const retObj = {
-            completions: all.completions,
-            failures: all.failures,
-            pending: all.pending,
-            backlog: all.backlog,
-            throughput: all.throughput,
-            byLocation,
-        };
-        return cb(null, retObj);
-    });
-}
-
-function getReplicationStates(log, cb, _testConfig) {
-    log.debug('requesting location replications states from backbeat api',
-        {
-            method: 'getReplicationStates',
-        });
-    const { host, port } = _testConfig || config.backbeat;
-    const endpoint = `http://${host}:${port}`;
-    async.parallel({
-        states: done => _makeRequest(endpoint, REQ_PATHS.crrStatus, done),
-        schedules: done => _makeRequest(endpoint, REQ_PATHS.crrSchedules, done),
-    }, (err, res) => {
+function _ingestionMetricRequest(endpoint, site, log, cb) {
+    const path = `${REQ_PATHS.ingestionMetricPrefix}/${site}`;
+    return _makeRequest(endpoint, path, (err, res) => {
         if (err) {
             if (err === 'responseError') {
                 log.error('error response from backbeat api', {
                     error: res,
-                    method: 'getReplicationStates',
+                    method: '_ingestionMetricRequest',
                 });
             } else {
                 log.error('unable to perform request to backbeat api', {
                     error: err,
-                    method: 'getReplicationStates',
+                    method: '_ingestionMetricRequest',
                 });
             }
             return cb(null, {});
+        }
+        const { completions, throughput, pending } = res;
+        if (!completions || !throughput || !pending) {
+            log.error('could not get metrics from backbeat', {
+                method: '_ingestionMetricRequest',
+            });
+            return cb(null, {});
+        }
+        const stats = {
+            completions: {
+                count: parseInt(completions.results.count, 10),
+            },
+            throughput: {
+                count: parseInt(throughput.results.count, 10),
+            },
+            pending: {
+                count: parseInt(pending.results.count, 10),
+            },
+        };
+        return cb(null, stats);
+    });
+}
+
+function _getMetricsByLocation(endpoint, sites, requestMethod, log, cb) {
+    async.mapLimit(
+        sites,
+        ASYNCLIMIT,
+        (site, next) => requestMethod(endpoint, site, log, (err, res) => {
+            if (err) {
+                log.debug('Error in retrieving site metrics', {
+                    method: '_getMetricsByLocation',
+                    error: err,
+                    site,
+                    requestType: requestMethod.name,
+                });
+                return next(null, { site, stats: {} });
+            }
+            return next(null, { site, stats: res });
+        }),
+        (err, locStats) => {
+            if (err) {
+                log.error('failed to get stats for site', {
+                    method: '_getMetricsByLocation',
+                    error: err,
+                    requestType: requestMethod.name,
+                });
+                return cb(null, {});
+            }
+            const retObj = {};
+            locStats.forEach(locStat => {
+                retObj[locStat.site] = locStat.stats;
+            });
+            return cb(null, retObj);
+        }
+    );
+}
+
+function _getMetrics(sites, requestMethod, log, cb, _testConfig) {
+    const conf = (_testConfig && _testConfig.backbeat) || config.backbeat;
+    const { host, port } = conf;
+    const endpoint = `http://${host}:${port}`;
+    return async.parallel({
+        all: done => requestMethod(endpoint, 'all', log, done),
+        byLocation: done => _getMetricsByLocation(endpoint, sites,
+            requestMethod, log, done),
+    }, (err, res) => {
+        if (err) {
+            return cb(err);
+        }
+        const all = (res && res.all) || {};
+        const byLocation = (res && res.byLocation) || {};
+        const retObj = Object.assign({}, all, { byLocation });
+        return cb(null, retObj);
+    });
+}
+
+function getCRRMetrics(log, cb, _testConfig) {
+    log.debug('request CRR metrics from backbeat api', {
+        method: 'getCRRMetrics',
+    });
+    const { replicationEndpoints } = _testConfig || config;
+    const sites = replicationEndpoints.map(endpoint => endpoint.site);
+    return _getMetrics(sites, _crrMetricRequest, log, (err, retObj) => {
+        if (err) {
+            log.error('failed to get CRR stats', {
+                method: 'getCRRMetrics',
+                error: err,
+            });
+            return cb(null, {});
+        }
+        return cb(null, retObj);
+    }, _testConfig);
+}
+
+function getIngestionMetrics(sites, log, cb, _testConfig) {
+    log.debug('request Ingestion metrics from backbeat api', {
+        method: 'getIngestionMetrics',
+    });
+    return _getMetrics(sites, _ingestionMetricRequest, log, (err, retObj) => {
+        if (err) {
+            log.error('failed to get Ingestion stats', {
+                method: 'getIngestionMetrics',
+                error: err,
+            });
+            return cb(null, {});
+        }
+        return cb(null, retObj);
+    }, _testConfig);
+}
+
+function _getStates(statusPath, schedulePath, log, cb, _testConfig) {
+    const conf = (_testConfig && _testConfig.backbeat) || config.backbeat;
+    const { host, port } = conf;
+    const endpoint = `http://${host}:${port}`;
+    async.parallel({
+        states: done => _makeRequest(endpoint, statusPath, done),
+        schedules: done => _makeRequest(endpoint, schedulePath, done),
+    }, (err, res) => {
+        if (err) {
+            return cb(err);
         }
         const locationSchedules = {};
         Object.keys(res.schedules).forEach(loc => {
@@ -268,6 +325,100 @@ function getReplicationStates(log, cb, _testConfig) {
             schedules: locationSchedules,
         };
         return cb(null, retObj);
+    });
+}
+
+function getReplicationStates(log, cb, _testConfig) {
+    log.debug('requesting replication location states from backbeat api', {
+        method: 'getReplicationStates',
+    });
+    const { crrStatus, crrSchedules } = REQ_PATHS;
+    return _getStates(crrStatus, crrSchedules, log, (err, res) => {
+        if (err) {
+            if (err === 'responseError') {
+                log.error('error response from backbeat api', {
+                    error: res,
+                    method: 'getReplicationStates',
+                    service: 'replication',
+                });
+            } else {
+                log.error('unable to perform request to backbeat api', {
+                    error: err,
+                    method: 'getReplicationStates',
+                    service: 'replication',
+                });
+            }
+            return cb(null, {});
+        }
+        return cb(null, res);
+    }, _testConfig);
+}
+
+function getIngestionStates(log, cb, _testConfig) {
+    log.debug('requesting location ingestion states from backbeat api', {
+        method: 'getIngestionStates',
+    });
+    const { ingestionStatus, ingestionSchedules } = REQ_PATHS;
+    return _getStates(ingestionStatus, ingestionSchedules, log, (err, res) => {
+        if (err) {
+            if (err === 'responseError') {
+                log.error('error response from backbeat api', {
+                    error: res,
+                    method: 'getIngestionStates',
+                    service: 'ingestion',
+                });
+            } else {
+                log.error('unable to perform request to backbeat api', {
+                    error: err,
+                    method: 'getIngestionStates',
+                    service: 'ingestion',
+                });
+            }
+            return cb(null, {});
+        }
+        return cb(null, res);
+    }, _testConfig);
+}
+
+function getIngestionInfo(log, cb, _testConfig) {
+    log.debug('requesting location ingestion info from backbeat api', {
+        method: 'getIngestionInfo',
+    });
+    async.waterfall([
+        done => getIngestionStates(log, done, _testConfig),
+        (stateObj, done) => {
+            // if getIngestionStates returned an error or the returned object
+            // did not return an expected response
+            if (Object.keys(stateObj).length === 0 || !stateObj.states) {
+                log.debug('no ingestion locations found', {
+                    method: 'getIngestionInfo',
+                });
+                return done(null, stateObj, {});
+            }
+            const sites = Object.keys(stateObj.states);
+            return getIngestionMetrics(sites, log, (err, res) => {
+                if (err) {
+                    log.error('failed to get Ingestion stats', {
+                        method: 'getIngestionInfo',
+                        error: err,
+                    });
+                    return done(null, stateObj, {});
+                }
+                return done(null, stateObj, res);
+            }, _testConfig);
+        },
+    ], (err, stateObj, metricObj) => {
+        if (err) {
+            log.error('failed to get ingestion info', {
+                method: 'getIngestionInfo',
+                error: err,
+            });
+            return cb(null, {});
+        }
+        return cb(null, {
+            metrics: metricObj,
+            status: stateObj,
+        });
     });
 }
 
@@ -296,8 +447,9 @@ function reportHandler(clientIP, req, res, log) {
         getDataDiskUsage: cb => data.getDiskUsage(log, cb),
         getVersion: cb => getGitVersion(cb),
         getObjectCount: cb => metadata.countItems(log, cb),
-        getCRRStats: cb => getCRRStats(log, cb),
+        getCRRMetrics: cb => getCRRMetrics(log, cb),
         getReplicationStates: cb => getReplicationStates(log, cb),
+        getIngestionInfo: cb => getIngestionInfo(log, cb),
     },
     (err, results) => {
         if (err) {
@@ -306,7 +458,7 @@ function reportHandler(clientIP, req, res, log) {
             log.errorEnd('could not gather report', { error: err });
         } else {
             const getObjectCount = results.getObjectCount;
-            const crrStatsObj = Object.assign({}, results.getCRRStats);
+            const crrStatsObj = Object.assign({}, results.getCRRMetrics);
             crrStatsObj.stalled = { count: getObjectCount.stalled || 0 };
             delete getObjectCount.stalled;
             const response = {
@@ -323,6 +475,8 @@ function reportHandler(clientIP, req, res, log) {
                 repStatus: results.getReplicationStates,
                 config: cleanup(config),
                 capabilities: getCapabilities(),
+                ingestStats: results.getIngestionInfo.metrics,
+                ingestionStatus: results.getIngestionInfo.status,
             };
             monitoring.crrCacheToProm(results);
             res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -336,7 +490,11 @@ function reportHandler(clientIP, req, res, log) {
 module.exports = {
     getCapabilities,
     reportHandler,
-    _crrRequest,
-    getCRRStats,
+    _crrMetricRequest,
+    getCRRMetrics,
     getReplicationStates,
+    _ingestionMetricRequest,
+    getIngestionMetrics,
+    getIngestionStates,
+    getIngestionInfo,
 };


### PR DESCRIPTION
Update the report handler to get ingestion location statuses and metrics.

There was an issue in determining ingestion-only locations. Pause/resume routes will return ingestion-only locations, so rely on first get pause statuses, and then for each of those locations, get metrics.

Changed "stats" -> "metrics" because naming between "stats" and "states" or "status" seemed too similar.