### PR TITLE
bugfix: S3C-2399 head-object part number size corrections

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -69,6 +69,10 @@ const constants = {
     maximumAllowedPartSize: process.env.MPU_TESTING === 'yes' ? 110100480 :
         5368709120,
 
+    // AWS sets a maximum total parts limit
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPart.html
+    maximumAllowedPartCount: 10000,
+
     // AWS states max size for user-defined metadata (x-amz-meta- headers) is
     // 2 KB: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html
     // In testing, AWS seems to allow up to 88 more bytes, so we do the same.

--- a/lib/api/apiUtils/object/partInfo.js
+++ b/lib/api/apiUtils/object/partInfo.js
@@ -1,0 +1,50 @@
+/**
+ * Checks for partNumber in request query and returns the part number
+ * @param {object} query - request query
+ * @return {(Integer|undefined)} - part number, zero if part number is less than
+ * 1 and undefined if no partNumber is found in the request query
+ */
+function getPartNumber(query) {
+    if (query && query.partNumber !== undefined) {
+        return Number.isNaN(query.partNumber) ?
+            0 : Number.parseInt(query.partNumber, 10);
+    }
+    return undefined;
+}
+
+/**
+ * Gets the size of the requested part of the object
+ * @param {object} objMD - object metadata
+ * @param {object} partNumber - part number
+ * @return {(Integer|undefined)} - size of the part or undefined
+ */
+function getPartSize(objMD, partNumber) {
+    let size;
+    if (partNumber && objMD && objMD.location
+        && objMD.location.length >= partNumber) {
+        const locations = [];
+        for (let i = 0; i < objMD.location.length; i++) {
+            const { dataStoreETag } = objMD.location[i];
+            const locationPartNumber =
+                Number.parseInt(dataStoreETag.split(':')[0], 10);
+            // Get all parts that belong to the requested part number
+            if (partNumber === locationPartNumber) {
+                locations.push(objMD.location[i]);
+            } else if (locationPartNumber > partNumber) {
+                break;
+            }
+        }
+        if (locations.length > 0) {
+            const { start } = locations[0];
+            const endLocation = locations[locations.length - 1];
+            const end = endLocation.start + endLocation.size - 1;
+            size = end - start + 1;
+        }
+    }
+    return size;
+}
+
+module.exports = {
+    getPartNumber,
+    getPartSize,
+};

--- a/lib/api/objectHead.js
+++ b/lib/api/objectHead.js
@@ -6,8 +6,10 @@ const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const collectResponseHeaders = require('../utilities/collectResponseHeaders');
 const { pushMetric } = require('../utapi/utilities');
 const { getVersionIdResHeader } = require('./apiUtils/object/versioning');
+const { getPartNumber, getPartSize } = require('./apiUtils/object/partInfo');
 
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
+const { maximumAllowedPartCount } = require('../../constants');
 
 /**
  * HEAD Object - Same as Get Object but only respond with headers
@@ -74,6 +76,18 @@ function objectHead(authInfo, request, log, callback) {
                 objMD['last-modified'], objMD['content-md5']);
             if (headerValResult.error) {
                 return callback(headerValResult.error, corsHeaders);
+            }
+            const partNumber = getPartNumber(request.query);
+            if (partNumber !== undefined) {
+                if (partNumber < 1 || partNumber > maximumAllowedPartCount) {
+                    return callback(errors.BadRequest, corsHeaders);
+                }
+                const partSize = getPartSize(objMD, partNumber);
+                if (!partSize) {
+                    return callback(errors.InvalidRange, corsHeaders);
+                }
+                // eslint-disable-next-line no-param-reassign
+                objMD['content-length'] = partSize;
             }
             const responseHeaders =
                 collectResponseHeaders(objMD, corsHeaders, verCfg);

--- a/tests/functional/aws-node-sdk/test/object/getPartSize.js
+++ b/tests/functional/aws-node-sdk/test/object/getPartSize.js
@@ -1,0 +1,153 @@
+const assert = require('assert');
+const async = require('async');
+
+const withV4 = require('../support/withV4');
+const BucketUtility = require('../../lib/utility/bucket-util');
+const { maximumAllowedPartCount } = require('../../../../../constants');
+
+const bucket = 'mpu-test-bucket';
+const object = 'mpu-test-object';
+
+const bodySize = 1024 * 1024 * 5;
+const bodyContent = 'a';
+const howManyParts = 3;
+const partNumbers = Array.from(Array(howManyParts).keys());
+const invalidPartNumbers = [-1, 0, maximumAllowedPartCount + 1];
+
+let ETags = [];
+
+function checkError(err, statusCode, code) {
+    assert.strictEqual(err.statusCode, statusCode);
+    assert.strictEqual(err.code, code);
+}
+
+function checkNoError(err) {
+    assert.equal(err, null,
+        `Expected success, got error ${JSON.stringify(err)}`);
+}
+
+function generateContent(partNumber) {
+    return Buffer.alloc(bodySize + partNumber, bodyContent);
+}
+
+describe('Part size tests with object head', () => {
+    withV4(sigCfg => {
+        let bucketUtil;
+        let s3;
+
+        function headObject(fields, cb) {
+            s3.headObject(Object.assign({
+                Bucket: bucket,
+                Key: object,
+            }, fields), cb);
+        }
+
+        beforeEach(function beforeF(done) {
+            bucketUtil = new BucketUtility('default', sigCfg);
+            s3 = bucketUtil.s3;
+
+            async.waterfall([
+                next => s3.createBucket({ Bucket: bucket }, err => next(err)),
+                next => s3.createMultipartUpload({ Bucket: bucket,
+                    Key: object }, (err, data) => {
+                    checkNoError(err);
+                    this.currentTest.UploadId = data.UploadId;
+                    return next();
+                }),
+                next => async.mapSeries(partNumbers, (partNumber, callback) => {
+                    const uploadPartParams = {
+                        Bucket: bucket,
+                        Key: object,
+                        PartNumber: partNumber + 1,
+                        UploadId: this.currentTest.UploadId,
+                        Body: generateContent(partNumber + 1),
+                    };
+
+                    return s3.uploadPart(uploadPartParams,
+                        (err, data) => {
+                            if (err) {
+                                return callback(err);
+                            }
+                            return callback(null, data.ETag);
+                        });
+                }, (err, results) => {
+                    checkNoError(err);
+                    ETags = results;
+                    return next();
+                }),
+                next => {
+                    const params = {
+                        Bucket: bucket,
+                        Key: object,
+                        MultipartUpload: {
+                            Parts: partNumbers.map(partNumber => ({
+                                ETag: ETags[partNumber],
+                                PartNumber: partNumber + 1,
+                            })),
+                        },
+                        UploadId: this.currentTest.UploadId,
+                    };
+                    return s3.completeMultipartUpload(params, next);
+                },
+            ], err => {
+                checkNoError(err);
+                done();
+            });
+        });
+
+        afterEach(done => {
+            async.waterfall([
+                next => s3.deleteObject({ Bucket: bucket, Key: object },
+                  err => next(err)),
+                next => s3.deleteBucket({ Bucket: bucket }, err => next(err)),
+            ], done);
+        });
+
+        it('should return the total size of the object ' +
+            'when --part-number is not used', done => {
+            const totalSize = partNumbers.reduce((total, current) =>
+                total + (bodySize + current + 1), 0);
+            headObject({}, (err, data) => {
+                checkNoError(err);
+                assert.equal(totalSize, data.ContentLength);
+                done();
+            });
+        });
+
+        partNumbers.forEach(part => {
+            it(`should return the size of part ${part + 1} ` +
+                `when --part-number is set to ${part + 1}`, done => {
+                const partNumber = Number.parseInt(part, 0) + 1;
+                const partSize = bodySize + partNumber;
+                headObject({ PartNumber: partNumber }, (err, data) => {
+                    checkNoError(err);
+                    assert.equal(partSize, data.ContentLength);
+                    done();
+                });
+            });
+        });
+
+        invalidPartNumbers.forEach(part => {
+            it(`should return an error when --part-number is set to ${part}`,
+            done => {
+                headObject({ PartNumber: part }, (err, data) => {
+                    checkError(err, 400, 'BadRequest');
+                    assert.strictEqual(data, null);
+                    done();
+                });
+            });
+        });
+
+        it('should return an error when incorrect --part-number is used',
+            done => {
+                headObject({ PartNumber: partNumbers.length + 1 },
+                (err, data) => {
+                    // the error response does not contain the actual
+                    // statusCode instead it has '416'
+                    checkError(err, 416, 416);
+                    assert.strictEqual(data, null);
+                    done();
+                });
+            });
+    });
+});


### PR DESCRIPTION
#### Why is this change required? What problem does it solve?
`head-object` with `--part-number` option returns total object size in the response instead of the specific part size. This is now corrected now and `--part-number` option with value ranging between 1-10000 returns the specific part size.

New unit tests are added for these corrections.