### PR TITLE
bugfix: S3C-2105 Push UTAPI metrics for CRR

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -18,6 +18,7 @@ const { BackendInfo } = require('../api/apiUtils/object/BackendInfo');
 const { locationConstraints } = require('../Config').config;
 const multipleBackendGateway = require('../data/multipleBackendGateway');
 const constants = require('../../constants');
+const { pushMetric } = require('../utapi/utilities');
 
 auth.setHandler(vault);
 
@@ -271,6 +272,13 @@ function putData(request, response, bucketInfo, objMd, log, callback) {
                 key,
                 dataStoreName,
             }];
+            pushMetric('putData', log, {
+                canonicalID,
+                bucket: context.bucketName,
+                keys: [context.objectKey],
+                newByteLength: payloadLen,
+                oldByteLength: null,
+            });
             return _respond(response, dataRetrievalInfo, log, callback);
         });
 }

--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -183,6 +183,8 @@ function listMetrics(metricType) {
  * @param {string} [metricObj.bucket] - (optional) bucket name
  * @param {AuthInfo} [metricObj.authInfo] - (optional) Instance of AuthInfo
  * class with requester's info
+ * @param {number} [metricObj.canonicalID] - (optional) The account's canonical
+ * ID used for the request
  * @param {number} [metricObj.byteLength] - (optional) current object size
  * (used, for example, for pushing 'deleteObject' metrics)
  * @param {number} [metricObj.newByteLength] - (optional) new object size
@@ -194,7 +196,7 @@ function listMetrics(metricType) {
  */
 function pushMetric(action, log, metricObj) {
     const { bucket, keys, byteLength, newByteLength,
-            oldByteLength, numberOfObjects, authInfo } = metricObj;
+            oldByteLength, numberOfObjects, authInfo, canonicalID } = metricObj;
     const utapiObj = {
         bucket,
         keys,
@@ -204,11 +206,14 @@ function pushMetric(action, log, metricObj) {
         numberOfObjects,
     };
     // If `authInfo` is included by the API, get the account's canonical ID for
-    // account-level metrics and the shortId for user-level metrics.
+    // account-level metrics and the shortId for user-level metrics. Otherwise
+    // check if the canonical ID is already provided for account-level metrics.
     if (authInfo) {
         utapiObj.accountId = authInfo.getCanonicalID();
         utapiObj.userId = authInfo.isRequesterAnIAMUser() ?
             authInfo.getShortid() : undefined;
+    } else if (canonicalID) {
+        utapiObj.accountId = canonicalID;
     }
     return utapi.pushMetric(action, log.getSerializedUids(), utapiObj);
 }


### PR DESCRIPTION
Push the following UTAPI metrics when a CRR operation occurs on the destination:

* storageUtilized
* numberOfObjects
* incomingBytes

Depends on https://github.com/scality/utapi/pull/236.