### PR TITLE
documentation: ZENKOIO-22 Update Old Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 ![Zenko CloudServer logo](res/scality-cloudserver-logo.png)
 
-[![CircleCI][badgepub]](https://circleci.com/gh/scality/S3)
-[![Scality CI][badgepriv]](http://ci.ironmann.io/gh/scality/S3)
-[![Docker Pulls][badgedocker]](https://hub.docker.com/r/scality/s3server/)
+[![Docker Pulls][badgedocker]](https://hub.docker.com/r/zenko/cloudserver)
 [![Docker Pulls][badgetwitter]](https://twitter.com/zenko)
 
 ## Overview

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -2,7 +2,7 @@
 version: 0.2
 
 branches:
-  feature/*, improvement/*, bugfix/*, w/*, q/*, hotfix/*:
+  feature/*, documentation/*, improvement/*, bugfix/*, w/*, q/*, hotfix/*:
     stage: pre-merge
   development/*:
     stage: post-merge


### PR DESCRIPTION
## Description
Updating the link to cloudserver image on dockerhub 
deleting references to CI systems

### Motivation and context
Points to zenko/cloudserver image now
We don't use Circle CI anymore
