### PR TITLE
bf: ZENKO-1948 fix env variable for vault host check

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -657,7 +657,7 @@ class Config extends EventEmitter {
                 this.vaultd.host = config.vaultd.host;
             }
             if (process.env.VAULTD_HOST !== undefined) {
-                assert.strictEqual(typeof process.env.VAULTDHOST, 'string',
+                assert.strictEqual(typeof process.env.VAULTD_HOST, 'string',
                     'bad config: vaultd host must be a string');
                 this.vaultd.host = process.env.VAULTD_HOST;
             }


### PR DESCRIPTION
## Description
Fix env variable for vault host check

Why is this change required? What problem does it solve?
To make cloudserver talk to vault 
