### PR TITLE
ci: only generate version on specific branches

### DIFF
--- a/eve/get_product_version.sh
+++ b/eve/get_product_version.sh
@@ -1,3 +1,13 @@
 #!/bin/sh
 
-cat .git/HEAD | sed 's/.*\///'
+LOCAL_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
+BRANCHES=(development q stabilization)
+
+for branch in ${BRANCHES[@]}; do
+    if echo "${LOCAL_BRANCH}\/" | grep -q ^${branch} ; then
+        cat .git/HEAD | sed 's/.*\///'
+        exit 0
+    fi
+done
+
+echo 0.0.0


### PR DESCRIPTION
Only generate product version for appropriate branches all others default to 0.0.0. This is needed because the version has to pass `^([0-9]+(\.[0-9]+){1,3}$)` regex otherwise it will cause issues with CI artifact uploads which uses this for the name generation.