### PR TITLE
ZENKO-2238 post merge deploy to new registry

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -394,42 +394,47 @@ stages:
       type: local
     steps:
       - Git: *clone
+      - ShellCommand: &wait_docker_daemon
+          name: Wait for Docker daemon to be ready
+          command: |
+            bash -c '
+            for i in {1..150}
+            do
+              docker info &> /dev/null && exit
+              sleep 2
+            done
+            echo "Could not reach Docker daemon from buildbot worker" >&2
+            exit 1'
+          haltOnFailure: true
       - ShellCommand: &docker_login
           name: Private Registry Login
           command: >
             docker login
-            -u '%(secret:private_registry_username)s'
-            -p '%(secret:private_registry_password)s'
-            '%(secret:private_registry_url)s'
-      - ShellCommand:
-          name: Dockerhub Login
-          command: >
-            docker login
-            -u '%(secret:dockerhub_ro_user)s'
-            -p '%(secret:dockerhub_ro_password)s'
-      - SetProperty: &docker_image_name
-          name: Set docker image name property
-          property: docker_image_name
-          value:
-            "%(secret:private_registry_url)s/zenko/cloudserver:\
-            %(prop:commit_short_revision)s"
+            -u '%(secret:harbor_login)s'
+            -p '%(secret:harbor_password)s'
+            registry.scality.com
+      - SetProperty: &registry_url
+          name: registry
+          property: registry_url
+          value: registry.scality.com/zenko-dev/cloudserver
+      - SetProperty: &docker_tag_revision
+          name: Set docker tag revision property
+          property: docker_tag_revision
+          value: "%(prop:registry_url)s:%(prop:commit_short_revision)s"
+      - SetProperty: &docker_tag_latest
+          name: Set docker tag latest property
+          property: docker_tag_latest
+          value: "%(prop:registry_url)s:latest-%(prop:product_version)s"
       - ShellCommand:
           name: Build docker image
           command: >-
             docker build
             --no-cache
-            -t %(prop:docker_image_name)s
+            -t %(prop:docker_tag_revision)s
+            -t %(prop:docker_tag_latest)s
             .
       - ShellCommand:
-          name: Tag images
+          name: Push images
           command: |
-            docker tag %(prop:docker_image_name)s zenko/cloudserver:$TAG
-            docker tag %(prop:docker_image_name)s zenko/cloudserver:latest
-          env:
-            TAG: "latest-%(prop:product_version)s"
-      - ShellCommand:
-          name: Push image
-          command: |
-            docker push %(prop:docker_image_name)s
-            docker push zenko/cloudserver:latest-%(prop:product_version)s
-            docker push zenko/cloudserver:latest
+            docker push %(prop:docker_tag_revision)s
+            docker push %(prop:docker_tag_latest)s

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -391,7 +391,10 @@ stages:
 
   post-merge:
     worker:
-      type: local
+      type: kube_pod
+      path: eve/workers/release/pod.yaml
+      images:
+        release: eve/workers/release
     steps:
       - Git: *clone
       - ShellCommand: &wait_docker_daemon

--- a/eve/workers/release/Dockerfile
+++ b/eve/workers/release/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:bionic
+
+WORKDIR /home/eve/workspace
+
+RUN apt-get update && apt-get install -y \
+    git \
+    gnupg2 \
+    lsb-release \
+    curl \
+    python3-buildbot-worker \
+    && adduser -u 1042 --home /home/eve eve \
+    && chown -R eve:eve /home/eve
+
+# Install docker cli
+ARG DOCKER_VERSION=18.06.1~ce~3-0~ubuntu
+
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
+ && echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+    | tee -a /etc/apt/sources.list.d/docker-ce.list \
+ && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    docker-ce=${DOCKER_VERSION} \
+ && rm -rf /var/lib/apt/lists/* /var/cache/apt
+
+USER eve

--- a/eve/workers/release/pod.yaml
+++ b/eve/workers/release/pod.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: release-worker
+spec:
+  containers:
+    - name: release-worker
+      image: "{{ images.release }}"
+      command: ["/bin/sh"]
+      args: ["-c", "buildbot-worker create-worker . ${BUILDMASTER}:${BUILDMASTER_PORT} ${WORKERNAME} ${WORKERPASS} && buildbot-worker start --nodaemon"]
+      resources:
+        requests:
+          cpu: "250m"
+          memory: 1Gi
+        limits:
+          cpu: "1"
+          memory: 1Gi
+      env:
+        - name: DOCKER_HOST
+          value: localhost:2375
+      volumeMounts:
+      - name: worker-workspace
+        mountPath: /home/eve/workspace
+    - name: dind-daemon
+      image: docker:18.06.1-dind
+      resources:
+        requests:
+          cpu: "500m"
+          memory: 1Gi
+        limits:
+          cpu: "1"
+          memory: 1Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-storage
+        mountPath: /var/lib/docker
+      - name: worker-workspace
+        mountPath: /home/eve/workspace
+  volumes:
+  - name: docker-storage
+    emptyDir: {}
+  - name: worker-workspace
+    emptyDir: {}


### PR DESCRIPTION
Now deploying cloudserver images to our own docker registry, but with public access.

https://registry.scality.com/harbor/projects/7/repositories/zenko-dev%2Fcloudserver 