### PR TITLE
bugfix: ZENKO-1606 MPU tagging during replication

### DIFF
--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -174,7 +174,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
             const mpuInfo =
                 { objectKey, uploadId, jsonList, bucketName, destBucket };
             return data.completeMPU(request, mpuInfo, mdInfo, location,
-            null, null, locationConstraintCheck, log,
+            null, null, null, locationConstraintCheck, log,
             (err, completeObjData) => {
                 if (err) {
                     return next(err, destBucket);

--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -579,6 +579,7 @@ function initiateMultipartUpload(request, response, log, callback) {
     const cacheControl = request.headers['x-scal-cache-control'];
     const contentDisposition = request.headers['x-scal-content-disposition'];
     const contentEncoding = request.headers['x-scal-content-encoding'];
+    const tags = request.headers['x-scal-tags'];
     const metaHeaders = { 'x-amz-meta-scal-replication-status': 'REPLICA' };
     if (sourceVersionId) {
         metaHeaders['x-amz-meta-scal-version-id'] = sourceVersionId;
@@ -592,9 +593,19 @@ function initiateMultipartUpload(request, response, log, callback) {
             return callback(errors.MalformedPOSTRequest);
         }
     }
+    let tagging;
+    if (tags !== undefined) {
+        try {
+            const parsedTags = JSON.parse(request.headers['x-scal-tags']);
+            tagging = querystring.stringify(parsedTags);
+        } catch (err) {
+            // FIXME: add error type MalformedJSON
+            return callback(errors.MalformedPOSTRequest);
+        }
+    }
     return dataClient.createMPU(request.objectKey, metaHeaders,
         request.bucketName, undefined, storageLocation, contentType,
-        cacheControl, contentDisposition, contentEncoding, log,
+        cacheControl, contentDisposition, contentEncoding, tagging, log,
         (err, data) => {
             if (err) {
                 log.error('error initiating multipart upload', {
@@ -671,6 +682,7 @@ function completeMultipartUpload(request, response, log, callback) {
     const cacheControl = request.headers['x-scal-cache-control'];
     const contentDisposition = request.headers['x-scal-content-disposition'];
     const contentEncoding = request.headers['x-scal-content-encoding'];
+    const tags = request.headers['x-scal-tags'];
     const data = [];
     let totalLength = 0;
     request.on('data', chunk => {
@@ -701,6 +713,18 @@ function completeMultipartUpload(request, response, log, callback) {
                 return callback(errors.MalformedPOSTRequest);
             }
         }
+        // Azure does not have a notion of initiating an MPU, so we put any
+        // tagging fields during the complete MPU if using Azure.
+        let tagging;
+        if (tags !== undefined) {
+            try {
+                const parsedTags = JSON.parse(request.headers['x-scal-tags']);
+                tagging = querystring.stringify(parsedTags);
+            } catch (err) {
+                // FIXME: add error type MalformedJSON
+                return callback(errors.MalformedPOSTRequest);
+            }
+        }
         const contentSettings = {
             contentType: contentType || undefined,
             cacheControl: cacheControl || undefined,
@@ -709,7 +733,8 @@ function completeMultipartUpload(request, response, log, callback) {
         };
         return dataClient.completeMPU(request.objectKey, uploadId,
             storageLocation, partList, undefined, request.bucketName,
-            metaHeaders, contentSettings, log, (err, retrievalInfo) => {
+            metaHeaders, contentSettings, tagging, log,
+            (err, retrievalInfo) => {
                 if (err) {
                     log.error('error completing MPU', {
                         error: err,

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "2.1.22",
+        "mime-types": "2.1.23",
         "negotiator": "0.6.1"
       }
     },
@@ -173,6 +173,16 @@
       "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
       "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
     },
+    "array-includes": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.3",
+        "es-abstract": "1.13.0"
+      }
+    },
     "array-map": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
@@ -189,16 +199,16 @@
       "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
     },
     "arsenal": {
-      "version": "github:scality/arsenal#64426b1450dd42af7e3b941e9a49256213aeeb4f",
+      "version": "github:scality/arsenal#cc6ed165ddc180a3473f5c7ce9b71f2de6fa5198",
       "requires": {
         "ajv": "4.10.0",
         "async": "2.6.2",
         "aws-sdk": "2.80.0",
-        "azure-storage": "2.10.2",
+        "azure-storage": "2.10.3",
         "backo": "1.1.0",
         "bson": "4.0.0",
         "debug": "4.1.1",
-        "diskusage": "1.0.0",
+        "diskusage": "1.1.0",
         "fcntl": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
         "https-proxy-agent": "2.2.1",
         "ioctl": "2.0.1",
@@ -261,9 +271,9 @@
           }
         },
         "diskusage": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/diskusage/-/diskusage-1.0.0.tgz",
-          "integrity": "sha512-eOrPVSZLxo8kXz03GA+gdKauSSmicNET/pXMZKXs1vkdZrEayeZmJYu1Eo2uzVhkQL748vq1irIi7hzoPWBRmQ==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/diskusage/-/diskusage-1.1.0.tgz",
+          "integrity": "sha512-T40n67o0HfQlf+wFOUq+lTqIDGaGasgwieN3FkYJ1H1Ur/YBUej0Mc4T+5aUG3kGJW8s1ir8wmGhq0OjpYqceQ==",
           "requires": {
             "es6-promise": "4.2.6",
             "nan": "2.13.2"
@@ -430,9 +440,9 @@
       }
     },
     "azure-storage": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.2.tgz",
-      "integrity": "sha512-pOyGPya9+NDpAfm5YcFfklo57HfjDbYLXxs4lomPwvRxmb0Di/A+a+RkUmEFzaQ8S13CqxK40bRRB0sjj2ZQxA==",
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.3.tgz",
+      "integrity": "sha512-IGLs5Xj6kO8Ii90KerQrrwuJKexLgSwYC4oLWmc11mzKe7Jt2E5IVg+ZQ8K53YWZACtVTMBNO3iGuA+4ipjJxQ==",
       "requires": {
         "browserify-mime": "1.2.9",
         "extend": "3.0.2",
@@ -753,7 +763,7 @@
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
           "requires": {
-            "mime-types": "2.1.22",
+            "mime-types": "2.1.23",
             "negotiator": "0.6.1"
           }
         },
@@ -1347,7 +1357,7 @@
           "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
           "optional": true,
           "requires": {
-            "mime-types": "2.1.22",
+            "mime-types": "2.1.23",
             "negotiator": "0.6.1"
           }
         },
@@ -2419,7 +2429,7 @@
         "ignore": "4.0.6",
         "import-fresh": "3.0.0",
         "imurmurhash": "0.1.4",
-        "inquirer": "6.2.2",
+        "inquirer": "6.3.1",
         "js-yaml": "3.13.1",
         "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
@@ -2564,9 +2574,9 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz",
-      "integrity": "sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
+      "integrity": "sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -2591,16 +2601,17 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.16.0.tgz",
-      "integrity": "sha512-z6oqWlf1x5GkHIFgrSvtmudnqM6Q60KM4KvpWi5ubonMjycLjndvd5+8VAZIsTlHC03djdgJuyKG6XO577px6A==",
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.17.2.tgz",
+      "integrity": "sha512-m+cSVxM7oLsIpmwNn2WXTJoReOF9f/CtLMo7qOVmKd1KntBy0hEcuNZ3erTmWjx+DxRO0Zcrm5KwAvI9wHcV5g==",
       "dev": true,
       "requires": {
+        "array-includes": "3.0.3",
         "contains-path": "0.1.0",
         "debug": "2.6.9",
         "doctrine": "1.5.0",
         "eslint-import-resolver-node": "0.3.2",
-        "eslint-module-utils": "2.3.0",
+        "eslint-module-utils": "2.4.0",
         "has": "1.0.3",
         "lodash": "4.17.11",
         "minimatch": "3.0.4",
@@ -2906,7 +2917,7 @@
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.7",
-        "mime-types": "2.1.22"
+        "mime-types": "2.1.23"
       }
     },
     "from": {
@@ -3090,9 +3101,9 @@
       }
     },
     "handlebars": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
-      "integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
       "dev": true,
       "requires": {
         "neo-async": "2.6.0",
@@ -3330,9 +3341,9 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
-      "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
+      "integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
       "dev": true,
       "requires": {
         "ansi-escapes": "3.2.0",
@@ -3730,7 +3741,7 @@
       "integrity": "sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==",
       "dev": true,
       "requires": {
-        "handlebars": "4.1.1"
+        "handlebars": "4.1.2"
       }
     },
     "items": {
@@ -4298,16 +4309,16 @@
       "integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg=="
     },
     "mime-db": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.39.0.tgz",
+      "integrity": "sha512-DTsrw/iWVvwHH+9Otxccdyy0Tgiil6TWK/xhfARJZF/QFhwOgZgOIvA2/VIGpM8U7Q8z5nDmdDWC6tuVMJNibw=="
     },
     "mime-types": {
-      "version": "2.1.22",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
-      "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+      "version": "2.1.23",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.23.tgz",
+      "integrity": "sha512-ROk/m+gMVSrRxTkMlaQOvFmFmYDc7sZgrjjM76abqmd2Cc5fCV7jAMA5XUccEtJ3cYiYdgixUVI+fApc2LkXlw==",
       "requires": {
-        "mime-db": "1.38.0"
+        "mime-db": "1.39.0"
       }
     },
     "mimic-fn": {
@@ -5184,7 +5195,7 @@
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.22",
+        "mime-types": "2.1.23",
         "oauth-sign": "0.9.0",
         "performance-now": "2.1.0",
         "qs": "6.5.2",
@@ -5945,7 +5956,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.22"
+        "mime-types": "2.1.23"
       }
     },
     "typewise": {
@@ -6050,7 +6061,7 @@
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
           "requires": {
-            "mime-types": "2.1.22",
+            "mime-types": "2.1.23",
             "negotiator": "0.6.1"
           }
         },
@@ -6621,7 +6632,7 @@
             "async": "2.6.2",
             "bson": "4.0.0",
             "debug": "4.1.1",
-            "diskusage": "1.0.0",
+            "diskusage": "1.1.0",
             "fcntl": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
             "ioctl": "2.0.1",
             "ioredis": "4.2.0",
@@ -6666,9 +6677,9 @@
           }
         },
         "diskusage": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/diskusage/-/diskusage-1.0.0.tgz",
-          "integrity": "sha512-eOrPVSZLxo8kXz03GA+gdKauSSmicNET/pXMZKXs1vkdZrEayeZmJYu1Eo2uzVhkQL748vq1irIi7hzoPWBRmQ==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/diskusage/-/diskusage-1.1.0.tgz",
+          "integrity": "sha512-T40n67o0HfQlf+wFOUq+lTqIDGaGasgwieN3FkYJ1H1Ur/YBUej0Mc4T+5aUG3kGJW8s1ir8wmGhq0OjpYqceQ==",
           "requires": {
             "es6-promise": "4.2.6",
             "nan": "2.13.2"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "github:scality/arsenal#64426b1",
+    "arsenal": "github:scality/arsenal#cc6ed16",
     "async": "~2.5.0",
     "aws-sdk": "2.28.0",
     "azure-storage": "^2.1.0",


### PR DESCRIPTION
Update MPU route requests to set tags on a target public cloud object.

Depends on https://github.com/scality/Arsenal/pull/773.