### PR TITLE
bf: special treatment for MPU MD5 if mdonly

### DIFF
--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -200,15 +200,22 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
                     const md5 = request.headers['x-amz-meta-md5chksum']
                         ? new Buffer(request.headers['x-amz-meta-md5chksum'],
                         'base64').toString('hex') : null;
+                    const numParts = request.headers['x-amz-meta-md5numparts'];
+                    let _md5;
+                    if (numParts === undefined) {
+                        _md5 = md5;
+                    } else {
+                        _md5 = `${md5}-${numParts}`;
+                    }
                     const versionId = request.headers['x-amz-meta-version-id'];
                     const dataGetInfo = {
                         key: objectKey,
                         dataStoreName: location,
                         dataStoreType: locationType,
                         dataStoreVersionId: versionId,
-                        dataStoreMD5: md5,
+                        dataStoreMD5: _md5,
                     };
-                    return next(null, dataGetInfo, md5);
+                    return next(null, dataGetInfo, _md5);
                 }
             }
             return dataStore(objectKeyContext, cipherBundle, request, size,


### PR DESCRIPTION
Rclone originally does not handle correctly the MD5 for MPU objects,
because their Etag is structure as "md5chksum-numparts".
Therefore a patch was made to not only transmit an x-amz-meta-md5chksum like
before but also to include an additional x-amz-meta-md5numparts.
This fix will check for this new header and reconstitute the MD5 correcly.
For non-MPU objects the behavior is unchanged and therefore backward
compatible.

# Pull request template

## Description

### Motivation and context

Why is this change required? What problem does it solve?

### Related issues

Please use the following link syntaxes #600 to reference issues in the
current repository

## Checklist

### Add tests to cover the changes

New tests added or existing tests modified to cover all changes

### Code conforms with the [style guide](https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#coding-style-guidelines)

### Sign your work

In order to contribute to the project, you must sign your work
https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#sign-your-work

Thank you again for contributing! We will try to test and integrate the change
as soon as we can.
