### PR TITLE
bugfix: S3C-2169 filter invalid user metadata headers

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -123,6 +123,9 @@ const constants = {
         '(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$'),
     // user metadata applied on zenko objects
     zenkoIDHeader: 'x-amz-meta-zenko-instance-id',
+    // response header to be sent when there are invalid
+    // user metadata in the object's metadata
+    invalidObjectUserMetadataHeader: 'x-amz-missing-meta',
 };
 
 module.exports = constants;

--- a/lib/api/apiUtils/object/checkUserMetadataSize.js
+++ b/lib/api/apiUtils/object/checkUserMetadataSize.js
@@ -1,0 +1,38 @@
+const { maximumMetaHeadersSize,
+    invalidObjectUserMetadataHeader } = require('../../../../constants');
+
+/**
+ * Checks the size of the user metadata in the object metadata and removes
+ * them from the response if the size of the user metadata is larger than
+ * the maximum size allowed. A custome metadata key is added to the response
+ * with the number of user metadata keys not returned as its value
+ * @param {object} responseMetadata - response metadata
+ * @return {object} responseMetaHeaders headers with object metadata to include
+ * in response to client
+ */
+function checkUserMetadataSize(responseMetadata) {
+    let md = {};
+    let userMetadataSize = 0;
+    md = JSON.parse(JSON.stringify(responseMetadata));
+    // collect the user metadata keys from the object metadata
+    const userMetadataHeaders = Object.keys(md)
+        .filter(key => key.startsWith('x-amz-meta-'));
+    // compute the size of all user metadata key and its value
+    userMetadataHeaders.forEach(header => {
+        userMetadataSize += header.length + md[header].length;
+    });
+    // check the size computed against the maximum allowed
+    // if the computed size is greater, then remove all the
+    // user metadata from the response object
+    if (userMetadataSize > maximumMetaHeadersSize) {
+        userMetadataHeaders.forEach(header => {
+            delete md[header];
+        });
+        // add the prescribed/custom metadata with number of user metadata
+        // as its value
+        md[invalidObjectUserMetadataHeader] = userMetadataHeaders.length;
+    }
+    return md;
+}
+
+module.exports = checkUserMetadataSize;

--- a/lib/utilities/collectResponseHeaders.js
+++ b/lib/utilities/collectResponseHeaders.js
@@ -1,4 +1,6 @@
 const { getVersionIdResHeader } = require('../api/apiUtils/object/versioning');
+const checkUserMetadataSize
+    = require('../api/apiUtils/object/checkUserMetadataSize');
 
 /**
  * Pulls data from saved object metadata to send in response
@@ -12,11 +14,13 @@ const { getVersionIdResHeader } = require('../api/apiUtils/object/versioning');
  * in response to client
  */
 function collectResponseHeaders(objectMD, corsHeaders, versioningCfg,
-  returnTagCount) {
+    returnTagCount) {
     // Add user meta headers from objectMD
-    const responseMetaHeaders = Object.assign({}, corsHeaders);
+    let responseMetaHeaders = Object.assign({}, corsHeaders);
     Object.keys(objectMD).filter(val => (val.startsWith('x-amz-meta-')))
         .forEach(id => { responseMetaHeaders[id] = objectMD[id]; });
+    // Check user metadata size
+    responseMetaHeaders = checkUserMetadataSize(responseMetaHeaders);
 
     // TODO: When implement lifecycle, add additional response headers
     // http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectHEAD.html

--- a/tests/unit/metadata/usermetadatasize/usermetadatasize.js
+++ b/tests/unit/metadata/usermetadatasize/usermetadatasize.js
@@ -1,0 +1,42 @@
+const assert = require('assert');
+const { invalidObjectUserMetadataHeader } = require('../../../../constants');
+const genMaxSizeMetaHeaders = require(
+    '../../../functional/aws-node-sdk/lib/utility/genMaxSizeMetaHeaders');
+const checkUserMetadataSize
+    = require('../../../../lib/api/apiUtils/object/checkUserMetadataSize');
+
+const userMetadataKey = 'x-amz-meta-';
+const metadata = {};
+
+let userMetadataKeys = 0;
+
+describe('Check user metadata size', () => {
+    before('Set up metadata', () => {
+        const md = genMaxSizeMetaHeaders();
+        Object.keys(md).forEach(key => {
+            metadata[`${userMetadataKey}${key}`] = md[key];
+        });
+        userMetadataKeys = Object.keys(metadata)
+            .filter(key => key.startsWith(userMetadataKey)).length;
+    });
+
+    it('Should return user metadata when the size is within limits', () => {
+        const responseMetadata = checkUserMetadataSize(metadata);
+        assert.notEqual(responseMetadata, undefined);
+        assert.strictEqual(userMetadataKeys > 0, true);
+    });
+
+    it('Should not return user metadata when the size exceeds limit', () => {
+        const firstMetadatKey = `${userMetadataKey}header0`;
+        // add one more byte to be over the limit
+        metadata[firstMetadatKey] = `${metadata[firstMetadatKey]}${'0'}`;
+        const responseMetadata = checkUserMetadataSize(metadata);
+        const invalidHeader
+            = responseMetadata[invalidObjectUserMetadataHeader];
+        const responseMetdataKeys = Object.keys(responseMetadata)
+            .filter(key => key.startsWith(userMetadataKey));
+        assert.notEqual(responseMetadata, undefined);
+        assert.strictEqual(responseMetdataKeys > 0, false);
+        assert.strictEqual(invalidHeader, userMetadataKeys);
+    });
+});


### PR DESCRIPTION
#### Why is this change required? What problem does it solve?
Objects with huge user metadata (more than 2KB) causes service interruption when HEADed. Restrictions(2KB max size) were placed to disallow creation of huge user metadata in version 7.4 of cloudserver. So objects created with older versions of cloudserver may have huge user metdata. New checks are added now when an object is HEADed, user metadata is not returned if the combined size of user metadata (including keys and values) is more than 2KB. A new header 'x-amz-missing-meta' is sent in this case with the number of user metadata keys as the header value.

New unit tests are added for this check.