### PR TITLE
Feature/s3 c 2283 bucket policy get

### DIFF
--- a/lib/api/bucketGetPolicy.js
+++ b/lib/api/bucketGetPolicy.js
@@ -1,7 +1,49 @@
 const { errors } = require('arsenal');
 
+const { metadataValidateBucket } = require('../metadata/metadataUtils');
+const collectCorsHeaders = require('../utilities/collectCorsHeaders');
+
+/**
+ * bucketGetPolicy - Get the bucket policy
+ * @param {AuthInfo} authInfo - Instance of AuthInfo class with requester's info
+ * @param {object} request - http request object
+ * @param {object} log - Werelogs logger
+ * @param {function} callback - callback to server
+ * @return {undefined}
+ */
 function bucketGetPolicy(authInfo, request, log, callback) {
-    return callback(errors.NotImplemented);
+    log.debug('processing request', { method: 'bucketGetPolicy' });
+    const { bucketName, headers, method } = request;
+    const metadataValParams = {
+        authInfo,
+        bucketName,
+        requestType: 'bucketOwnerAction',
+    };
+    if (!process.env.BUCKET_POLICY) {
+        return callback(errors.NotImplemented);
+    }
+
+    return metadataValidateBucket(metadataValParams, log, (err, bucket) => {
+        const corsHeaders = collectCorsHeaders(headers.origin, method, bucket);
+        if (err) {
+            log.debug('error processing request', {
+                error: err,
+                method: 'bucketGetPolicy',
+            });
+            return callback(err, null, corsHeaders);
+        }
+        const bucketPolicy = bucket.getBucketPolicy();
+        if (!bucketPolicy) {
+            log.debug('error processing request', {
+                error: errors.NoSuchBucketPolicy,
+                method: 'bucketGetPolicy',
+            });
+            return callback(errors.NoSuchBucketPolicy, null,
+                corsHeaders);
+        }
+        // TODO: implement Utapi metric support
+        return callback(null, bucketPolicy, corsHeaders);
+    });
 }
 
 module.exports = bucketGetPolicy;

--- a/tests/functional/aws-node-sdk/test/bucket/getBucketPolicy.js
+++ b/tests/functional/aws-node-sdk/test/bucket/getBucketPolicy.js
@@ -1,0 +1,87 @@
+const assert = require('assert');
+const { errors } = require('arsenal');
+const { S3 } = require('aws-sdk');
+
+const getConfig = require('../support/config');
+const BucketUtility = require('../../lib/utility/bucket-util');
+
+const bucket = 'getbucketpolicy-testbucket';
+const bucketPolicy = {
+    Version: '2012-10-17',
+    Statement: [{
+        Sid: 'test-id',
+        Effect: 'Allow',
+        Principle: '*',
+        Action: 's3:putBucketPolicy',
+        Resource: 'arn:aws:s3::getbucketpolicy-testbucket',
+    }],
+};
+const expectedPolicy = {
+    Sid: 'test-id',
+    Effect: 'Allow',
+    Principle: '*',
+    Action: 's3:putBucketPolicy',
+    Resource: 'arn:aws:s3::getbucketpolicy-testbucket',
+};
+
+// Check for the expected error response code and status code.
+function assertError(err, expectedErr, cb) {
+    if (expectedErr === null) {
+        assert.strictEqual(err, null, `expected no error but got '${err}'`);
+    } else {
+        assert.strictEqual(err.code, expectedErr, 'incorrect error response ' +
+            `code: should be '${expectedErr}' but got '${err.code}'`);
+        assert.strictEqual(err.statusCode, errors[expectedErr].code,
+            'incorrect error status code: should be 400 but got ' +
+            `'${err.statusCode}'`);
+    }
+    cb();
+}
+
+const describeSkipUntilImpl =
+    process.env.BUCKET_POLICY ? describe : describe.skip;
+
+describeSkipUntilImpl('aws-sdk test get bucket policy', () => {
+    const config = getConfig('default', { signatureVersion: 'v4' });
+    const s3 = new S3(config);
+    const otherAccountS3 = new BucketUtility('lisa', {}).s3;
+
+    it('should return NoSuchBucket error if bucket does not exist', done => {
+        s3.getBucketPolicy({ Bucket: bucket }, err =>
+            assertError(err, 'NoSuchBucket', done));
+    });
+
+    describe('policy rules', () => {
+        beforeEach(done => s3.createBucket({ Bucket: bucket }, done));
+
+        afterEach(done => s3.deleteBucket({ Bucket: bucket }, done));
+
+        it('should return AccessDenied if user is not bucket owner', done => {
+            otherAccountS3.getBucketPolicy({ Bucket: bucket },
+            err => assertError(err, 'AccessDenied', done));
+        });
+
+        it('should return NoSuchBucketPolicy error if no policy put to bucket',
+        done => {
+            s3.getBucketPolicy({ Bucket: bucket }, err => {
+                assertError(err, 'NoSuchBucketPolicy', done);
+            });
+        });
+
+        it('should get bucket policy', done => {
+            s3.putBucketPolicy({
+                Bucket: bucket,
+                Policy: bucketPolicy,
+            }, err => {
+                assert.equal(err, null, `Err putting bucket policy: ${err}`);
+                s3.getBucketPolicy({ Bucket: bucket },
+                (err, res) => {
+                    assert.equal(err, null, 'Error getting bucket policy: ' +
+                        `${err}`);
+                    assert.deepStrictEqual(res.Statement[0], expectedPolicy);
+                    done();
+                });
+            });
+        });
+    });
+});

--- a/tests/unit/api/bucketGetPolicy.js
+++ b/tests/unit/api/bucketGetPolicy.js
@@ -1,0 +1,72 @@
+const assert = require('assert');
+
+const { bucketPut } = require('../../../lib/api/bucketPut');
+const bucketGetPolicy = require('../../../lib/api/bucketGetPolicy');
+const bucketPutPolicy = require('../../../lib/api/bucketPutPolicy');
+const { cleanup,
+    DummyRequestLogger,
+    makeAuthInfo }
+    = require('../helpers');
+
+const log = new DummyRequestLogger();
+const authInfo = makeAuthInfo('accessKey1');
+const bucketName = 'getbucketpolicy-testbucket';
+
+const testBasicRequest = {
+    bucketName,
+    headers: { host: `${bucketName}.s3.amazonaws.com` },
+    url: '/',
+};
+
+const expectedBucketPolicy = {
+    version: '2012-10-17',
+    statements: [
+        {
+            sid: '',
+            effect: '',
+            resource: '',
+            principal: '',
+            actions: '',
+        },
+    ],
+};
+
+const testPutPolicyRequest = {
+    bucketName,
+    headers: { host: `${bucketName}.s3.amazonaws.com` },
+    post: JSON.stringify(expectedBucketPolicy),
+};
+
+const describeSkipUntilImpl =
+    process.env.BUCKET_POLICY ? describe : describe.skip;
+
+describeSkipUntilImpl('getBucketPolicy API', () => {
+    before(() => cleanup());
+    beforeEach(done => bucketPut(authInfo, testBasicRequest, log, done));
+    afterEach(() => cleanup());
+
+    it('should return NoSuchBucketPolicy error if ' +
+    'bucket has no policy', done => {
+        bucketGetPolicy(authInfo, testBasicRequest, log, err => {
+            assert.strictEqual(err.NoSuchBucketPolicy, true);
+            done();
+        });
+    });
+
+    describe('after bucket policy has been put', () => {
+        beforeEach(done => {
+            bucketPutPolicy(authInfo, testPutPolicyRequest, log, err => {
+                assert.equal(err, null);
+                done();
+            });
+        });
+
+        it('should return bucket policy', done => {
+            bucketGetPolicy(authInfo, testBasicRequest, log, (err, res) => {
+                assert.equal(err, null);
+                assert.deepStrictEqual(expectedBucketPolicy, res);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Add the basic get bucket policy API. Includes updated Arsenal routes, but won't function until a few more changes are made in Arsenal and BUCKET_POLICY env var requirement is removed.

Depends on https://github.com/scality/cloudserver/pull/1999