### PR TITLE
ZENKOIO-61 - ft: allow meta-mdonly put for all backends

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -204,7 +204,8 @@ stages:
             source /root/.aws/exports &> /dev/null
             set -ex
             bash wait_for_local_port.bash 8000 40
-            npm run multiple_backend_test"
+            npm run multiple_backend_test
+            npm run ft_awssdk_external_backends"
           <<: *follow-s3-log
           env:
             <<: *multiple-backend-vars

--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -167,11 +167,29 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
 
     const requestLogger =
         logger.newRequestLoggerFromSerializedUids(log.getSerializedUids());
+    const mdOnlyHeader = request.headers['x-amz-meta-mdonly'];
+    const mdOnlySize = request.headers['x-amz-meta-size'];
     return async.waterfall([
         function storeData(next) {
             if (size === 0 && !dontSkipBackend[locationType]) {
                 metadataStoreParams.contentMD5 = constants.emptyFileMd5;
                 return next(null, null, null);
+            }
+            // Handle mdOnlyHeader as a metadata only operation. If
+            // the object in question is actually 0 byte or has a body size
+            // then handle normally.
+            if (mdOnlyHeader === 'true' && mdOnlySize > 0 && size === 0) {
+                log.debug('metadata only operation x-amz-meta-mdonly');
+                const md5 = new Buffer(request.headers
+                    ['x-amz-meta-md5chksum'], 'base64').toString('hex');
+                const dataGetInfo = {
+                    key: objectKey,
+                    dataStoreName: location,
+                    dataStoreType: locationType,
+                    dataStoreVersionId: request.headers['x-amz-version-id'],
+                    dataStoreMD5: md5,
+                };
+                return next(null, dataGetInfo, md5);
             }
             return dataStore(objectKeyContext, cipherBundle, request, size,
                     streamingV4Params, backendInfo, log, next);
@@ -184,7 +202,7 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
             // regular puts are stored in the same data structure,
             // place the retrieval info here into a single element array
             const { key, dataStoreName, dataStoreType, dataStoreETag,
-                dataStoreVersionId, dataStoreSize, dataStoreMD5 } = dataGetInfo;
+                dataStoreVersionId } = dataGetInfo;
             const prefixedDataStoreETag = dataStoreETag
                       ? `1:${dataStoreETag}`
                       : `1:${calculatedHash}`;
@@ -196,13 +214,11 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
                 dataGetInfoArr[0].cipheredDataKey =
                     cipherBundle.cipheredDataKey;
             }
-            if (dataStoreSize !== undefined) {
-                metadataStoreParams.size = dataStoreSize;
+            if (mdOnlyHeader === 'true') {
+                metadataStoreParams.size = mdOnlySize;
+                dataGetInfoArr[0].size = mdOnlySize;
             }
             metadataStoreParams.contentMD5 = calculatedHash;
-            if (dataStoreMD5 !== undefined) {
-                metadataStoreParams.contentMD5 = dataStoreMD5;
-            }
             return next(null, dataGetInfoArr);
         },
         function getVersioningInfo(infoArr, next) {

--- a/tests/functional/aws-node-sdk/test/multipleBackend/put/put.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/put/put.js
@@ -73,7 +73,7 @@ function awsGetCheck(objectKey, s3MD5, awsMD5, location, cb) {
     });
 }
 
-describe('MultipleBackend put object', function testSuite() {
+describe.only('MultipleBackend put object', function testSuite() {
     this.timeout(250000);
     withV4(sigCfg => {
         beforeEach(() => {


### PR DESCRIPTION
Moves the meta-mdonly check into Cloudserver allowing for any supported backend to allow for metadata only operations. This also adds three tests along with enabling the `ft_awssdk_external_backends` test suite to enable the tests in CI.