### PR TITLE
ZENKO-1840 fix secure MongoDB access

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -103,14 +103,6 @@ if [[ "$MONGODB_DATABASE" ]]; then
    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .mongodb.database=\"$MONGODB_DATABASE\""
 fi
 
-if [[ "$MONGODB_AUTH_USERNAME" ]]; then
-   JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .mongodb.authCredentials.username=\"$MONGODB_AUTH_USERNAME\""
-fi
-
-if [[ "$MONGODB_AUTH_PASSWORD" ]]; then
-   JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .mongodb.authCredentials.password=\"$MONGODB_AUTH_PASSWORD\""
-fi
-
 if [ -z "$REDIS_HA_NAME" ]; then
     REDIS_HA_NAME='mymaster'
 fi

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -837,6 +837,13 @@ class Config extends EventEmitter {
 
         if (config.mongodb) {
             this.mongodb = config.mongodb;
+            if (process.env.MONGODB_AUTH_USERNAME &&
+                process.env.MONGODB_AUTH_PASSWORD) {
+                this.mongodb.authCredentials = {
+                  username: process.env.MONGODB_AUTH_USERNAME,
+                  password: process.env.MONGODB_AUTH_PASSWORD,
+                };
+            }
         } else {
             this.mongodb = {};
         }


### PR DESCRIPTION
The env variable lookup for creds should not be in the entrypoint anymore but in cloudserver directly.

The operator is deploying mounting configmaps (read-only) as config files, containing correct values already, except for these credentials that will come from secrets and will be injected through env vars.