### PR TITLE
bugfix: S3C-2369 bump sproxydclient with batch delete fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "mongodb": "^2.2.31",
     "node-uuid": "^1.4.3",
     "npm-run-all": "~4.1.5",
-    "sproxydclient": "scality/sproxydclient#a8d7b93",
+    "sproxydclient": "scality/sproxydclient#0e17e27",
     "utapi": "scality/utapi#71a3bc9",
     "utf8": "~2.1.1",
     "uuid": "^3.0.1",


### PR DESCRIPTION


## Description
Bump Sproxydclient
### Motivation and context

S3C-2369 - Batch delete in sproxyd limits the number of keys that can be submitted in a request to 1000. Without this fix, deleting multiple keys resulted in 400 from Sproxyd

