### PR TITLE
bugfix: S3C-2504 rework chunked upload stream handling

### DIFF
--- a/lib/api/apiUtils/object/prepareStream.js
+++ b/lib/api/apiUtils/object/prepareStream.js
@@ -7,12 +7,12 @@ const V4Transform = require('../../../auth/streamingV4/V4Transform');
  * accessKey, signatureFromRequest, region, scopeDate, timestamp, and
  * credentialScope (to be used for streaming v4 auth if applicable)
  * @param {RequestLogger} log - the current request logger
- * @param {function} cb - callback containing the result for V4Transform
+ * @param {function} errCb - callback called if an error occurs
  * @return {object|null} - V4Transform object if v4 Auth request, or
  * the original stream, or null if the request has no V4 params but
  * the type of request requires them
  */
-function prepareStream(stream, streamingV4Params, log, cb) {
+function prepareStream(stream, streamingV4Params, log, errCb) {
     if (stream.headers['x-amz-content-sha256'] ===
         'STREAMING-AWS4-HMAC-SHA256-PAYLOAD') {
         if (typeof streamingV4Params !== 'object') {
@@ -22,7 +22,7 @@ function prepareStream(stream, streamingV4Params, log, cb) {
             // and we should return an error to the client.
             return null;
         }
-        const v4Transform = new V4Transform(streamingV4Params, log, cb);
+        const v4Transform = new V4Transform(streamingV4Params, log, errCb);
         stream.pipe(v4Transform);
         return v4Transform;
     }

--- a/lib/api/apiUtils/object/storeObject.js
+++ b/lib/api/apiUtils/object/storeObject.js
@@ -1,4 +1,4 @@
-const { errors } = require('arsenal');
+const { errors, jsutil } = require('arsenal');
 
 const data = require('../../../data/wrapper');
 const { prepareStream } = require('./prepareStream');
@@ -57,7 +57,8 @@ function checkHashMatchMD5(stream, hashedStream, dataRetrievalInfo, log, cb) {
  */
 function dataStore(objectContext, cipherBundle, stream, size,
     streamingV4Params, backendInfo, log, cb) {
-    const dataStream = prepareStream(stream, streamingV4Params, log, cb);
+    const cbOnce = jsutil.once(cb);
+    const dataStream = prepareStream(stream, streamingV4Params, log, cbOnce);
     if (!dataStream) {
         return process.nextTick(() => cb(errors.InvalidArgument));
     }
@@ -68,19 +69,19 @@ function dataStore(objectContext, cipherBundle, stream, size,
                 log.error('error in datastore', {
                     error: err,
                 });
-                return cb(err);
+                return cbOnce(err);
             }
             if (!dataRetrievalInfo) {
                 log.fatal('data put returned neither an error nor a key', {
                     method: 'storeObject::dataStore',
                 });
-                return cb(errors.InternalError);
+                return cbOnce(errors.InternalError);
             }
             log.trace('dataStore: backend stored key', {
                 dataRetrievalInfo,
             });
             return checkHashMatchMD5(stream, hashedStream,
-                                     dataRetrievalInfo, log, cb);
+                                     dataRetrievalInfo, log, cbOnce);
         });
 }
 

--- a/lib/auth/streamingV4/V4Transform.js
+++ b/lib/auth/streamingV4/V4Transform.js
@@ -25,14 +25,14 @@ class V4Transform extends Transform {
      * header plus the string 'aws4_request' joined with '/':
      * timestamp/region/aws-service/aws4_request
      * @param {object} log - logger object
-     * @param {function} cb - callback to api
+     * @param {function} errCb - callback called if an error occurs
      */
-    constructor(streamingV4Params, log, cb) {
+    constructor(streamingV4Params, log, errCb) {
         const { accessKey, signatureFromRequest, region, scopeDate, timestamp,
             credentialScope } = streamingV4Params;
         super({});
         this.log = log;
-        this.cb = cb;
+        this.errCb = errCb;
         this.accessKey = accessKey;
         this.region = region;
         this.scopeDate = scopeDate;
@@ -50,6 +50,7 @@ class V4Transform extends Transform {
         this.currentMetadata = [];
         this.lastPieceDone = false;
         this.lastChunk = false;
+        this.clientError = false;
     }
 
     /**
@@ -192,6 +193,10 @@ class V4Transform extends Transform {
         // signature + \r\n + chunk-data + \r\n
         // Last transfer-encoding chunk will have size 0 and no chunk-data.
 
+        // if there was an error earlier, ignore the remaining data
+        if (this.clientError) {
+            return callback();
+        }
         if (this.lastPieceDone) {
             const slice = chunk.slice(0, 10);
             this.log.trace('received chunk after end.' +
@@ -268,7 +273,13 @@ class V4Transform extends Transform {
             // final callback
             err => {
                 if (err) {
-                    return this.cb(err);
+                    this.clientError = true;
+                    // Emit the 'clientError' event to notify
+                    // listeners that the client did not provide a
+                    // valid stream of content, e.g. due to a wrong
+                    // signature.
+                    this.emit('clientError');
+                    this.errCb(err);
                 }
                 // get next chunk
                 return callback();

--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -102,6 +102,10 @@ function _put(cipherBundle, value, valueSize,
     if (value) {
         hashedStream = new MD5Sum();
         value.pipe(hashedStream);
+        value.once('clientError', () => {
+            log.trace('destroying hashed stream');
+            hashedStream.destroy();
+        });
     }
 
     if (implName === 'multipleBackends') {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "mongodb": "^2.2.31",
     "node-uuid": "^1.4.3",
     "npm-run-all": "~4.1.5",
-    "sproxydclient": "scality/sproxydclient#0e17e27",
+    "sproxydclient": "scality/sproxydclient#bb239db",
     "utapi": "scality/utapi#b522b3d",
     "utf8": "~2.1.1",
     "uuid": "^3.0.1",

--- a/tests/functional/raw-node/test/badChunkSignatureV4.js
+++ b/tests/functional/raw-node/test/badChunkSignatureV4.js
@@ -1,0 +1,127 @@
+const http = require('http');
+const async = require('async');
+const assert = require('assert');
+
+const HttpRequestAuthV4 = require('../utils/HttpRequestAuthV4');
+const config = require('../../config.json');
+
+const DUMMY_SIGNATURE =
+      'baadc0debaadc0debaadc0debaadc0debaadc0debaadc0debaadc0debaadc0de';
+
+http.globalAgent.keepAlive = true;
+
+const PORT = 8000;
+const BUCKET = 'bad-chunk-signature-v4';
+
+const N_PUTS = 100;
+const N_DATA_CHUNKS = 20;
+const DATA_CHUNK_SIZE = 128 * 1024;
+const ALTER_CHUNK_SIGNATURE = true;
+
+const CHUNK_DATA = Buffer.alloc(DATA_CHUNK_SIZE).fill('0').toString();
+
+function createBucket(cb) {
+    const req = new HttpRequestAuthV4(
+        `http://${config.ipAddress}:${PORT}/${BUCKET}`, {
+            accessKey: config.accessKey,
+            secretKey: config.secretKey,
+            method: 'PUT',
+            headers: {
+                connection: 'keep-alive',
+            },
+        }, res => {
+            assert.strictEqual(res.statusCode, 200);
+            res.on('data', () => {});
+            res.on('end', cb);
+        });
+
+    req.on('error', err => {
+        assert.ifError(err);
+    });
+    req.end();
+}
+
+class HttpChunkedUploadWithBadSignature extends HttpRequestAuthV4 {
+    constructor(url, params, callback) {
+        super(url, params, callback);
+        this._chunkId = 0;
+        this._alterSignatureChunkId = params.alterSignatureChunkId;
+    }
+
+    getChunkSignature(chunkData) {
+        let signature;
+        if (this._chunkId === this._alterSignatureChunkId) {
+            // console.log(
+            //     `ALTERING SIGNATURE OF DATA CHUNK #${this._chunkId}`);
+            signature = DUMMY_SIGNATURE;
+        } else {
+            signature = super.getChunkSignature(chunkData);
+        }
+        ++this._chunkId;
+        return signature;
+    }
+}
+
+function testChunkedPutWithBadSignature(n, alterSignatureChunkId, cb) {
+    const req = new HttpChunkedUploadWithBadSignature(
+        `http://${config.ipAddress}:${PORT}/${BUCKET}/obj-${n}`, {
+            accessKey: config.accessKey,
+            secretKey: config.secretKey,
+            method: 'PUT',
+            headers: {
+                'content-length': N_DATA_CHUNKS * DATA_CHUNK_SIZE,
+                'connection': 'keep-alive',
+            },
+            alterSignatureChunkId,
+        }, res => {
+            if (alterSignatureChunkId >= 0 &&
+                alterSignatureChunkId <= N_DATA_CHUNKS) {
+                assert.strictEqual(res.statusCode, 403);
+            } else {
+                assert.strictEqual(res.statusCode, 200);
+            }
+            res.on('data', () => {});
+            res.on('end', cb);
+        });
+
+    req.on('error', err => {
+        assert.ifError(err);
+    });
+    async.timesSeries(N_DATA_CHUNKS, (chunkIndex, done) => {
+        // console.log(`SENDING NEXT CHUNK OF LENGTH ${CHUNK_DATA.length}`);
+        if (req.write(CHUNK_DATA)) {
+            process.nextTick(done);
+        } else {
+            req.once('drain', done);
+        }
+    }, () => {
+        req.end();
+    });
+}
+
+describe('streaming V4 signature with bad chunk signature', () => {
+    it('Cloudserver should be robust against bad signature in streaming ' +
+    'payload', function badSignatureInStreamingPayload(cb) {
+        this.timeout(120000);
+        createBucket(() => {
+            async.timesLimit(N_PUTS, 10, (n, done) => {
+                // multiple test cases depend on the value of
+                // alterSignatureChunkId:
+                // alterSignatureChunkId >= 0 &&
+                // alterSignatureChunkId < N_DATA_CHUNKS
+                //    <=> alter the signature of the target data chunk
+                // alterSignatureChunkId == N_DATA_CHUNKS
+                //    <=> alter the signature of the last empty chunk that
+                //        carries the last payload signature
+                // alterSignatureChunkId > N_DATA_CHUNKS
+                //    <=> no signature is altered (regular test case)
+                // By making n go from 0 to nDatachunks+1, we cover all
+                // above cases.
+
+                const alterSignatureChunkId = ALTER_CHUNK_SIGNATURE ?
+                      (n % (N_DATA_CHUNKS + 2)) : null;
+                testChunkedPutWithBadSignature(n, alterSignatureChunkId, done);
+            }, err => cb(err));
+        });
+    });
+});

--- a/tests/functional/raw-node/utils/HttpRequestAuthV4.js
+++ b/tests/functional/raw-node/utils/HttpRequestAuthV4.js
@@ -1,0 +1,255 @@
+const crypto = require('crypto');
+const http = require('http');
+const stream = require('stream');
+const url = require('url');
+
+const SERVICE = 's3';
+const REGION = 'us-east-1';
+const EMPTY_STRING_HASH = crypto.createHash('sha256').digest('hex');
+
+/**
+ * Execute and sign HTTP requests with AWS signature v4 scheme
+ *
+ * The purpose of this class is primarily testing, where the various
+ * functions used to generate the signing content can be overriden for
+ * specific test needs, like altering signatures or hashes.
+ *
+ * It provides a writable stream interface like the request object
+ * returned by http.request().
+ */
+class HttpRequestAuthV4 extends stream.Writable {
+    /**
+     * @constructor
+     * @param {string} url - HTTP URL to the S3 server
+     * @param {object} params - request parameters
+     * @param {string} params.accessKey - AWS access key
+     * @param {string} params.secretKey - AWS secret key
+     * @param {string} [params.method="GET"] - HTTP method
+     * @param {object} [params.headers] - HTTP request headers
+     * example: {
+     *     'connection': 'keep-alive',
+     *     'content-length': 1000, // mandatory for PUT object requests
+     *     'x-amz-content-sha256': '...' // streaming V4 encoding is used
+     *                                   // if not provided
+     * }
+     * @param {function} callback - called when a response arrives:
+     * callback(res) (see http.request())
+     */
+    constructor(url, params, callback) {
+        super();
+        this._url = url;
+        this._accessKey = params.accessKey;
+        this._secretKey = params.secretKey;
+        this._httpParams = params;
+        this._callback = callback;
+
+        this._httpRequest = null;
+        this._timestamp = null;
+        this._signingKey = null;
+        this._chunkedUpload = false;
+        this._lastSignature = null;
+
+        this.once('finish', () => {
+            if (!this._httpRequest) {
+                this._initiateRequest(false);
+            }
+            if (this._chunkedUpload) {
+                this._httpRequest.end(this.constructChunkPayload(''));
+            } else {
+                this._httpRequest.end();
+            }
+        });
+    }
+
+    getCredentialScope() {
+        const signingDate = this._timestamp.slice(0, 8);
+        const credentialScope =
+              `${signingDate}/${REGION}/${SERVICE}/aws4_request`;
+        // console.log(`CREDENTIAL SCOPE: "${credentialScope}"`);
+        return credentialScope;
+    }
+
+    getSigningKey() {
+        const signingDate = this._timestamp.slice(0, 8);
+        const dateKey = crypto.createHmac('sha256', `AWS4${this._secretKey}`)
+              .update(signingDate, 'binary').digest();
+        const dateRegionKey = crypto.createHmac('sha256', dateKey)
+              .update(REGION, 'binary').digest();
+        const dateRegionServiceKey = crypto.createHmac('sha256', dateRegionKey)
+              .update(SERVICE, 'binary').digest();
+        this._signingKey = crypto.createHmac('sha256', dateRegionServiceKey)
+              .update('aws4_request', 'binary').digest();
+    }
+
+    createSignature(stringToSign) {
+        if (!this._signingKey) {
+            this.getSigningKey();
+        }
+        return crypto.createHmac('sha256', this._signingKey)
+            .update(stringToSign).digest('hex');
+    }
+
+    getCanonicalRequest(urlObj, signedHeaders) {
+        const method = this._httpParams.method || 'GET';
+        const signedHeadersList = Object.keys(signedHeaders).sort();
+        const qsParams = [];
+        urlObj.searchParams.forEach((value, key) => {
+            qsParams.push({ key, value });
+        });
+        const canonicalQueryString =
+              qsParams
+              .sort((a, b) => {
+                  if (a.key !== b.key) {
+                      return a.key < b.key ? -1 : 1;
+                  }
+                  return a.value < b.value ? -1 : 1;
+              })
+              .map(param => `${encodeURI(param.key)}=${encodeURI(param.value)}`)
+              .join('&');
+        const canonicalSignedHeaders = signedHeadersList
+              .map(header => `${header}:${signedHeaders[header]}\n`)
+              .join('');
+        const canonicalRequest = [
+            method,
+            urlObj.pathname,
+            canonicalQueryString,
+            canonicalSignedHeaders,
+            signedHeadersList.join(';'),
+            signedHeaders['x-amz-content-sha256'],
+        ].join('\n');
+
+        // console.log(`CANONICAL REQUEST: "${canonicalRequest}"`);
+        return canonicalRequest;
+    }
+
+    constructRequestStringToSign(canonicalReq) {
+        const canonicalReqHash =
+              crypto.createHash('sha256').update(canonicalReq).digest('hex');
+        const stringToSign = `AWS4-HMAC-SHA256\n${this._timestamp}\n` +
+              `${this.getCredentialScope()}\n${canonicalReqHash}`;
+        // console.log(`STRING TO SIGN: "${stringToSign}"`);
+        return stringToSign;
+    }
+
+    getAuthorizationSignature(urlObj, signedHeaders) {
+        const canonicalRequest =
+              this.getCanonicalRequest(urlObj, signedHeaders);
+        this._lastSignature = this.createSignature(
+            this.constructRequestStringToSign(canonicalRequest));
+        return this._lastSignature;
+    }
+
+    getAuthorizationHeader(urlObj, signedHeaders) {
+        const authorizationSignature =
+              this.getAuthorizationSignature(urlObj, signedHeaders);
+        const signedHeadersList = Object.keys(signedHeaders).sort();
+
+        return ['AWS4-HMAC-SHA256',
+                `Credential=${this._accessKey}/${this.getCredentialScope()},`,
+                `SignedHeaders=${signedHeadersList.join(';')},`,
+                `Signature=${authorizationSignature}`,
+               ].join(' ');
+    }
+
+    constructChunkStringToSign(chunkData) {
+        const currentChunkHash =
+              crypto.createHash('sha256').update(chunkData.toString())
+              .digest('hex');
+        const stringToSign = `AWS4-HMAC-SHA256-PAYLOAD\n${this._timestamp}\n` +
+              `${this.getCredentialScope()}\n${this._lastSignature}\n` +
+              `${EMPTY_STRING_HASH}\n${currentChunkHash}`;
+        // console.log(`CHUNK STRING TO SIGN: "${stringToSign}"`);
+        return stringToSign;
+    }
+
+    getChunkSignature(chunkData) {
+        const stringToSign = this.constructChunkStringToSign(chunkData);
+        this._lastSignature = this.createSignature(stringToSign);
+        return this._lastSignature;
+    }
+
+    constructChunkPayload(chunkData) {
+        if (!this._chunkedUpload) {
+            return chunkData;
+        }
+        const chunkSignature = this.getChunkSignature(chunkData);
+        return [chunkData.length.toString(16),
+                ';chunk-signature=',
+                chunkSignature,
+                '\r\n',
+                chunkData,
+                '\r\n',
+               ].join('');
+    }
+
+    _constructRequest(hasDataToSend) {
+        const dateObj = new Date();
+        const isoDate = dateObj.toISOString();
+        this._timestamp = [
+            isoDate.slice(0, 4),
+            isoDate.slice(5, 7),
+            isoDate.slice(8, 13),
+            isoDate.slice(14, 16),
+            isoDate.slice(17, 19),
+            'Z',
+        ].join('');
+
+        const urlObj = new url.URL(this._url);
+        const signedHeaders = {
+            'host': urlObj.host,
+            'x-amz-date': this._timestamp,
+        };
+        const httpHeaders = Object.assign({}, this._httpParams.headers);
+        let contentLengthHeader;
+        Object.keys(httpHeaders).forEach(header => {
+            const lowerHeader = header.toLowerCase();
+            if (lowerHeader === 'content-length') {
+                contentLengthHeader = header;
+            }
+            if (!['connection',
+                  'transfer-encoding'].includes(lowerHeader)) {
+                signedHeaders[lowerHeader] = httpHeaders[header];
+            }
+        });
+        if (!signedHeaders['x-amz-content-sha256']) {
+            if (hasDataToSend) {
+                signedHeaders['x-amz-content-sha256'] =
+                    'STREAMING-AWS4-HMAC-SHA256-PAYLOAD';
+                signedHeaders['content-encoding'] = 'aws-chunked';
+                this._chunkedUpload = true;
+                if (contentLengthHeader !== undefined) {
+                    signedHeaders['x-amz-decoded-content-length'] =
+                        httpHeaders[contentLengthHeader];
+                    delete signedHeaders['content-length'];
+                    delete httpHeaders[contentLengthHeader];
+                    httpHeaders['transfer-encoding'] = 'chunked';
+                }
+            } else {
+                signedHeaders['x-amz-content-sha256'] = EMPTY_STRING_HASH;
+            }
+        }
+        httpHeaders.Authorization =
+            this.getAuthorizationHeader(urlObj, signedHeaders);
+
+        return Object.assign(httpHeaders, signedHeaders);
+    }
+
+    _initiateRequest(hasDataToSend) {
+        const httpParams = Object.assign({}, this._httpParams);
+        httpParams.headers = this._constructRequest(hasDataToSend);
+        this._httpRequest = http.request(this._url, httpParams, this._callback);
+    }
+
+    _write(chunk, encoding, callback) {
+        if (!this._httpRequest) {
+            this._initiateRequest(true);
+        }
+        const payload = this.constructChunkPayload(chunk);
+        if (this._httpRequest.write(payload)) {
+            return callback();
+        }
+        return this._httpRequest.once('drain', callback);
+    }
+}
+
+module.exports = HttpRequestAuthV4;

--- a/tests/unit/auth/V4Transform.js
+++ b/tests/unit/auth/V4Transform.js
@@ -49,10 +49,27 @@ describe('V4Transform class', () => {
         });
     });
 
-    it('should ignore data sent after final chunk', done => {
+    it('should raise an error if signature is wrong', done => {
         const v4Transform = new V4Transform(streamingV4Params, log, err => {
-            assert.strictEqual(err, null);
+            assert(err);
             done();
+        });
+        const filler1 = '8;chunk-signature=51d2511f7c6887907dff20474d8db6' +
+        '7d557e5f515a6fa6a8466bb12f8833bcca\r\ncontents\r\n';
+        const filler2 = '0;chunk-signature=baadc0debaadc0debaadc0debaadc0de' +
+        'baadc0debaadc0debaadc0debaadc0de\r\n';
+        const chunks = [
+            Buffer.from(filler1),
+            Buffer.from(filler2),
+            null,
+        ];
+        const authMe = new AuthMe(chunks);
+        authMe.pipe(v4Transform);
+    });
+
+    it('should ignore data sent after final chunk', done => {
+        const v4Transform = new V4Transform(streamingV4Params, log, () => {
+            assert(false);
         });
         const filler1 = '8;chunk-signature=51d2511f7c6887907dff20474d8db6' +
         '7d557e5f515a6fa6a8466bb12f8833bcca\r\ncontents\r\n';

--- a/yarn.lock
+++ b/yarn.lock
@@ -209,7 +209,6 @@ arraybuffer.slice@0.0.6:
   version "7.4.3"
   resolved "https://codeload.github.com/scality/Arsenal/tar.gz/a7b6fc8fb8ed332fd2695e1c0fafad726116727e"
   dependencies:
-    "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
     ajv "4.10.0"
     async "~2.1.5"
@@ -217,6 +216,7 @@ arraybuffer.slice@0.0.6:
     diskusage "^1.1.1"
     ioredis "4.9.5"
     ipaddr.js "1.2.0"
+    joi "^10.6"
     level "~5.0.1"
     level-sublevel "~6.6.5"
     node-forge "^0.7.1"
@@ -602,7 +602,6 @@ bucketclient@scality/bucketclient#6d2d5a4:
   dependencies:
     arsenal scality/Arsenal#9f2e74e
     werelogs scality/werelogs#4e0d97c
-    yarn "^1.17.3"
 
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
@@ -3387,9 +3386,9 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sproxydclient@scality/sproxydclient#0e17e27:
-  version "7.4.1"
-  resolved "https://codeload.github.com/scality/sproxydclient/tar.gz/0e17e27b35971aab4bc9a6ce40f7eab2f054314e"
+sproxydclient@scality/sproxydclient#bb239db:
+  version "7.4.6"
+  resolved "https://codeload.github.com/scality/sproxydclient/tar.gz/bb239db5c8de734cf1976a8123ca2d23e22c55a3"
   dependencies:
     async "^3.1.0"
     werelogs scality/werelogs#4e0d97c
@@ -3743,13 +3742,13 @@ utapi@scality/utapi#b522b3d:
   version "7.4.5"
   resolved "https://codeload.github.com/scality/utapi/tar.gz/b522b3d782b1e29b640a25b79ba5c06e445eaf71"
   dependencies:
-    arsenal scality/Arsenal#dd6fde6
+    arsenal scality/Arsenal#32c895b
     async "^2.0.1"
     ioredis "^4.9.5"
     node-schedule "1.2.0"
     uuid "^3.3.2"
-    vaultclient scality/vaultclient#cc9ba34
-    werelogs scality/werelogs#4e0d97c
+    vaultclient scality/vaultclient#478710c
+    werelogs scality/werelogs#0a4c576
 
 utf8@2.1.2, utf8@~2.1.1:
   version "2.1.2"


### PR DESCRIPTION
*Note*: for branches development/8.1+, since some storage code has moved to Arsenal, part of the changes will need to be ported there (lib/data/wrapper.js and the dependency update on sproxydclient).

- make sure the V4Transform._transform() callback is always called
  even in case of error. When there is a client error (like a chunked
  stream signature mismatch), continue consuming the data but do not
  send it to sproxyd. Do not emit an 'error' event as this confuses
  the HTTP stack and retains bad client connections,

- instead of an 'error' event, emit a custom 'clientError' event on
  V4Transform in case of client error to allow a cleanup of sproxyd
  connections,

- depend on a fix of sproxydclient that aborts sproxyd requests when
  the input stream is closed.