### PR TITLE
bugfix: S3C-2076 Logical operator line break error

### DIFF
--- a/lib/utapi/utapiReindex.js
+++ b/lib/utapi/utapiReindex.js
@@ -3,8 +3,8 @@ const { config } = require('../Config');
 
 const reindexConfig = config.utapi && config.utapi.reindex;
 if (reindexConfig && reindexConfig.password === undefined) {
-    reindexConfig.password = config.utapi && config.utapi.redis
-    && config.utapi.redis.password;
+    reindexConfig.password = config.utapi && config.utapi.redis &&
+        config.utapi.redis.password;
 }
 const reindex = new UtapiReindex(reindexConfig);
 reindex.start();


### PR DESCRIPTION
Line break before the logical AND operator prevents proper object attribute reassignment.