### PR TITLE
bugfix: S3C-1959 add sanity check for data deletion

### DIFF
--- a/lib/api/apiUtils/object/locationKeysSanityCheck.js
+++ b/lib/api/apiUtils/object/locationKeysSanityCheck.js
@@ -1,0 +1,22 @@
+/**
+* Check keys that exist in the current list which will be used in composing
+* object. This method checks against accidentally removing data keys due to
+* instability from the metadata layer. The check returns true if there was no
+* match and false if at least one key from the previous list exists in the
+* current list
+* @param {array|string} prev - list of keys from the object being overwritten
+* @param {array} curr - list of keys to be used in composing current object
+* @returns {array} list of keys that can be deleted
+*/
+export default function locationKeysSanityCheck(prev, curr) {
+    if (!prev || prev.length === 0) {
+        return true;
+    }
+    // backwards compatibility check if object is of model version 2
+    if (typeof prev === 'string') {
+        return curr.every(v => v.key !== prev);
+    }
+    const keysMap = {};
+    prev.forEach(v => { keysMap[v.key] = true; });
+    return curr.every(v => !keysMap[v.key]);
+}

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -10,9 +10,8 @@ import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import constants from '../../constants';
 import metadata from '../metadata/wrapper';
 import services from '../services';
-
 import { logger } from '../utilities/logger';
-
+import locationKeysSanityCheck from './apiUtils/object/locationKeysSanityCheck';
 /*
    Format of xml request:
    <CompleteMultipartUpload>
@@ -388,9 +387,16 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     if (objMD && objMD.location) {
                         const dataToDelete = Array.isArray(objMD.location) ?
                             objMD.location : [objMD.location];
-                        data.batchDelete(dataToDelete, logger
-                            .newRequestLoggerFromSerializedUids(log
-                            .getSerializedUids()));
+                        // check keys against accidental deletion, if any
+                        // existing key is found in the current object,
+                        // deletion is skipped
+                        const sanityCheckPassed = locationKeysSanityCheck(
+                            dataToDelete, dataLocations);
+                        if (sanityCheckPassed) {
+                            data.batchDelete(dataToDelete, logger
+                                .newRequestLoggerFromSerializedUids(log
+                                .getSerializedUids()));
+                        }
                     }
                     return next(null, mpuBucket, mpuOverviewKey,
                         aggregateETag, storedPartsAsObjects,

--- a/tests/unit/api/apiUtils/locationKeysSanityCheck.js
+++ b/tests/unit/api/apiUtils/locationKeysSanityCheck.js
@@ -1,0 +1,35 @@
+import assert from 'assert';
+import locationKeysSanityCheck from
+    '../../../../lib/api/apiUtils/object/locationKeysSanityCheck';
+
+describe('Sanity check for location keys', () => {
+    it('should return true for no match ', () => {
+        const prev = [{ key: 'aaa' }, { key: 'bbb' }, { key: 'ccc' }];
+        const curr = [{ key: 'ddd' }, { key: 'eee' }, { key: 'fff' }];
+        assert.strictEqual(locationKeysSanityCheck(prev, curr), true);
+    });
+
+    it('should return false if there is a match of 1 key', () => {
+        const prev = [{ key: 'aaa' }, { key: 'bbb' }, { key: 'ccc' }];
+        const curr = [{ key: 'ddd' }, { key: 'aaa' }, { key: 'fff' }];
+        assert.strictEqual(locationKeysSanityCheck(prev, curr), false);
+    });
+
+    it('should return false if all keys match', () => {
+        const prev = [{ key: 'aaa' }, { key: 'bbb' }, { key: 'ccc' }];
+        const curr = [{ key: 'aaa' }, { key: 'bbb' }, { key: 'ccc' }];
+        assert.strictEqual(locationKeysSanityCheck(prev, curr), false);
+    });
+
+    it('should return false if there is match (model version 2)', () => {
+        const prev = 'ccc';
+        const curr = [{ key: 'aaa' }, { key: 'bbb' }, { key: 'ccc' }];
+        assert.strictEqual(locationKeysSanityCheck(prev, curr), false);
+    });
+
+    it('should return true if there is no match(model version 2)', () => {
+        const prev = 'aaa';
+        const curr = [{ key: 'ddd' }, { key: 'eee' }, { key: 'fff' }];
+        assert.strictEqual(locationKeysSanityCheck(prev, curr), true);
+    });
+});


### PR DESCRIPTION

## Description
Add sanity check for data deletion
### Motivation and context

When metadata service is unstable it's possible that an object has successfully
completed composing, final object written to the destination bucket but metadata
service returned HTTP code 500. In this case, the server returns HTTP code 500 to the client and
if the client retries the complete mpu request, it tries to compose the object again but this
time accidentally deleting data keys from the previous request as it assumes that it is overwriting
an existing object where in reality it is deleting the very own keys of the object it is composing.
This check ensures that the current object being composed does not
accidentally delete current keys.

(cherry picked from commit 111f90e500c89477d951ab0b663ba0ec29aaa98d)
