### PR TITLE
feature: add metrics and secure channel servers

### DIFF
--- a/bin/metrics_server.js
+++ b/bin/metrics_server.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+'use strict'; // eslint-disable-line strict
+
+const {
+    startWSManagementClient,
+    startPushConnectionHealthCheckServer,
+} = require('../lib/management/push');
+
+const logger = require('../lib/utilities/logger');
+
+const {
+    PUSH_ENDPOINT: pushEndpoint,
+    INSTANCE_ID: instanceId,
+    MANAGEMENT_TOKEN: managementToken,
+} = process.env;
+
+if (!pushEndpoint) {
+    logger.error('missing push endpoint env var');
+    process.exit(1);
+}
+
+if (!instanceId) {
+    logger.error('missing instance id env var');
+    process.exit(1);
+}
+
+if (!managementToken) {
+    logger.error('missing management token env var');
+    process.exit(1);
+}
+
+startPushConnectionHealthCheckServer(err => {
+    if (err) {
+        logger.error('could not start healthcheck server', { error: err });
+        process.exit(1);
+    }
+    const url = `${pushEndpoint}/${instanceId}/ws?metrics=1`;
+    startWSManagementClient(url, managementToken, err => {
+        if (err) {
+            logger.error('connection failed, exiting', { error: err });
+            process.exit(1);
+        }
+        logger.info('no more connection, exiting');
+        process.exit(0);
+    });
+});

--- a/bin/secure_channel_proxy.js
+++ b/bin/secure_channel_proxy.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+'use strict'; // eslint-disable-line strict
+
+const {
+    startWSManagementClient,
+    startPushConnectionHealthCheckServer,
+} = require('../lib/management/push');
+
+const logger = require('../lib/utilities/logger');
+
+const {
+    PUSH_ENDPOINT: pushEndpoint,
+    INSTANCE_ID: instanceId,
+    MANAGEMENT_TOKEN: managementToken,
+} = process.env;
+
+if (!pushEndpoint) {
+    logger.error('missing push endpoint env var');
+    process.exit(1);
+}
+
+if (!instanceId) {
+    logger.error('missing instance id env var');
+    process.exit(1);
+}
+
+if (!managementToken) {
+    logger.error('missing management token env var');
+    process.exit(1);
+}
+
+startPushConnectionHealthCheckServer(err => {
+    if (err) {
+        logger.error('could not start healthcheck server', { error: err });
+        process.exit(1);
+    }
+    const url = `${pushEndpoint}/${instanceId}/ws?proxy=1`;
+    startWSManagementClient(url, managementToken, err => {
+        if (err) {
+            logger.error('connection failed, exiting', { error: err });
+            process.exit(1);
+        }
+        logger.info('no more connection, exiting');
+        process.exit(0);
+    });
+});

--- a/lib/management/index.js
+++ b/lib/management/index.js
@@ -51,7 +51,8 @@ function initManagementDatabase(log, callback) {
 function startManagementListeners(instanceId, token) {
     const mode = process.env.MANAGEMENT_MODE || 'push';
     if (mode === 'push') {
-        startWSManagementClient(pushEndpoint, instanceId, token);
+        const url = `${pushEndpoint}/${instanceId}/ws`;
+        startWSManagementClient(url, token);
     } else {
         startPollingManagementClient(managementEndpoint, instanceId, token);
     }

--- a/lib/management/push.js
+++ b/lib/management/push.js
@@ -5,6 +5,7 @@ const request = require('request');
 const { URL } = require('url');
 const WebSocket = require('ws');
 const assert = require('assert');
+const http = require('http');
 
 const _config = require('../Config').config;
 const logger = require('../utilities/logger');
@@ -28,7 +29,13 @@ const {
 const PING_INTERVAL_MS = 10000;
 const subprotocols = [ChannelMessageV0.protocolName];
 
+const cloudServerHost = process.env.SECURE_CHANNEL_DEFAULT_FORWARD_TO_HOST
+    || 'localhost';
+const cloudServerPort = process.env.SECURE_CHANNEL_DEFAULT_FORWARD_TO_PORT
+    || _config.port;
+
 let overlayMessageListener = null;
+let connected = false;
 
 // No wildcard nor cidr/mask match for now
 function createWSAgent(pushEndpoint, env, log) {
@@ -71,14 +78,14 @@ function createWSAgent(pushEndpoint, env, log) {
  * Receives pushed Websocket messages on configuration updates, and
  * sends stat messages in response to API sollicitations.
  *
- * @param {string} pushEndpoint API endpoint
- * @param {string} instanceId UUID of this deployment
+ * @param {string} url API endpoint
  * @param {string} token API authentication token
+ * @param {function} cb end-of-connection callback
  *
  * @returns {undefined}
  */
-function startWSManagementClient(pushEndpoint, instanceId, token) {
-    logger.info('connecting to push server');
+function startWSManagementClient(url, token, cb) {
+    logger.info('connecting to push server', { url });
     function _logError(error, errorMessage, method) {
         if (error) {
             logger.error(`management client error: ${errorMessage}`,
@@ -90,9 +97,8 @@ function startWSManagementClient(pushEndpoint, instanceId, token) {
     const headers = {
         'x-instance-authentication-token': token,
     };
-    const agent = createWSAgent(pushEndpoint, process.env, logger);
+    const agent = createWSAgent(url, process.env, logger);
 
-    const url = `${pushEndpoint}/${instanceId}/ws`;
     const ws = new WebSocket(url, subprotocols, { headers, agent });
     let pingTimeout = null;
 
@@ -112,7 +118,7 @@ function startWSManagementClient(pushEndpoint, instanceId, token) {
         if (process.env.PUSH_STATS === 'false') {
             return;
         }
-        const fromURL = `http://localhost:${_config.port}/_/report`;
+        const fromURL = `http://${cloudServerHost}:${cloudServerPort}/_/report`;
         const fromOptions = {
             headers: {
                 'x-scal-report-token': process.env.REPORT_TOKEN,
@@ -141,11 +147,7 @@ function startWSManagementClient(pushEndpoint, instanceId, token) {
     function receiveChannelData(channelId, payload) {
         let socket = socketsByChannelId[channelId];
         if (!socket) {
-            const host = process.env.SECURE_CHANNEL_DEFAULT_FORWARD_TO_HOST
-              || 'localhost';
-            const port = process.env.SECURE_CHANNEL_DEFAULT_FORWARD_TO_PORT
-              || _config.port;
-            socket = net.createConnection(port, host);
+            socket = net.createConnection(cloudServerPort, cloudServerHost);
 
             socket.on('data', data => {
                 ws.send(ChannelMessageV0.
@@ -189,6 +191,7 @@ function startWSManagementClient(pushEndpoint, instanceId, token) {
     }
 
     ws.on('open', () => {
+        connected = true;
         logger.info('connected to push server');
 
         metadata.notifyBucketChange(() => {
@@ -199,20 +202,30 @@ function startWSManagementClient(pushEndpoint, instanceId, token) {
         initiatePing();
     });
 
+    const cbOnce = cb ? arsenal.jsutil.once(cb) : null;
+
     ws.on('close', () => {
         logger.info('disconnected from push server, reconnecting in 10s');
         metadata.notifyBucketChange(null);
         _config.removeListener('browser-access-enabled-change',
             browserAccessChangeHandler);
-        setTimeout(startWSManagementClient, 10000, pushEndpoint,
-            instanceId, token);
+        setTimeout(startWSManagementClient, 10000, url, token);
+        connected = false;
+
+        if (cbOnce) {
+            process.nextTick(cbOnce);
+        }
     });
 
     ws.on('error', err => {
+        connected = false;
         logger.error('error from push server connection', {
             error: err,
             errorMessage: err.message,
         });
+        if (cbOnce) {
+            process.nextTick(cbOnce, err);
+        }
     });
 
     ws.on('ping', () => {
@@ -226,7 +239,6 @@ function startWSManagementClient(pushEndpoint, instanceId, token) {
     ws.on('message', data => {
         const log = logger.newRequestLogger();
         const message = new ChannelMessageV0(data);
-
         switch (message.getType()) {
         case CONFIG_OVERLAY_MESSAGE:
             if (!isManagementAgentUsed()) {
@@ -244,7 +256,8 @@ function startWSManagementClient(pushEndpoint, instanceId, token) {
             closeChannel(message.getChannelNumber());
             break;
         case CHANNEL_PAYLOAD_MESSAGE:
-            if (_config.browserAccessEnabled) {
+            // browserAccessEnabled defaults to true unless explicitly false
+            if (_config.browserAccessEnabled !== false) {
                 receiveChannelData(
                     message.getChannelNumber(), message.getPayload());
             }
@@ -261,8 +274,27 @@ function addOverlayMessageListener(callback) {
     overlayMessageListener = callback;
 }
 
+function startPushConnectionHealthCheckServer(cb) {
+    const server = http.createServer((req, res) => {
+        if (req.url !== '/_/healthcheck') {
+            res.writeHead(404);
+            res.write('Not Found');
+        } else if (connected) {
+            res.writeHead(200);
+            res.write('Connected');
+        } else {
+            res.writeHead(503);
+            res.write('Not Connected');
+        }
+        res.end();
+    });
+
+    server.listen(_config.port, cb);
+}
+
 module.exports = {
     createWSAgent,
     startWSManagementClient,
+    startPushConnectionHealthCheckServer,
     addOverlayMessageListener,
 };

--- a/package.json
+++ b/package.json
@@ -96,6 +96,8 @@
     "start_s3server": "node index.js",
     "start_dmd": "npm-run-all --parallel start_mdserver start_dataserver",
     "start_utapi": "node lib/utapi/utapi.js",
+    "start_secure_channel_proxy": "node bin/secure_channel_proxy.js",
+    "start_metrics_server": "node bin/metrics_server.js",
     "utapi_replay": "node lib/utapi/utapiReplay.js",
     "utapi_reindex": "node lib/utapi/utapiReindex.js",
     "management_agent": "node managementAgent.js",


### PR DESCRIPTION
This allows using specialized connections for each usage:
- configuration push
- metrics collection (to be later moved to prom scraping)
- secure channel

This way each connection handler can be restricted in what it can
do for reliability and security purposes.

Should be functionally equivalent for current deployment mode, the new scripts are to be used with Zenko Operator.