### PR TITLE
bugfix: ZENKO-2101 Update UTAPI dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prom-client": "^10.2.3",
     "request": "^2.81.0",
     "sql-where-parser": "~2.2.1",
-    "utapi": "scality/utapi#72aedba",
+    "utapi": "scality/utapi#5ccb8d0",
     "utf-8-validate": "^4.0.2",
     "utf8": "~2.1.1",
     "uuid": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3836,9 +3836,9 @@ url@0.10.3:
     punycode "1.3.2"
     querystring "0.2.0"
 
-utapi@scality/utapi#72aedba:
-  version "7.4.5"
-  resolved "https://codeload.github.com/scality/utapi/tar.gz/72aedba8bab198cf682bcfc7ffca7ac9e2afe6c0"
+utapi@scality/utapi#5ccb8d0:
+  version "8.0.0"
+  resolved "https://codeload.github.com/scality/utapi/tar.gz/5ccb8d03bef59e9048daa592947427cbfb8db802"
   dependencies:
     arsenal scality/Arsenal#32c895b
     async "^2.0.1"


### PR DESCRIPTION
Retarget the UTAPI dependency to the head of branch development/8.1.