### PR TITLE
bugfix: S3C-2105 Add utapi CRR conditions

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -18,7 +18,7 @@ const { BackendInfo } = require('../api/apiUtils/object/BackendInfo');
 const { locationConstraints } = require('../Config').config;
 const multipleBackendGateway = require('../data/multipleBackendGateway');
 const constants = require('../../constants');
-const { pushMetric } = require('../utapi/utilities');
+const { pushReplicationMetric } = require('./utilities/pushReplicationMetric');
 
 auth.setHandler(vault);
 
@@ -272,13 +272,6 @@ function putData(request, response, bucketInfo, objMd, log, callback) {
                 key,
                 dataStoreName,
             }];
-            pushMetric('putData', log, {
-                canonicalID,
-                bucket: context.bucketName,
-                keys: [context.objectKey],
-                newByteLength: payloadLen,
-                oldByteLength: null,
-            });
             return _respond(response, dataRetrievalInfo, log, callback);
         });
 }
@@ -325,6 +318,7 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
                     });
                     return callback(err);
                 }
+                pushReplicationMetric(objMd, omVal, bucketName, objectKey, log);
                 return _respond(response, md, log, callback);
             });
     });

--- a/lib/routes/utilities/pushReplicationMetric.js
+++ b/lib/routes/utilities/pushReplicationMetric.js
@@ -1,0 +1,35 @@
+const assert = require('assert');
+
+const { ObjectMD } = require('arsenal').models;
+const { pushMetric } = require('../../utapi/utilities');
+
+function shouldPushMetric(prevObjectMD, newObjectMD) {
+    // We only want to update metrics for a destination bucket.
+    if (newObjectMD.getReplicationStatus() !== 'REPLICA') {
+        return false;
+    }
+    try {
+        // Replication of object tags and ACLs should not increment metrics.
+        assert.deepStrictEqual(prevObjectMD.getAcl(), newObjectMD.getAcl());
+        assert.deepStrictEqual(prevObjectMD.getTags(), newObjectMD.getTags());
+    } catch (e) {
+        return false;
+    }
+    return true;
+}
+
+function pushReplicationMetric(prevValue, newValue, bucket, key, log) {
+    const prevObjectMD = new ObjectMD(prevValue);
+    const newObjectMD = new ObjectMD(newValue);
+    if (!shouldPushMetric(prevObjectMD, newObjectMD)) {
+        return undefined;
+    }
+    return pushMetric('putData', log, {
+        bucket,
+        keys: [key],
+        newByteLength: newObjectMD.getContentLength(),
+        oldByteLength: null,
+    });
+}
+
+module.exports = { pushReplicationMetric, shouldPushMetric };

--- a/tests/unit/utils/pushReplicationMetric.js
+++ b/tests/unit/utils/pushReplicationMetric.js
@@ -1,0 +1,71 @@
+const assert = require('assert');
+const { ObjectMD } = require('arsenal').models;
+
+const { shouldPushMetric } =
+    require('../../../lib/routes/utilities/pushReplicationMetric');
+
+describe('shouldPushMetric', () => {
+    it('should push metrics when putting a new replica version', () => {
+        const prevObjectMD = new ObjectMD();
+        const objectMD = new ObjectMD()
+            .setReplicationStatus('REPLICA');
+        const result = shouldPushMetric(prevObjectMD, objectMD);
+        assert.strictEqual(result, true);
+    });
+
+    it('should not push metrics for non-replica operations', () => {
+        const prevObjectMD = new ObjectMD();
+        const objectMD = new ObjectMD()
+            .setReplicationStatus('COMPLETED');
+        const result = shouldPushMetric(prevObjectMD, objectMD);
+        assert.strictEqual(result, false);
+    });
+
+    it('should not push metrics for replica operations with tagging', () => {
+        const prevObjectMD = new ObjectMD();
+        const objectMD = new ObjectMD()
+            .setReplicationStatus('REPLICA')
+            .setTags({ 'object-tag-key': 'object-tag-value' });
+        const result = shouldPushMetric(prevObjectMD, objectMD);
+        assert.strictEqual(result, false);
+    });
+
+    it('should not push metrics for replica operations when deleting tagging',
+    () => {
+        const prevObjectMD = new ObjectMD()
+            .setTags({ 'object-tag-key': 'object-tag-value' });
+        const objectMD = new ObjectMD().setReplicationStatus('REPLICA');
+        const result = shouldPushMetric(prevObjectMD, objectMD);
+        assert.strictEqual(result, false);
+    });
+
+    it('should not push metrics for replica operations with acl', () => {
+        const prevObjectMD = new ObjectMD();
+        const objectMD = new ObjectMD();
+        const publicACL = objectMD.getAcl();
+        publicACL.Canned = 'public-read';
+        objectMD
+            .setReplicationStatus('REPLICA')
+            .setAcl(publicACL);
+        const result = shouldPushMetric(prevObjectMD, objectMD);
+        assert.strictEqual(result, false);
+    });
+
+    it('should not push metrics for replica operations when resetting acl',
+    () => {
+        const prevObjectMD = new ObjectMD();
+        const publicACL = prevObjectMD.getAcl();
+        publicACL.Canned = 'public-read';
+        prevObjectMD
+            .setReplicationStatus('REPLICA')
+            .setAcl(publicACL);
+        const objectMD = new ObjectMD();
+        const privateACL = objectMD.getAcl();
+        privateACL.Canned = 'private';
+        objectMD
+            .setReplicationStatus('REPLICA')
+            .setAcl(privateACL);
+        const result = shouldPushMetric(prevObjectMD, objectMD);
+        assert.strictEqual(result, false);
+    });
+});


### PR DESCRIPTION
When backbeat updates metadata upon putting a replica during CRR of a new object version or delete marker, push the following metrics:

* storageUtilized
* numberOfObjects
* incomingBytes

No metrics should be pushed for replication of tagging or ACLs.