### PR TITLE
FORWARD PORT: bugfix: ZENKO-2250 rework chunked upload stream handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "github:scality/Arsenal#635d2fe",
+    "arsenal": "github:scality/Arsenal#a75db31",
     "async": "~2.5.0",
     "aws-sdk": "2.80.0",
     "azure-storage": "^2.1.0",

--- a/tests/functional/raw-node/test/badChunkSignatureV4.js
+++ b/tests/functional/raw-node/test/badChunkSignatureV4.js
@@ -95,7 +95,7 @@ function testChunkedPutWithBadSignature(n, alterSignatureChunkId, cb) {
     });
 }
 
-describe.skip('streaming V4 signature with bad chunk signature', () => {
+describe('streaming V4 signature with bad chunk signature', () => {
     const bucketUtil = new BucketUtility('default', {});
 
     before(done => createBucket(bucketUtil, done));

--- a/yarn.lock
+++ b/yarn.lock
@@ -232,9 +232,9 @@ arraybuffer.slice@~0.0.7:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
   integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
 
-"arsenal@github:scality/Arsenal#635d2fe":
+"arsenal@github:scality/Arsenal#a75db31":
   version "8.1.4"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/635d2fe6d9421e2a59c4fa213594ef2785b17709"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/a75db3122faba57f8ce93124ec29719824e9f6d6"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
@@ -321,6 +321,7 @@ arsenal@scality/Arsenal#c57cde8:
   version "8.1.4"
   resolved "https://codeload.github.com/scality/Arsenal/tar.gz/c57cde88bb04fe9803ec08c3a883f6eb986e4149"
   dependencies:
+    "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
     ajv "4.10.0"
     async "~2.6.1"
@@ -335,7 +336,6 @@ arsenal@scality/Arsenal#c57cde8:
     https-proxy-agent "^2.2.0"
     ioredis "4.9.5"
     ipaddr.js "1.8.1"
-    joi "^14.3.0"
     level "~5.0.1"
     level-sublevel "~6.6.5"
     mongodb "^3.0.1"
@@ -344,7 +344,7 @@ arsenal@scality/Arsenal#c57cde8:
     simple-glob "^0.2.0"
     socket.io "~2.2.0"
     socket.io-client "~2.2.0"
-    sproxydclient "github:scality/sproxydclient#a6ec980"
+    sproxydclient "github:scality/sproxydclient#13e87ea"
     utf8 "3.0.0"
     uuid "^3.0.1"
     werelogs scality/werelogs#0ff7ec82
@@ -1949,11 +1949,6 @@ hoek@4.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
   integrity sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==
 
-hoek@6.x.x:
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-6.1.3.tgz#73b7d33952e01fe27a38b0457294b79dd8da242c"
-  integrity sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==
-
 hosted-git-info@^2.1.4:
   version "2.8.5"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.5.tgz#759cfcf2c4d156ade59b0b2dfabddc42a6b9c70c"
@@ -2225,13 +2220,6 @@ isemail@2.x.x:
   resolved "https://registry.yarnpkg.com/isemail/-/isemail-2.2.1.tgz#0353d3d9a62951080c262c2aa0a42b8ea8e9e2a6"
   integrity sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY=
 
-isemail@3.x.x:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/isemail/-/isemail-3.2.0.tgz#59310a021931a9fb06bbb51e155ce0b3f236832c"
-  integrity sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==
-  dependencies:
-    punycode "2.x.x"
-
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -2370,15 +2358,6 @@ joi@^10.6:
     isemail "2.x.x"
     items "2.x.x"
     topo "2.x.x"
-
-joi@^14.3.0:
-  version "14.3.1"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-14.3.1.tgz#164a262ec0b855466e0c35eea2a885ae8b6c703c"
-  integrity sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==
-  dependencies:
-    hoek "6.x.x"
-    isemail "3.x.x"
-    topo "3.x.x"
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -3530,15 +3509,15 @@ punycode@1.3.2:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
   integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
 
-punycode@2.x.x, punycode@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
-  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
-
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
+
+punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 qs@~6.5.2:
   version "6.5.2"
@@ -4078,11 +4057,12 @@ sprintf-js@~1.0.2:
     async "^3.1.0"
     werelogs scality/werelogs#351a2a3
 
-"sproxydclient@github:scality/sproxydclient#a6ec980":
-  version "7.4.0"
-  resolved "https://codeload.github.com/scality/sproxydclient/tar.gz/a6ec98079fcbfde113de3f3afdcb57835d2ac55f"
+"sproxydclient@github:scality/sproxydclient#4f619d6":
+  version "8.0.1"
+  resolved "https://codeload.github.com/scality/sproxydclient/tar.gz/4f619d65bad67b8fbe87b14910fb94c3d5541127"
   dependencies:
-    werelogs scality/werelogs#0ff7ec82
+    async "^3.1.0"
+    werelogs scality/werelogs#351a2a3
 
 sql-where-parser@~2.2.1:
   version "2.2.1"
@@ -4368,13 +4348,6 @@ topo@2.x.x:
   integrity sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=
   dependencies:
     hoek "4.x.x"
-
-topo@3.x.x:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/topo/-/topo-3.0.3.tgz#d5a67fb2e69307ebeeb08402ec2a2a6f5f7ad95c"
-  integrity sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==
-  dependencies:
-    hoek "6.x.x"
 
 tough-cookie@~2.4.3:
   version "2.4.3"


### PR DESCRIPTION
Forward-port of https://scality.atlassian.net/browse/S3C-2504 to Zenko (depends on https://github.com/scality/Arsenal/pull/915)

Update Arsenal dependency and re-enable streaming V4 functional test
