### PR TITLE
bugfix: ZENKO-1606 Replicate tags from object PUT

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -1,6 +1,7 @@
 const url = require('url');
 const async = require('async');
 const httpProxy = require('http-proxy');
+const querystring = require('querystring');
 
 const backbeatProxy = httpProxy.createProxyServer({
     ignorePath: true,
@@ -470,6 +471,7 @@ function putObject(request, response, log, callback) {
     const cacheControl = request.headers['x-scal-cache-control'];
     const contentDisposition = request.headers['x-scal-content-disposition'];
     const contentEncoding = request.headers['x-scal-content-encoding'];
+    const tagging = request.headers['x-scal-tags'];
     const metaHeaders = { 'x-amz-meta-scal-replication-status': 'REPLICA' };
     if (sourceVersionId) {
         metaHeaders['x-amz-meta-scal-version-id'] = sourceVersionId;
@@ -494,6 +496,15 @@ function putObject(request, response, log, callback) {
         contentDisposition,
         contentEncoding,
     };
+    if (tagging !== undefined) {
+        try {
+            const tags = JSON.parse(request.headers['x-scal-tags']);
+            context.tagging = querystring.stringify(tags);
+        } catch (err) {
+            // FIXME: add error type MalformedJSON
+            return callback(errors.MalformedPOSTRequest);
+        }
+    }
     const payloadLen = parseInt(request.headers['content-length'], 10);
     const backendInfo = new BackendInfo(config, storageLocation);
     return dataStore(context, CIPHER, request, payloadLen, {}, backendInfo, log,


### PR DESCRIPTION
If tags are passed in the header from backbeat during a put object request to the public cloud, we should also send that to the destination cloud.