### PR TITLE
bugfix: utapi reindex needs configuration to overwrite defaults

### DIFF
--- a/lib/utapi/utapiReindex.js
+++ b/lib/utapi/utapiReindex.js
@@ -1,5 +1,6 @@
 const UtapiReindex = require('utapi').UtapiReindex;
 const { config } = require('../Config');
 
-const reindex = new UtapiReindex(config.utapi && config.utapi.reindex);
+const reindexConfig = config.utapi.reindex ? config.utapi.reindex : config.utapi
+const reindex = new UtapiReindex(reindexConfig);
 reindex.start();


### PR DESCRIPTION
currently the config param is sent as a boolean value, and does not overwrite the defaults in UtapiReindex scripts 