### PR TITLE
INTEGRATION [PR#1859 > development/7.5] Bugfix/S3C-2172- Return NoSuchBucket if bucket name is invalid on DELETE

### DIFF
--- a/tests/functional/aws-node-sdk/test/versioning/bucketDelete.js
+++ b/tests/functional/aws-node-sdk/test/versioning/bucketDelete.js
@@ -84,5 +84,13 @@ describe('aws-node-sdk test delete bucket', () => {
                 }),
             ], done);
         });
+
+        it('should return error 404 NoSuchBucket if the bucket name is invalid',
+        done => {
+            s3.deleteBucket({ Bucket: 'bucketA' }, err => {
+                checkError(err, 'NoSuchBucket');
+                return done();
+            });
+        });
     });
 });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1859.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.5/bugfix/S3C-2172-bucket-error`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.5/bugfix/S3C-2172-bucket-error
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.5/bugfix/S3C-2172-bucket-error
```

Please always comment pull request #1859 instead of this one.