### PR TITLE
Feature/s3 c 2284 bucket policy delete

### DIFF
--- a/lib/api/bucketDeletePolicy.js
+++ b/lib/api/bucketDeletePolicy.js
@@ -1,7 +1,49 @@
-const { errors } = require('arsenal');
+const metadata = require('../metadata/wrapper');
+const { metadataValidateBucket } = require('../metadata/metadataUtils');
+const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 
+/**
+ * bucketDeletePolicy - Delete the bucket policy
+ * @param {AuthInfo} authInfo - Instance of AuthInfo class with requester's info
+ * @param {object} request - http request object
+ * @param {object} log - Werelogs logger
+ * @param {function} callback - callback to server
+ * @return {undefined}
+ */
 function bucketDeletePolicy(authInfo, request, log, callback) {
-    return callback(errors.NotImplemented);
+    log.debug('processing request', { method: 'bucketDeletePolicy' });
+    const { bucketName, headers, method } = request;
+    const metadataValParams = {
+        authInfo,
+        bucketName,
+        requestType: 'bucketOwnerAction',
+    };
+    return metadataValidateBucket(metadataValParams, log, (err, bucket) => {
+        const corsHeaders = collectCorsHeaders(headers.origin, method, bucket);
+        if (err) {
+            log.debug('error processing request', {
+                error: err,
+                method: 'bucketDeletePolicy',
+            });
+            return callback(err, corsHeaders);
+        }
+        if (!bucket.getBucketPolicy()) {
+            log.trace('no existing bucket policy', {
+                method: 'bucketDeletePolicy',
+            });
+            // TODO: implement Utapi metric support
+            return callback(null, corsHeaders);
+        }
+        log.trace('deleting bucket policy in metadata');
+        bucket.setBucketPolicy(null);
+        return metadata.updateBucket(bucketName, bucket, log, err => {
+            if (err) {
+                return callback(err, corsHeaders);
+            }
+            // TODO: implement Utapi metric support
+            return callback(null, corsHeaders);
+        });
+    });
 }
 
 module.exports = bucketDeletePolicy;

--- a/tests/functional/aws-node-sdk/test/bucket/deleteBucketPolicy.js
+++ b/tests/functional/aws-node-sdk/test/bucket/deleteBucketPolicy.js
@@ -1,0 +1,81 @@
+const assert = require('assert');
+const { errors } = require('arsenal');
+const { S3 } = require('aws-sdk');
+
+const getConfig = require('../support/config');
+const BucketUtility = require('../../lib/utility/bucket-util');
+
+const bucket = 'deletebucketpolicy-test-bucket';
+const bucketPolicy = {
+    Version: '2012-10-17',
+    Statement: [{
+        Sid: 'test-id',
+        Effect: 'Allow',
+        Principle: '*',
+        Action: 's3:putBucketPolicy',
+        Resource: `arn:aws:s3::${bucket}`,
+    }],
+};
+
+// Check for the expected error response code and status code.
+function assertError(err, expectedErr, cb) {
+    if (expectedErr === null) {
+        assert.strictEqual(err, null, `expected no error but got '${err}'`);
+    } else {
+        assert.strictEqual(err.code, expectedErr, 'incorrect error response ' +
+            `code: should be '${expectedErr}' but got '${err.code}'`);
+        assert.strictEqual(err.statusCode, errors[expectedErr].code,
+            'incorrect error status code: should be 400 but got ' +
+            `'${err.statusCode}'`);
+    }
+    cb();
+}
+
+const describeSkipUntilImpl =
+    process.env.BUCKET_POLICY ? describe : describe.skip;
+
+describeSkipUntilImpl('aws-sdk test delete bucket policy', () => {
+    let s3;
+    let otherAccountS3;
+
+    before(done => {
+        const config = getConfig('default', { signatureVersion: 'v4' });
+        s3 = new S3(config);
+        otherAccountS3 = new BucketUtility('lisa', {}).s3;
+        return done();
+    });
+
+    it('should return NoSuchBucket error if bucket does not exist', done => {
+        s3.deleteBucketPolicy({ Bucket: bucket }, err =>
+            assertError(err, 'NoSuchBucket', done));
+    });
+
+    describe('policy rules', () => {
+        beforeEach(done => s3.createBucket({ Bucket: bucket }, done));
+
+        afterEach(done => s3.deleteBucket({ Bucket: bucket }, done));
+
+        it('should return AccessDenied if user is not bucket owner', done => {
+            otherAccountS3.deleteBucketPolicy({ Bucket: bucket },
+            err => assertError(err, 'AccessDenied', done));
+        });
+
+        it('should return no error if no policy on bucket', done => {
+            s3.deleteBucketPolicy({ Bucket: bucket }, err =>
+                assertError(err, null, done));
+        });
+
+        it('should delete policy from bucket', done => {
+            const params = { Bucket: bucket, Policy: bucketPolicy };
+            s3.putBucketPolicy(params, err => {
+                assert.equal(err, null);
+                s3.deleteBucketPolicy({ Bucket: bucket }, err => {
+                    assert.equal(err, null);
+                    s3.getBucketPolicy({ Bucket: bucket },
+                    err =>
+                        assertError(err, 'NoSuchBucketPolicy', done));
+                });
+            });
+        });
+    });
+});

--- a/tests/unit/api/bucketDeletePolicy.js
+++ b/tests/unit/api/bucketDeletePolicy.js
@@ -1,0 +1,68 @@
+const assert = require('assert');
+const async = require('async');
+
+const { bucketPut } = require('../../../lib/api/bucketPut');
+const bucketPutPolicy = require('../../../lib/api/bucketPutPolicy');
+const bucketDeletePolicy = require('../../../lib/api/bucketDeletePolicy');
+const { cleanup,
+    DummyRequestLogger,
+    makeAuthInfo }
+    = require('../helpers');
+const metadata = require('../../../lib/metadata/wrapper');
+
+const log = new DummyRequestLogger();
+const authInfo = makeAuthInfo('accessKey1');
+const bucketName = 'bucketname';
+
+function _makeRequest(includePolicy) {
+    const request = {
+        bucketName,
+        headers: { host: `${bucketName}.s3.amazonaws.com` },
+        url: '/',
+    };
+    if (includePolicy) {
+        const examplePolicy = {
+            version: '2012-10-17',
+            statements: [
+                {
+                    sid: '',
+                    effect: 'Allow',
+                    resource: 'arn:aws:s3::bucketname',
+                    principal: '*',
+                    actions: ['s3:sampleAction'],
+                },
+            ],
+        };
+        request.post = JSON.stringify(examplePolicy);
+    }
+    return request;
+}
+
+const describeSkipUntilImpl =
+    process.env.BUCKET_POLICY ? describe : describe.skip;
+
+describeSkipUntilImpl('deleteBucketPolicy API', () => {
+    before(() => cleanup());
+    beforeEach(done => bucketPut(authInfo, _makeRequest(), log, done));
+    afterEach(() => cleanup());
+
+    it('should not return an error even if no policy put', done => {
+        bucketDeletePolicy(authInfo, _makeRequest(), log, err => {
+            assert.equal(err, null, `Err deleting policy: ${err}`);
+            done();
+        });
+    });
+    it('should delete bucket policy', done => {
+        async.series([
+            next => bucketPutPolicy(authInfo, _makeRequest(true), log, next),
+            next => bucketDeletePolicy(authInfo, _makeRequest(), log, next),
+            next => metadata.getBucket(bucketName, log, next),
+        ], (err, results) => {
+            assert.equal(err, null, `Expected success, got error: ${err}`);
+            const bucket = results[2];
+            const bucketPolicy = bucket.getBucketPolicy();
+            assert.equal(bucketPolicy, null);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Add the basic delete bucket policy API. Includes updated Arsenal routes, but won't function until a few more changes are made in Arsenal and BUCKET_POLICY env var requirement is removed.

Depends on #1999 and #2011 