### PR TITLE
bf: S3C-2099 zenko userMD for delete markers

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -121,6 +121,8 @@ const constants = {
     azureAccountNameRegex: /^[a-z0-9]{3,24}$/,
     base64Regex: new RegExp('^(?:[A-Za-z0-9+/]{4})*' +
         '(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$'),
+    // user metadata applied on zenko objects
+    zenkoIDHeader: 'x-amz-meta-zenko-instance-id',
 };
 
 module.exports = constants;

--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -14,11 +14,37 @@ const getReplicationInfo = require('./getReplicationInfo');
 const { config } = require('../../../Config');
 const validateWebsiteHeader = require('./websiteServing')
     .validateWebsiteHeader;
-const { externalBackends, versioningNotImplBackends } = constants;
+const {
+    externalBackends, versioningNotImplBackends, zenkoIDHeader,
+} = constants;
 
 const externalVersioningErrorMessage = 'We do not currently support putting ' +
 'a versioned object to a location-constraint of type Azure.';
 
+/**
+ * Retro-propagation is where S3C ingestion will re-ingest an object whose
+ * request originated from Zenko.
+ * To avoid this, Zenko requests which create objects/versions will be tagged
+ * with a user-metadata header defined in constants.zenkoIDHeader. When
+ * ingesting objects into Zenko, we can determine if this object has already
+ * been created in Zenko.
+ * Delete marker requests cannot specify user-metadata fields, so we instead
+ * rely on checking the "user-agent" to see the origin of a request.
+ * If delete marker, and user-agent came from a Zenko client, we add the
+ * user-metadata field to the object metadata.
+ * @param {Object} metaHeaders - user metadata object
+ * @param {http.ClientRequest} request - client request with user-agent header
+ * @param {Boolean} isDeleteMarker - delete marker indicator
+ * @return {undefined}
+ */
+function _checkAndApplyZenkoMD(metaHeaders, request, isDeleteMarker) {
+    const userAgent = request.headers['user-agent'];
+
+    if (isDeleteMarker && userAgent && userAgent.includes('Zenko')) {
+        // eslint-disable-next-line no-param-reassign
+        metaHeaders[zenkoIDHeader] = 'zenko';
+    }
+}
 
 function _storeInMDandDeleteData(bucketName, dataGetInfo, cipherBundle,
     metadataStoreParams, dataToDelete, deleteLog, requestMethod, callback) {
@@ -82,6 +108,9 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
         });
         return process.nextTick(() => callback(metaHeaders));
     }
+    // if receiving a request from Zenko for a delete marker, we place a
+    // user-metadata field on the object
+    _checkAndApplyZenkoMD(metaHeaders, request, isDeleteMarker);
 
     log.trace('meta headers', { metaHeaders, method: 'objectPut' });
     const objectKeyContext = {


### PR DESCRIPTION
# Pull request template

## Description

To solve retro-propagation for S3C ingestion, we need to
mark objects with a user-metadata field on all objects
created in a Zenko deployment.

For delete markers, we cannot send a request specifying
user-metadata as it does not comply with aws s3 standards.
Instead, we must somehow detect these delete markers on
S3C and apply the user-md ourselves. We rely on the
'user-agent' header.

### Motivation and context

Why is this change required? What problem does it solve?

S3C ingestion retro-propagation for delete markers only.
These changes will differ from dev/8.1

**Targeting changes for 7.4, 7.5, and 8.0.**
**8.1 will have different changes**

### Additional info

When a user creates an object/version via Zenko for an S3C location, and this S3C location has ingestion enabled, the object/version will be re-ingested and we will then have duplicate versions.

To deal with retro-propagation, we tried solving it by using replication group id, but the request from Zenko to S3C will create a new version on S3C. We also are trying to avoid changing the ObjectMD model for compatibility. So we are left with setting a user metadata field on objects that were created via Zenko.

The plan is to set a user metadata field "zenko-source-identifier" on all objects/versions that were initiated by Zenko. For delete markers, to be compliant with s3 deleteObject call, we cannot specify metadata field. So instead (this pr), delete marker requests from user-agent containing "Zenko" will need to apply the user metadata to the object md object itself
