### PR TITLE
Bugfixes: MD5 and VersionID for AWS OOB

### DIFF
--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -187,25 +187,28 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
     const mdOnlySize = request.headers['x-amz-meta-size'];
     return async.waterfall([
         function storeData(next) {
-            if (size === 0 && !dontSkipBackend[locationType]) {
-                metadataStoreParams.contentMD5 = constants.emptyFileMd5;
-                return next(null, null, null);
-            }
-            // Handle mdOnlyHeader as a metadata only operation. If
-            // the object in question is actually 0 byte or has a body size
-            // then handle normally.
-            if (mdOnlyHeader === 'true' && mdOnlySize > 0 && size === 0) {
-                log.debug('metadata only operation x-amz-meta-mdonly');
-                const md5 = new Buffer(request.headers
-                    ['x-amz-meta-md5chksum'], 'base64').toString('hex');
-                const dataGetInfo = {
-                    key: objectKey,
-                    dataStoreName: location,
-                    dataStoreType: locationType,
-                    dataStoreVersionId: request.headers['x-amz-version-id'],
-                    dataStoreMD5: md5,
-                };
-                return next(null, dataGetInfo, md5);
+            if (size === 0) {
+                if (!dontSkipBackend[locationType]) {
+                    metadataStoreParams.contentMD5 = constants.emptyFileMd5;
+                    return next(null, null, null);
+                }
+                // Handle mdOnlyHeader as a metadata only operation. If
+                // the object in question is actually 0 byte or has a body size
+                // then handle normally.
+                if (mdOnlyHeader === 'true' && mdOnlySize > 0) {
+                    log.debug('metadata only operation x-amz-meta-mdonly');
+                    const md5 = request.headers['x-amz-meta-md5chksum']
+                        ? new Buffer(request.headers['x-amz-meta-md5chksum'],
+                        'base64').toString('hex') : null;
+                    const dataGetInfo = {
+                        key: objectKey,
+                        dataStoreName: location,
+                        dataStoreType: locationType,
+                        dataStoreVersionId: request.headers['x-amz-version-id'],
+                        dataStoreMD5: md5,
+                    };
+                    return next(null, dataGetInfo, md5);
+                }
             }
             return dataStore(objectKeyContext, cipherBundle, request, size,
                     streamingV4Params, backendInfo, log, next);

--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -200,11 +200,12 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
                     const md5 = request.headers['x-amz-meta-md5chksum']
                         ? new Buffer(request.headers['x-amz-meta-md5chksum'],
                         'base64').toString('hex') : null;
+                    const versionId = request.headers['x-amz-meta-version-id'];
                     const dataGetInfo = {
                         key: objectKey,
                         dataStoreName: location,
                         dataStoreType: locationType,
-                        dataStoreVersionId: request.headers['x-amz-version-id'],
+                        dataStoreVersionId: versionId,
                         dataStoreMD5: md5,
                     };
                     return next(null, dataGetInfo, md5);


### PR DESCRIPTION
Included are two bug fixes:
- fix ingest MD5 inconsistencies
This commit fixes a bug where cloudserver can crash if there is an ingestion
request without the x-amz-meta-md5chksum header. By assigning null to the value
in the event that it is undefined, this behavior is prevented.
- fix mdOnly version IDs
This commit fixes a bug where "metadata only" puts used for ingestion do not
add the server version ID. Without this, getting older versions of an ingested
object would fail.