### PR TITLE
ft: S3C-2277 put bucket policy api

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -86,7 +86,6 @@ const constants = {
         'logging',
         'metrics',
         'notification',
-        'policy',
         'requestPayment',
         'restore',
         'torrent',

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -4,6 +4,7 @@ const bucketDelete = require('./bucketDelete');
 const bucketDeleteCors = require('./bucketDeleteCors');
 const bucketDeleteWebsite = require('./bucketDeleteWebsite');
 const bucketDeleteLifecycle = require('./bucketDeleteLifecycle');
+const bucketDeletePolicy = require('./bucketDeletePolicy');
 const bucketGet = require('./bucketGet');
 const bucketGetACL = require('./bucketGetACL');
 const bucketGetCors = require('./bucketGetCors');
@@ -11,6 +12,7 @@ const bucketGetVersioning = require('./bucketGetVersioning');
 const bucketGetWebsite = require('./bucketGetWebsite');
 const bucketGetLocation = require('./bucketGetLocation');
 const bucketGetLifecycle = require('./bucketGetLifecycle');
+const bucketGetPolicy = require('./bucketGetPolicy');
 const bucketHead = require('./bucketHead');
 const { bucketPut } = require('./bucketPut');
 const bucketPutACL = require('./bucketPutACL');
@@ -19,6 +21,7 @@ const bucketPutVersioning = require('./bucketPutVersioning');
 const bucketPutWebsite = require('./bucketPutWebsite');
 const bucketPutReplication = require('./bucketPutReplication');
 const bucketPutLifecycle = require('./bucketPutLifecycle');
+const bucketPutPolicy = require('./bucketPutPolicy');
 const bucketGetReplication = require('./bucketGetReplication');
 const bucketDeleteReplication = require('./bucketDeleteReplication');
 const corsPreflight = require('./corsPreflight');
@@ -183,6 +186,9 @@ const api = {
     bucketPutLifecycle,
     bucketGetLifecycle,
     bucketDeleteLifecycle,
+    bucketPutPolicy,
+    bucketGetPolicy,
+    bucketDeletePolicy,
     corsPreflight,
     completeMultipartUpload,
     initiateMultipartUpload,

--- a/lib/api/bucketDeletePolicy.js
+++ b/lib/api/bucketDeletePolicy.js
@@ -1,0 +1,7 @@
+const { errors } = require('arsenal');
+
+function bucketDeletePolicy(authInfo, request, log, callback) {
+    return callback(errors.NotImplemented);
+}
+
+module.exports = bucketDeletePolicy;

--- a/lib/api/bucketGetPolicy.js
+++ b/lib/api/bucketGetPolicy.js
@@ -1,0 +1,7 @@
+const { errors } = require('arsenal');
+
+function bucketGetPolicy(authInfo, request, log, callback) {
+    return callback(errors.NotImplemented);
+}
+
+module.exports = bucketGetPolicy;

--- a/lib/api/bucketPutPolicy.js
+++ b/lib/api/bucketPutPolicy.js
@@ -1,0 +1,70 @@
+const async = require('async');
+const { BucketPolicy } = require('arsenal').models;
+
+const collectCorsHeaders = require('../utilities/collectCorsHeaders');
+const metadata = require('../metadata/wrapper');
+const { metadataValidateBucket } = require('../metadata/metadataUtils');
+const { errors } = require('arsenal');
+
+/**
+ * bucketPutPolicy - create or update a bucket policy
+ * @param {AuthInfo} authInfo - Instance of AuthInfo class with requester's info
+ * @param {object} request - http request object
+ * @param {object} log - Werelogs logger
+ * @param {function} callback - callback to server
+ * @return {undefined}
+ */
+function bucketPutPolicy(authInfo, request, log, callback) {
+    log.debug('processing request', { method: 'bucketPutPolicy' });
+
+    const { bucketName } = request;
+    const metadataValParams = {
+        authInfo,
+        bucketName,
+        requestType: 'bucketOwnerAction',
+    };
+
+    if (!process.env.BUCKET_POLICY) {
+        return callback(errors.NotImplemented);
+    }
+
+    return async.waterfall([
+        next => {
+            const policyJSON = JSON.parse(request.post);
+            const bucketPolicy = new BucketPolicy(policyJSON);
+            // if there was an error getting bucket policy,
+            // returned policyObj will contain 'error' key
+            process.nextTick(() => {
+                const policyObj = bucketPolicy.getBucketPolicy();
+                if (policyObj.error) {
+                    return next(policyObj.error);
+                }
+                return next(null, policyObj);
+            });
+        },
+        (bucketPolicy, next) => metadataValidateBucket(metadataValParams, log,
+            (err, bucket) => {
+                if (err) {
+                    return next(err, bucket);
+                }
+                return next(null, bucket, bucketPolicy);
+            }),
+        (bucket, bucketPolicy, next) => {
+            bucket.setBucketPolicy(bucketPolicy);
+            metadata.updateBucket(bucket.getName(), bucket, log,
+                err => next(err, bucket));
+        },
+    ], (err, bucket) => {
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, bucket);
+        if (err) {
+            log.trace('error processing request',
+                { error: err, method: 'bucketPutPolicy' });
+            return callback(err, corsHeaders);
+        }
+        // TODO: implement Utapi metric support
+        return callback(null, corsHeaders);
+    });
+}
+
+module.exports = bucketPutPolicy;

--- a/tests/functional/aws-node-sdk/test/bucket/putBucketPolicy.js
+++ b/tests/functional/aws-node-sdk/test/bucket/putBucketPolicy.js
@@ -1,0 +1,109 @@
+const assert = require('assert');
+const { errors } = require('arsenal');
+const { S3 } = require('aws-sdk');
+
+const getConfig = require('../support/config');
+const BucketUtility = require('../../lib/utility/bucket-util');
+
+const bucket = 'policyputtestbucket';
+const basicStatement = {
+    Sid: 'statement-id',
+    Effect: 'Allow',
+    Principal: '*',
+    Action: ['s3:putBucketPolicy'],
+    Resource: 'aws:arn:s3::example-bucket',
+};
+
+function getPolicyParams(paramToChange) {
+    const newParam = {};
+    const bucketPolicy = {
+        Version: '2012-10-17',
+        Statement: [basicStatement],
+    };
+    if (paramToChange) {
+        newParam[paramToChange.key] = paramToChange.value;
+        bucketPolicy.Statement[0] = Object.assign({}, basicStatement, newParam);
+    }
+    return {
+        Bucket: bucket,
+        Policy: bucketPolicy,
+    };
+}
+
+// Check for the expected error response code and status code.
+function assertError(err, expectedErr, cb) {
+    if (expectedErr === null) {
+        assert.strictEqual(err, null, `expected no error but got '${err}'`);
+    } else {
+        assert.strictEqual(err.code, expectedErr, 'incorrect error response ' +
+            `code: should be '${expectedErr}' but got '${err.code}'`);
+        assert.strictEqual(err.statusCode, errors[expectedErr].code,
+            'incorrect error status code: should be  ' +
+            `${errors[expectedErr].code}, but got '${err.statusCode}'`);
+    }
+    cb();
+}
+
+const describeSkipUntilImpl =
+    process.env.BUCKET_POLICY ? describe : describe.skip;
+
+describeSkipUntilImpl('aws-sdk test put bucket policy', () => {
+    let s3;
+    let otherAccountS3;
+
+    before(done => {
+        const config = getConfig('default', { signatureVersion: 'v4' });
+        s3 = new S3(config);
+        otherAccountS3 = new BucketUtility('lisa', {}).s3;
+        return done();
+    });
+
+    it('should return NoSuchBucket error if bucket does not exist', done => {
+        const params = getPolicyParams();
+        s3.putBucketPolicy(params, err =>
+            assertError(err, 'NoSuchBucket', done));
+    });
+
+    describe('config rules', () => {
+        beforeEach(done => s3.createBucket({ Bucket: bucket }, done));
+
+        afterEach(done => s3.deleteBucket({ Bucket: bucket }, done));
+
+        it('should return AccessDenied if user is not bucket owner', done => {
+            const params = getPolicyParams();
+            otherAccountS3.putBucketPolicy(params,
+                err => assertError(err, 'AccessDenied', done));
+        });
+
+        it('should put a bucket policy on bucket', done => {
+            const params = getPolicyParams();
+            s3.putBucketPolicy(params, err =>
+                assertError(err, null, done));
+        });
+
+        it('should not allow bucket policy with no Action', done => {
+            const params = getPolicyParams({ key: 'Action', value: '' });
+            s3.putBucketPolicy(params, err =>
+                assertError(err, 'MalformedPolicy', done));
+        });
+
+        it('should not allow bucket policy with no Effect', done => {
+            const params = getPolicyParams({ key: 'Effect', value: '' });
+            s3.putBucketPolicy(params, err =>
+                assertError(err, 'MalformedPolicy', done));
+        });
+
+        it('should not allow bucket policy with no Resource', done => {
+            const params = getPolicyParams({ key: 'Resource', value: '' });
+            s3.putBucketPolicy(params, err =>
+                assertError(err, 'MalformedPolicy', done));
+        });
+
+        it('should not allow bucket policy with no Principal',
+        done => {
+            const params = getPolicyParams({ key: 'Principal', value: '' });
+            s3.putBucketPolicy(params, err =>
+                assertError(err, 'MalformedPolicy', done));
+        });
+    });
+});

--- a/tests/unit/api/bucketPutPolicy.js
+++ b/tests/unit/api/bucketPutPolicy.js
@@ -1,0 +1,66 @@
+const assert = require('assert');
+
+const { bucketPut } = require('../../../lib/api/bucketPut');
+const bucketPutPolicy = require('../../../lib/api/bucketPutPolicy');
+const { cleanup,
+    DummyRequestLogger,
+    makeAuthInfo }
+    = require('../helpers');
+const metadata = require('../../../lib/metadata/wrapper');
+
+const log = new DummyRequestLogger();
+const authInfo = makeAuthInfo('accessKey1');
+const bucketName = 'bucketname';
+const testBucketPutRequest = {
+    bucketName,
+    headers: { host: `${bucketName}.s3.amazonaws.com` },
+    url: '/',
+};
+
+const expectedBucketPolicy = {
+    version: '2012-10-17',
+    statements: [
+        {
+            sid: '',
+            effect: 'Allow',
+            resource: 'arn:aws:s3::bucketname',
+            principal: '*',
+            actions: ['s3:sampleAction'],
+        },
+    ],
+};
+
+const testPutPolicyRequest = {
+    bucketName,
+    headers: {
+        host: `${bucketName}.s3.amazonaws.com`,
+    },
+    post: JSON.stringify(expectedBucketPolicy),
+};
+
+const describeSkipUntilImpl =
+    process.env.BUCKET_POLICY ? describe : describe.skip;
+
+describeSkipUntilImpl('putBucketPolicy API', () => {
+    before(() => cleanup());
+    beforeEach(done => bucketPut(authInfo, testBucketPutRequest, log, done));
+    afterEach(() => cleanup());
+
+    it('should update a bucket\'s metadata with bucket policy obj', done => {
+        bucketPutPolicy(authInfo, testPutPolicyRequest, log, err => {
+            if (err) {
+                process.stdout.write(`Err putting bucket policy ${err}`);
+                return done(err);
+            }
+            return metadata.getBucket(bucketName, log, (err, bucket) => {
+                if (err) {
+                    process.stdout.write(`Err retrieving bucket MD ${err}`);
+                    return done(err);
+                }
+                const bucketPolicy = bucket.getBucketPolicy();
+                assert.deepStrictEqual(bucketPolicy, expectedBucketPolicy);
+                return done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Add the basic put bucket policy API and dummies for get and delete (in PRs to follow). Includes updated Arsenal routes, but won't function until a few more changes are made in Arsenal and BUCKET_POLICY env var requirement is removed.