### PR TITLE
bf: S3C 2412 fix bucket pol principal eval

### DIFF
--- a/lib/api/apiUtils/authorization/permissionChecks.js
+++ b/lib/api/apiUtils/authorization/permissionChecks.js
@@ -165,22 +165,46 @@ function _checkActions(requestType, actions, log) {
     return evaluators.isActionApplicable(mappedAction, actions, log);
 }
 
-function _checkPrincipal(canonicalID, arn, principal) {
+function _getAccountId(arn) {
+    // account or user arn is of format 'arn:aws:iam::<12-digit-acct-id>:etc...
+    return arn.substr(13, 12);
+}
+
+function _isAccountId(principal) {
+    return (principal.length === 12 && /^\d+$/.test(principal));
+}
+
+function _checkPrincipal(requester, principal) {
     if (principal === '*') {
         return true;
     }
-    if (principal.CanonicalUser && principal.CanonicalUser === canonicalID) {
+    if (principal === requester) {
         return true;
     }
-    if (Array.isArray(principal.CanonicalUser)
-    && principal.CanonicalUser.includes(canonicalID)) {
+    if (_isAccountId(principal)) {
+        return _getAccountId(requester) === principal;
+    }
+    if (principal.endsWith('root')) {
+        return _getAccountId(requester) === _getAccountId(principal);
+    }
+    return false;
+}
+
+function _checkPrincipals(canonicalID, arn, principal) {
+    if (principal === '*') {
         return true;
     }
-    if (principal.AWS && (principal.AWS === '*' || principal.AWS === arn)) {
-        return true;
+    if (principal.CanonicalUser) {
+        if (Array.isArray(principal.CanonicalUser)) {
+            return principal.CanonicalUser.some(p => _checkPrincipal(canonicalID, p));
+        }
+        return _checkPrincipal(canonicalID, principal.CanonicalUser);
     }
-    if (Array.isArray(principal.AWS) && principal.AWS.includes(arn)) {
-        return true;
+    if (principal.AWS) {
+        if (Array.isArray(principal.AWS)) {
+            return principal.AWS.some(p => _checkPrincipal(arn, p));
+        }
+        return _checkPrincipal(arn, principal.AWS);
     }
     return false;
 }
@@ -190,7 +214,7 @@ function checkBucketPolicy(policy, requestType, canonicalID, arn, log) {
     let copiedStatement = JSON.parse(JSON.stringify(policy.Statement));
     while (copiedStatement.length > 0) {
         const s = copiedStatement[0];
-        const principalMatch = _checkPrincipal(canonicalID, arn, s.Principal);
+        const principalMatch = _checkPrincipals(canonicalID, arn, s.Principal);
         const actionMatch = _checkActions(requestType, s.Action, log);
 
         if (principalMatch && actionMatch && s.Effect === 'Deny') {


### PR DESCRIPTION
In bucket policies, if the `Principal` key is set to an account arn or account id, any account or user arns with matching ids should be allowed.
Added a bunch of tests cases with all the combinations