### PR TITLE
ft: ZENKO-1661 rename ingestion status report var

### DIFF
--- a/lib/utilities/reportHandler.js
+++ b/lib/utilities/reportHandler.js
@@ -476,7 +476,7 @@ function reportHandler(clientIP, req, res, log) {
                 config: cleanup(config),
                 capabilities: getCapabilities(),
                 ingestStats: results.getIngestionInfo.metrics,
-                ingestionStatus: results.getIngestionInfo.status,
+                ingestStatus: results.getIngestionInfo.status,
             };
             monitoring.crrCacheToProm(results);
             res.writeHead(200, { 'Content-Type': 'application/json' });


### PR DESCRIPTION
Rename ingestion status report variable from `ingestionStatus` to `ingestStatus` to comply with naming in pensieve
