### PR TITLE
bugfix: S3C-2504 cleanup test bucket

### DIFF
--- a/tests/functional/raw-node/test/badChunkSignatureV4.js
+++ b/tests/functional/raw-node/test/badChunkSignatureV4.js
@@ -2,6 +2,9 @@ const http = require('http');
 const async = require('async');
 const assert = require('assert');
 
+const BucketUtility =
+    require('../../aws-node-sdk/lib/utility/bucket-util');
+
 const HttpRequestAuthV4 = require('../utils/HttpRequestAuthV4');
 const config = require('../../config.json');
 
@@ -20,25 +23,18 @@ const ALTER_CHUNK_SIGNATURE = true;
 
 const CHUNK_DATA = Buffer.alloc(DATA_CHUNK_SIZE).fill('0').toString();
 
-function createBucket(cb) {
-    const req = new HttpRequestAuthV4(
-        `http://${config.ipAddress}:${PORT}/${BUCKET}`, {
-            accessKey: config.accessKey,
-            secretKey: config.secretKey,
-            method: 'PUT',
-            headers: {
-                connection: 'keep-alive',
-            },
-        }, res => {
-            assert.strictEqual(res.statusCode, 200);
-            res.on('data', () => {});
-            res.on('end', cb);
-        });
+function createBucket(bucketUtil, cb) {
+    const createBucket = async.asyncify(bucketUtil.createOne.bind(bucketUtil));
+    createBucket(BUCKET, cb);
+}
 
-    req.on('error', err => {
-        assert.ifError(err);
-    });
-    req.end();
+function cleanupBucket(bucketUtil, cb) {
+    const emptyBucket = async.asyncify(bucketUtil.empty.bind(bucketUtil));
+    const deleteBucket = async.asyncify(bucketUtil.deleteOne.bind(bucketUtil));
+    async.series([
+        done => emptyBucket(BUCKET, done),
+        done => deleteBucket(BUCKET, done),
+    ], cb);
 }
 
 class HttpChunkedUploadWithBadSignature extends HttpRequestAuthV4 {
@@ -100,28 +96,30 @@ function testChunkedPutWithBadSignature(n, alterSignatureChunkId, cb) {
 }
 
 describe('streaming V4 signature with bad chunk signature', () => {
+    const bucketUtil = new BucketUtility('default', {});
+
+    before(done => createBucket(bucketUtil, done));
+    after(done => cleanupBucket(bucketUtil, done));
     it('Cloudserver should be robust against bad signature in streaming ' +
     'payload', function badSignatureInStreamingPayload(cb) {
         this.timeout(120000);
-        createBucket(() => {
-            async.timesLimit(N_PUTS, 10, (n, done) => {
-                // multiple test cases depend on the value of
-                // alterSignatureChunkId:
-                // alterSignatureChunkId >= 0 &&
-                // alterSignatureChunkId < N_DATA_CHUNKS
-                //    <=> alter the signature of the target data chunk
-                // alterSignatureChunkId == N_DATA_CHUNKS
-                //    <=> alter the signature of the last empty chunk that
-                //        carries the last payload signature
-                // alterSignatureChunkId > N_DATA_CHUNKS
-                //    <=> no signature is altered (regular test case)
-                // By making n go from 0 to nDatachunks+1, we cover all
-                // above cases.
+        async.timesLimit(N_PUTS, 10, (n, done) => {
+            // multiple test cases depend on the value of
+            // alterSignatureChunkId:
+            // alterSignatureChunkId >= 0 &&
+            // alterSignatureChunkId < N_DATA_CHUNKS
+            //    <=> alter the signature of the target data chunk
+            // alterSignatureChunkId == N_DATA_CHUNKS
+            //    <=> alter the signature of the last empty chunk that
+            //        carries the last payload signature
+            // alterSignatureChunkId > N_DATA_CHUNKS
+            //    <=> no signature is altered (regular test case)
+            // By making n go from 0 to nDatachunks+1, we cover all
+            // above cases.
 
-                const alterSignatureChunkId = ALTER_CHUNK_SIGNATURE ?
-                      (n % (N_DATA_CHUNKS + 2)) : null;
-                testChunkedPutWithBadSignature(n, alterSignatureChunkId, done);
-            }, err => cb(err));
-        });
+            const alterSignatureChunkId = ALTER_CHUNK_SIGNATURE ?
+                  (n % (N_DATA_CHUNKS + 2)) : null;
+            testChunkedPutWithBadSignature(n, alterSignatureChunkId, done);
+        }, err => cb(err));
     });
 });


### PR DESCRIPTION
Delete bucket after streaming V4 test to avoid side-effects with other
tests (observed on 8.1+ branches with mongodb
reportHandler::countItems test).
