### PR TITLE
bugfix: ZENKO-2503 allow ACLs with same email in single request

### DIFF
--- a/lib/utilities/aclUtils.js
+++ b/lib/utilities/aclUtils.js
@@ -193,14 +193,17 @@ aclUtils.isValidCanonicalId = function isValidCanonicalId(canonicalID) {
 
 aclUtils.reconstructUsersIdentifiedByEmail =
     function reconstruct(userInfofromVault, userGrantInfo) {
-        return userInfofromVault.map(item => {
-            const userEmail = item.email.toLowerCase();
+        return userGrantInfo.map(item => {
+            const userEmail = item.identifier.toLowerCase();
+            const user = {};
             // Find the full user grant info based on email
-            const user = userGrantInfo
-                .find(elem => elem.identifier.toLowerCase() === userEmail);
+            const userId = userInfofromVault
+                .find(elem => elem.email.toLowerCase() === userEmail);
             // Set the identifier to be the canonicalID instead of email
-            user.identifier = item.canonicalID;
+            user.identifier = userId.canonicalID;
             user.userIDType = 'id';
+            // copy over ACL grant type: i.e. READ/WRITE...
+            user.grantType = item.grantType;
             return user;
         });
     };

--- a/tests/functional/aws-node-sdk/test/bucket/putAcl.js
+++ b/tests/functional/aws-node-sdk/test/bucket/putAcl.js
@@ -80,6 +80,25 @@ describe('PUT Bucket ACL', () => {
             });
         });
 
+        it('should set multiple ACL permissions with same grantee specified' +
+        'using email', done => {
+            s3.putBucketAcl({
+                Bucket: bucketName,
+                GrantRead: 'emailAddress=sampleaccount1@sampling.com',
+                GrantWrite: 'emailAddress=sampleaccount1@sampling.com',
+            }, err => {
+                assert(!err);
+                s3.getBucketAcl({
+                    Bucket: bucketName,
+                }, (err, res) => {
+                    assert(!err);
+                    // expect both READ and WRITE grants to exist
+                    assert.strictEqual(res.Grants.length, 2);
+                    return done();
+                });
+            });
+        });
+
         it('should return InvalidArgument if invalid grantee ' +
             'user ID provided in ACL header request', done => {
             s3.putBucketAcl({

--- a/tests/unit/api/bucketPutACL.js
+++ b/tests/unit/api/bucketPutACL.js
@@ -203,6 +203,50 @@ describe('putBucketACL API', () => {
         });
     });
 
+    it('should set all ACLs sharing the same email in request headers',
+        done => {
+            const testACLRequest = {
+                bucketName,
+                namespace,
+                headers: {
+                    'host': `${bucketName}.s3.amazonaws.com`,
+                    'x-amz-grant-full-control':
+                        'emailaddress="sampleaccount1@sampling.com"' +
+                        ',emailaddress="sampleaccount2@sampling.com"',
+                    'x-amz-grant-read':
+                        'emailaddress="sampleaccount1@sampling.com"',
+                    'x-amz-grant-write':
+                        'emailaddress="sampleaccount1@sampling.com"',
+                    'x-amz-grant-read-acp':
+                        'id=79a59df900b949e55d96a1e698fbacedfd6e09d98eac' +
+                        'f8f8d5218e7cd47ef2be',
+                    'x-amz-grant-write-acp':
+                        'id=79a59df900b949e55d96a1e698fbacedfd6e09d98eac' +
+                        'f8f8d5218e7cd47ef2bf',
+                },
+                url: '/?acl',
+                query: { acl: '' },
+            };
+            bucketPutACL(authInfo, testACLRequest, log, err => {
+                assert.strictEqual(err, undefined);
+                metadata.getBucket(bucketName, log, (err, md) => {
+                    assert(md.getAcl().WRITE.indexOf(canonicalIDforSample1)
+                        > -1);
+                    assert(md.getAcl().READ.indexOf(canonicalIDforSample1)
+                        > -1);
+                    assert(md.getAcl().FULL_CONTROL
+                        .indexOf(canonicalIDforSample1) > -1);
+                    assert(md.getAcl().FULL_CONTROL
+                        .indexOf(canonicalIDforSample2) > -1);
+                    assert(md.getAcl().READ_ACP
+                        .indexOf(canonicalIDforSample1) > -1);
+                    assert(md.getAcl().WRITE_ACP
+                        .indexOf(canonicalIDforSample2) > -1);
+                    done();
+                });
+            });
+        });
+
     it('should return an error if invalid grantee user ID ' +
     'provided in ACL header request', done => {
         // Canonical ID should be a 64-digit hex string


### PR DESCRIPTION
fix bugs to allow multiple ACLs added in a single request using the same email identifier (previously would only add 1 of the many ACL settings)

fixes target branch of closed pr: https://github.com/scality/cloudserver/pull/2308