### PR TITLE
INTEGRATION [PR#2306 > development/8.2] ZENKO-2277 installing curl and gpg due to parent image upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,11 @@ COPY ./yarn.lock /usr/src/app/
 
 WORKDIR /usr/src/app
 
+RUN apt-get update \
+    && apt-get install -y \
+    curl \
+    gnupg2
+
 RUN curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb http://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-slim
+FROM node:10.18.0-slim
 MAINTAINER Giorgio Regni <gr@scality.com>
 
 ENV NO_PROXY localhost,127.0.0.1


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2306.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/bugfix/ZENKO-2277-fix-cloudserver-image-build`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/bugfix/ZENKO-2277-fix-cloudserver-image-build
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/bugfix/ZENKO-2277-fix-cloudserver-image-build
```

Please always comment pull request #2306 instead of this one.