### PR TITLE
INTEGRATION [PR#2293 > development/7.6] bugfix: S3C-2527 effectively reuse sproxyd connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "mongodb": "^2.2.31",
     "node-uuid": "^1.4.3",
     "npm-run-all": "~4.1.5",
-    "sproxydclient": "scality/sproxydclient#bb239db",
+    "sproxydclient": "scality/sproxydclient#77a2de0",
     "utapi": "scality/utapi#b522b3d",
     "utf8": "~2.1.1",
     "uuid": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3387,9 +3387,9 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sproxydclient@scality/sproxydclient#bb239db:
-  version "7.4.6"
-  resolved "https://codeload.github.com/scality/sproxydclient/tar.gz/bb239db5c8de734cf1976a8123ca2d23e22c55a3"
+sproxydclient@scality/sproxydclient#77a2de0:
+  version "7.4.7"
+  resolved "https://codeload.github.com/scality/sproxydclient/tar.gz/77a2de096cdc9cca1e4038714890dfb004f6a9c4"
   dependencies:
     async "^3.1.0"
     werelogs scality/werelogs#4e0d97c


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2293.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.6/bugfix/S3C-2527-sproxydclientDependencyUpdate`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.6/bugfix/S3C-2527-sproxydclientDependencyUpdate
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.6/bugfix/S3C-2527-sproxydclientDependencyUpdate
```

Please always comment pull request #2293 instead of this one.