### PR TITLE
bugfix: S3C-2169 filter invalid user metadata headers

### DIFF
--- a/lib/api/apiUtils/object/checkUserMetadataSize.js
+++ b/lib/api/apiUtils/object/checkUserMetadataSize.js
@@ -11,28 +11,28 @@ const { maximumMetaHeadersSize,
  * in response to client
  */
 function checkUserMetadataSize(responseMetadata) {
-    let md = {};
     let userMetadataSize = 0;
-    md = JSON.parse(JSON.stringify(responseMetadata));
     // collect the user metadata keys from the object metadata
-    const userMetadataHeaders = Object.keys(md)
+    const userMetadataHeaders = Object.keys(responseMetadata)
         .filter(key => key.startsWith('x-amz-meta-'));
     // compute the size of all user metadata key and its value
     userMetadataHeaders.forEach(header => {
-        userMetadataSize += header.length + md[header].length;
+        userMetadataSize += header.length + responseMetadata[header].length;
     });
     // check the size computed against the maximum allowed
     // if the computed size is greater, then remove all the
     // user metadata from the response object
     if (userMetadataSize > maximumMetaHeadersSize) {
+        const md = Object.assign({}, responseMetadata);
         userMetadataHeaders.forEach(header => {
             delete md[header];
         });
         // add the prescribed/custom metadata with number of user metadata
         // as its value
         md[invalidObjectUserMetadataHeader] = userMetadataHeaders.length;
+        return md;
     }
-    return md;
+    return responseMetadata;
 }
 
 module.exports = checkUserMetadataSize;

--- a/tests/unit/metadata/usermetadatasize/usermetadatasize.js
+++ b/tests/unit/metadata/usermetadatasize/usermetadatasize.js
@@ -22,8 +22,11 @@ describe('Check user metadata size', () => {
 
     it('Should return user metadata when the size is within limits', () => {
         const responseMetadata = checkUserMetadataSize(metadata);
-        assert.notEqual(responseMetadata, undefined);
+        const invalidHeader
+            = responseMetadata[invalidObjectUserMetadataHeader];
         assert.strictEqual(userMetadataKeys > 0, true);
+        assert.strictEqual(invalidHeader, undefined);
+        assert.deepStrictEqual(metadata, responseMetadata);
     });
 
     it('Should not return user metadata when the size exceeds limit', () => {
@@ -33,10 +36,10 @@ describe('Check user metadata size', () => {
         const responseMetadata = checkUserMetadataSize(metadata);
         const invalidHeader
             = responseMetadata[invalidObjectUserMetadataHeader];
-        const responseMetdataKeys = Object.keys(responseMetadata)
+        const responseMetadataKeys = Object.keys(responseMetadata)
             .filter(key => key.startsWith(userMetadataKey));
         assert.notEqual(responseMetadata, undefined);
-        assert.strictEqual(responseMetdataKeys > 0, false);
+        assert.strictEqual(responseMetadataKeys.length > 0, false);
         assert.strictEqual(invalidHeader, userMetadataKeys);
     });
 });


### PR DESCRIPTION
#### Why is this change required? What problem does it solve?
Objects with huge user metadata (more than 2KB) causes service interruption when HEADed. Restrictions(2KB max size) were placed to disallow creation of huge user metadata in version 7.4 of cloudserver. So objects created with older versions of cloudserver may have huge user metdata. New checks are added now when an object is HEADed, user metadata is not returned if the combined size of user metadata (including keys and values) is more than 2KB. A new header 'x-amz-missing-meta' is sent in this case with the number of user metadata keys as the header value.

New unit tests are added for this check.