### PR TITLE
bugfix: 2206 x-forwarded-for ip extraction

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -278,6 +278,30 @@ function parseUtapiReindex({ enabled, schedule, sentinel, bucketd }) {
     }
 }
 
+function requestsConfigAssert(requestsConfig) {
+    if (requestsConfig.viaProxy !== undefined) {
+        assert(typeof requestsConfig.viaProxy === 'boolean',
+        'config: invalid requests configuration. viaProxy must be a ' +
+        'boolean');
+
+        if (requestsConfig.viaProxy) {
+            assert(Array.isArray(requestsConfig.trustedProxyCIDRs) &&
+            requestsConfig.trustedProxyCIDRs.length > 0 &&
+            requestsConfig.trustedProxyCIDRs
+                .every(ip => typeof ip === 'string'),
+            'config: invalid requests configuration. ' +
+            'trustedProxyCIDRs must be set if viaProxy is set to true ' +
+            'and must be an array');
+
+            assert(typeof requestsConfig.extractClientIPFromHeader === 'string'
+            && requestsConfig.extractClientIPFromHeader.length > 0,
+            'config: invalid requests configuration. ' +
+            'extractClientIPFromHeader must be set if viaProxy is ' +
+            'set to true and must be a string');
+        }
+    }
+}
+
 /**
  * Reads from a config file and returns the content as a config object
  */
@@ -955,6 +979,17 @@ class Config extends EventEmitter {
             process.env.REPORT_TOKEN ||
             config.reportToken ||
             uuid.v4().toString();
+
+        // requests-proxy configuration
+        this.requests = {
+            viaProxy: false,
+            trustedProxyCIDRs: [],
+            extractClientIPFromHeader: '',
+        };
+        if (config.requests !== undefined) {
+            requestsConfigAssert(config.requests);
+            this.requests = config.requests;
+        }
     }
 
     _configureBackends() {
@@ -1151,4 +1186,5 @@ module.exports = {
     cosParse,
     ConfigObject: Config,
     config: new Config(),
+    requestsConfigAssert,
 };

--- a/lib/api/apiUtils/authorization/prepareRequestContexts.js
+++ b/lib/api/apiUtils/authorization/prepareRequestContexts.js
@@ -6,6 +6,8 @@ const apiMethodWithVersion = { objectGetACL: true, objectPutACL: true,
     objectGet: true, objectDelete: true, objectPutTagging: true,
     objectGetTagging: true, objectDeleteTagging: true };
 
+const requestUtils = require('../../../utilities/requestUtils');
+
 function isHeaderAcl(headers) {
     return headers['x-amz-grant-read'] || headers['x-amz-grant-read-acp'] ||
     headers['x-amz-grant-write-acp'] || headers['x-amz-grant-full-control'] ||
@@ -33,8 +35,7 @@ function prepareRequestContexts(apiMethod, request, sourceBucket,
     // null as the requestContext to Vault so it will only do an authentication
     // check.
 
-    const ip = request.headers['x-forwarded-for'] ||
-    request.socket.remoteAddress;
+    const ip = requestUtils.getClientIp(request);
 
     function generateRequestContext(apiMethod) {
         return new RequestContext(request.headers,

--- a/lib/api/bucketPut.js
+++ b/lib/api/bucketPut.js
@@ -8,6 +8,7 @@ const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const { config } = require('../Config');
 const aclUtils = require('../utilities/aclUtils');
 const { pushMetric } = require('../utapi/utilities');
+const requestUtils = require('../utilities/requestUtils');
 
 let { restEndpoints, locationConstraints } = config;
 config.on('rest-endpoints-update', () => {
@@ -130,8 +131,7 @@ function bucketPut(authInfo, request, log, callback) {
             if (authInfo.isRequesterAnIAMUser()) {
                 const authParams = auth.server.extractParams(request, log, 's3',
                     request.query);
-                const ip = request.headers['x-forwarded-for'] ||
-                request.socket.remoteAddress;
+                const ip = requestUtils.getClientIp(request);
                 const requestContextParams = {
                     constantParams: {
                         headers: request.headers,

--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -16,6 +16,7 @@ const { preprocessingVersioningDelete }
     = require('./apiUtils/object/versioning');
 const createAndStoreObject = require('./apiUtils/object/createAndStoreObject');
 const { metadataGetObject } = require('../metadata/metadataUtils');
+const requestUtils = require('../utilities/requestUtils');
 
 const versionIdUtils = versioning.VersionID;
 
@@ -343,8 +344,7 @@ function multiObjectDelete(authInfo, request, log, callback) {
             // params on to this api
             const authParams = auth.server.extractParams(request, log,
                 's3', request.query);
-            const ip = request.headers['x-forwarded-for'] ||
-            request.socket.remoteAddress;
+            const ip = requestUtils.getClientIp(request);
             const requestContextParams = {
                 constantParams: {
                     headers: request.headers,

--- a/lib/routes/routeMetadata.js
+++ b/lib/routes/routeMetadata.js
@@ -5,6 +5,7 @@ const { auth, errors, s3routes, policies } = require('arsenal');
 const { config } = require('../Config');
 const constants = require('../../constants');
 const vault = require('../auth/vault');
+const requestUtils = require('../utilities/requestUtils');
 
 const RequestContext = policies.RequestContext;
 const { responseJSONBody } = s3routes.routesUtils;
@@ -44,8 +45,7 @@ function routeMetadata(clientIP, request, response, log) {
         && !['bucket', 'log', 'id'].includes(subResource)) {
         return responseJSONBody(errors.NotImplemented, null, response, log);
     }
-    const ip = request.headers['x-forwarded-for'] ||
-    request.socket.remoteAddress;
+    const ip = requestUtils.getClientIp(request);
     const requestContexts = [new RequestContext(request.headers, request.query,
         request.generalResource, request.specificResource, ip,
         request.connection.encrypted, request.resourceType, 'metadata')];

--- a/lib/utilities/requestUtils.js
+++ b/lib/utilities/requestUtils.js
@@ -1,0 +1,35 @@
+const { ipCheck } = require('arsenal');
+const { config } = require('../Config');
+
+/**
+ * getClientIp - Gets the client IP from the request
+ * @param {object} request - http request object
+ * @param {object} s3config - (optional) s3 config
+ * @return {string} - returns client IP from the request
+ */
+function getClientIp(request, s3config) {
+    const clientIp = request.socket.remoteAddress;
+    const requestConfig = (s3config || config).requests;
+    if (requestConfig && requestConfig.viaProxy) {
+        /**
+         * if requests are configured to come via proxy,
+         * check from config which proxies are to be trusted and
+         * which header to be used to extract client IP
+         */
+        if (ipCheck.ipMatchCidrList(requestConfig.trustedProxyCIDRs,
+            clientIp)) {
+            const ipFromHeader
+            // eslint-disable-next-line operator-linebreak
+                = request.headers[requestConfig.extractClientIPFromHeader];
+            if (ipFromHeader && ipFromHeader.trim().length) {
+                return ipFromHeader.split(',')[0].trim();
+            }
+        }
+    }
+
+    return clientIp;
+}
+
+module.exports = {
+    getClientIp,
+};

--- a/tests/unit/testConfigs/requestsConfigTest.js
+++ b/tests/unit/testConfigs/requestsConfigTest.js
@@ -1,0 +1,98 @@
+const assert = require('assert');
+const { requestsConfigAssert } = require('../../../lib/Config');
+
+describe('requestsConfigAssert', () => {
+    it('should not throw an error if there is no requests config', () => {
+        assert.doesNotThrow(() => {
+            requestsConfigAssert({});
+        },
+        'should not throw an error if there is no requests config');
+    });
+    it('should not throw an error if requests config via proxy is set to false',
+    () => {
+        assert.doesNotThrow(() => {
+            requestsConfigAssert({
+                viaProxy: false,
+                trustedProxyCIDRs: [],
+                extractClientIPFromHeader: '',
+            });
+        },
+        'shouldnt throw an error if requests config via proxy is set to false');
+    });
+    it('should not throw an error if requests config via proxy is true, ' +
+        'trustedProxyCIDRs & extractClientIPFromHeader are set', () => {
+        assert.doesNotThrow(() => {
+            requestsConfigAssert({
+                viaProxy: true,
+                trustedProxyCIDRs: ['123.123.123.123'],
+                extractClientIPFromHeader: 'x-forwarded-for',
+            });
+        },
+        'should not throw an error if requests config ' +
+        'via proxy is set correctly');
+    });
+    it('should throw an error if requests.viaProxy is not a boolean',
+    () => {
+        assert.throws(() => {
+            requestsConfigAssert({
+                viaProxy: 1,
+                trustedProxyCIDRs: ['123.123.123.123'],
+                extractClientIPFromHeader: 'x-forwarded-for',
+            });
+        },
+        '/config: invalid requests configuration. viaProxy must be a ' +
+        'boolean/');
+    });
+    it('should throw an error if requests.trustedProxyCIDRs is not an array',
+    () => {
+        assert.throws(() => {
+            requestsConfigAssert({
+                viaProxy: true,
+                trustedProxyCIDRs: 1,
+                extractClientIPFromHeader: 'x-forwarded-for',
+            });
+        },
+        '/config: invalid requests configuration. ' +
+        'trustedProxyCIDRs must be set if viaProxy is set to true ' +
+        'and must be an array/');
+    });
+    it('should throw an error if requests.trustedProxyCIDRs array is empty',
+    () => {
+        assert.throws(() => {
+            requestsConfigAssert({
+                viaProxy: true,
+                trustedProxyCIDRs: [],
+                extractClientIPFromHeader: 'x-forwarded-for',
+            });
+        },
+        '/config: invalid requests configuration. ' +
+        'trustedProxyCIDRs must be set if viaProxy is set to true ' +
+        'and must be an array/');
+    });
+    it('should throw an error if requests.extractClientIPFromHeader ' +
+    'is not a string', () => {
+        assert.throws(() => {
+            requestsConfigAssert({
+                viaProxy: true,
+                trustedProxyCIDRs: [],
+                extractClientIPFromHeader: 1,
+            });
+        },
+        '/config: invalid requests configuration. ' +
+        'extractClientIPFromHeader must be set if viaProxy is ' +
+        'set to true and must be a string/');
+    });
+    it('should throw an error if requests.extractClientIPFromHeader ' +
+    'is empty', () => {
+        assert.throws(() => {
+            requestsConfigAssert({
+                viaProxy: true,
+                trustedProxyCIDRs: [],
+                extractClientIPFromHeader: '',
+            });
+        },
+        '/config: invalid requests configuration. ' +
+        'extractClientIPFromHeader must be set if viaProxy is ' +
+        'set to true and must be a string/');
+    });
+});

--- a/tests/unit/utils/requestUtils.js
+++ b/tests/unit/utils/requestUtils.js
@@ -1,0 +1,64 @@
+const assert = require('assert');
+const DummyRequest = require('../DummyRequest');
+const requestUtils = require('../../../lib/utilities/requestUtils');
+
+describe('requestUtils.getClientIp', () => {
+    // s3 config with 'requests.viaProxy` enabled
+    const configWithProxy
+        = require('../../unit/utils/requests-test-proxy.json');
+    // s3 config with 'requests.viaProxy` disabled
+    const configWithoutProxy = require('../../../config.json');
+    const testClientIp1 = '192.168.100.1';
+    const testClientIp2 = '192.168.104.0';
+    const testProxyIp = '192.168.100.2';
+
+    it('should return client Ip address from header ' +
+        'if the request comes via proxies', () => {
+        const request = new DummyRequest({
+            headers: {
+                'x-forwarded-for': [testClientIp1, testProxyIp].join(','),
+            },
+            url: '/',
+            parsedHost: 'localhost',
+            socket: {
+                remoteAddress: testProxyIp,
+            },
+        });
+        const result = requestUtils.getClientIp(request, configWithProxy);
+        assert.strictEqual(result, testClientIp1);
+    });
+
+    it('should not return client Ip address from header ' +
+        'if the request is not forwarded from proxies or ' +
+        'fails ip check', () => {
+        const request = new DummyRequest({
+            headers: {
+                'x-forwarded-for': [testClientIp1, testProxyIp].join(','),
+            },
+            url: '/',
+            parsedHost: 'localhost',
+            socket: {
+                remoteAddress: testClientIp2,
+            },
+        });
+        const result = requestUtils.getClientIp(request, configWithoutProxy);
+        assert.strictEqual(result, testClientIp2);
+    });
+
+    it('should not return client Ip address from header ' +
+        'if the request is forwarded from proxies, but the request' +
+        'has no expected header or the header value is empty', () => {
+        const request = new DummyRequest({
+            headers: {
+                'x-forwarded-for': ' ',
+            },
+            url: '/',
+            parsedHost: 'localhost',
+            socket: {
+                remoteAddress: testClientIp2,
+            },
+        });
+        const result = requestUtils.getClientIp(request, configWithProxy);
+        assert.strictEqual(result, testClientIp2);
+    });
+});

--- a/tests/unit/utils/requests-test-proxy.json
+++ b/tests/unit/utils/requests-test-proxy.json
@@ -79,8 +79,8 @@
 	"database": "metadata"
     },
     "requests": {
-        "viaProxy": false,
-        "trustedProxyCIDRs": [],
-        "extractClientIPFromHeader": ""
+        "viaProxy": true,
+        "trustedProxyCIDRs": ["192.168.100.0/22"],
+        "extractClientIPFromHeader": "x-forwarded-for"
     }
 }


### PR DESCRIPTION
#### Why is this change required? What problem does it solve?
IAM policy match for IP fails if the S3 requests are made via proxies or from load balancers. `x-forwarded-for` header will be set in the request in such cases and it is used for getting the client IP. `x-forwarded-for` will contain list of IPs including the client IP and the proxy's separated by comma. Changes are made to extract only client IP and forward to vault for policy checks. Unit tests are added to check the new IP extraction utility.