### PR TITLE
bf(ZENKO-1829): Add init container for installing pykmip certs

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -83,10 +83,6 @@ models:
       command: bash eve/workers/build/credentials.bash
       haltOnFailure: True
       env: *global-env
-  - ShellCommand: &pykmip-certificates
-      name: Setup certificated for PyKMIP
-      command: cp eve/workers/pykmip/certs/* /ssl-kmip/
-      haltOnFailure: True
   - ShellCommand: &npm-install
       name: install modules
       command: npm install
@@ -271,7 +267,6 @@ stages:
           <<: *global-env
     steps:
       - Git: *clone
-      - ShellCommand: *pykmip-certificates
       - ShellCommand: *credentials
       - ShellCommand: *npm-install
       - ShellCommand:

--- a/eve/workers/pod.yaml
+++ b/eve/workers/pod.yaml
@@ -11,6 +11,16 @@ spec:
     hostnames:
     - "bucketwebsitetester.s3-website-us-east-1.amazonaws.com"
     - "pykmip.local"
+  {% if vars.pykmip is defined and vars.pykmip == 'enabled' -%}
+  initContainers:
+    - name: kmip-certs-installer
+      image: {{ images.pykmip }}
+      command: [ 'sh', '-c', 'cp /ssl/* /ssl-kmip/']
+      volumeMounts:
+        - name: kmip-certs
+          readOnly: false
+          mountPath: /ssl-kmip
+  {%- endif %}
   containers:
     {% if vars.env.S3METADATA is defined and vars.env.S3METADATA == "mongodb" -%}
     - name: mongo
@@ -41,9 +51,6 @@ spec:
         - name: artifacts
           readOnly: true
           mountPath: /artifacts
-        - name: kmip-certs
-          readOnly: false
-          mountPath: /ssl-kmip
       command:
         - bash
         - -lc


### PR DESCRIPTION
# Pull request template

## Description

### Motivation and context

Why is this change required? What problem does it solve?

Race condition between cloudserver startup and cert installation
