### PR TITLE
bugfix: S3C-2052 Delete orphaned data in APIs

### DIFF
--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -7,6 +7,7 @@ const data = require('../../../data/wrapper');
 const services = require('../../../services');
 const logger = require('../../../utilities/logger');
 const { dataStore } = require('./storeObject');
+const { dataDelete } = require('./deleteObject');
 const locationConstraintCheck = require('./locationConstraintCheck');
 const { versioningPreprocessing } = require('./versioning');
 const removeAWSChunked = require('./removeAWSChunked');
@@ -51,7 +52,12 @@ function _storeInMDandDeleteData(bucketName, dataGetInfo, cipherBundle,
     services.metadataStoreObject(bucketName, dataGetInfo,
         cipherBundle, metadataStoreParams, (err, result) => {
             if (err) {
-                return callback(err);
+                // Make a best effort single attempt to cleanup any orphaned
+                // data while returning the original error from the metadata
+                // layer.
+                return dataDelete(dataGetInfo, requestMethod, deleteLog, () => {
+                    callback(err);
+                });
             }
             if (dataToDelete) {
                 const newDataStoreName = Array.isArray(dataGetInfo) ?

--- a/lib/api/apiUtils/object/deleteObject.js
+++ b/lib/api/apiUtils/object/deleteObject.js
@@ -1,9 +1,25 @@
 const data = require('../../../data/wrapper');
 
-function dataDelete(objectGetInfo, log, cb) {
-    data.delete(objectGetInfo, log, err => {
+function dataDelete(locations, method, log, cb) {
+    if (!Array.isArray(locations) || locations.length === 0) {
+        return process.nextTick(() => cb());
+    }
+    if (locations.length === 1) {
+        return data.delete(locations[0], log, err => {
+            if (err) {
+                log.error('error deleting object data', {
+                    error: err,
+                    method: 'dataDelete',
+                });
+                return cb(err);
+            }
+            return cb();
+        });
+    }
+    const dataStoreName = locations[0].dataStoreName;
+    return data.batchDelete(locations, method, dataStoreName, log, err => {
         if (err) {
-            log.error('error deleting object data', {
+            log.error('error batch deleting object data', {
                 error: err,
                 method: 'dataDelete',
             });

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -16,6 +16,7 @@ const logger = require('../utilities/logger');
 const services = require('../services');
 const { pushMetric } = require('../utapi/utilities');
 const removeAWSChunked = require('./apiUtils/object/removeAWSChunked');
+const { dataDelete } = require('./apiUtils/object/deleteObject');
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const validateWebsiteHeader = require('./apiUtils/object/websiteServing')
     .validateWebsiteHeader;
@@ -398,7 +399,13 @@ function objectCopy(authInfo, request, sourceBucket,
                     if (err) {
                         log.debug('error processing versioning info',
                         { error: err });
-                        return next(err, null, destBucketMD);
+                        // Make a best effort single attempt to cleanup any
+                        // orphaned data while returning the original error from
+                        // the metadata layer.
+                        return dataDelete(
+                            destDataGetInfoArr, request.method, log, () => {
+                                next(err, null, destBucketMD);
+                            });
                     }
                     // eslint-disable-next-line
                     storeMetadataParams.versionId = options.versionId;
@@ -421,7 +428,13 @@ function objectCopy(authInfo, request, sourceBucket,
                 storeMetadataParams, (err, result) => {
                     if (err) {
                         log.debug('error storing new metadata', { error: err });
-                        return next(err, null, destBucketMD);
+                        // Make a best effort single attempt to cleanup any
+                        // orphaned data while returning the original error from
+                        // the metadata layer.
+                        return dataDelete(
+                            destDataGetInfoArr, request.method, log, () => {
+                                next(err, null, destBucketMD);
+                            });
                     }
                     const sourceObjSize = storeMetadataParams.size;
                     const destObjPrevSize = (destObjMD &&

--- a/lib/api/objectPutCopyPart.js
+++ b/lib/api/objectPutCopyPart.js
@@ -10,6 +10,7 @@ const { pushMetric } = require('../utapi/utilities');
 const logger = require('../utilities/logger');
 const services = require('../services');
 const setUpCopyLocator = require('./apiUtils/object/setUpCopyLocator');
+const { dataDelete } = require('./apiUtils/object/deleteObject');
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 
 const versionIdUtils = versioning.VersionID;
@@ -261,7 +262,13 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
                     if (err && !err.NoSuchKey) {
                         log.debug('error getting current part (if any)',
                         { error: err });
-                        return next(err);
+                        // Make a best effort single attempt to cleanup any
+                        // orphaned data while returning the original error from
+                        // the metadata layer.
+                        return dataDelete(
+                            locations, request.method, log, () => {
+                                next(err);
+                            });
                     }
                     let oldLocations;
                     let prevObjectSize = null;
@@ -295,7 +302,13 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
                     if (err) {
                         log.debug('error storing new metadata',
                         { error: err, method: 'storeNewPartMetadata' });
-                        return next(err);
+                        // Make a best effort single attempt to cleanup any
+                        // orphaned data while returning the original error from
+                        // the metadata layer.
+                        return dataDelete(
+                            locations, request.method, log, () => {
+                                next(err);
+                            });
                     }
                     return next(null, oldLocations, destBucketMD, totalHash,
                         lastModified, sourceVerId, serverSideEncryption,

--- a/lib/api/objectPutPart.js
+++ b/lib/api/objectPutPart.js
@@ -323,12 +323,13 @@ function objectPutPart(authInfo, request, streamingV4Params, log,
                             error: err,
                             method: 'objectPutPart::metadata.putObjectMD',
                         });
-                        // Make a best effort single attempt to cleanup the
+                        // Make a best effort single attempt to cleanup any
                         // orphaned data while returning the original error from
                         // the metadata layer.
-                        return dataDelete(dataGetInfo, log, () => {
-                            next(err, destinationBucket);
-                        });
+                        return dataDelete(
+                            partLocations, request.method, log, () => {
+                                next(err, destinationBucket);
+                            });
                     }
                     return next(null, oldLocations, objectLocationConstraint,
                         destinationBucket, hexDigest, prevObjectSize);

--- a/lib/metadata/in_memory/backend.js
+++ b/lib/metadata/in_memory/backend.js
@@ -23,7 +23,18 @@ function inc(str) {
 }
 
 const metastore = {
-    errors: {}, // Used for simulation of metadata errors.
+    // Used for simulation of metadata errors.
+    error: () => {},
+
+    setErrorFunc(func) {
+        this.error = func;
+        return this;
+    },
+
+    clearErrorFunc() {
+        this.error = () => {};
+        return this;
+    },
 
     createBucket: (bucketName, bucketMD, log, cb) => {
         process.nextTick(() => {
@@ -80,8 +91,9 @@ const metastore = {
     },
 
     putObject: (bucketName, objName, objVal, params, log, cb) => {
-        if (metastore.errors.putObject) {
-            return process.nextTick(() => cb(metastore.errors.putObject));
+        const err = metastore.error(metastore.putObject.name);
+        if (err) {
+            return process.nextTick(() => cb(err));
         }
         return process.nextTick(() => {
             metastore.getBucketAttributes(bucketName, log, err => {
@@ -155,7 +167,11 @@ const metastore = {
     },
 
     getObject: (bucketName, objName, params, log, cb) => {
-        process.nextTick(() => {
+        const err = metastore.error(metastore.getObject.name, objName);
+        if (err) {
+            return process.nextTick(() => cb(err));
+        }
+        return process.nextTick(() => {
             metastore.getBucketAttributes(bucketName, log, err => {
                 if (err) {
                     return cb(err);

--- a/tests/unit/api/apiUtils/deleteObject.js
+++ b/tests/unit/api/apiUtils/deleteObject.js
@@ -5,38 +5,94 @@ const helpers = require('../../helpers');
 const { ds, backend } = require('../../../../lib/data/in_memory/backend');
 const { dataDelete } =
     require('../../../../lib/api/apiUtils/object/deleteObject');
-const log = new Logger('_').newRequestLogger();
 
 describe('dataDelete utility', () => {
+    let log;
     const key = 1;
+    const key2 = 2;
     const value = Buffer.from('_');
 
-    beforeEach(() => helpers.cleanup());
+    beforeEach(() => {
+        helpers.cleanup();
+        // Batch delete calls log.end();
+        log = new Logger('_').newRequestLogger();
+    });
+
+    it('should check that the locations are an array', done => {
+        const locations = {};
+        dataDelete(locations, 'PUT', log, done);
+    });
+
+    it('should check that the locations are an array > 0 in length', done => {
+        const locations = [];
+        dataDelete(locations, 'PUT', log, done);
+    });
 
     describe('success case', () => {
-        beforeEach(done => {
-            ds[key] = { value };
-            dataDelete({ key }, log, done);
+        describe('with a single location', () => {
+            beforeEach(done => {
+                ds[key] = { value };
+                const locations = [{ key }];
+                dataDelete(locations, 'PUT', log, done);
+            });
+
+            it('should delete the key', () => {
+                assert.strictEqual(ds[key], undefined);
+            });
         });
 
-        it('should delete the key', () => {
-            assert.strictEqual(ds[key], undefined);
+        describe('with multiple locations', () => {
+            beforeEach(done => {
+                ds[key] = { value };
+                ds[key2] = { value };
+                const locations = [{ key }, { key: key2 }];
+                dataDelete(locations, 'PUT', log, done);
+            });
+
+            it('should delete each key', () => {
+                assert.strictEqual(ds[key], undefined);
+                assert.strictEqual(ds[key2], undefined);
+            });
         });
     });
 
     describe('error case', () => {
-        beforeEach(done => {
-            ds[key] = { value };
-            backend.errors.delete = errors.InternalError;
-            dataDelete({ key }, log, err => {
-                delete backend.errors.delete;
-                assert.deepStrictEqual(err, errors.InternalError);
-                done();
+        describe('with a single location', () => {
+            beforeEach(done => {
+                ds[key] = { value };
+                const locations = [{ key }];
+                backend.errors.delete = errors.InternalError;
+                dataDelete(locations, 'PUT', log, err => {
+                    assert.deepStrictEqual(err, errors.InternalError);
+                    done();
+                });
+            });
+
+            afterEach(() => delete backend.errors.delete);
+
+            it('should not delete the key', () => {
+                assert.deepStrictEqual(ds[key], { value });
             });
         });
 
-        it('should not delete the key', () => {
-            assert.deepStrictEqual(ds[key], { value });
+        describe('with multiple locations', () => {
+            beforeEach(done => {
+                ds[key] = { value };
+                ds[key2] = { value };
+                const locations = [{ key }, { key: key2 }];
+                backend.errors.delete = errors.InternalError;
+                dataDelete(locations, 'PUT', log, err => {
+                    assert.deepStrictEqual(err, errors.InternalError);
+                    done();
+                });
+            });
+
+            afterEach(() => delete backend.errors.delete);
+
+            it('should delete each key', () => {
+                assert.deepStrictEqual(ds[key], { value });
+                assert.deepStrictEqual(ds[key2], { value });
+            });
         });
     });
 });

--- a/tests/unit/api/objectCopy.js
+++ b/tests/unit/api/objectCopy.js
@@ -1,14 +1,24 @@
 const assert = require('assert');
 const async = require('async');
 
+const { errors } = require('arsenal');
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const bucketPutVersioning = require('../../../lib/api/bucketPutVersioning');
 const objectPut = require('../../../lib/api/objectPut');
 const objectCopy = require('../../../lib/api/objectCopy');
 const { ds } = require('../../../lib/data/in_memory/backend');
+const metastore = require('../../../lib/metadata/in_memory/backend');
 const DummyRequest = require('../DummyRequest');
 const { cleanup, DummyRequestLogger, makeAuthInfo, versioningTestUtils }
     = require('../helpers');
+
+const initiateMultipartUpload
+    = require('../../../lib/api/initiateMultipartUpload');
+const completeMultipartUpload
+    = require('../../../lib/api/completeMultipartUpload');
+const { parseString } = require('xml2js');
+const crypto = require('crypto');
+const objectPutPart = require('../../../lib/api/objectPutPart');
 
 const log = new DummyRequestLogger();
 const canonicalID = 'accessKey1';
@@ -49,14 +59,13 @@ describe('objectCopy with versioning', () => {
     const objData = ['foo0', 'foo1', 'foo2'].map(str =>
         Buffer.from(str, 'utf8'));
 
-    const testPutObjectRequests = objData.slice(0, 2).map(data =>
-        versioningTestUtils.createPutObjectRequest(destBucketName, objectKey,
-            data));
-    testPutObjectRequests.push(versioningTestUtils
-        .createPutObjectRequest(sourceBucketName, objectKey, objData[2]));
-
-    before(done => {
+    beforeEach(done => {
         cleanup();
+        const testPutObjectRequests = objData.slice(0, 2).map(data =>
+            versioningTestUtils.createPutObjectRequest(
+                destBucketName, objectKey, data));
+        testPutObjectRequests.push(versioningTestUtils
+            .createPutObjectRequest(sourceBucketName, objectKey, objData[2]));
         async.series([
             callback => bucketPut(authInfo, putDestBucketRequest, log,
                 callback),
@@ -101,5 +110,262 @@ describe('objectCopy with versioning', () => {
                     done();
                 });
             });
+    });
+
+    describe('getObjectMD error condition', () => {
+        function errorFunc(method) {
+            if (method === metastore.getObject.name) {
+                return errors.InternalError;
+            }
+            return null;
+        }
+
+        describe('non-0-byte object', () => {
+            beforeEach(done => {
+                assert.deepStrictEqual(ds[1].value, objData[0]);
+                assert.deepStrictEqual(ds[2].value, objData[1]);
+                assert.deepStrictEqual(ds[3].value, objData[2]);
+                metastore.setErrorFunc(errorFunc);
+                const req = _createObjectCopyRequest(destBucketName);
+                objectCopy(
+                    authInfo, req, sourceBucketName, objectKey, null, log,
+                    err => {
+                        assert.deepStrictEqual(err, errors.InternalError);
+                        done();
+                    });
+            });
+
+            afterEach(() => metastore.clearErrorFunc());
+
+            it('should delete the destination data', () => {
+                assert.strictEqual(ds.length, 5);
+                assert.strictEqual(ds[0], undefined);
+                // The source data for null version.
+                assert.deepStrictEqual(ds[1].value, objData[0]);
+                 // The destination data for null version.
+                assert.deepStrictEqual(ds[2].value, objData[1]);
+                // The source data for version 1.
+                assert.deepStrictEqual(ds[3].value, objData[2]);
+                // The destination data for version 1.
+                assert.strictEqual(ds[4], undefined);
+            });
+        });
+
+        describe('0-byte object', () => {
+            function errorFunc(method) {
+                if (method === metastore.getObject.name) {
+                    return errors.InternalError;
+                }
+                return null;
+            }
+
+            beforeEach(done => {
+                cleanup();
+
+                const data = Buffer.from('', 'utf8');
+                const srcRequest = versioningTestUtils.createPutObjectRequest(
+                    sourceBucketName, objectKey, data);
+                const destRequest = versioningTestUtils.createPutObjectRequest(
+                    destBucketName, objectKey, data);
+
+                async.series([
+                    next => bucketPut(
+                        authInfo, putSourceBucketRequest, log, next),
+                    next => bucketPut(
+                        authInfo, putDestBucketRequest, log, next),
+                    next => objectPut(
+                        authInfo, destRequest, null, log, next),
+                    next => bucketPutVersioning(
+                        authInfo, enableVersioningRequest, log, next),
+                    next => objectPut(
+                        authInfo, destRequest, null, log, next),
+                    next => bucketPutVersioning(
+                        authInfo, suspendVersioningRequest, log, next),
+                    next => objectPut(
+                        authInfo, srcRequest, null, log, next),
+                ], err => {
+                    if (err) {
+                        return done(err);
+                    }
+                    assert.strictEqual(ds.length, 0);
+                    metastore.setErrorFunc(errorFunc);
+                    const req = _createObjectCopyRequest(destBucketName);
+                    return objectCopy(authInfo, req, sourceBucketName,
+                        objectKey, null, log, err => {
+                            assert.deepStrictEqual(err, errors.InternalError);
+                            done();
+                        });
+                });
+            });
+
+            afterEach(() => metastore.clearErrorFunc());
+
+            it('should not attempt deletion of the data', () => {
+                assert.strictEqual(ds.length, 0);
+            });
+        });
+    });
+
+    describe('putObjectMD error condition', () => {
+        function errorFunc(method) {
+            if (method === metastore.putObject.name) {
+                return errors.InternalError;
+            }
+            return null;
+        }
+
+        beforeEach(done => {
+            assert.deepStrictEqual(ds[1].value, objData[0]);
+            assert.deepStrictEqual(ds[2].value, objData[1]);
+            assert.deepStrictEqual(ds[3].value, objData[2]);
+            metastore.setErrorFunc(errorFunc);
+            const req = _createObjectCopyRequest(destBucketName);
+            objectCopy(
+                authInfo, req, sourceBucketName, objectKey, null, log, err => {
+                    assert.deepStrictEqual(err, errors.InternalError);
+                    done();
+                });
+        });
+
+        afterEach(() => metastore.clearErrorFunc());
+
+        it('should delete the destination data', () => {
+            assert.strictEqual(ds.length, 5);
+            assert.strictEqual(ds[0], undefined);
+            // The source data for null version.
+            assert.deepStrictEqual(ds[1].value, objData[0]);
+             // The destination data for null version.
+            assert.deepStrictEqual(ds[2].value, objData[1]);
+            // The source data for version 1.
+            assert.deepStrictEqual(ds[3].value, objData[2]);
+            // The destination data for version 1.
+            assert.strictEqual(ds[4], undefined);
+        });
+    });
+});
+
+describe('copy object from MPU', () => {
+    const initiateMPURequest = {
+        bucketName: sourceBucketName,
+        namespace,
+        objectKey,
+        headers: { host: 'localhost' },
+        url: `/${objectKey}?uploads`,
+    };
+
+    function _createPutPartRequest(uploadId, partNumber, partBody) {
+        return new DummyRequest({
+            bucketName: sourceBucketName,
+            namespace,
+            objectKey,
+            headers: { host: 'localhost' },
+            url: `/${objectKey}?partNumber=${partNumber}&uploadId=${uploadId}`,
+            query: {
+                partNumber,
+                uploadId,
+            },
+            calculatedHash: crypto
+                .createHash('md5')
+                .update(partBody)
+                .digest('hex'),
+        }, partBody);
+    }
+
+    function _completeMPURequest(uploadId, parts) {
+        const body = [];
+        body.push('<CompleteMultipartUpload>');
+        parts.forEach(part => {
+            body.push(
+                '<Part>' +
+                    `<PartNumber>${part.partNumber}</PartNumber>` +
+                    `<ETag>"${part.eTag}"</ETag>` +
+                '</Part>'
+            );
+        });
+        body.push('</CompleteMultipartUpload>');
+        return {
+            bucketName: sourceBucketName,
+            namespace,
+            objectKey,
+            parsedHost: 'localhost',
+            url: `/${objectKey}?uploadId=${uploadId}`,
+            headers: { host: 'localhost' },
+            query: { uploadId },
+            post: body,
+        };
+    }
+
+    const partOneData = Buffer.alloc((1024 * 1024) * 5, 1);
+    const partTwoData = Buffer.alloc((1024 * 1024) * 5, 2);
+
+    beforeEach(done => {
+        cleanup();
+        const parts = [];
+        let uploadID;
+
+        async.waterfall([
+            next => bucketPut(authInfo, putSourceBucketRequest, log,
+                err => next(err)),
+            next => bucketPut(authInfo, putDestBucketRequest, log,
+                err => next(err)),
+            next => initiateMultipartUpload(
+                authInfo, initiateMPURequest, log, next),
+            (result, _, next) =>
+                parseString(result, next),
+            (json, next) => {
+                uploadID = json.InitiateMultipartUploadResult.UploadId[0];
+                const req = _createPutPartRequest(uploadID, 1, partOneData);
+                objectPutPart(authInfo, req, null, log, (err, eTag) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    parts.push({ partNumber: 1, eTag });
+                    return next();
+                });
+            },
+            next => {
+                const req = _createPutPartRequest(uploadID, 2, partTwoData);
+                objectPutPart(authInfo, req, null, log, (err, eTag) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    parts.push({ partNumber: 2, eTag });
+                    return next();
+                });
+            },
+            next => {
+                const req = _completeMPURequest(uploadID, parts);
+                completeMultipartUpload(authInfo, req, log, next);
+            },
+        ], err => {
+            if (err) {
+                return done(err);
+            }
+            assert.deepStrictEqual(ds[1].value, partOneData);
+            assert.deepStrictEqual(ds[2].value, partTwoData);
+            const req = _createObjectCopyRequest(destBucketName);
+            function errorFunc(method) {
+                if (method === metastore.putObject.name) {
+                    return errors.InternalError;
+                }
+                return null;
+            }
+            metastore.setErrorFunc(errorFunc);
+            return objectCopy(authInfo, req, sourceBucketName, objectKey, null,
+                log, err => {
+                    assert.deepStrictEqual(err, errors.InternalError);
+                    done();
+                });
+        });
+    });
+
+    afterEach(() => metastore.clearErrorFunc());
+
+    it('should cleanup data', () => {
+        assert.strictEqual(ds.length, 5);
+        assert.deepStrictEqual(ds[1].value, partOneData);
+        assert.deepStrictEqual(ds[2].value, partTwoData);
+        assert.strictEqual(ds[3], undefined);
+        assert.strictEqual(ds[4], undefined);
     });
 });

--- a/tests/unit/api/objectCopyPart.js
+++ b/tests/unit/api/objectCopyPart.js
@@ -1,12 +1,16 @@
 const assert = require('assert');
 const async = require('async');
 const { parseString } = require('xml2js');
+const { errors } = require('arsenal');
+const constants = require('../../../constants');
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const objectPut = require('../../../lib/api/objectPut');
 const objectPutCopyPart = require('../../../lib/api/objectPutCopyPart');
 const initiateMultipartUpload
 = require('../../../lib/api/initiateMultipartUpload');
 const { metadata } = require('../../../lib/metadata/in_memory/metadata');
+const { ds } = require('../../../lib/data/in_memory/backend');
+const metastore = require('../../../lib/metadata/in_memory/backend');
 const DummyRequest = require('../DummyRequest');
 const { cleanup, DummyRequestLogger, makeAuthInfo, versioningTestUtils }
     = require('../helpers');
@@ -59,13 +63,13 @@ const putSourceBucketRequest = _createBucketPutRequest(sourceBucketName);
 const initiateRequest = _createInitiateRequest(destBucketName);
 
 describe('objectCopyPart', () => {
-    let uploadId;
     const objData = Buffer.from('foo', 'utf8');
-    const testPutObjectRequest =
-        versioningTestUtils.createPutObjectRequest(sourceBucketName, objectKey,
-            objData);
-    before(done => {
+    let uploadId;
+
+    beforeEach(done => {
         cleanup();
+        const testPutObjectRequest = versioningTestUtils
+            .createPutObjectRequest(sourceBucketName, objectKey, objData);
         async.waterfall([
             callback => bucketPut(authInfo, putDestBucketRequest, log,
                 err => callback(err)),
@@ -80,13 +84,16 @@ describe('objectCopyPart', () => {
                 return done(err);
             }
             return parseString(res, (err, json) => {
+                if (err) {
+                    return done(err);
+                }
                 uploadId = json.InitiateMultipartUploadResult.UploadId[0];
                 return done();
             });
         });
     });
 
-    after(() => cleanup());
+    afterEach(() => cleanup());
 
     it('should copy part even if legacy metadata without dataStoreName',
     done => {
@@ -101,5 +108,66 @@ describe('objectCopyPart', () => {
                 assert.ifError(err, `Unexpected err: ${err}`);
                 done();
             });
+    });
+
+    describe('getObjectMD error condition', () => {
+        function errorFunc(method, objName) {
+            if (method !== metastore.getObject.name) {
+                return null;
+            }
+            if (objName !== `${uploadId}${constants.splitter}00001`) {
+                return null;
+            }
+            return errors.InternalError;
+        }
+
+        beforeEach(done => {
+            assert.deepStrictEqual(ds[1].value, objData);
+            const req = _createObjectCopyPartRequest(destBucketName, uploadId);
+            metastore.setErrorFunc(errorFunc);
+            objectPutCopyPart(
+                authInfo, req, sourceBucketName, objectKey, null, log, err => {
+                    assert.deepStrictEqual(err, errors.InternalError);
+                    done();
+                });
+        });
+
+        afterEach(() => metastore.clearErrorFunc());
+
+        it('should delete the destination data', () => {
+            assert.strictEqual(ds.length, 3);
+            assert.strictEqual(ds[0], undefined);
+            assert.deepStrictEqual(ds[1].value, objData); // The source data.
+            assert.strictEqual(ds[2], undefined); // The destination data.
+        });
+    });
+
+    describe('putObjectMD error condition', () => {
+        function errorFunc(method) {
+            if (method === metastore.putObject.name) {
+                return errors.InternalError;
+            }
+            return null;
+        }
+
+        beforeEach(done => {
+            assert.deepStrictEqual(ds[1].value, objData);
+            const req = _createObjectCopyPartRequest(destBucketName, uploadId);
+            metastore.setErrorFunc(errorFunc);
+            objectPutCopyPart(
+                authInfo, req, sourceBucketName, objectKey, null, log, err => {
+                    assert.deepStrictEqual(err, errors.InternalError);
+                    done();
+                });
+        });
+
+        afterEach(() => metastore.clearErrorFunc());
+
+        it('should delete the destination data', () => {
+            assert.strictEqual(ds.length, 3);
+            assert.strictEqual(ds[0], undefined);
+            assert.deepStrictEqual(ds[1].value, objData); // The source data.
+            assert.strictEqual(ds[2], undefined); // The destination data.
+        });
     });
 });

--- a/tests/unit/api/objectPut.js
+++ b/tests/unit/api/objectPut.js
@@ -9,6 +9,7 @@ const { parseTagFromQuery } = s3middleware.tagging;
 const { cleanup, DummyRequestLogger, makeAuthInfo, versioningTestUtils }
     = require('../helpers');
 const { ds } = require('../../../lib/data/in_memory/backend');
+const metastore = require('../../../lib/metadata/in_memory/backend');
 const metadata = require('../metadataswitch');
 const objectPut = require('../../../lib/api/objectPut');
 const DummyRequest = require('../DummyRequest');
@@ -245,6 +246,70 @@ describe('objectPut API', () => {
                             done();
                         });
                 });
+        });
+    });
+
+    describe('putObjectMD error condition', () => {
+        function errorFunc(method) {
+            if (method === metastore.putObject.name) {
+                return errors.InternalError;
+            }
+            return null;
+        }
+
+        afterEach(() => metastore.clearErrorFunc());
+
+        describe('non-0-byte object', () => {
+            beforeEach(done => {
+                bucketPut(authInfo, testPutBucketRequest, log, err => {
+                    if (err) {
+                        return done(err);
+                    }
+                    assert.strictEqual(ds.length, 0);
+                    metastore.setErrorFunc(errorFunc);
+                    return objectPut(
+                        authInfo, testPutObjectRequest, null, log, err => {
+                            assert.deepStrictEqual(err, errors.InternalError);
+                            done();
+                        });
+                });
+            });
+
+            it('should delete the data', () => {
+                assert.strictEqual(ds.length, 2);
+                assert.strictEqual(ds[0], undefined);
+                assert.strictEqual(ds[1], undefined);
+            });
+        });
+
+        describe('0-byte object', () => {
+            const postBody = Buffer.from('', 'utf8');
+            const testPutObjectRequest = new DummyRequest({
+                bucketName,
+                namespace,
+                objectKey: objectName,
+                headers: { host: `${bucketName}.s3.amazonaws.com` },
+                url: '/',
+            }, postBody);
+
+            beforeEach(done => {
+                bucketPut(authInfo, testPutBucketRequest, log, err => {
+                    if (err) {
+                        return done(err);
+                    }
+                    assert.strictEqual(ds.length, 0);
+                    metastore.setErrorFunc(errorFunc);
+                    return objectPut(
+                        authInfo, testPutObjectRequest, null, log, err => {
+                            assert.deepStrictEqual(err, errors.InternalError);
+                            done();
+                        });
+                });
+            });
+
+            it('should not attempt deletion of the data', () => {
+                assert.strictEqual(ds.length, 0);
+            });
         });
     });
 

--- a/tests/unit/api/objectPutPart.js
+++ b/tests/unit/api/objectPutPart.js
@@ -80,21 +80,30 @@ describe('Multipart Upload API', () => {
         const authInfo = helpers.makeAuthInfo();
         const log = new helpers.DummyRequestLogger();
 
+        function errorFunc(method) {
+            if (method === metastore.putObject.name) {
+                return errors.InternalError;
+            }
+            return null;
+        }
+
         beforeEach(done => {
             async.waterfall([
                 next => createBucket(authInfo, log, next),
                 (_, next) => initiateMPU(authInfo, log, next),
                 (res, _, next) => parseUploadID(res, next),
                 (uploadId, next) => {
-                    metastore.errors.putObject = errors.InternalError;
+                    assert.strictEqual(ds.length, 0);
+                    metastore.setErrorFunc(errorFunc);
                     putMPUPart(uploadId, authInfo, log, err => {
-                        delete metastore.errors.putObject;
                         assert(err === errors.InternalError);
                         return next();
                     });
                 },
             ], done);
         });
+
+        afterEach(() => metastore.clearErrorFunc());
 
         it('should cleanup orphaned data', () => {
             assert.strictEqual(ds.length, 2);


### PR DESCRIPTION
Forward port of https://github.com/scality/cloudserver/pull/2074 to stabilization branch.

Cleanup orphaned data in error cases for
the following APIs:

* objectPut
* objectCopy
* objectCopyPart