### PR TITLE
bugfix: fix utapi redis configuration parsing

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -847,47 +847,50 @@ class Config extends EventEmitter {
             this.utapi.localCache = config.localCache;
             assert(config.redis, 'missing required property of utapi ' +
                 'configuration: redis');
-            if (config.utapi.redis.sentinels) {
-                this.utapi.redis = { sentinels: [], name: null };
+            if (config.utapi.redis) {
+                if (config.utapi.redis.sentinels) {
+                    this.utapi.redis = { sentinels: [], name: null };
 
-                assert(typeof config.utapi.redis.name === 'string',
-                    'bad config: redis sentinel name must be a string');
-                this.utapi.redis.name = config.utapi.redis.name;
+                    assert(typeof config.utapi.redis.name === 'string',
+                        'bad config: redis sentinel name must be a string');
+                    this.utapi.redis.name = config.utapi.redis.name;
 
-                assert(Array.isArray(config.utapi.redis.sentinels),
-                    'bad config: redis sentinels must be an array');
-                config.utapi.redis.sentinels.forEach(item => {
-                    const { host, port } = item;
-                    assert(typeof host === 'string',
-                        'bad config: redis sentinel host must be a string');
-                    assert(typeof port === 'number',
-                        'bad config: redis sentinel port must be a number');
-                    this.utapi.redis.sentinels.push({ host, port });
-                });
-            } else {
-                // check for standalone configuration
-                this.utapi.redis = {};
-                assert(typeof config.utapi.redis.host === 'string',
-                    'bad config: redis.host must be a string');
-                assert(typeof config.utapi.redis.port === 'number',
-                    'bad config: redis.port must be a number');
-                this.utapi.redis.host = config.utapi.redis.host;
-                this.utapi.redis.port = config.utapi.redis.port;
-            }
-            if (config.utapi.redis.password !== undefined) {
-                assert(
-                    this._verifyRedisPassword(config.utapi.redis.password),
-                    'config: invalid password for utapi redis. password' +
-                    ' must be a string');
-                this.utapi.redis.password = config.utapi.redis.password;
-            }
-            if (config.utapi.redis.sentinelPassword !== undefined) {
-                assert(
-                this._verifyRedisPassword(config.utapi.redis.sentinelPassword),
-                    'config: invalid password for utapi redis. password' +
-                    ' must be a string');
-                this.utapi.redis.sentinelPassword =
-                    config.utapi.redis.sentinelPassword;
+                    assert(Array.isArray(config.utapi.redis.sentinels),
+                        'bad config: redis sentinels must be an array');
+                    config.utapi.redis.sentinels.forEach(item => {
+                        const { host, port } = item;
+                        assert(typeof host === 'string',
+                            'bad config: redis sentinel host must be a string');
+                        assert(typeof port === 'number',
+                            'bad config: redis sentinel port must be a number');
+                        this.utapi.redis.sentinels.push({ host, port });
+                    });
+                } else {
+                    // check for standalone configuration
+                    this.utapi.redis = {};
+                    assert(typeof config.utapi.redis.host === 'string',
+                        'bad config: redis.host must be a string');
+                    assert(typeof config.utapi.redis.port === 'number',
+                        'bad config: redis.port must be a number');
+                    this.utapi.redis.host = config.utapi.redis.host;
+                    this.utapi.redis.port = config.utapi.redis.port;
+                }
+                if (config.utapi.redis.password !== undefined) {
+                    assert(
+                        this._verifyRedisPassword(config.utapi.redis.password),
+                        'config: invalid password for utapi redis. password' +
+                        ' must be a string');
+                    this.utapi.redis.password = config.utapi.redis.password;
+                }
+                if (config.utapi.redis.sentinelPassword !== undefined) {
+                    assert(
+                    this._verifyRedisPassword(
+                        config.utapi.redis.sentinelPassword),
+                        'config: invalid password for utapi redis. password' +
+                        ' must be a string');
+                    this.utapi.redis.sentinelPassword =
+                        config.utapi.redis.sentinelPassword;
+                }
             }
             if (config.utapi.metrics) {
                 this.utapi.metrics = config.utapi.metrics;


### PR DESCRIPTION
Zenko does not have `config.utapi.redis` set by default. 

Fixes https://scality.atlassian.net/browse/ZENKO-1883