### PR TITLE
bugfix: S3C-1959 Sanity check for data deletion

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -140,8 +140,8 @@ stages:
           command: |
             set -ex
             mkdir -p $CIRCLE_TEST_REPORTS/unit
-            npm run unit_coverage
-            npm run unit_coverage_legacy_location
+            npm test
+            npm run test_legacy_location
           env: &shared-vars
             <<: *global-env
             S3_LOCATION_FILE: tests/locationConfig/locationConfigTests.json

--- a/lib/api/apiUtils/object/locationKeysSanityCheck.js
+++ b/lib/api/apiUtils/object/locationKeysSanityCheck.js
@@ -1,0 +1,24 @@
+/**
+* Check keys that exist in the current list which will be used in composing
+* object. This method checks against accidentally removing data keys due to
+* instability from the metadata layer. The check returns true if there was no
+* match and false if at least one key from the previous list exists in the
+* current list
+* @param {array|string} prev - list of keys from the object being overwritten
+* @param {array} curr - list of keys to be used in composing current object
+* @returns {array} list of keys that can be deleted
+*/
+function locationKeysSanityCheck(prev, curr) {
+    if (!prev || prev.length === 0) {
+        return true;
+    }
+    // backwards compatibility check if object is of model version 2
+    if (typeof prev === 'string') {
+        return curr.every(v => v.key !== prev);
+    }
+    const keysMap = {};
+    prev.forEach(v => { keysMap[v.key] = true; });
+    return curr.every(v => !keysMap[v.key]);
+}
+
+module.exports = locationKeysSanityCheck;

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -21,6 +21,8 @@ const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { skipMpuPartProcessing } = require('../data/external/utils');
 const locationConstraintCheck
     = require('./apiUtils/object/locationConstraintCheck');
+const locationKeysSanityCheck
+    = require('./apiUtils/object/locationKeysSanityCheck');
 
 const logger = require('../utilities/logger');
 
@@ -350,13 +352,22 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     // unless the preexisting object and the completed mpu
                     // are on external backends
                     if (dataToDelete) {
+                        // check keys against accidental deletion, if any
+                        // existing key is found in the current object,
+                        // deletion is skipped
+                        const sanityCheckPassed =
+                            locationKeysSanityCheck(dataToDelete,
+                                dataLocations);
+
                         const newDataStoreName =
                             Array.isArray(dataLocations) && dataLocations[0] ?
                             dataLocations[0].dataStoreName : null;
-                        data.batchDelete(dataToDelete, request.method,
-                            newDataStoreName,
-                            logger.newRequestLoggerFromSerializedUids(log
-                            .getSerializedUids()));
+                        if (sanityCheckPassed) {
+                            data.batchDelete(dataToDelete, request.method,
+                                newDataStoreName,
+                                logger.newRequestLoggerFromSerializedUids(log
+                                .getSerializedUids()));
+                        }
                     }
                     return next(null, mpuBucket, keysToDelete, aggregateETag,
                         extraPartLocations, destinationBucket,

--- a/tests/locationConfig/locationConfigTests.json
+++ b/tests/locationConfig/locationConfigTests.json
@@ -122,7 +122,7 @@
             "serviceCredentials": {
                 "scopes": "https://www.googleapis.com/auth/cloud-platform",
                 "serviceEmail": "fake001",
-                "servieKey": "fake001"
+                "serviceKey": "fake001"
             }
         }
     },
@@ -139,7 +139,7 @@
             "serviceCredentials": {
                 "scopes": "https://www.googleapis.com/auth/cloud-platform",
                 "serviceEmail": "fake002",
-                "servieKey": "fake002"
+                "serviceKey": "fake002"
             }
         }
     },
@@ -156,7 +156,7 @@
             "serviceCredentials": {
                 "scopes": "https://www.googleapis.com/auth/cloud-platform",
                 "serviceEmail": "fake001",
-                "servieKey": "fake001"
+                "serviceKey": "fake001"
             }
         }
     },
@@ -175,7 +175,7 @@
             "serviceCredentials": {
                 "scopes": "https://www.googleapis.com/auth/cloud-platform",
                 "serviceEmail": "fake001",
-                "servieKey": "fake001"
+                "serviceKey": "fake001"
             }
         }
     },
@@ -193,7 +193,7 @@
             "serviceCredentials": {
                 "scopes": "https://www.googleapis.com/auth/cloud-platform",
                 "serviceEmail": "fake001",
-                "servieKey": "fake001"
+                "serviceKey": "fake001"
             }
         }
     }

--- a/tests/unit/api/apiUtils/jsonList.json
+++ b/tests/unit/api/apiUtils/jsonList.json
@@ -1,0 +1,39 @@
+{
+    "$": {
+        "xmlns": "http://s3.amazonaws.com/doc/2006-03-01/"
+    },
+    "Part": [
+        {
+            "ETag": [
+                "\"d41d8cd98f00b204e9800998ecf8427e\""
+            ],
+            "PartNumber": [
+                "1"
+            ]
+        },
+        {
+            "ETag": [
+                "\"d41d8cd98f00b204e9800998ecf8427e\""
+            ],
+            "PartNumber": [
+                "2"
+            ]
+        },
+        {
+            "ETag": [
+                "\"d41d8cd98f00b204e9800998ecf8427e\""
+            ],
+            "PartNumber": [
+                "3"
+            ]
+        },
+        {
+            "ETag": [
+                "\"d41d8cd98f00b204e9800998ecf8427e\""
+            ],
+            "PartNumber": [
+                "4"
+            ]
+        }
+    ]
+}

--- a/tests/unit/api/apiUtils/locationKeysSanityCheck.js
+++ b/tests/unit/api/apiUtils/locationKeysSanityCheck.js
@@ -1,0 +1,35 @@
+const assert = require('assert');
+const locationKeysSanityCheck =
+      require('../../../../lib/api/apiUtils/object/locationKeysSanityCheck');
+
+describe('Sanity check for location keys', () => {
+    it('should return true for no match ', () => {
+        const prev = [{ key: 'aaa' }, { key: 'bbb' }, { key: 'ccc' }];
+        const curr = [{ key: 'ddd' }, { key: 'eee' }, { key: 'fff' }];
+        assert.strictEqual(locationKeysSanityCheck(prev, curr), true);
+    });
+
+    it('should return false if there is a match of 1 key', () => {
+        const prev = [{ key: 'aaa' }, { key: 'bbb' }, { key: 'ccc' }];
+        const curr = [{ key: 'ddd' }, { key: 'aaa' }, { key: 'fff' }];
+        assert.strictEqual(locationKeysSanityCheck(prev, curr), false);
+    });
+
+    it('should return false if all keys match', () => {
+        const prev = [{ key: 'aaa' }, { key: 'bbb' }, { key: 'ccc' }];
+        const curr = [{ key: 'aaa' }, { key: 'bbb' }, { key: 'ccc' }];
+        assert.strictEqual(locationKeysSanityCheck(prev, curr), false);
+    });
+
+    it('should return false if there is match (model version 2)', () => {
+        const prev = 'ccc';
+        const curr = [{ key: 'aaa' }, { key: 'bbb' }, { key: 'ccc' }];
+        assert.strictEqual(locationKeysSanityCheck(prev, curr), false);
+    });
+
+    it('should return true if there is no match(model version 2)', () => {
+        const prev = 'aaa';
+        const curr = [{ key: 'ddd' }, { key: 'eee' }, { key: 'fff' }];
+        assert.strictEqual(locationKeysSanityCheck(prev, curr), true);
+    });
+});

--- a/tests/unit/api/apiUtils/processMpuParts.js
+++ b/tests/unit/api/apiUtils/processMpuParts.js
@@ -1,0 +1,45 @@
+const assert = require('assert');
+const { Logger } = require('werelogs');
+const log = new Logger('S3').newRequestLogger();
+const { validateAndFilterMpuParts } =
+    require('../../../../lib/api/apiUtils/object/processMpuParts');
+
+let storedParts;
+let jsonList;
+
+// r - number of parts to remove
+function _buildExpectedResult(r) {
+    const result = [];
+    for (let i = 0; i < r; i++) {
+        jsonList.Part.shift();
+        result.push(...storedParts[i].value.partLocations);
+    }
+    return result;
+}
+
+describe('processMpuParts::validateAndFilterMpuParts', () => {
+    let mpuOverviewKey;
+    let splitter;
+    beforeEach(() => {
+        mpuOverviewKey =
+            '"overview..|..fred..|..8e51eecb51ca4caa96dc4ebd51514f2a"';
+        splitter = '..|..';
+        storedParts = require('./storedParts');
+        jsonList = require('./jsonList');
+    });
+    afterEach(() => {
+        mpuOverviewKey = null;
+        splitter = null;
+    });
+
+    [0, 2, 4].forEach(n => {
+        it(`should filter ${n} parts that are not used in complete mpu`,
+            () => {
+                const expected = _buildExpectedResult(n);
+
+                const result = validateAndFilterMpuParts(storedParts, jsonList,
+                    mpuOverviewKey, splitter, log);
+                assert.deepStrictEqual(expected, result.extraPartLocations);
+            });
+    });
+});

--- a/tests/unit/api/apiUtils/storedParts.json
+++ b/tests/unit/api/apiUtils/storedParts.json
@@ -1,0 +1,63 @@
+[
+    {
+        "key": "7dffb33c7a734b0f89ed09f74b0b8d74..|..00001",
+        "value": {
+            "Size": 6000000,
+            "ETag": "d41d8cd98f00b204e9800998ecf8427e",
+            "LastModified": "2019-04-30T20:53:23.620Z",
+            "Owner": {},
+            "partLocations": [
+                {
+                    "key": "1a1ff57af576995bdf229471fcc34ecd939175f0",
+                    "dataStoreName": "file"
+                }
+            ]
+        }
+    },
+    {
+        "key": "7dffb33c7a734b0f89ed09f74b0b8d74..|..00002",
+        "value": {
+            "Size": 6000000,
+            "ETag": "d41d8cd98f00b204e9800998ecf8427e",
+            "LastModified": "2019-04-30T20:53:26.719Z",
+            "Owner": {},
+            "partLocations": [
+                {
+                    "key": "8bfef6c626c922948ded4be63dd7c4a0f1c8ba2a",
+                    "dataStoreName": "file"
+                }
+            ]
+        }
+    },
+    {
+        "key": "7dffb33c7a734b0f89ed09f74b0b8d74..|..00003",
+        "value": {
+            "Size": 6000000,
+            "ETag": "d41d8cd98f00b204e9800998ecf8427e",
+            "LastModified": "2019-04-30T20:53:29.303Z",
+            "Owner": {},
+            "partLocations": [
+                {
+                    "key": "a431c768950aa5cccbd2d8a0b914bf6160ab3cd0",
+                    "dataStoreName": "file"
+                }
+            ]
+        }
+    },
+    {
+        "key": "7dffb33c7a734b0f89ed09f74b0b8d74..|..00004",
+        "value": {
+            "Size": 6000000,
+            "ETag": "d41d8cd98f00b204e9800998ecf8427e",
+            "LastModified": "2019-04-30T20:53:31.182Z",
+            "Owner": {},
+            "partLocations": [
+                {
+                    "key": "43b8c90e4af62333f246843b15ca263a179d86cb",
+                    "dataStoreName": "file"
+                }
+            ]
+        }
+    }
+]
+


### PR DESCRIPTION
## Description
Add sanity check for deletion of data keys
### Motivation and context

When metadata service is unstable it's possible that an object has successfully
completed composing, final object written to the destination bucket but metadata
service returned HTTP code 500. In this case, the server returns HTTP code 500 to the client and
if the client retries the complete mpu request, it tries to compose the object again but this
time accidentally deleting data keys from the previous request as it assumes that it is overwriting
an existing object where in reality it is deleting the very own keys of the object it is composing.
This check ensures that the current object being composed does not
accidentally delete current keys.

### Other commits accompanying this PR

- test: process mpu parts
- improvement: avoid coverage use npm test instead
- bugfix: fix typo in test setup
