### PR TITLE
Bugfix/S3C-2172- Return NoSuchBucket if bucket name is invalid on DELETE

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "github:scality/Arsenal#bfb4a30",
+    "arsenal": "github:scality/Arsenal#30ccf9a",
     "async": "~2.5.0",
     "aws-sdk": "2.28.0",
     "azure-storage": "^2.1.0",

--- a/tests/functional/aws-node-sdk/test/versioning/bucketDelete.js
+++ b/tests/functional/aws-node-sdk/test/versioning/bucketDelete.js
@@ -84,5 +84,13 @@ describe('aws-node-sdk test delete bucket', () => {
                 }),
             ], done);
         });
+
+        it('should return error 404 NoSuchBucket if the bucket name is invalid',
+        done => {
+            s3.deleteBucket({ Bucket: 'bucketA' }, err => {
+                checkError(err, 'NoSuchBucket');
+                return done();
+            });
+        });
     });
 });


### PR DESCRIPTION

## Description

### Motivation and context
When a delete bucket request is sent with an invalid bucket name
the server returns NoSuchBucket instead of InvalidBucketName error
to be compatible with AWS S3.