### PR TITLE
ft: enable AWS and Ceph OOB on reportHandler

### DIFF
--- a/lib/utilities/reportHandler.js
+++ b/lib/utilities/reportHandler.js
@@ -46,6 +46,8 @@ function getCapabilities() {
         secureChannelOptimizedPath: hasWSOptionalDependencies(),
         s3cIngestLocation: true,
         nfsIngestLocation: true,
+        cephIngestLocation: true,
+        awsIngestLocation: true,
     };
 }
 


### PR DESCRIPTION
Adds in supported ingestion locations to the reportHandler (AWS and Ceph).