### PR TITLE
bugfix: S3C-1805 Consecutive hyphen in bucketnames

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "github:scality/Arsenal#f8bf038",
+    "arsenal": "github:scality/Arsenal#a7b6fc8",
     "async": "~2.5.0",
     "aws-sdk": "2.28.0",
     "azure-storage": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -193,9 +193,9 @@ arraybuffer.slice@0.0.6:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz#f33b2159f0532a3f3107a272c0ccfbd1ad2979ca"
   integrity sha1-8zshWfBTKj8xB6JywMz70a0peco=
 
-"arsenal@github:scality/Arsenal#f8bf038", arsenal@scality/Arsenal#f8bf038:
+"arsenal@github:scality/Arsenal#a7b6fc8":
   version "7.4.3"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/f8bf038b81d352dbe9637c49d09df9e548461792"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/a7b6fc8fb8ed332fd2695e1c0fafad726116727e"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
@@ -260,6 +260,31 @@ arsenal@scality/Arsenal#dd6fde6:
     level "~5.0.1"
     level-sublevel "~6.6.5"
     mongodb "^3.0.1"
+    node-forge "^0.7.1"
+    simple-glob "^0.1"
+    socket.io "~1.7.3"
+    socket.io-client "~1.7.3"
+    utf8 "2.1.2"
+    uuid "^3.0.1"
+    werelogs scality/werelogs#0ff7ec82
+    xml2js "~0.4.16"
+  optionalDependencies:
+    ioctl "2.0.0"
+
+arsenal@scality/Arsenal#f8bf038:
+  version "7.4.3"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/f8bf038b81d352dbe9637c49d09df9e548461792"
+  dependencies:
+    "@hapi/joi" "^15.1.0"
+    JSONStream "^1.0.0"
+    ajv "4.10.0"
+    async "~2.1.5"
+    debug "~2.3.3"
+    diskusage "^1.1.1"
+    ioredis "4.9.5"
+    ipaddr.js "1.2.0"
+    level "~5.0.1"
+    level-sublevel "~6.6.5"
     node-forge "^0.7.1"
     simple-glob "^0.1"
     socket.io "~1.7.3"


### PR DESCRIPTION
#### Why is this change required? What problem does it solve?
Bucket names with consecutive hyphens were not allowed and the request was responded with error 'InvalidBucketName'. Consecutive hyphens in bucket names are allowed in AWS S3, so corrections are made to allow consecutive hyphens in bucket names.