### PR TITLE
ZENKO-2240 fixup get product version

### DIFF
--- a/eve/get_product_version.sh
+++ b/eve/get_product_version.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 LOCAL_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
 BRANCHES=(development q stabilization)

--- a/eve/get_product_version.sh
+++ b/eve/get_product_version.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-LOCAL_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
-BRANCHES=(development q stabilization)
+script_full_path=$(readlink -f "$0")
+file_dir=$(dirname "$script_full_path")/..
 
-for branch in ${BRANCHES[@]}; do
-    if echo "${LOCAL_BRANCH}\/" | grep -q ^${branch} ; then
-        cat .git/HEAD | sed 's/.*\///'
-        exit 0
-    fi
-done
+PACKAGE_VERSION=$(cat $file_dir/package.json \
+  | grep version \
+  | head -1 \
+  | awk -F: '{ print $2 }' \
+  | sed 's/[",]//g' \
+  | tr -d '[[:space:]]')
 
-echo 0.0.0
+echo $PACKAGE_VERSION

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "1.1.0",
+  "version": "6.4.0",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Now we're retrieving the version from the package.json file.

we use to have a version defined as 0.0.0 on our post-merge deliveries which causes some kind of confusion because this tag was used to deploy things on docker hub. 

You can see that we have a `latest-0.0.0` tag defined [here](https://hub.docker.com/repository/docker/zenko/cloudserver/tags?page=1&name=0.0.0)

Before:
```
➜  cloudserver git:(development/7.4) ✗ ./eve/get_product_version.sh 
./eve/get_product_version.sh: 4: Syntax error: "(" unexpected
```
after
```
➜  cloudserver git:(bugfix/ZENKO-2240-fixup-get-product-version) ✗ ./eve/get_product_version.sh 
6.4.0
```
