### PR TITLE
improvement: ingestion metrics ZENKOIO-100

### DIFF
--- a/lib/api/objectPut.js
+++ b/lib/api/objectPut.js
@@ -103,6 +103,14 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
                     'putObject');
                 return callback(err, responseHeaders);
             }
+            // ingestSize assumes that these custom headers indicate
+            // an ingestion PUT which is a metadata only operation.
+            // Since these headers can be modified client side, they
+            // should be used with caution if needed for precise
+            // metrics.
+            const ingestSize = (request.headers['x-amz-meta-mdonly']
+                && !Number.isNaN(request.headers['x-amz-meta-size']))
+                ? Number.parseInt(request.headers['x-amz-meta-size'], 10) : null;
             const newByteLength = request.parsedContentLength;
 
             // Utapi expects null or a number for oldByteLength:
@@ -134,7 +142,8 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
                 oldByteLength: isVersionedObj ? null : oldByteLength,
             });
             monitoring.promMetrics('PUT', bucketName, '200',
-                'putObject', newByteLength, oldByteLength, isVersionedObj);
+                'putObject', newByteLength, oldByteLength, isVersionedObj,
+                null, ingestSize);
             return callback(null, responseHeaders);
         });
     });

--- a/lib/utilities/monitoringHandler.js
+++ b/lib/utilities/monitoringHandler.js
@@ -11,6 +11,14 @@ const numberOfObjects = new client.Gauge({
     name: 'cloud_server_number_of_objects',
     help: 'Total number of objects',
 });
+const numberOfIngestedObjects = new client.Gauge({
+    name: 'cloud_server_number_of_ingested_objects',
+    help: 'Number of out of band ingestion',
+});
+const dataIngested = new client.Gauge({
+    name: 'cloud_server_data_ingested',
+    help: 'Cumulative size of data ingested in bytes',
+});
 const dataDiskAvailable = new client.Gauge({
     name: 'cloud_server_data_disk_available',
     help: 'Available data disk storage in bytes',
@@ -45,7 +53,7 @@ const httpResponseSizeBytes = new client.Summary({
 
 function promMetrics(requestType, bucketName, code, typeOfRequest,
     newByteLength, oldByteLength, isVersionedObj,
-    numOfObjectsRemoved) {
+    numOfObjectsRemoved, ingestSize) {
     let bytes;
 
     httpRequestsTotal.labels(requestType, 'cloud_server', code).inc();
@@ -59,6 +67,10 @@ function promMetrics(requestType, bucketName, code, typeOfRequest,
             .observe(bytes);
         dataDiskAvailable.dec(bytes);
         dataDiskFree.dec(bytes);
+        if (ingestSize) {
+            numberOfIngestedObjects.inc();
+            dataIngested.inc(ingestSize);
+        }
         numberOfObjects.inc();
     }
     if (typeOfRequest === 'createBucket' && code === '200') {
@@ -80,10 +92,11 @@ function promMetrics(requestType, bucketName, code, typeOfRequest,
     && code === '200') {
         dataDiskAvailable.inc(newByteLength);
         dataDiskFree.inc(newByteLength);
-        if (numOfObjectsRemoved) {
-            numberOfObjects.dec(numOfObjectsRemoved);
-        } else {
-            numberOfObjects.dec();
+        const objs = numOfObjectsRemoved || 1;
+        numberOfObjects.dec(objs);
+        if (ingestSize) {
+            numberOfIngestedObjects.dec(objs);
+            dataIngested.dec(ingestSize);
         }
     }
 }

--- a/lib/utilities/monitoringHandler.js
+++ b/lib/utilities/monitoringHandler.js
@@ -59,7 +59,7 @@ function promMetrics(requestType, bucketName, code, typeOfRequest,
     httpRequestsTotal.labels(requestType, 'cloud_server', code).inc();
     if ((typeOfRequest === 'putObject' ||
     typeOfRequest === 'copyObject' ||
-    typeOfRequest === 'putOjectPart') &&
+    typeOfRequest === 'putObjectPart') &&
     code === '200') {
         bytes = newByteLength - (isVersionedObj ? 0 : oldByteLength);
         httpRequestSizeBytes

--- a/lib/utilities/monitoringHandler.js
+++ b/lib/utilities/monitoringHandler.js
@@ -64,7 +64,7 @@ function promMetrics(requestType, bucketName, code, typeOfRequest,
         bytes = newByteLength - (isVersionedObj ? 0 : oldByteLength);
         httpRequestSizeBytes
             .labels(requestType, 'cloud_server', code)
-            .observe(bytes);
+            .observe(newByteLength);
         dataDiskAvailable.dec(bytes);
         dataDiskFree.dec(bytes);
         if (ingestSize) {


### PR DESCRIPTION
Adds two Prometheus gauges for Rclone specific metrics for metrics monitoring purposes. 

Metrics added:
  - a counter of the Ingested Objects 
  - total size of data ingested (not metadata size)

Parallel/related fixes:
- a minor bug with how `httpRequestSizeBytes` is calculated.
- typo causing multipart uploads to not calculate metrics