### PR TITLE
Revert "bugfix: S3C-2052 Delete orphaned data in APIs"

### DIFF
--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -7,7 +7,6 @@ const data = require('../../../data/wrapper');
 const services = require('../../../services');
 const logger = require('../../../utilities/logger');
 const { dataStore } = require('./storeObject');
-const { dataDelete } = require('./deleteObject');
 const locationConstraintCheck = require('./locationConstraintCheck');
 const { versioningPreprocessing } = require('./versioning');
 const removeAWSChunked = require('./removeAWSChunked');
@@ -52,12 +51,7 @@ function _storeInMDandDeleteData(bucketName, dataGetInfo, cipherBundle,
     services.metadataStoreObject(bucketName, dataGetInfo,
         cipherBundle, metadataStoreParams, (err, result) => {
             if (err) {
-                // Make a best effort single attempt to cleanup any orphaned
-                // data while returning the original error from the metadata
-                // layer.
-                return dataDelete(dataGetInfo, requestMethod, deleteLog, () => {
-                    callback(err);
-                });
+                return callback(err);
             }
             if (dataToDelete) {
                 const newDataStoreName = Array.isArray(dataGetInfo) ?

--- a/lib/api/apiUtils/object/deleteObject.js
+++ b/lib/api/apiUtils/object/deleteObject.js
@@ -1,25 +1,9 @@
 const data = require('../../../data/wrapper');
 
-function dataDelete(locations, method, log, cb) {
-    if (!Array.isArray(locations) || locations.length === 0) {
-        return process.nextTick(() => cb());
-    }
-    if (locations.length === 1) {
-        return data.delete(locations[0], log, err => {
-            if (err) {
-                log.error('error deleting object data', {
-                    error: err,
-                    method: 'dataDelete',
-                });
-                return cb(err);
-            }
-            return cb();
-        });
-    }
-    const dataStoreName = locations[0].dataStoreName;
-    return data.batchDelete(locations, method, dataStoreName, log, err => {
+function dataDelete(objectGetInfo, log, cb) {
+    data.delete(objectGetInfo, log, err => {
         if (err) {
-            log.error('error batch deleting object data', {
+            log.error('error deleting object data', {
                 error: err,
                 method: 'dataDelete',
             });

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -16,7 +16,6 @@ const logger = require('../utilities/logger');
 const services = require('../services');
 const { pushMetric } = require('../utapi/utilities');
 const removeAWSChunked = require('./apiUtils/object/removeAWSChunked');
-const { dataDelete } = require('./apiUtils/object/deleteObject');
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const validateWebsiteHeader = require('./apiUtils/object/websiteServing')
     .validateWebsiteHeader;
@@ -399,13 +398,7 @@ function objectCopy(authInfo, request, sourceBucket,
                     if (err) {
                         log.debug('error processing versioning info',
                         { error: err });
-                        // Make a best effort single attempt to cleanup any
-                        // orphaned data while returning the original error from
-                        // the metadata layer.
-                        return dataDelete(
-                            destDataGetInfoArr, request.method, log, () => {
-                                next(err, null, destBucketMD);
-                            });
+                        return next(err, null, destBucketMD);
                     }
                     // eslint-disable-next-line
                     storeMetadataParams.versionId = options.versionId;
@@ -428,13 +421,7 @@ function objectCopy(authInfo, request, sourceBucket,
                 storeMetadataParams, (err, result) => {
                     if (err) {
                         log.debug('error storing new metadata', { error: err });
-                        // Make a best effort single attempt to cleanup any
-                        // orphaned data while returning the original error from
-                        // the metadata layer.
-                        return dataDelete(
-                            destDataGetInfoArr, request.method, log, () => {
-                                next(err, null, destBucketMD);
-                            });
+                        return next(err, null, destBucketMD);
                     }
                     const sourceObjSize = storeMetadataParams.size;
                     const destObjPrevSize = (destObjMD &&

--- a/lib/api/objectPutCopyPart.js
+++ b/lib/api/objectPutCopyPart.js
@@ -10,7 +10,6 @@ const { pushMetric } = require('../utapi/utilities');
 const logger = require('../utilities/logger');
 const services = require('../services');
 const setUpCopyLocator = require('./apiUtils/object/setUpCopyLocator');
-const { dataDelete } = require('./apiUtils/object/deleteObject');
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 
 const versionIdUtils = versioning.VersionID;
@@ -262,13 +261,7 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
                     if (err && !err.NoSuchKey) {
                         log.debug('error getting current part (if any)',
                         { error: err });
-                        // Make a best effort single attempt to cleanup any
-                        // orphaned data while returning the original error from
-                        // the metadata layer.
-                        return dataDelete(
-                            locations, request.method, log, () => {
-                                next(err);
-                            });
+                        return next(err);
                     }
                     let oldLocations;
                     let prevObjectSize = null;
@@ -302,13 +295,7 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
                     if (err) {
                         log.debug('error storing new metadata',
                         { error: err, method: 'storeNewPartMetadata' });
-                        // Make a best effort single attempt to cleanup any
-                        // orphaned data while returning the original error from
-                        // the metadata layer.
-                        return dataDelete(
-                            locations, request.method, log, () => {
-                                next(err);
-                            });
+                        return next(err);
                     }
                     return next(null, oldLocations, destBucketMD, totalHash,
                         lastModified, sourceVerId, serverSideEncryption,

--- a/lib/api/objectPutPart.js
+++ b/lib/api/objectPutPart.js
@@ -323,13 +323,12 @@ function objectPutPart(authInfo, request, streamingV4Params, log,
                             error: err,
                             method: 'objectPutPart::metadata.putObjectMD',
                         });
-                        // Make a best effort single attempt to cleanup any
+                        // Make a best effort single attempt to cleanup the
                         // orphaned data while returning the original error from
                         // the metadata layer.
-                        return dataDelete(
-                            partLocations, request.method, log, () => {
-                                next(err, destinationBucket);
-                            });
+                        return dataDelete(dataGetInfo, log, () => {
+                            next(err, destinationBucket);
+                        });
                     }
                     return next(null, oldLocations, objectLocationConstraint,
                         destinationBucket, hexDigest, prevObjectSize);

--- a/lib/metadata/in_memory/backend.js
+++ b/lib/metadata/in_memory/backend.js
@@ -23,18 +23,7 @@ function inc(str) {
 }
 
 const metastore = {
-    // Used for simulation of metadata errors.
-    error: () => {},
-
-    setErrorFunc(func) {
-        this.error = func;
-        return this;
-    },
-
-    clearErrorFunc() {
-        this.error = () => {};
-        return this;
-    },
+    errors: {}, // Used for simulation of metadata errors.
 
     createBucket: (bucketName, bucketMD, log, cb) => {
         process.nextTick(() => {
@@ -91,9 +80,8 @@ const metastore = {
     },
 
     putObject: (bucketName, objName, objVal, params, log, cb) => {
-        const err = metastore.error(metastore.putObject.name);
-        if (err) {
-            return process.nextTick(() => cb(err));
+        if (metastore.errors.putObject) {
+            return process.nextTick(() => cb(metastore.errors.putObject));
         }
         return process.nextTick(() => {
             metastore.getBucketAttributes(bucketName, log, err => {
@@ -167,11 +155,7 @@ const metastore = {
     },
 
     getObject: (bucketName, objName, params, log, cb) => {
-        const err = metastore.error(metastore.getObject.name, objName);
-        if (err) {
-            return process.nextTick(() => cb(err));
-        }
-        return process.nextTick(() => {
+        process.nextTick(() => {
             metastore.getBucketAttributes(bucketName, log, err => {
                 if (err) {
                     return cb(err);

--- a/tests/unit/api/apiUtils/deleteObject.js
+++ b/tests/unit/api/apiUtils/deleteObject.js
@@ -5,94 +5,38 @@ const helpers = require('../../helpers');
 const { ds, backend } = require('../../../../lib/data/in_memory/backend');
 const { dataDelete } =
     require('../../../../lib/api/apiUtils/object/deleteObject');
+const log = new Logger('_').newRequestLogger();
 
 describe('dataDelete utility', () => {
-    let log;
     const key = 1;
-    const key2 = 2;
     const value = Buffer.from('_');
 
-    beforeEach(() => {
-        helpers.cleanup();
-        // Batch delete calls log.end();
-        log = new Logger('_').newRequestLogger();
-    });
-
-    it('should check that the locations are an array', done => {
-        const locations = {};
-        dataDelete(locations, 'PUT', log, done);
-    });
-
-    it('should check that the locations are an array > 0 in length', done => {
-        const locations = [];
-        dataDelete(locations, 'PUT', log, done);
-    });
+    beforeEach(() => helpers.cleanup());
 
     describe('success case', () => {
-        describe('with a single location', () => {
-            beforeEach(done => {
-                ds[key] = { value };
-                const locations = [{ key }];
-                dataDelete(locations, 'PUT', log, done);
-            });
-
-            it('should delete the key', () => {
-                assert.strictEqual(ds[key], undefined);
-            });
+        beforeEach(done => {
+            ds[key] = { value };
+            dataDelete({ key }, log, done);
         });
 
-        describe('with multiple locations', () => {
-            beforeEach(done => {
-                ds[key] = { value };
-                ds[key2] = { value };
-                const locations = [{ key }, { key: key2 }];
-                dataDelete(locations, 'PUT', log, done);
-            });
-
-            it('should delete each key', () => {
-                assert.strictEqual(ds[key], undefined);
-                assert.strictEqual(ds[key2], undefined);
-            });
+        it('should delete the key', () => {
+            assert.strictEqual(ds[key], undefined);
         });
     });
 
     describe('error case', () => {
-        describe('with a single location', () => {
-            beforeEach(done => {
-                ds[key] = { value };
-                const locations = [{ key }];
-                backend.errors.delete = errors.InternalError;
-                dataDelete(locations, 'PUT', log, err => {
-                    assert.deepStrictEqual(err, errors.InternalError);
-                    done();
-                });
-            });
-
-            afterEach(() => delete backend.errors.delete);
-
-            it('should not delete the key', () => {
-                assert.deepStrictEqual(ds[key], { value });
+        beforeEach(done => {
+            ds[key] = { value };
+            backend.errors.delete = errors.InternalError;
+            dataDelete({ key }, log, err => {
+                delete backend.errors.delete;
+                assert.deepStrictEqual(err, errors.InternalError);
+                done();
             });
         });
 
-        describe('with multiple locations', () => {
-            beforeEach(done => {
-                ds[key] = { value };
-                ds[key2] = { value };
-                const locations = [{ key }, { key: key2 }];
-                backend.errors.delete = errors.InternalError;
-                dataDelete(locations, 'PUT', log, err => {
-                    assert.deepStrictEqual(err, errors.InternalError);
-                    done();
-                });
-            });
-
-            afterEach(() => delete backend.errors.delete);
-
-            it('should delete each key', () => {
-                assert.deepStrictEqual(ds[key], { value });
-                assert.deepStrictEqual(ds[key2], { value });
-            });
+        it('should not delete the key', () => {
+            assert.deepStrictEqual(ds[key], { value });
         });
     });
 });

--- a/tests/unit/api/objectCopy.js
+++ b/tests/unit/api/objectCopy.js
@@ -1,24 +1,14 @@
 const assert = require('assert');
 const async = require('async');
 
-const { errors } = require('arsenal');
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const bucketPutVersioning = require('../../../lib/api/bucketPutVersioning');
 const objectPut = require('../../../lib/api/objectPut');
 const objectCopy = require('../../../lib/api/objectCopy');
 const { ds } = require('../../../lib/data/in_memory/backend');
-const metastore = require('../../../lib/metadata/in_memory/backend');
 const DummyRequest = require('../DummyRequest');
 const { cleanup, DummyRequestLogger, makeAuthInfo, versioningTestUtils }
     = require('../helpers');
-
-const initiateMultipartUpload
-    = require('../../../lib/api/initiateMultipartUpload');
-const completeMultipartUpload
-    = require('../../../lib/api/completeMultipartUpload');
-const { parseString } = require('xml2js');
-const crypto = require('crypto');
-const objectPutPart = require('../../../lib/api/objectPutPart');
 
 const log = new DummyRequestLogger();
 const canonicalID = 'accessKey1';
@@ -59,13 +49,14 @@ describe('objectCopy with versioning', () => {
     const objData = ['foo0', 'foo1', 'foo2'].map(str =>
         Buffer.from(str, 'utf8'));
 
-    beforeEach(done => {
+    const testPutObjectRequests = objData.slice(0, 2).map(data =>
+        versioningTestUtils.createPutObjectRequest(destBucketName, objectKey,
+            data));
+    testPutObjectRequests.push(versioningTestUtils
+        .createPutObjectRequest(sourceBucketName, objectKey, objData[2]));
+
+    before(done => {
         cleanup();
-        const testPutObjectRequests = objData.slice(0, 2).map(data =>
-            versioningTestUtils.createPutObjectRequest(
-                destBucketName, objectKey, data));
-        testPutObjectRequests.push(versioningTestUtils
-            .createPutObjectRequest(sourceBucketName, objectKey, objData[2]));
         async.series([
             callback => bucketPut(authInfo, putDestBucketRequest, log,
                 callback),
@@ -110,262 +101,5 @@ describe('objectCopy with versioning', () => {
                     done();
                 });
             });
-    });
-
-    describe('getObjectMD error condition', () => {
-        function errorFunc(method) {
-            if (method === metastore.getObject.name) {
-                return errors.InternalError;
-            }
-            return null;
-        }
-
-        describe('non-0-byte object', () => {
-            beforeEach(done => {
-                assert.deepStrictEqual(ds[1].value, objData[0]);
-                assert.deepStrictEqual(ds[2].value, objData[1]);
-                assert.deepStrictEqual(ds[3].value, objData[2]);
-                metastore.setErrorFunc(errorFunc);
-                const req = _createObjectCopyRequest(destBucketName);
-                objectCopy(
-                    authInfo, req, sourceBucketName, objectKey, null, log,
-                    err => {
-                        assert.deepStrictEqual(err, errors.InternalError);
-                        done();
-                    });
-            });
-
-            afterEach(() => metastore.clearErrorFunc());
-
-            it('should delete the destination data', () => {
-                assert.strictEqual(ds.length, 5);
-                assert.strictEqual(ds[0], undefined);
-                // The source data for null version.
-                assert.deepStrictEqual(ds[1].value, objData[0]);
-                 // The destination data for null version.
-                assert.deepStrictEqual(ds[2].value, objData[1]);
-                // The source data for version 1.
-                assert.deepStrictEqual(ds[3].value, objData[2]);
-                // The destination data for version 1.
-                assert.strictEqual(ds[4], undefined);
-            });
-        });
-
-        describe('0-byte object', () => {
-            function errorFunc(method) {
-                if (method === metastore.getObject.name) {
-                    return errors.InternalError;
-                }
-                return null;
-            }
-
-            beforeEach(done => {
-                cleanup();
-
-                const data = Buffer.from('', 'utf8');
-                const srcRequest = versioningTestUtils.createPutObjectRequest(
-                    sourceBucketName, objectKey, data);
-                const destRequest = versioningTestUtils.createPutObjectRequest(
-                    destBucketName, objectKey, data);
-
-                async.series([
-                    next => bucketPut(
-                        authInfo, putSourceBucketRequest, log, next),
-                    next => bucketPut(
-                        authInfo, putDestBucketRequest, log, next),
-                    next => objectPut(
-                        authInfo, destRequest, null, log, next),
-                    next => bucketPutVersioning(
-                        authInfo, enableVersioningRequest, log, next),
-                    next => objectPut(
-                        authInfo, destRequest, null, log, next),
-                    next => bucketPutVersioning(
-                        authInfo, suspendVersioningRequest, log, next),
-                    next => objectPut(
-                        authInfo, srcRequest, null, log, next),
-                ], err => {
-                    if (err) {
-                        return done(err);
-                    }
-                    assert.strictEqual(ds.length, 0);
-                    metastore.setErrorFunc(errorFunc);
-                    const req = _createObjectCopyRequest(destBucketName);
-                    return objectCopy(authInfo, req, sourceBucketName,
-                        objectKey, null, log, err => {
-                            assert.deepStrictEqual(err, errors.InternalError);
-                            done();
-                        });
-                });
-            });
-
-            afterEach(() => metastore.clearErrorFunc());
-
-            it('should not attempt deletion of the data', () => {
-                assert.strictEqual(ds.length, 0);
-            });
-        });
-    });
-
-    describe('putObjectMD error condition', () => {
-        function errorFunc(method) {
-            if (method === metastore.putObject.name) {
-                return errors.InternalError;
-            }
-            return null;
-        }
-
-        beforeEach(done => {
-            assert.deepStrictEqual(ds[1].value, objData[0]);
-            assert.deepStrictEqual(ds[2].value, objData[1]);
-            assert.deepStrictEqual(ds[3].value, objData[2]);
-            metastore.setErrorFunc(errorFunc);
-            const req = _createObjectCopyRequest(destBucketName);
-            objectCopy(
-                authInfo, req, sourceBucketName, objectKey, null, log, err => {
-                    assert.deepStrictEqual(err, errors.InternalError);
-                    done();
-                });
-        });
-
-        afterEach(() => metastore.clearErrorFunc());
-
-        it('should delete the destination data', () => {
-            assert.strictEqual(ds.length, 5);
-            assert.strictEqual(ds[0], undefined);
-            // The source data for null version.
-            assert.deepStrictEqual(ds[1].value, objData[0]);
-             // The destination data for null version.
-            assert.deepStrictEqual(ds[2].value, objData[1]);
-            // The source data for version 1.
-            assert.deepStrictEqual(ds[3].value, objData[2]);
-            // The destination data for version 1.
-            assert.strictEqual(ds[4], undefined);
-        });
-    });
-});
-
-describe('copy object from MPU', () => {
-    const initiateMPURequest = {
-        bucketName: sourceBucketName,
-        namespace,
-        objectKey,
-        headers: { host: 'localhost' },
-        url: `/${objectKey}?uploads`,
-    };
-
-    function _createPutPartRequest(uploadId, partNumber, partBody) {
-        return new DummyRequest({
-            bucketName: sourceBucketName,
-            namespace,
-            objectKey,
-            headers: { host: 'localhost' },
-            url: `/${objectKey}?partNumber=${partNumber}&uploadId=${uploadId}`,
-            query: {
-                partNumber,
-                uploadId,
-            },
-            calculatedHash: crypto
-                .createHash('md5')
-                .update(partBody)
-                .digest('hex'),
-        }, partBody);
-    }
-
-    function _completeMPURequest(uploadId, parts) {
-        const body = [];
-        body.push('<CompleteMultipartUpload>');
-        parts.forEach(part => {
-            body.push(
-                '<Part>' +
-                    `<PartNumber>${part.partNumber}</PartNumber>` +
-                    `<ETag>"${part.eTag}"</ETag>` +
-                '</Part>'
-            );
-        });
-        body.push('</CompleteMultipartUpload>');
-        return {
-            bucketName: sourceBucketName,
-            namespace,
-            objectKey,
-            parsedHost: 'localhost',
-            url: `/${objectKey}?uploadId=${uploadId}`,
-            headers: { host: 'localhost' },
-            query: { uploadId },
-            post: body,
-        };
-    }
-
-    const partOneData = Buffer.alloc((1024 * 1024) * 5, 1);
-    const partTwoData = Buffer.alloc((1024 * 1024) * 5, 2);
-
-    beforeEach(done => {
-        cleanup();
-        const parts = [];
-        let uploadID;
-
-        async.waterfall([
-            next => bucketPut(authInfo, putSourceBucketRequest, log,
-                err => next(err)),
-            next => bucketPut(authInfo, putDestBucketRequest, log,
-                err => next(err)),
-            next => initiateMultipartUpload(
-                authInfo, initiateMPURequest, log, next),
-            (result, _, next) =>
-                parseString(result, next),
-            (json, next) => {
-                uploadID = json.InitiateMultipartUploadResult.UploadId[0];
-                const req = _createPutPartRequest(uploadID, 1, partOneData);
-                objectPutPart(authInfo, req, null, log, (err, eTag) => {
-                    if (err) {
-                        return next(err);
-                    }
-                    parts.push({ partNumber: 1, eTag });
-                    return next();
-                });
-            },
-            next => {
-                const req = _createPutPartRequest(uploadID, 2, partTwoData);
-                objectPutPart(authInfo, req, null, log, (err, eTag) => {
-                    if (err) {
-                        return next(err);
-                    }
-                    parts.push({ partNumber: 2, eTag });
-                    return next();
-                });
-            },
-            next => {
-                const req = _completeMPURequest(uploadID, parts);
-                completeMultipartUpload(authInfo, req, log, next);
-            },
-        ], err => {
-            if (err) {
-                return done(err);
-            }
-            assert.deepStrictEqual(ds[1].value, partOneData);
-            assert.deepStrictEqual(ds[2].value, partTwoData);
-            const req = _createObjectCopyRequest(destBucketName);
-            function errorFunc(method) {
-                if (method === metastore.putObject.name) {
-                    return errors.InternalError;
-                }
-                return null;
-            }
-            metastore.setErrorFunc(errorFunc);
-            return objectCopy(authInfo, req, sourceBucketName, objectKey, null,
-                log, err => {
-                    assert.deepStrictEqual(err, errors.InternalError);
-                    done();
-                });
-        });
-    });
-
-    afterEach(() => metastore.clearErrorFunc());
-
-    it('should cleanup data', () => {
-        assert.strictEqual(ds.length, 5);
-        assert.deepStrictEqual(ds[1].value, partOneData);
-        assert.deepStrictEqual(ds[2].value, partTwoData);
-        assert.strictEqual(ds[3], undefined);
-        assert.strictEqual(ds[4], undefined);
     });
 });


### PR DESCRIPTION
This reverts commit 6ca0c6fbcc863301c6a25efbc5fd6cce9f0acd95.

In the course of testing a metadata orphan persisted when the data had been cleaned up after an error was returned by metadata (the operation later succeeded despite returning an error). We are reverting this change in anticipation of the 8.0 release as a data orphan would be preferable to a metadata orphan.