### PR TITLE
ci: remove artifacts property

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -102,11 +102,6 @@ stages:
     worker:
       type: local
     steps:
-      - SetProperty:
-          property: artifacts_name
-          value: "scality-s3-%(prop:buildnumber)s"
-          haltOnFailure: True
-
       - TriggerStages:
           name: Launch all workers
           stage_names:


### PR DESCRIPTION
S3C-2222 This removes the conflicting artifact name which causes issues with
the CI pipeline that is expected to auto generate the artifact name.
