### PR TITLE
bugfix: ZENKO-1872 Check array length

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -921,6 +921,9 @@ function _performConditionalDelete(request, response, locations, log, cb) {
 }
 
 function _shouldConditionallyDelete(request, locations) {
+    if (locations.length === 0) {
+        return false;
+    }
     const storageClass = request.headers['x-scal-storage-class'];
     const type =
         storageClass &&

--- a/tests/multipleBackend/routes/routeBackbeat.js
+++ b/tests/multipleBackend/routes/routeBackbeat.js
@@ -964,6 +964,22 @@ describeSkipIfAWS('backbeat routes', () => {
                 },
             ], done);
         });
+        it('should skip batch delete of empty location array', done => {
+            async.series([
+                done => {
+                    const options = {
+                        authCredentials: backbeatAuthCredentials,
+                        hostname: ipAddress,
+                        port: 8000,
+                        method: 'POST',
+                        path: '/_/backbeat/batchdelete',
+                        requestBody: '{"Locations":[]}',
+                        jsonResponse: true,
+                    };
+                    makeRequest(options, done);
+                },
+            ], done);
+        });
 
         it('should not put delete tags if the source is not Azure and ' +
         'if-unmodified-since header is not provided', done => {


### PR DESCRIPTION
In some cases the locations array for an object's metadata is empty. In such a case a `TypeError` is thrown when attempting to access the `dataStoreVersionId` [here](https://github.com/scality/cloudserver/compare/bugfix/ZENKO-1872-unable-to-delete-objects-from?expand=1#diff-5c3dc4783e2d0f782449eea237c8f691R933).

```
TypeError: Cannot read property 'dataStoreVersionId' of undefined
    at _shouldConditionallyDelete (/usr/src/app/lib/routes/routeBackbeat.js:930:42)
    at _getRequestPayload (/usr/src/app/lib/routes/routeBackbeat.js:950:13)
    at IncomingMessage.req.on.on.on (/usr/src/app/lib/routes/routeBackbeat.js:106:22)
    at emitNone (events.js:111:20)
    at IncomingMessage.emit (events.js:208:7)
    at endReadableNT (_stream_readable.js:1064:12)
    at _combinedTickCallback (internal/process/next_tick.js:139:11)
    at process._tickDomainCallback (internal/process/next_tick.js:219:9)
```

This change protects against such a situation.