### PR TITLE
INTEGRATION [PR#1930 > development/8.0] ci: only generate version on specific branches

### DIFF
--- a/eve/get_product_version.sh
+++ b/eve/get_product_version.sh
@@ -1,3 +1,13 @@
 #!/bin/sh
 
-cat .git/HEAD | sed 's/.*\///'
+LOCAL_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
+BRANCHES=(development q stabilization)
+
+for branch in ${BRANCHES[@]}; do
+    if echo "${LOCAL_BRANCH}\/" | grep -q ^${branch} ; then
+        cat .git/HEAD | sed 's/.*\///'
+        exit 0
+    fi
+done
+
+echo 0.0.0


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1930.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.0/improvement/ZENKO-1867-fix-product-version`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.0/improvement/ZENKO-1867-fix-product-version
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.0/improvement/ZENKO-1867-fix-product-version
```

Please always comment pull request #1930 instead of this one.