### PR TITLE
bugfix: S3C-2243 fix check for location type

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1026,7 +1026,8 @@ class Config extends EventEmitter {
     }
 
     getLocationConstraintType(locationConstraint) {
-        return this.locationConstraints[locationConstraint].type;
+        return this.locationConstraints[locationConstraint] &&
+            this.locationConstraints[locationConstraint].type;
     }
 
     setRestEndpoints(restEndpoints) {

--- a/lib/data/multipleBackendGateway.js
+++ b/lib/data/multipleBackendGateway.js
@@ -120,6 +120,7 @@ const multipleBackendGateway = {
     batchDelete: (dataStoreName, keys, log, callback) => {
         const client = clients[dataStoreName];
         if (client.batchDelete) {
+            log.debug('submitting keys for batch delete', { keys });
             return client.batchDelete(keys, log.getSerializedUids(), callback);
         }
         return callback(errors.NotImplemented);

--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -271,19 +271,24 @@ const data = {
             method: 'batchDelete',
         });
         const keys = [];
+        let backendName = '';
         const shouldBatchDelete = locations.every(l => {
+            // legacy sproxyd location, should fallback to using regular delete
             if (typeof l === 'string') {
-                keys.push(l);
-                return true;
+                return false;
             }
-            if (l.dataStoreName === 'sproxyd') {
-                keys.push(l.key);
+            const { dataStoreName, key } = l;
+            backendName = dataStoreName;
+            const type = config.getLocationConstraintType(dataStoreName);
+            // filter out possible `null` created by NFS
+            if (key && type === 'scality') {
+                keys.push(key);
                 return true;
             }
             return false;
         });
         if (shouldBatchDelete) {
-            return client.batchDelete('sproxyd', keys, log, cb);
+            return client.batchDelete(backendName, { keys }, log, cb);
         }
         return async.eachLimit(locations, 5, (loc, next) => {
             process.nextTick(() => data.delete(loc, log, next));


### PR DESCRIPTION
This fixes the check where the logic should be looking at the type
of location instead of the name to leverage batch delete. It also fixes
the format sent to the sproxydclient which expects and object with keys
as an attribute whose value is an array of sproxyd keys.