### PR TITLE
INTEGRATION [PR#2319 > development/8.2] S3C-2582 Setting up maven repo on https instead of http

### DIFF
--- a/tests/functional/jaws/pom.xml
+++ b/tests/functional/jaws/pom.xml
@@ -7,7 +7,7 @@
       <id>central</id>
       <name>Maven Repository Switchboard</name>
       <layout>default</layout>
-      <url>http://repo1.maven.org/maven2</url>
+      <url>https://repo1.maven.org/maven2</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -18,7 +18,7 @@
     <pluginRepository>
       <id>central</id>
       <name>Maven Plugin Repository</name>
-      <url>http://repo1.maven.org/maven2</url>
+      <url>https://repo1.maven.org/maven2</url>
       <layout>default</layout>
       <snapshots>
         <enabled>false</enabled>


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2319.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/bugfix/S3C-2582-update-maven-repo`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/bugfix/S3C-2582-update-maven-repo
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/bugfix/S3C-2582-update-maven-repo
```

Please always comment pull request #2319 instead of this one.