### PR TITLE
INTEGRATION [PR#1992 > development/8.0] bf(ZENKO-1829): Add init container for installing pykmip certs

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -83,10 +83,6 @@ models:
       command: bash eve/workers/build/credentials.bash
       haltOnFailure: True
       env: *global-env
-  - ShellCommand: &pykmip-certificates
-      name: Setup certificated for PyKMIP
-      command: cp eve/workers/pykmip/certs/* /ssl-kmip/
-      haltOnFailure: True
   - ShellCommand: &npm-install
       name: install modules
       command: npm install
@@ -271,7 +267,6 @@ stages:
           <<: *global-env
     steps:
       - Git: *clone
-      - ShellCommand: *pykmip-certificates
       - ShellCommand: *credentials
       - ShellCommand: *npm-install
       - ShellCommand:

--- a/eve/workers/pod.yaml
+++ b/eve/workers/pod.yaml
@@ -11,6 +11,16 @@ spec:
     hostnames:
     - "bucketwebsitetester.s3-website-us-east-1.amazonaws.com"
     - "pykmip.local"
+  {% if vars.pykmip is defined and vars.pykmip == 'enabled' -%}
+  initContainers:
+    - name: kmip-certs-installer
+      image: {{ images.pykmip }}
+      command: [ 'sh', '-c', 'cp /ssl/* /ssl-kmip/']
+      volumeMounts:
+        - name: kmip-certs
+          readOnly: false
+          mountPath: /ssl-kmip
+  {%- endif %}
   containers:
     {% if vars.env.S3METADATA is defined and vars.env.S3METADATA == "mongodb" -%}
     - name: mongo
@@ -41,9 +51,6 @@ spec:
         - name: artifacts
           readOnly: true
           mountPath: /artifacts
-        - name: kmip-certs
-          readOnly: false
-          mountPath: /ssl-kmip
       command:
         - bash
         - -lc


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1992.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.0/bugfix/ZENKO-1829_Add_init_container_for_certs`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.0/bugfix/ZENKO-1829_Add_init_container_for_certs
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.0/bugfix/ZENKO-1829_Add_init_container_for_certs
```

Please always comment pull request #1992 instead of this one.