### PR TITLE
bugfix: S3C-2391 list_objects_v2 no-fetch-owner corrections

### DIFF
--- a/lib/api/bucketGet.js
+++ b/lib/api/bucketGet.js
@@ -192,6 +192,10 @@ function processMasterVersions(bucketName, listParams, list) {
             tag: 'NextContinuationToken',
             value: generateToken(list.NextContinuationToken),
         });
+        xmlParams.push({
+            tag: 'KeyCount',
+            value: list.Contents ? list.Contents.length : 0,
+        });
     } else {
         xmlParams.push({ tag: 'Marker', value: listParams.marker || '' });
         xmlParams.push({ tag: 'NextMarker', value: list.NextMarker });
@@ -200,7 +204,7 @@ function processMasterVersions(bucketName, listParams, list) {
     const escapeXmlFn = listParams.encoding === 'url' ?
         querystring.escape : escapeForXml;
     xmlParams.forEach(p => {
-        if (p.value) {
+        if (p.value || p.tag === 'KeyCount') {
             xml.push(`<${p.tag}>${escapeXmlFn(p.value)}</${p.tag}>`);
         } else if (p.tag !== 'NextMarker' &&
                 p.tag !== 'EncodingType' &&
@@ -312,7 +316,7 @@ function bucketGet(authInfo, request, log, callback) {
         listParams.startAfter = params['start-after'];
         listParams.continuationToken =
             decryptToken(params['continuation-token']);
-        listParams.fetchOwner = params['fetch-owner'];
+        listParams.fetchOwner = params['fetch-owner'] === 'true';
     } else {
         listParams.marker = params.marker;
     }

--- a/tests/functional/aws-node-sdk/schema/bucketV2.json
+++ b/tests/functional/aws-node-sdk/schema/bucketV2.json
@@ -1,101 +1,104 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://jsonschema.net",
-    "type": "object",
-    "properties": {
-      "Contents": {
-        "id": "http://jsonschema.net/Contents",
-        "type": "array",
-        "minItems": 0,
-        "items": {
-          "id": "http://jsonschema.net/Buckets/0",
-          "type": "object",
-          "properties": {
-            "Key": {
-              "id": "http://jsonschema.net/Contents/0/Key",
-              "type": "string"
-            },
-            "LastModified": {
-              "id": "http://jsonschema.net/Contents/0/LastModified",
-              "type": "object"
-            },
-            "ETag": {
-              "id": "http://jsonschema.net/Contents/0/ETag",
-              "type": "string"
-            },
-            "Size": {
-              "id": "http://jsonschema.net/Contents/0/Size",
-              "type": "integer"
-            },
-            "StorageClass": {
-              "id": "http://jsonschema.net/Contents/0/StorageClass",
-              "enum": [ "STANDARD", "REDUCED_REDUNDANCY", "GLACIER" ]
-            },
-            "Owner": {
-              "id": "http://jsonschema.net/Contents/0/Owner",
-              "type": "object",
-              "properties": {
-                "DisplayName": {
-                  "id": "http://jsonschema.net/Contents/0/Owner/DisplayName",
-                  "type": "string"
-                },
-                "ID": {
-                  "id": "http://jsonschema.net/Contents/0/Owner/ID",
-                  "type": "string"
-                }
-              },
-              "required": [ "DisplayName", "ID" ]
-            }
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://jsonschema.net",
+  "type": "object",
+  "properties": {
+    "Contents": {
+      "id": "http://jsonschema.net/Contents",
+      "type": "array",
+      "minItems": 0,
+      "items": {
+        "id": "http://jsonschema.net/Buckets/0",
+        "type": "object",
+        "properties": {
+          "Key": {
+            "id": "http://jsonschema.net/Contents/0/Key",
+            "type": "string"
           },
-          "required": [
-            "Key",
-            "LastModified",
-            "ETag",
-            "Size",
-            "StorageClass"
-          ]
-        }
-      },
-      "StartAfter": {
-        "id": "http://jsonschema.net/StartAfter",
-        "type": "string"
-      },
-      "ContinuationToken": {
-          "id": "http://jsonschema.net/ContinuationToken",
-          "type": "string"
-      },
-      "NextContinuationToken": {
-          "id": "http://jsonschema.net/NextContinuationToken",
-          "type": "string"
-      },
-      "Name": {
-        "id": "http://jsonschema.net/Name",
-        "type": "string"
-      },
-      "Prefix": {
-        "id": "http://jsonschema.net/Prefix",
-        "type": "string"
-      },
-      "MaxKeys": {
-        "id": "http://jsonschema.net/MaxKeys",
-        "type": "integer"
-      },
-      "CommonPrefixes": {
-        "id": "http://jsonschema.net/CommonPrefixes",
-        "type": "array"
-      },
-      "IsTruncated": {
-        "id": "http://jsonschema.net/IsTruncated",
-        "type": "boolean"
+          "LastModified": {
+            "id": "http://jsonschema.net/Contents/0/LastModified",
+            "type": "object"
+          },
+          "ETag": {
+            "id": "http://jsonschema.net/Contents/0/ETag",
+            "type": "string"
+          },
+          "Size": {
+            "id": "http://jsonschema.net/Contents/0/Size",
+            "type": "integer"
+          },
+          "StorageClass": {
+            "id": "http://jsonschema.net/Contents/0/StorageClass",
+            "enum": [ "STANDARD", "REDUCED_REDUNDANCY", "GLACIER" ]
+          },
+          "Owner": {
+            "id": "http://jsonschema.net/Contents/0/Owner",
+            "type": "object",
+            "properties": {
+              "DisplayName": {
+                "id": "http://jsonschema.net/Contents/0/Owner/DisplayName",
+                "type": "string"
+              },
+              "ID": {
+                "id": "http://jsonschema.net/Contents/0/Owner/ID",
+                "type": "string"
+              }
+            },
+            "required": [ "DisplayName", "ID" ]
+          }
+        },
+        "required": [
+          "Key",
+          "LastModified",
+          "ETag",
+          "Size",
+          "StorageClass"
+        ]
       }
     },
-    "required": [
-      "IsTruncated",
-      "Contents",
-      "Name",
-      "Prefix",
-      "MaxKeys",
-      "CommonPrefixes"
-    ]
-  }
-  
+    "StartAfter": {
+      "id": "http://jsonschema.net/StartAfter",
+      "type": "string"
+    },
+    "ContinuationToken": {
+        "id": "http://jsonschema.net/ContinuationToken",
+        "type": "string"
+    },
+    "NextContinuationToken": {
+        "id": "http://jsonschema.net/NextContinuationToken",
+        "type": "string"
+    },
+    "Name": {
+      "id": "http://jsonschema.net/Name",
+      "type": "string"
+    },
+    "Prefix": {
+      "id": "http://jsonschema.net/Prefix",
+      "type": "string"
+    },
+    "KeyCount": {
+      "id": "http://jsonschema.net/KeyCount",
+      "type": "integer"
+    },
+    "MaxKeys": {
+      "id": "http://jsonschema.net/MaxKeys",
+      "type": "integer"
+    },
+    "CommonPrefixes": {
+      "id": "http://jsonschema.net/CommonPrefixes",
+      "type": "array"
+    },
+    "IsTruncated": {
+      "id": "http://jsonschema.net/IsTruncated",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "IsTruncated",
+    "Contents",
+    "Name",
+    "Prefix",
+    "MaxKeys",
+    "CommonPrefixes"
+  ]
+}


### PR DESCRIPTION
#### Why is this change required? What problem does it solve?
`list-objects-v2` with `--no-fetch-owner` option returns owner information in the response. This is now corrected and `--no-fetch-owner` option no longer returns owner information. 

`list-objects-v2` was also missing the attribute `KeyCount` in the response. `KeyCount` will now be available in the response of `list-objects-v2` and the value will be the count of keys returned. 

New unit tests are added for these corrections.