### PR TITLE
Bugfix/s3 c 2118 abort mpu crash 2

### DIFF
--- a/dataserver.js
+++ b/dataserver.js
@@ -4,6 +4,16 @@ const arsenal = require('arsenal');
 const { config } = require('./lib/Config.js');
 const logger = require('./lib/utilities/logger');
 
+process.on('uncaughtException', err => {
+    logger.fatal('caught error', {
+        error: err.message,
+        stack: err.stack,
+        workerId: this.worker ? this.worker.id : undefined,
+        workerPid: this.worker ? this.worker.process.pid : undefined,
+    });
+    process.exit(1);
+});
+
 if (config.backends.data === 'file' ||
     (config.backends.data === 'multiple' &&
      config.backends.metadata !== 'scality')) {

--- a/lib/api/multipartDelete.js
+++ b/lib/api/multipartDelete.js
@@ -37,23 +37,20 @@ function multipartDelete(authInfo, request, log, callback) {
                     method: 'multipartDelete',
                     uploadId,
                 });
+                // if legacy behavior is enabled for 'us-east-1' and
+                // request is from 'us-east-1', return 404 instead of
+                // 204
+                return callback(err, corsHeaders);
+            }
+            if (!err) {
+                // NoSuchUpload should not be recorded by Utapi
                 pushMetric('abortMultipartUpload', log, {
                     authInfo,
                     bucket: bucketName,
                     keys: [objectKey],
                     byteLength: partSizeSum,
                 });
-                // if legacy behavior is enabled for 'us-east-1' and
-                // request is from 'us-east-1', return 404 instead of
-                // 204
-                return callback(err, corsHeaders);
             }
-            pushMetric('abortMultipartUpload', log, {
-                authInfo,
-                bucket: bucketName,
-                keys: [objectKey],
-                byteLength: partSizeSum,
-            });
             return callback(null, corsHeaders);
         }, request);
 }

--- a/mdserver.js
+++ b/mdserver.js
@@ -3,6 +3,17 @@
 const { config } = require('./lib/Config.js');
 const MetadataFileServer =
           require('arsenal').storage.metadata.MetadataFileServer;
+const logger = require('./lib/utilities/logger');
+
+process.on('uncaughtException', err => {
+    logger.fatal('caught error', {
+        error: err.message,
+        stack: err.stack,
+        workerId: this.worker ? this.worker.id : undefined,
+        workerPid: this.worker ? this.worker.process.pid : undefined,
+    });
+    process.exit(1);
+});
 
 if (config.backends.metadata === 'file') {
     const mdServer = new MetadataFileServer(

--- a/tests/functional/aws-node-sdk/test/object/abortMPU.js
+++ b/tests/functional/aws-node-sdk/test/object/abortMPU.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-
+const uuid = require('uuid/v4');
 const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
 
@@ -55,6 +55,34 @@ describe('Abort MPU', () => {
                 UploadId: uploadId },
             err => {
                 checkError(err, 'InvalidRequest', 'A key must be specified');
+                done();
+            });
+        });
+    });
+});
+
+describe('Abort MPU - No Such Upload', () => {
+    withV4(sigCfg => {
+        let bucketUtil;
+        let s3;
+
+        beforeEach(() => {
+            bucketUtil = new BucketUtility('default', sigCfg);
+            s3 = bucketUtil.s3;
+            return s3.createBucketAsync({ Bucket: bucket });
+        });
+
+        afterEach(() => bucketUtil.deleteOne(bucket));
+
+        it('should return NoSuchUpload error when aborting non-existent mpu',
+        done => {
+            s3.abortMultipartUpload({
+                Bucket: bucket,
+                Key: key,
+                UploadId: uuid().replace(/-/g, '') },
+            err => {
+                assert.notEqual(err, null, 'Expected failure but got success');
+                assert.strictEqual(err.code, 'NoSuchUpload');
                 done();
             });
         });


### PR DESCRIPTION
## Description

### Motivation and context

Aborting a non-existing MPU kills the worker as there is missing Utapi information raises an exception.

### Related issues

This PR adds event handler for `uncaughtException` for mdServer and dataServer.
