### PR TITLE
bf: S3C 2424 bucket policy api perms

### DIFF
--- a/lib/api/apiUtils/authorization/permissionChecks.js
+++ b/lib/api/apiUtils/authorization/permissionChecks.js
@@ -3,7 +3,6 @@ const constants = require('../../../../constants');
 
 const actionMap = {
     's3:AbortMultipartUpload': 'multipartDelete',
-    's3:CreateBucket': 'bucketPut',
     's3:DeleteBucket': 'bucketDelete',
     's3:DeleteBucketPolicy': 'bucketDeletePolicy',
     's3:DeleteBucketWebsite': 'bucketDeleteWebsite',
@@ -20,8 +19,7 @@ const actionMap = {
     's3:GetObjectAcl': 'objectGetACL',
     's3:GetObjectTagging': 'objectGetTagging',
     's3:GetReplicationConfiguration': 'bucketGetReplication',
-    's3:HeadBucket': 'bucketHead',
-    's3:ListBucket': 'bucketGet',
+    's3:ListBucket': 'bucketHead',
     's3:ListBucketMultipartUploads': 'listMultipartUploads',
     's3:ListMultipartUploadParts': 'listParts',
     's3:PutBucketAcl': 'bucketPutACL',
@@ -34,7 +32,6 @@ const actionMap = {
     's3:PutObjectAcl': 'objectPutACL',
     's3:PutObjectTagging': 'objectPutTagging',
     's3:PutReplicationConfiguration': 'bucketPutReplication',
-    's3:ReplicateObject': 'objectCopy',
 };
 
 // whitelist buckets to allow public read on objects

--- a/lib/metadata/metadataUtils.js
+++ b/lib/metadata/metadataUtils.js
@@ -183,6 +183,12 @@ function metadataValidateBucketAndObj(params, log, callback) {
                 objectKey, versionId, log, next);
         },
         function checkBucketAuth(bucket, objMD, next) {
+            // if requester is not bucket owner, bucket policy actions should be denied with
+            // MethodNotAllowed error
+            const onlyOwnerAllowed = ['bucketDeletePolicy', 'bucketGetPolicy', 'bucketPutPolicy'];
+            if (bucket.getOwner() !== canonicalID && onlyOwnerAllowed.includes(requestType)) {
+                return next(errors.MethodNotAllowed, bucket);
+            }
             if (!isBucketAuthorized(bucket, requestType, canonicalID,
             requestArn, log)) {
                 log.debug('access denied for user on bucket', { requestType });
@@ -260,6 +266,12 @@ function metadataValidateBucket(params, log, callback) {
     return metadataGetBucket(requestType, bucketName, log, (err, bucket) => {
         if (err) {
             return callback(err);
+        }
+        // if requester is not bucket owner, bucket policy actions should be denied with
+        // MethodNotAllowed error
+        const onlyOwnerAllowed = ['bucketDeletePolicy', 'bucketGetPolicy', 'bucketPutPolicy'];
+        if (bucket.getOwner() !== canonicalID && onlyOwnerAllowed.includes(requestType)) {
+            return callback(errors.MethodNotAllowed, bucket);
         }
         // still return bucket for cors headers
         if (!isBucketAuthorized(bucket, requestType, canonicalID, requestArn,

--- a/tests/unit/api/bucketPolicyAuth.js
+++ b/tests/unit/api/bucketPolicyAuth.js
@@ -17,7 +17,7 @@ const otherUserArn = 'arn:aws:iam::123456789012:user/other';
 const otherAccountUserArn = 'arn:aws:iam:987654321098:user/other';
 const accountArn = 'arn:aws:iam::123456789012:root';
 const accountId = '123456789012';
-const bucAction = 'bucketPut';
+const bucAction = 'bucketHead';
 const objAction = 'objectPut';
 const basePolicyObj = {
     Version: '2012-10-17',
@@ -133,7 +133,7 @@ const authTests = [
         bucketId: canonicalIdToVet,
         objectId: canonicalIdToVet,
         keyToChange: 'Action',
-        bucketValue: ['s3:CreateBucket'],
+        bucketValue: ['s3:ListBucket'],
         objectValue: ['s3:PutObject'],
         expected: true,
     },


### PR DESCRIPTION
A couple of changes to make functionality match AWS:
1. Remove a few actions that are listed in AWS documentation, but aren't actually allowed to be set in a bucket policy after manual testing
2. For the Put, Get, and DeleteBucketPolicy APIs, if the requester is not associated with the bucket account owner, the request should fail with a MethodNotAllowed error, even if permission is explicitly set in the bucket policy. Errors will be tested in end to end tests

The tests only changed to reflect the removal of a couple of actions