### PR TITLE
Bugfix/s3 c 2544 diff acct metrics

### DIFF
--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -424,6 +424,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
         const xml = convertToXml('completeMultipartUpload', xmlParams);
         pushMetric('completeMultipartUpload', log, {
             authInfo,
+            canonicalID: destinationBucket.getOwner(),
             bucket: bucketName,
             keys: [objectKey],
         });

--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -485,6 +485,7 @@ function multiObjectDelete(authInfo, request, log, callback) {
         const deletedKeys = successfullyDeleted.map(item => item.key);
         pushMetric('multiObjectDelete', log, {
             authInfo,
+            canonicalID: bucket.getOwner(),
             bucket: bucketName,
             keys: deletedKeys,
             byteLength: Number.parseInt(totalContentLengthDeleted, 10),

--- a/lib/api/multipartDelete.js
+++ b/lib/api/multipartDelete.js
@@ -46,6 +46,7 @@ function multipartDelete(authInfo, request, log, callback) {
                 // NoSuchUpload should not be recorded by Utapi
                 pushMetric('abortMultipartUpload', log, {
                     authInfo,
+                    canonicalID: destinationBucket.getOwner(),
                     bucket: bucketName,
                     keys: [objectKey],
                     byteLength: partSizeSum,

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -498,6 +498,7 @@ function objectCopy(authInfo, request, sourceBucket,
         }
         pushMetric('copyObject', log, {
             authInfo,
+            canonicalID: destBucketMD.getOwner(),
             bucket: destBucketName,
             keys: [destObjectKey],
             newByteLength: sourceObjSize,

--- a/lib/api/objectDelete.js
+++ b/lib/api/objectDelete.js
@@ -154,6 +154,7 @@ function objectDelete(authInfo, request, log, cb) {
             });
             pushMetric('deleteObject', log, {
                 authInfo,
+                canonicalID: bucketMD.getOwner(),
                 bucket: bucketName,
                 keys: [objectKey],
                 byteLength: Number.parseInt(objectMD['content-length'], 10),

--- a/lib/api/objectPut.js
+++ b/lib/api/objectPut.js
@@ -111,8 +111,11 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
                         versionIdUtils.encode(storingResult.versionId);
                 }
             }
+            // only the bucket owner's metrics should be updated, regardless of
+            // who the requester is
             pushMetric('putObject', log, {
                 authInfo,
+                canonicalID: bucket.getOwner(),
                 bucket: bucketName,
                 keys: [objectKey],
                 newByteLength,

--- a/lib/api/objectPutCopyPart.js
+++ b/lib/api/objectPutCopyPart.js
@@ -358,6 +358,7 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
         additionalHeaders['x-amz-copy-source-version-id'] = sourceVerId;
         pushMetric('uploadPartCopy', log, {
             authInfo,
+            canonicalID: destBucketMD.getOwner(),
             bucket: destBucketName,
             keys: [destObjectKey],
             newByteLength: copyObjectSize,

--- a/lib/api/objectPutPart.js
+++ b/lib/api/objectPutPart.js
@@ -367,6 +367,7 @@ function objectPutPart(authInfo, request, streamingV4Params, log,
         }
         pushMetric('uploadPart', log, {
             authInfo,
+            canonicalID: destinationBucket.getOwner(),
             bucket: bucketName,
             keys: [objectKey],
             newByteLength: size,

--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -8,6 +8,17 @@ const _config = require('../Config').config;
 // setup utapi client
 const utapi = new UtapiClient(_config.utapi);
 
+const bucketOwnerMetrics = [
+    'completeMultipartUpload',
+    'multiObjectDelete',
+    'abortMultipartUpload',
+    'copyObject',
+    'deleteObject',
+    'putObject',
+    'uploadPartCopy',
+    'uploadPart',
+];
+
 function _listMetrics(host,
                       port,
                       metric,
@@ -212,6 +223,13 @@ function pushMetric(action, log, metricObj) {
         utapiObj.accountId = authInfo.getCanonicalID();
         utapiObj.userId = authInfo.isRequesterAnIAMUser() ?
             authInfo.getShortid() : undefined;
+        // If action impacts 'numberOfObjectsStored' or 'storageUtilized' metric
+        // only the bucket owner account's metrics should be updated
+        const canonicalIdMatch = authInfo.getCanonicalID() === canonicalID;
+        if (bucketOwnerMetrics.includes(action) && !canonicalIdMatch) {
+            utapiObj.accountId = canonicalID;
+            utapiObj.userId = undefined;
+        }
     } else if (canonicalID) {
         utapiObj.accountId = canonicalID;
     }


### PR DESCRIPTION
Fix for incorrect metric handling. Previously, metrics were collected solely based on the requester. With this fix, if an account makes a stat-changing request (i.e. puts or deletes an object) in a different account's bucket, the bucket owner's metrics will be updated instead of the requester's.