### PR TITLE
bugfix: S3C-2410 Unsupported operations are responded with Not Implem…

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -83,18 +83,26 @@ const constants = {
         .update('', 'binary').digest('hex'),
 
     // Queries supported by AWS that we do not currently support.
+    // Non-bucket queries
     unsupportedQueries: [
         'accelerate',
         'analytics',
+        'encryption',
         'inventory',
+        'legal-hold',
         'logging',
         'metrics',
         'notification',
+        'object-lock',
         'policy',
+        'policyStatus',
+        'publicAccessBlock',
         'requestPayment',
         'restore',
+        'retention',
         'torrent',
     ],
+
     // Headers supported by AWS that we do not currently support.
     unsupportedHeaders: [
         'x-amz-server-side-encryption',
@@ -130,6 +138,11 @@ const constants = {
     // response header to be sent when there are invalid
     // user metadata in the object's metadata
     invalidObjectUserMetadataHeader: 'x-amz-missing-meta',
+    // Bucket specific queries supported by AWS that we do not currently support
+    // these queries may or may not be supported at object level
+    unsupportedBucketQueries: [
+        'tagging',
+    ],
 };
 
 module.exports = constants;

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -57,9 +57,7 @@ const api = {
     callApiMethod(apiMethod, request, response, log, callback) {
         let returnTagCount = true;
 
-        const validationRes =
-            validateQueryAndHeaders(request.method, request.query,
-                request.headers, log);
+        const validationRes = validateQueryAndHeaders(request, log);
         if (validationRes.error) {
             log.debug('request query / header validation failed', {
                 error: validationRes.error,

--- a/lib/utilities/validateQueryAndHeaders.js
+++ b/lib/utilities/validateQueryAndHeaders.js
@@ -17,13 +17,27 @@ function _validateKeys(unsupportedKeys, obj) {
 
 /**
  * validateQueryAndHeaders - Check request for unsupported queries or headers
- * @param {string} reqMethod - request method
- * @param {object} reqQuery - request query object
- * @param {object} reqHeaders - request headers object
+ * @param {object} request - request object
  * @param {object} log - Werelogs logger
  * @return {object} - empty object or object with error boolean property
  */
-function validateQueryAndHeaders(reqMethod, reqQuery, reqHeaders, log) {
+function validateQueryAndHeaders(request, log) {
+    const reqMethod = request.method;
+    const reqQuery = request.query;
+    const reqHeaders = request.headers;
+    const isBucketQuery = !request.objectKey;
+    // if the request is at bucket level, check for unsupported bucket queries
+    if (isBucketQuery) {
+        const unsupportedQuery =
+            _validateKeys(constants.unsupportedBucketQueries, reqQuery);
+        if (unsupportedQuery) {
+            log.debug('encountered unsupported query', {
+                query: unsupportedQuery,
+                method: 'validateQueryAndHeaders',
+            });
+            return { error: errors.NotImplemented };
+        }
+    }
     const unsupportedQuery = _validateKeys(constants.unsupportedQueries,
         reqQuery);
     if (unsupportedQuery) {

--- a/tests/functional/raw-node/test/unsupportedQuries.js
+++ b/tests/functional/raw-node/test/unsupportedQuries.js
@@ -23,3 +23,20 @@ describe('unsupported query requests:', () => {
         });
     });
 });
+
+describe('unsupported bucket query requests:', () => {
+    constants.unsupportedBucketQueries.forEach(query => {
+        const queryObj = {};
+        queryObj[query] = '';
+
+        itSkipIfAWS(`should respond with NotImplemented for ?${query} request`,
+        done => {
+            makeS3Request({ method: 'GET', queryObj, bucket },
+            err => {
+                assert.strictEqual(err.code, 'NotImplemented');
+                assert.strictEqual(err.statusCode, 501);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
#### Why is this change required? What problem does it solve?
More unsupported queries in requests are identified. These are added to the unsupported queries list.

Tests are added to check new unsupported queries.