### PR TITLE
bugfix: S3C-2517 fix crash with invalid chunked-upload

### DIFF
--- a/lib/api/apiUtils/object/prepareStream.js
+++ b/lib/api/apiUtils/object/prepareStream.js
@@ -8,11 +8,20 @@ const V4Transform = require('../../../auth/streamingV4/V4Transform');
  * credentialScope (to be used for streaming v4 auth if applicable)
  * @param {RequestLogger} log - the current request logger
  * @param {function} cb - callback containing the result for V4Transform
- * @return {object} - V4Transform object if v4 Auth request, or else the stream
+ * @return {object|null} - V4Transform object if v4 Auth request, or
+ * the original stream, or null if the request has no V4 params but
+ * the type of request requires them
  */
 function prepareStream(stream, streamingV4Params, log, cb) {
     if (stream.headers['x-amz-content-sha256'] ===
         'STREAMING-AWS4-HMAC-SHA256-PAYLOAD') {
+        if (typeof streamingV4Params !== 'object') {
+            // this might happen if the user provided a valid V2
+            // Authentication header, while the chunked upload method
+            // requires V4: in such case we don't get any V4 params
+            // and we should return an error to the client.
+            return null;
+        }
         const v4Transform = new V4Transform(streamingV4Params, log, cb);
         stream.pipe(v4Transform);
         return v4Transform;

--- a/lib/api/apiUtils/object/storeObject.js
+++ b/lib/api/apiUtils/object/storeObject.js
@@ -58,7 +58,11 @@ function checkHashMatchMD5(stream, hashedStream, dataRetrievalInfo, log, cb) {
 function dataStore(objectContext, cipherBundle, stream, size,
     streamingV4Params, backendInfo, log, cb) {
     const dataStream = prepareStream(stream, streamingV4Params, log, cb);
-    data.put(cipherBundle, dataStream, size, objectContext, backendInfo, log,
+    if (!dataStream) {
+        return process.nextTick(() => cb(errors.InvalidArgument));
+    }
+    return data.put(
+        cipherBundle, dataStream, size, objectContext, backendInfo, log,
         (err, dataRetrievalInfo, hashedStream) => {
             if (err) {
                 log.error('error in datastore', {

--- a/tests/functional/s3curl/tests.js
+++ b/tests/functional/s3curl/tests.js
@@ -478,6 +478,23 @@ describe('s3curl putObject', () => {
                 });
         });
 
+    it('should not be able to put an object if using streaming ' +
+    'chunked-upload with a valid V2 signature',
+        done => {
+            provideRawOutput([
+                '--debug',
+                `--put=${upload}`,
+                '--',
+                '-H',
+                'x-amz-content-sha256: STREAMING-AWS4-HMAC-SHA256-PAYLOAD',
+                `${endpoint}/${bucket}/${prefix}${delimiter}${upload}1`,
+                '-v'],
+                (httpCode, rawOutput) => {
+                    assert.strictEqual(httpCode, '400 BAD REQUEST');
+                    assertError(rawOutput.stdout, 'InvalidArgument', done);
+                });
+        });
+
     it('should not be able to put an object in a bucket with an invalid name',
         done => {
             provideRawOutput([


### PR DESCRIPTION
A Cloudserver worker can crash if a client provides the
"x-amz-content-sha256" header with a value of
"STREAMING-AWS4-HMAC-SHA256-PAYLOAD" to use chunked upload, but
provides a valid AWS V2 signature (chunked-upload requires a V4
signature).

This fixes to instead respond with a 400 Bad Request.
