### PR TITLE
improvement: allow sse header for encrypted buckets

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -104,7 +104,6 @@ const constants = {
 
     // Headers supported by AWS that we do not currently support.
     unsupportedHeaders: [
-        'x-amz-server-side-encryption',
         'x-amz-server-side-encryption-customer-algorithm',
         'x-amz-server-side-encryption-aws-kms-key-id',
         'x-amz-server-side-encryption-context',

--- a/lib/api/apiUtils/object/checkEncryption.js
+++ b/lib/api/apiUtils/object/checkEncryption.js
@@ -1,0 +1,29 @@
+/**
+ * Checks the object encryption request against bucket encryption for matching
+ * SSE-S3 configuration
+ * @param {object} objectRequest - http request
+ * @param {object} serverSideEncryption - bucket encryption info
+ * @return {boolean} returns true if the object request has correct SSE-S3
+ * configuration
+ */
+function isValidSSES3(objectRequest, serverSideEncryption) {
+    // x-amz-server-side-encryption is allowed only if bucket
+    // encryption is enabled and if the value is AES256
+    // NOTE: object level encryption is not supported, but we allow
+    // encryption headers in the object request headers!
+    const sseHeader = objectRequest.headers['x-amz-server-side-encryption'];
+    const encryptionAlgorithm = 'AES256';
+
+    const result = ((!serverSideEncryption && sseHeader) ||
+        (serverSideEncryption && sseHeader
+            && sseHeader === encryptionAlgorithm
+            && serverSideEncryption.algorithm !== encryptionAlgorithm) ||
+        (serverSideEncryption && sseHeader
+            && sseHeader !== encryptionAlgorithm
+            && serverSideEncryption.algorithm === encryptionAlgorithm));
+    return !result;
+}
+
+module.exports = {
+    isValidSSES3,
+};

--- a/lib/api/initiateMultipartUpload.js
+++ b/lib/api/initiateMultipartUpload.js
@@ -14,6 +14,7 @@ const validateWebsiteHeader = require('./apiUtils/object/websiteServing')
     .validateWebsiteHeader;
 const { config } = require('../Config');
 const multipleBackendGateway = require('../data/multipleBackendGateway');
+const checkObjectEncryption = require('./apiUtils/object/checkEncryption');
 
 const externalVersioningErrorMessage = 'We do not currently support putting ' +
 'a versioned object to a location-constraint of type Azure.';
@@ -45,6 +46,9 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'initiateMultipartUpload' });
     const bucketName = request.bucketName;
     const objectKey = request.objectKey;
+    const invalidSSEError
+        = errors.InvalidArgument.customizeDescription('The encryption method '
+        + 'specified is not supported');
     // Note that we are using the string set forth in constants.js
     // to split components in the storage
     // of each MPU.  AWS does not restrict characters in object keys so
@@ -164,6 +168,10 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
         const serverSideEncryption =
             destinationBucket.getServerSideEncryption();
         let cipherBundle = null;
+        if (!checkObjectEncryption.isValidSSES3(request,
+            serverSideEncryption)) {
+            return callback(invalidSSEError);
+        }
         if (serverSideEncryption) {
             cipherBundle = {
                 algorithm: serverSideEncryption.algorithm,

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -20,6 +20,7 @@ const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const validateWebsiteHeader = require('./apiUtils/object/websiteServing')
     .validateWebsiteHeader;
 const { config } = require('../Config');
+const checkObjectEncryption = require('./apiUtils/object/checkEncryption');
 
 const versionIdUtils = versioning.VersionID;
 const locationHeader = constants.objectLocationConstraintHeader;
@@ -213,6 +214,9 @@ function objectCopy(authInfo, request, sourceBucket,
     };
     const websiteRedirectHeader =
         request.headers['x-amz-website-redirect-location'];
+    const invalidSSEError
+        = errors.InvalidArgument.customizeDescription('The encryption method '
+        + 'specified is not supported');
 
     if (!validateWebsiteHeader(websiteRedirectHeader)) {
         const err = errors.InvalidRedirectLocation;
@@ -325,7 +329,10 @@ function objectCopy(authInfo, request, sourceBucket,
             const isVersionedObj = vcfg && vcfg.Status === 'Enabled';
             const destLocationConstraintName =
                 storeMetadataParams.dataStoreName;
-
+            if (!checkObjectEncryption.isValidSSES3(request,
+                serverSideEncryption)) {
+                return callback(invalidSSEError);
+            }
             // skip if source and dest and location constraint the same and
             // versioning is not enabled
             // still send along serverSideEncryption info so algo

--- a/lib/api/objectPut.js
+++ b/lib/api/objectPut.js
@@ -9,6 +9,7 @@ const { checkQueryVersionId } = require('./apiUtils/object/versioning');
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
 const kms = require('../kms/wrapper');
+const checkObjectEncryption = require('./apiUtils/object/checkEncryption');
 
 const versionIdUtils = versioning.VersionID;
 
@@ -41,6 +42,8 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
     if (queryContainsVersionId instanceof Error) {
         return callback(queryContainsVersionId);
     }
+    const invalidSSEError = errors.InvalidArgument.customizeDescription(
+        'The encryption method specified is not supported');
     const bucketName = request.bucketName;
     const objectKey = request.objectKey;
     const requestType = 'objectPut';
@@ -73,6 +76,10 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
             },
             function createCipherBundle(next) {
                 const serverSideEncryption = bucket.getServerSideEncryption();
+                if (!checkObjectEncryption.isValidSSES3(request,
+                    serverSideEncryption)) {
+                    return next(invalidSSEError);
+                }
                 if (serverSideEncryption) {
                     return kms.createCipherBundle(
                             serverSideEncryption, log, next);

--- a/tests/functional/aws-node-sdk/test/object/objectCopy.js
+++ b/tests/functional/aws-node-sdk/test/object/objectCopy.js
@@ -659,13 +659,13 @@ describe('Object Copy', () => {
                 });
         });
 
-        it('should return Not Implemented error for obj. encryption using ' +
+        it('should return InvalidArgument error for obj. encryption using ' +
             'AWS-managed encryption keys', done => {
             const params = { Bucket: destBucketName, Key: 'key',
                 CopySource: `${sourceBucketName}/${sourceObjName}`,
                 ServerSideEncryption: 'AES256' };
             s3.copyObject(params, err => {
-                assert.strictEqual(err.code, 'NotImplemented');
+                assert.strictEqual(err.code, 'InvalidArgument');
                 done();
             });
         });

--- a/tests/functional/aws-node-sdk/test/object/put.js
+++ b/tests/functional/aws-node-sdk/test/object/put.js
@@ -104,12 +104,12 @@ describe('PUT object', () => {
                 });
             });
 
-        it('should return Not Implemented error for obj. encryption using ' +
+        it('should return InvalidArgument error for obj. encryption using ' +
             'AWS-managed encryption keys', done => {
             const params = { Bucket: bucket, Key: 'key',
                 ServerSideEncryption: 'AES256' };
             s3.putObject(params, err => {
-                assert.strictEqual(err.code, 'NotImplemented');
+                assert.strictEqual(err.code, 'InvalidArgument');
                 done();
             });
         });

--- a/tests/functional/aws-node-sdk/test/versioning/objectCopy.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectCopy.js
@@ -572,13 +572,13 @@ describe('Object Version Copy', () => {
                 });
         });
 
-        it('should return Not Implemented error for obj. encryption using ' +
+        it('should return InvalidArgument error for obj. encryption using ' +
             'AWS-managed encryption keys', done => {
             const params = { Bucket: destBucketName, Key: 'key',
                 CopySource: copySource,
                 ServerSideEncryption: 'AES256' };
             s3.copyObject(params, err => {
-                assert.strictEqual(err.code, 'NotImplemented');
+                assert.strictEqual(err.code, 'InvalidArgument');
                 done();
             });
         });

--- a/tests/unit/api/apiUtils/checkObjectEncryption.js
+++ b/tests/unit/api/apiUtils/checkObjectEncryption.js
@@ -1,0 +1,94 @@
+const assert = require('assert');
+
+const checkObjectEncryption
+    = require('../../../../lib/api/apiUtils/object/checkEncryption');
+
+describe('object util checkEncryption.isValidSSES3', () => {
+    it('should respond true if server side encryption matches object '
+        + 'encryption request', () => {
+        const serverSideEncryption = {
+            algorithm: 'AES256',
+        };
+
+        const request = {
+            headers: {
+                'x-amz-server-side-encryption': 'AES256',
+            },
+        };
+
+        const isValidSSES3
+            = checkObjectEncryption.isValidSSES3(request, serverSideEncryption);
+        assert.strictEqual(isValidSSES3, true);
+    });
+
+    it('should respond true if there is no bucket encryption and '
+        + 'no encryption header in object request', () => {
+        const request = {
+            headers: {},
+        };
+
+        const isValidSSES3
+            = checkObjectEncryption.isValidSSES3(request, null);
+        assert.strictEqual(isValidSSES3, true);
+    });
+
+    it('should respond true if there is no encryption header '
+        + 'and bucket encryption algorithm is AES256', () => {
+        const serverSideEncryption = {
+            algorithm: 'AES256',
+        };
+        const request = {
+            headers: {},
+        };
+
+        const isValidSSES3
+            = checkObjectEncryption.isValidSSES3(request, serverSideEncryption);
+        assert.strictEqual(isValidSSES3, true);
+    });
+
+    it('should respond false if there is encryption header in object request '
+        + 'and no bucket encryption', () => {
+        const request = {
+            headers: {
+                'x-amz-server-side-encryption': 'AES256',
+            },
+        };
+
+        const isValidSSES3
+            = checkObjectEncryption.isValidSSES3(request, null);
+        assert.strictEqual(isValidSSES3, false);
+    });
+
+    it('should respond false if the encryption header value is not AES256 '
+        + 'and bucket encryption algorithm is AES256', () => {
+        const serverSideEncryption = {
+            algorithm: 'AES256',
+        };
+        const request = {
+            headers: {
+                'x-amz-server-side-encryption': 'rsa',
+            },
+        };
+
+        const isValidSSES3
+            = checkObjectEncryption.isValidSSES3(request, serverSideEncryption);
+        assert.strictEqual(isValidSSES3, false);
+    });
+
+    it('should respond false if the encryption header value is AES256 '
+        + 'and bucket encryption algorithm is not AES256', () => {
+        const serverSideEncryption = {
+            algorithm: 'rsa',
+        };
+        const request = {
+            headers: {
+                'x-amz-server-side-encryption': 'AES256',
+            },
+        };
+
+        const isValidSSES3
+            = checkObjectEncryption.isValidSSES3(request, serverSideEncryption);
+        assert.strictEqual(isValidSSES3, false);
+    });
+});
+


### PR DESCRIPTION
### Why is this change required? What problem does it solve?
Allows encryption header (SSE-S3) in object requests if bucket level encryption is enabled. Necessary unit tests are added/updated to support this change.
