### PR TITLE
bugfix: S3C-2410 Unsupported operations are responded with Not Implem…

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -94,13 +94,6 @@ const constants = {
         'requestPayment',
         'restore',
         'torrent',
-        'legal-hold',
-        'retention',
-        'encryption',
-        'publicAccessBlock',
-        'policyStatus',
-        'tagging',
-        'object-lock',
     ],
     // Headers supported by AWS that we do not currently support.
     unsupportedHeaders: [

--- a/constants.js
+++ b/constants.js
@@ -99,7 +99,6 @@ const constants = {
         'encryption',
         'publicAccessBlock',
         'policyStatus',
-        'tagging',
         'object-lock',
     ],
     // Headers supported by AWS that we do not currently support.

--- a/constants.js
+++ b/constants.js
@@ -94,6 +94,13 @@ const constants = {
         'requestPayment',
         'restore',
         'torrent',
+        'legal-hold',
+        'retention',
+        'encryption',
+        'publicAccessBlock',
+        'policyStatus',
+        'tagging',
+        'object-lock',
     ],
     // Headers supported by AWS that we do not currently support.
     unsupportedHeaders: [


### PR DESCRIPTION
#### Why is this change required? What problem does it solve?
More unsupported queries in requests are identified. These are added to the unsupported queries list.