### PR TITLE
INTEGRATION [PR#1908 > development/7.5] bugfix: utapi reindex needs configuration to overwrite defaults

### DIFF
--- a/lib/utapi/utapiReindex.js
+++ b/lib/utapi/utapiReindex.js
@@ -1,5 +1,7 @@
 const UtapiReindex = require('utapi').UtapiReindex;
 const { config } = require('../Config');
 
-const reindex = new UtapiReindex(config.utapi && config.utapi.reindex);
+const reindexConfig = config.utapi.reindex ?
+    config.utapi.reindex : config.utapi;
+const reindex = new UtapiReindex(reindexConfig);
 reindex.start();


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1908.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.5/bugfix/S3C-2076-utapi-reindex-config`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.5/bugfix/S3C-2076-utapi-reindex-config
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.5/bugfix/S3C-2076-utapi-reindex-config
```

Please always comment pull request #1908 instead of this one.