### PR TITLE
RELENG-2986 applying a 0 burst policy

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -155,8 +155,8 @@ stages:
         aggressor: eve/workers/build
         s3: "."
       vars:
-        aggressorMemLimit: "2Gi"
-        s3MemLimit: "2Gi"
+        aggressorMem: "2Gi"
+        s3Mem: "2Gi"
         env:
           <<: *multiple-backend-vars
           <<: *global-env
@@ -198,8 +198,8 @@ stages:
         aggressor: eve/workers/build
         s3: "."
       vars:
-        aggressorMemLimit: "2Gi"
-        s3MemLimit: "1664Mi"
+        aggressorMem: "2Gi"
+        s3Mem: "1664Mi"
         redis: enabled
         env:
           <<: *mongo-vars
@@ -227,8 +227,8 @@ stages:
         aggressor: eve/workers/build
         s3: "."
       vars:
-        aggressorMemLimit: "1920Mi"
-        s3MemLimit: "2Gi"
+        aggressorMem: "1920Mi"
+        s3Mem: "2Gi"
         redis: enabled
         env:
           <<: *file-mem-mpu

--- a/eve/workers/pod.yaml
+++ b/eve/workers/pod.yaml
@@ -17,7 +17,7 @@ spec:
       imagePullPolicy: IfNotPresent
       resources:
         requests:
-          cpu: 100m
+          cpu: 500m
           memory: 1Gi
         limits:
           cpu: 500m
@@ -28,11 +28,11 @@ spec:
       imagePullPolicy: IfNotPresent
       resources:
         requests:
-          cpu: 100m
-          memory: 1Gi
+          cpu: "1"
+          memory: {{ vars.aggressorMem }}
         limits:
           cpu: "1"
-          memory: {{ vars.aggressorMemLimit }}
+          memory: {{ vars.aggressorMem }}
       volumeMounts:
         - name: creds
           readOnly: false
@@ -64,11 +64,11 @@ spec:
       imagePullPolicy: IfNotPresent
       resources:
         requests:
-          cpu: 200m
-          memory: 1Gi
+          cpu: "2"
+          memory: {{ vars.s3Mem }}
         limits:
           cpu: "2"
-          memory: {{ vars.s3MemLimit }}
+          memory: {{ vars.s3Mem }}
       volumeMounts:
         - name: creds
           readOnly: false
@@ -118,7 +118,7 @@ spec:
       imagePullPolicy: IfNotPresent
       resources:
         requests:
-          cpu: 100m
+          cpu: 200m
           memory: 128Mi
         limits:
           cpu: 200m
@@ -130,7 +130,7 @@ spec:
       imagePullPolicy: IfNotPresent
       resources:
         requests:
-          cpu: 100m
+          cpu: 250m
           memory: 128Mi
         limits:
           cpu: 250m


### PR DESCRIPTION
TL;DR bumping cpu and memory resources on the CI

On CI workloads, you cannot guess the state of the node you're going
to schedule in, therefore, for functional tests it is advised to not do
any burst on resources.

Here you'll see the requested VS what is actually beeing used for CPU resources on one build
![image](https://user-images.githubusercontent.com/8408330/61817120-a56c0c00-ae02-11e9-8c32-9fbe4e5164a0.png)
note that we use a lot more than we ask for, which is the info that the kubernetes node scheduler use to schedule the pods, and what I'm afraid is that we might schedule in some builds our workload on a already stressed node.

Therefore the 0 burst policy, we request what we need, nothing more, nothing less.

This is what the same chart looks like with the builds from now on.
![image](https://user-images.githubusercontent.com/8408330/61817461-71ddb180-ae03-11e9-9b1a-2bd5c73f82b8.png)
