### PR TITLE
bugfix: S3C-2397 Check invalid range

### DIFF
--- a/lib/api/apiUtils/object/setUpCopyLocator.js
+++ b/lib/api/apiUtils/object/setUpCopyLocator.js
@@ -1,8 +1,28 @@
 const { errors } = require('arsenal');
-const { parseRange } = require('arsenal/lib/network/http/utils');
+const {
+    parseRangeSpec,
+    parseRange,
+} = require('arsenal/lib/network/http/utils');
 
 const constants = require('../../../../constants');
 const setPartRanges = require('./setPartRanges');
+
+/**
+ * Ensure an object copy part range header is of the form 'bytes=first-last'.
+ * @param {string | undefined} header - header from request, if any
+ * @return {object | null} custom error if header is incorrect form or null
+ */
+function parseRangeHeader(header) {
+    const { error } = parseRangeSpec(header);
+    if (error) {
+        const description = 'The x-amz-copy-source-range value must be ' +
+            'of the form bytes=first-last where first and last are the ' +
+            'zero-based offsets of the first and last bytes to copy';
+        return error.customizeDescription(description);
+    }
+    return null;
+}
+
 /**
  * Uses the source object metadata and the requestHeaders
  * to determine the location of the data to be copied and the
@@ -39,6 +59,10 @@ function setUpCopyLocator(sourceObjMD, rangeHeader, log) {
         parseInt(sourceObjMD['content-length'], 10);
     let copyObjectSize = sourceSize;
     if (rangeHeader) {
+        const rangeHeaderError = parseRangeHeader(rangeHeader);
+        if (rangeHeaderError) {
+            return { error: rangeHeaderError };
+        }
         const { range, error } = parseRange(rangeHeader, sourceSize);
         if (error) {
             return { error };

--- a/tests/functional/aws-node-sdk/test/object/copyPart.js
+++ b/tests/functional/aws-node-sdk/test/object/copyPart.js
@@ -144,6 +144,27 @@ describe('Object Part Copy', () => {
                 });
         });
 
+        it('should return InvalidArgument error given invalid range', done => {
+            s3.putObject({
+                Bucket: sourceBucketName,
+                Key: sourceObjName,
+                Body: Buffer.alloc(oneHundredMBPlus11, 'packing'),
+            }, err => {
+                checkNoError(err);
+                s3.uploadPartCopy({ Bucket: destBucketName,
+                    Key: destObjName,
+                    CopySource: `${sourceBucketName}/${sourceObjName}`,
+                    PartNumber: 1,
+                    UploadId: uploadId,
+                    CopySourceRange: 'bad-range-parameter',
+                },
+                err => {
+                    checkError(err, 'InvalidArgument');
+                    done();
+                });
+            });
+        });
+
         it('should return EntityTooLarge error if attempt to copy ' +
             'object larger than max and do not specify smaller ' +
             'range in request', done => {


### PR DESCRIPTION
An invalid range header (i.e. not of the form `bytes=first-last`) when performing a copy object part operation results in an `InvalidArgument` error when using AWS. This PR introduces the same behavior to CloudServer for compatibility purposes.

Note that the behavior when providing an invalid range with the object GET API results in retrieving the entire object rather than an error. Thus the object GET API is not modified.