### PR TITLE
bugfix: ZENKO-1809 replication from nfs

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -116,7 +116,16 @@ const constants = {
     // user metadata header to set object locationConstraint
     objectLocationConstraintHeader: 'x-amz-meta-scal-location-constraint',
     legacyLocations: ['sproxyd', 'legacy'],
-    serviceAccounts: ['replication', 'lifecycle', 'gc', 'md-ingestion'],
+    // declare here all existing service accounts and their properties
+    // (if any, otherwise an empty object)
+    serviceAccountProperties: {
+        replication: {},
+        lifecycle: {},
+        gc: {},
+        'md-ingestion': {
+            canReplicate: true,
+        },
+    },
     /* eslint-disable camelcase */
     externalBackends: { aws_s3: true, azure: true, gcp: true, pfs: true },
     // some of the available data backends  (if called directly rather

--- a/lib/api/apiUtils/authorization/aclChecks.js
+++ b/lib/api/apiUtils/authorization/aclChecks.js
@@ -4,17 +4,21 @@ const constants = require('../../../../constants');
 const publicReadBuckets = process.env.ALLOW_PUBLIC_READ_BUCKETS ?
     process.env.ALLOW_PUBLIC_READ_BUCKETS.split(',') : [];
 
-function isBackbeatUser(canonicalID) {
+function getServiceAccountProperties(canonicalID) {
     const canonicalIDArray = canonicalID.split('/');
     const serviceName = canonicalIDArray[canonicalIDArray.length - 1];
-    return constants.serviceAccounts.includes(serviceName);
+    return constants.serviceAccountProperties[serviceName];
+}
+
+function isServiceAccount(canonicalID) {
+    return getServiceAccountProperties(canonicalID) !== undefined;
 }
 
 function isBucketAuthorized(bucket, requestType, canonicalID) {
     // Check to see if user is authorized to perform a
     // particular action on bucket based on ACLs.
     // TODO: Add IAM checks and bucket policy checks.
-    if (bucket.getOwner() === canonicalID || isBackbeatUser(canonicalID)) {
+    if (bucket.getOwner() === canonicalID || isServiceAccount(canonicalID)) {
         return true;
     } else if (requestType === 'bucketOwnerAction') {
         // only bucket owner can modify or retrieve this property of a bucket
@@ -80,7 +84,7 @@ function isObjAuthorized(bucket, objectMD, requestType, canonicalID) {
         return true;
     }
 
-    if (isBackbeatUser(canonicalID)) {
+    if (isServiceAccount(canonicalID)) {
         return true;
     }
     // account is authorized if:
@@ -145,5 +149,6 @@ function isObjAuthorized(bucket, objectMD, requestType, canonicalID) {
 module.exports = {
     isBucketAuthorized,
     isObjAuthorized,
-    isBackbeatUser,
+    getServiceAccountProperties,
+    isServiceAccount,
 };

--- a/lib/api/apiUtils/bucket/bucketCreation.js
+++ b/lib/api/apiUtils/bucket/bucketCreation.js
@@ -9,7 +9,7 @@ const createKeyForUserBucket = require('./createKeyForUserBucket');
 const metadata = require('../../../metadata/wrapper');
 const kms = require('../../../kms/wrapper');
 const isLegacyAWSBehavior = require('../../../utilities/legacyAWSBehavior');
-const { isBackbeatUser } = require('../authorization/aclChecks');
+const { isServiceAccount } = require('../authorization/aclChecks');
 
 const usersBucket = constants.usersBucket;
 const oldUsersBucket = constants.oldUsersBucket;
@@ -230,7 +230,7 @@ function createBucket(authInfo, bucketName, headers,
         const existingBucketMD = results.getAnyExistingBucketInfo;
         if (existingBucketMD instanceof BucketInfo &&
             existingBucketMD.getOwner() !== canonicalID &&
-            !isBackbeatUser(canonicalID)) {
+            !isServiceAccount(canonicalID)) {
             // return existingBucketMD to collect cors headers
             return cb(errors.BucketAlreadyExists, existingBucketMD);
         }

--- a/lib/api/apiUtils/object/getReplicationInfo.js
+++ b/lib/api/apiUtils/object/getReplicationInfo.js
@@ -1,5 +1,6 @@
 const s3config = require('../../../Config').config;
-const { isBackbeatUser } = require('../authorization/aclChecks');
+const { isServiceAccount, getServiceAccountProperties } =
+      require('../authorization/aclChecks');
 const { replicationBackends } = require('arsenal').constants;
 
 function _getBackend(objectMD, site) {
@@ -87,16 +88,28 @@ function getReplicationInfo(objKey, bucketMD, isMD, objSize, operationType,
     // - replication configuration applies to the object (i.e. a rule matches
     //   object prefix) but the status is disabled
     //
-    // - object owner is an internal service account like Lifecycle
-    //   (because we do not want to replicate objects created from
-    //   actions triggered by internal services, by design)
+    // - object owner is an internal service account like Lifecycle,
+    //   unless the account properties explicitly allow it to
+    //   replicate like MD ingestion (because we do not want to
+    //   replicate objects created from actions triggered by internal
+    //   services, by design)
 
-    if (config && (!authInfo || !isBackbeatUser(authInfo.getCanonicalID()))) {
-        const rule = config.rules.find(rule =>
-            (objKey.startsWith(rule.prefix) && rule.enabled));
-        if (rule) {
-            return _getReplicationInfo(rule, config, content, operationType,
-                objectMD, bucketMD);
+    if (config) {
+        let doReplicate = false;
+        if (!authInfo || !isServiceAccount(authInfo.getCanonicalID())) {
+            doReplicate = true;
+        } else {
+            const serviceAccountProps = getServiceAccountProperties(
+                authInfo.getCanonicalID());
+            doReplicate = serviceAccountProps.canReplicate;
+        }
+        if (doReplicate) {
+            const rule = config.rules.find(
+                rule => (objKey.startsWith(rule.prefix) && rule.enabled));
+            if (rule) {
+                return _getReplicationInfo(
+                    rule, config, content, operationType, objectMD, bucketMD);
+            }
         }
     }
     return undefined;

--- a/lib/management/configuration.js
+++ b/lib/management/configuration.js
@@ -188,7 +188,7 @@ function patchConfiguration(newConf, log, cb) {
                     location.type = 'pfs';
                     if (l.details) {
                         location.details = {
-                            supportsVersioning: false,
+                            supportsVersioning: true,
                             bucketMatch: true,
                             pfsDaemonEndpoint: {
                                 host: `${l.name}-cosmos-pfsd`,

--- a/tests/unit/api/apiUtils/authorization/aclChecks.js
+++ b/tests/unit/api/apiUtils/authorization/aclChecks.js
@@ -1,0 +1,26 @@
+const assert = require('assert');
+
+const { isServiceAccount, getServiceAccountProperties } =
+      require('../../../../../lib/api/apiUtils/authorization/aclChecks');
+
+describe('aclChecks', () => {
+    it('should return whether a canonical ID is a service account', () => {
+        assert.strictEqual(isServiceAccount('abcdefghijkl'), false);
+        assert.strictEqual(isServiceAccount('abcdefghijkl/notaservice'), false);
+        assert.strictEqual(isServiceAccount('abcdefghijkl/lifecycle'), true);
+        assert.strictEqual(isServiceAccount('abcdefghijkl/md-ingestion'), true);
+    });
+
+    it('should return properties of a service account by canonical ID', () => {
+        assert.strictEqual(
+            getServiceAccountProperties('abcdefghijkl'), undefined);
+        assert.strictEqual(
+            getServiceAccountProperties('abcdefghijkl/notaservice'), undefined);
+        assert.deepStrictEqual(
+            getServiceAccountProperties('abcdefghijkl/lifecycle'), {});
+        assert.deepStrictEqual(
+            getServiceAccountProperties('abcdefghijkl/md-ingestion'), {
+                canReplicate: true,
+            });
+    });
+});

--- a/tests/unit/api/apiUtils/getReplicationInfo.js
+++ b/tests/unit/api/apiUtils/getReplicationInfo.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 
 const BucketInfo = require('arsenal').models.BucketInfo;
+const AuthInfo = require('arsenal').auth.AuthInfo;
 const getReplicationInfo =
       require('../../../../lib/api/apiUtils/object/getReplicationInfo');
 
@@ -142,6 +143,70 @@ describe('getReplicationInfo helper', () => {
             storageClass: 'awsbackend:preferred_read,azurebackend',
             role: 'arn:aws:iam::root:role/s3-replication-role',
             storageType: 'aws_s3,azure',
+            isNFS: null,
+        });
+    });
+
+    it('should not get replication info when service account type ' +
+    'cannot trigger replication', () => {
+        const replicationConfig = {
+            role: 'arn:aws:iam::root:role/s3-replication-role',
+            rules: [{
+                prefix: '',
+                enabled: true,
+                storageClass: 'awsbackend',
+            }],
+            destination: 'tosomewhere',
+        };
+        const bucketInfo = new BucketInfo(
+            'testbucket', 'abcdef/lifecycle', 'Lifecycle Service Account',
+            new Date().toJSON(),
+            null, null, null, null, null, null, null, null, null,
+            replicationConfig);
+        const authInfo = new AuthInfo({
+            canonicalID: 'abcdef/lifecycle',
+            accountDisplayName: 'Lifecycle Service Account',
+        });
+        const replicationInfo = getReplicationInfo(
+            'fookey', bucketInfo, true, 123, null, null, authInfo);
+        assert.deepStrictEqual(replicationInfo, undefined);
+    });
+
+    it('should get replication info when service account type can ' +
+    'trigger replication', () => {
+        const replicationConfig = {
+            role: 'arn:aws:iam::root:role/s3-replication-role',
+            rules: [{
+                prefix: '',
+                enabled: true,
+                storageClass: 'awsbackend',
+            }],
+            destination: 'tosomewhere',
+        };
+        const bucketInfo = new BucketInfo(
+            'testbucket', 'abcdef/md-ingestion',
+            'Metadata Ingestion Service Account',
+            new Date().toJSON(),
+            null, null, null, null, null, null, null, null, null,
+            replicationConfig);
+        const authInfo = new AuthInfo({
+            canonicalID: 'abcdef/md-ingestion',
+            accountDisplayName: 'Metadata Ingestion Service Account',
+        });
+        const replicationInfo = getReplicationInfo(
+            'fookey', bucketInfo, true, 123, null, null, authInfo);
+        assert.deepStrictEqual(replicationInfo, {
+            status: 'PENDING',
+            backends: [{
+                site: 'awsbackend',
+                status: 'PENDING',
+                dataStoreVersionId: '',
+            }],
+            content: ['METADATA'],
+            destination: 'tosomewhere',
+            storageClass: 'awsbackend',
+            role: 'arn:aws:iam::root:role/s3-replication-role',
+            storageType: 'aws_s3',
             isNFS: null,
         });
     });


### PR DESCRIPTION
* bugfix: ZENKO-1809 flag nfs location type as supporting versioning

Change the supportsVersioning flag to true for NFS locations, as
although versioning is set initially by cloudserver, they should also
support new calls to putBucketVersioning() with Status=Enabled. This
partially fixes replication support by making sure the orbit workflow
can be applied to NFS locations.

* bugfix: ZENKO-1809 allow replication from md-ingestion account

Allow md-ingestion service account to trigger replication on new
objects, so that NFS ingestion buckets are allowed to replicate to
cloud locations.
