### PR TITLE
improvement: ZENKO-1944 Make Vaultd host modular

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -656,6 +656,11 @@ class Config extends EventEmitter {
                                    'bad config: vaultd host must be a string');
                 this.vaultd.host = config.vaultd.host;
             }
+            if (process.env.VAULTD_HOST !== undefined) {
+                assert.strictEqual(typeof process.env.VAULTDHOST, 'string',
+                    'bad config: vaultd host must be a string');
+                this.vaultd.host = process.env.VAULTD_HOST;
+            }
         }
 
         if (config.dataClient) {


### PR DESCRIPTION
## Description
This pull request adds an option of getting host for vaultd from env variable
### Motivation and context

Why is this change required? What problem does it solve?
Clouserver needs to talk to Vault. In S3C this was possible using `localhost` as host but in kubernetes we need to mention the service name. This pull request adds an option for host.

### Related issues
#[ZENKO-1611](https://scality.atlassian.net/browse/ZENKO-1611)