### PR TITLE
ZENKO-2277 installing curl and gpg due to parent image upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,11 @@ COPY ./yarn.lock /usr/src/app/
 
 WORKDIR /usr/src/app
 
+RUN apt-get update \
+    && apt-get install -y \
+    curl \
+    gnupg2
+
 RUN curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb http://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-slim
+FROM node:10.18.0-slim
 MAINTAINER Giorgio Regni <gr@scality.com>
 
 ENV NO_PROXY localhost,127.0.0.1


### PR DESCRIPTION
as the image node:10-slim received an update and removed the commands
curl and gpg, we lost the ability to build cloudserver.
We're now installing them specifically.
