### PR TITLE
bugfix: utapi reindex needs configuration to overwrite defaults

### DIFF
--- a/lib/utapi/utapiReindex.js
+++ b/lib/utapi/utapiReindex.js
@@ -1,5 +1,10 @@
 const UtapiReindex = require('utapi').UtapiReindex;
 const { config } = require('../Config');
 
-const reindex = new UtapiReindex(config.utapi && config.utapi.reindex);
+const reindexConfig = config.utapi && config.utapi.reindex;
+if (reindexConfig && reindexConfig.password === undefined) {
+    reindexConfig.password = config.utapi && config.utapi.redis
+    && config.utapi.redis.password;
+}
+const reindex = new UtapiReindex(reindexConfig);
 reindex.start();


### PR DESCRIPTION
current config missing password 