### PR TITLE
INTEGRATION [PR#2315 > development/8.1] Bugfix/s3 c 2564 kms remove ssl option quotes

### DIFF
--- a/lib/kms/utilities.js
+++ b/lib/kms/utilities.js
@@ -79,7 +79,7 @@ function createEncryptedBucket() {
         .option('-b, --bucket <bucket>', 'Name of the bucket')
         .option('-h, --host <host>', 'Host of the server')
         .option('-p, --port <port>', 'Port of the server')
-        .option('-s', '--ssl', 'Enable ssl')
+        .option('-s, --ssl', 'Enable ssl')
         .option('-v, --verbose')
         .option('-l, --location-constraint <locationConstraint>',
         'location Constraint')


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2315.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-2564-kms-remove-ssl-option-quotes`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-2564-kms-remove-ssl-option-quotes
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-2564-kms-remove-ssl-option-quotes
```

Please always comment pull request #2315 instead of this one.