### PR TITLE
bf: S3C 2435 fix object action parse

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "github:scality/Arsenal#12ad2d9",
+    "arsenal": "github:scality/Arsenal#b0e56d6",
     "async": "~2.5.0",
     "aws-sdk": "2.28.0",
     "azure-storage": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -163,9 +163,9 @@ arraybuffer.slice@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz#f33b2159f0532a3f3107a272c0ccfbd1ad2979ca"
 
-"arsenal@github:scality/Arsenal#12ad2d9":
+"arsenal@github:scality/Arsenal#b0e56d6":
   version "7.4.3"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/12ad2d9423c97c8cd7f339887c743d6b4a004c6a"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/b0e56d64cd80e6f234edc8abd285532610027285"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
@@ -217,6 +217,7 @@ arsenal@scality/Arsenal#9f2e74e:
   version "7.4.3"
   resolved "https://codeload.github.com/scality/Arsenal/tar.gz/9f2e74ec6972527c2a9ca6ecb4155618f123fc19"
   dependencies:
+    "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
     ajv "4.10.0"
     async "~2.1.5"
@@ -224,7 +225,6 @@ arsenal@scality/Arsenal#9f2e74e:
     diskusage "^1.1.1"
     ioredis "4.9.5"
     ipaddr.js "1.2.0"
-    joi "^10.6"
     level "~5.0.1"
     level-sublevel "~6.6.5"
     node-forge "^0.7.1"


### PR DESCRIPTION
Updates Arsenal to include the fixes for object action parsing in bucket policies