### PR TITLE
S3C-2597-bucket-policy-can-id

### DIFF
--- a/lib/api/apiUtils/authorization/permissionChecks.js
+++ b/lib/api/apiUtils/authorization/permissionChecks.js
@@ -206,8 +206,13 @@ function _checkPrincipals(canonicalID, arn, principal) {
     return false;
 }
 
-function checkBucketPolicy(policy, requestType, canonicalID, arn, log) {
+function checkBucketPolicy(policy, requestType, canonicalID, arn, bucketOwner, log) {
     let permission = 'defaultDeny';
+    // if requester is user within bucket owner account, actions should be
+    // allowed unless explicitly denied (assumes allowed by IAM policy)
+    if (bucketOwner === canonicalID) {
+        permission = 'allow';
+    }
     let copiedStatement = JSON.parse(JSON.stringify(policy.Statement));
     while (copiedStatement.length > 0) {
         const s = copiedStatement[0];
@@ -226,11 +231,18 @@ function checkBucketPolicy(policy, requestType, canonicalID, arn, log) {
     return permission;
 }
 
-function isBucketAuthorized(bucket, requestType, canonicalID, arn, log) {
+function isBucketAuthorized(bucket, requestType, canonicalID, authInfo, log) {
     // Check to see if user is authorized to perform a
     // particular action on bucket based on ACLs.
     // TODO: Add IAM checks
-    if (bucket.getOwner() === canonicalID) {
+    let requesterIsNotUser = true;
+    let arn = null;
+    if (authInfo) {
+        requesterIsNotUser = !authInfo.isRequesterAnIAMUser();
+        arn = authInfo.getArn();
+    }
+    // if the bucket owner is an account, users should not have default access
+    if ((bucket.getOwner() === canonicalID) && requesterIsNotUser) {
         return true;
     }
     const aclPermission = checkBucketAcls(bucket, requestType, canonicalID);
@@ -242,26 +254,34 @@ function isBucketAuthorized(bucket, requestType, canonicalID, arn, log) {
         return aclPermission;
     }
     const bucketPolicyPermission = checkBucketPolicy(bucketPolicy, requestType,
-        canonicalID, arn, log);
+        canonicalID, arn, bucket.getOwner(), log);
     if (bucketPolicyPermission === 'explicitDeny') {
         return false;
     }
     return (aclPermission || (bucketPolicyPermission === 'allow'));
 }
 
-function isObjAuthorized(bucket, objectMD, requestType, canonicalID, arn, log) {
+function isObjAuthorized(bucket, objectMD, requestType, canonicalID, authInfo, log) {
     const bucketOwner = bucket.getOwner();
     if (!objectMD) {
         return false;
     }
-    if (objectMD['owner-id'] === canonicalID) {
+    let requesterIsNotUser = true;
+    let arn = null;
+    if (authInfo) {
+        requesterIsNotUser = !authInfo.isRequesterAnIAMUser();
+        arn = authInfo.getArn();
+    }
+    if (objectMD['owner-id'] === canonicalID && requesterIsNotUser) {
         return true;
     }
     // account is authorized if:
     // - requesttype is included in bucketOwnerActions and
     // - account is the bucket owner
+    // - requester is account, not user
     if (constants.bucketOwnerActions.includes(requestType)
-    && bucketOwner === canonicalID) {
+    && (bucketOwner === canonicalID)
+    && requesterIsNotUser) {
         return true;
     }
     const aclPermission = checkObjectAcls(bucket, objectMD, requestType,
@@ -271,7 +291,7 @@ function isObjAuthorized(bucket, objectMD, requestType, canonicalID, arn, log) {
         return aclPermission;
     }
     const bucketPolicyPermission = checkBucketPolicy(bucketPolicy, requestType,
-        canonicalID, arn, log);
+        canonicalID, arn, bucket.getOwner(), log);
     if (bucketPolicyPermission === 'explicitDeny') {
         return false;
     }

--- a/lib/api/bucketDeleteCors.js
+++ b/lib/api/bucketDeleteCors.js
@@ -20,7 +20,6 @@ const requestType = 'bucketDeleteCors';
 function bucketDeleteCors(authInfo, request, log, callback) {
     const bucketName = request.bucketName;
     const canonicalID = authInfo.getCanonicalID();
-    const requestArn = authInfo.getArn();
 
     return metadata.getBucket(bucketName, log, (err, bucket) => {
         const corsHeaders = collectCorsHeaders(request.headers.origin,
@@ -34,7 +33,7 @@ function bucketDeleteCors(authInfo, request, log, callback) {
         }
         log.trace('found bucket in metadata');
 
-        if (!isBucketAuthorized(bucket, requestType, canonicalID, requestArn,
+        if (!isBucketAuthorized(bucket, requestType, canonicalID, authInfo,
         log)) {
             log.debug('access denied for user on bucket', {
                 requestType,

--- a/lib/api/bucketDeleteWebsite.js
+++ b/lib/api/bucketDeleteWebsite.js
@@ -12,7 +12,6 @@ const requestType = 'bucketDeleteWebsite';
 function bucketDeleteWebsite(authInfo, request, log, callback) {
     const bucketName = request.bucketName;
     const canonicalID = authInfo.getCanonicalID();
-    const requestArn = authInfo.getArn();
 
     return metadata.getBucket(bucketName, log, (err, bucket) => {
         const corsHeaders = collectCorsHeaders(request.headers.origin,
@@ -26,7 +25,7 @@ function bucketDeleteWebsite(authInfo, request, log, callback) {
         }
         log.trace('found bucket in metadata');
 
-        if (!isBucketAuthorized(bucket, requestType, canonicalID, requestArn,
+        if (!isBucketAuthorized(bucket, requestType, canonicalID, authInfo,
         log)) {
             log.debug('access denied for user on bucket', {
                 requestType,

--- a/lib/api/bucketGetCors.js
+++ b/lib/api/bucketGetCors.js
@@ -21,7 +21,6 @@ const requestType = 'bucketGetCors';
 function bucketGetCors(authInfo, request, log, callback) {
     const bucketName = request.bucketName;
     const canonicalID = authInfo.getCanonicalID();
-    const requestArn = authInfo.getArn();
 
     metadata.getBucket(bucketName, log, (err, bucket) => {
         if (err) {
@@ -35,7 +34,7 @@ function bucketGetCors(authInfo, request, log, callback) {
         const corsHeaders = collectCorsHeaders(request.headers.origin,
             request.method, bucket);
 
-        if (!isBucketAuthorized(bucket, requestType, canonicalID, requestArn,
+        if (!isBucketAuthorized(bucket, requestType, canonicalID, authInfo,
         log)) {
             log.debug('access denied for user on bucket', {
                 requestType,

--- a/lib/api/bucketGetLocation.js
+++ b/lib/api/bucketGetLocation.js
@@ -22,7 +22,6 @@ const requestType = 'bucketGetLocation';
 function bucketGetLocation(authInfo, request, log, callback) {
     const bucketName = request.bucketName;
     const canonicalID = authInfo.getCanonicalID();
-    const requestArn = authInfo.getArn();
 
     return metadata.getBucket(bucketName, log, (err, bucket) => {
         if (err) {
@@ -37,7 +36,7 @@ function bucketGetLocation(authInfo, request, log, callback) {
         const corsHeaders = collectCorsHeaders(request.headers.origin,
             request.method, bucket);
 
-        if (!isBucketAuthorized(bucket, requestType, canonicalID, requestArn,
+        if (!isBucketAuthorized(bucket, requestType, canonicalID, authInfo,
         log)) {
             log.debug('access denied for account on bucket', {
                 requestType,

--- a/lib/api/bucketGetWebsite.js
+++ b/lib/api/bucketGetWebsite.js
@@ -21,7 +21,6 @@ const requestType = 'bucketGetWebsite';
 function bucketGetWebsite(authInfo, request, log, callback) {
     const bucketName = request.bucketName;
     const canonicalID = authInfo.getCanonicalID();
-    const requestArn = authInfo.getArn();
 
     metadata.getBucket(bucketName, log, (err, bucket) => {
         if (err) {
@@ -35,7 +34,7 @@ function bucketGetWebsite(authInfo, request, log, callback) {
 
         const corsHeaders = collectCorsHeaders(request.headers.origin,
             request.method, bucket);
-        if (!isBucketAuthorized(bucket, requestType, canonicalID, requestArn,
+        if (!isBucketAuthorized(bucket, requestType, canonicalID, authInfo,
         log)) {
             log.debug('access denied for user on bucket', {
                 requestType,

--- a/lib/api/bucketPutCors.js
+++ b/lib/api/bucketPutCors.js
@@ -24,7 +24,6 @@ function bucketPutCors(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'bucketPutCors' });
     const bucketName = request.bucketName;
     const canonicalID = authInfo.getCanonicalID();
-    const requestArn = authInfo.getArn();
 
     if (!request.post) {
         log.debug('CORS xml body is missing',
@@ -68,7 +67,7 @@ function bucketPutCors(authInfo, request, log, callback) {
         },
         function validateBucketAuthorization(bucket, rules, corsHeaders, next) {
             if (!isBucketAuthorized(bucket, requestType, canonicalID,
-            requestArn, log)) {
+            authInfo, log)) {
                 log.debug('access denied for account on bucket', {
                     requestType,
                 });

--- a/lib/api/bucketPutWebsite.js
+++ b/lib/api/bucketPutWebsite.js
@@ -23,7 +23,6 @@ function bucketPutWebsite(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'bucketPutWebsite' });
     const bucketName = request.bucketName;
     const canonicalID = authInfo.getCanonicalID();
-    const requestArn = authInfo.getArn();
 
     if (!request.post) {
         return callback(errors.MissingRequestBodyError);
@@ -48,7 +47,7 @@ function bucketPutWebsite(authInfo, request, log, callback) {
         },
         function validateBucketAuthorization(bucket, config, next) {
             if (!isBucketAuthorized(bucket, requestType, canonicalID,
-            requestArn, log)) {
+            authInfo, log)) {
                 log.debug('access denied for user on bucket', {
                     requestType,
                     method: 'bucketPutWebsite',

--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -318,7 +318,6 @@ function multiObjectDelete(authInfo, request, log, callback) {
 
     const bucketName = request.bucketName;
     const canonicalID = authInfo.getCanonicalID();
-    const requestArn = authInfo.getArn();
 
     return async.waterfall([
         function parseXML(next) {
@@ -450,7 +449,7 @@ function multiObjectDelete(authInfo, request, log, callback) {
                         bucketMD);
                 }
                 if (!isBucketAuthorized(bucketMD, 'objectDelete',
-                    canonicalID, requestArn, log)) {
+                    canonicalID, authInfo, log)) {
                     log.trace("access denied due to bucket acl's");
                     // if access denied at the bucket level, no access for
                     // any of the objects so all results will be error results

--- a/lib/api/objectPutPart.js
+++ b/lib/api/objectPutPart.js
@@ -82,7 +82,6 @@ function objectPutPart(authInfo, request, streamingV4Params, log,
     log.trace('owner canonicalid to send to data', {
         canonicalID: authInfo.getCanonicalID,
     });
-    const requestArn = authInfo.getArn();
     // Note that keys in the query object retain their case, so
     // `request.query.uploadId` must be called with that exact capitalization.
     const uploadId = request.query.uploadId;
@@ -111,7 +110,7 @@ function objectPutPart(authInfo, request, streamingV4Params, log,
             // `requestType` is the general 'objectPut'.
             const requestType = 'objectPut';
             if (!isBucketAuthorized(destinationBucket, requestType,
-                canonicalID, requestArn, log)) {
+                canonicalID, authInfo, log)) {
                 log.debug('access denied for user on bucket', { requestType });
                 return next(errors.AccessDenied, destinationBucket);
             }

--- a/lib/metadata/metadataUtils.js
+++ b/lib/metadata/metadataUtils.js
@@ -176,7 +176,6 @@ function metadataGetObject(bucketName, objectKey, versionId, log, cb) {
 function metadataValidateBucketAndObj(params, log, callback) {
     const { authInfo, bucketName, objectKey, versionId, requestType, preciseRequestType } = params;
     const canonicalID = authInfo.getCanonicalID();
-    const requestArn = authInfo.getArn();
     async.waterfall([
         function getBucketAndObjectMD(next) {
             return metadataGetBucketAndObject(requestType, bucketName,
@@ -190,7 +189,7 @@ function metadataValidateBucketAndObj(params, log, callback) {
                 return next(errors.MethodNotAllowed, bucket);
             }
             if (!isBucketAuthorized(bucket, (preciseRequestType || requestType), canonicalID,
-            requestArn, log)) {
+            authInfo, log)) {
                 log.debug('access denied for user on bucket', { requestType });
                 return next(errors.AccessDenied, bucket);
             }
@@ -208,7 +207,7 @@ function metadataValidateBucketAndObj(params, log, callback) {
                 return next(null, bucket);
             }
             if (!isObjAuthorized(bucket, objMD, requestType, canonicalID,
-            requestArn, log)) {
+            authInfo, log)) {
                 log.debug('access denied for user on object', { requestType });
                 return next(errors.AccessDenied, bucket);
             }
@@ -262,7 +261,6 @@ function metadataGetBucket(requestType, bucketName, log, cb) {
 function metadataValidateBucket(params, log, callback) {
     const { authInfo, bucketName, requestType, preciseRequestType } = params;
     const canonicalID = authInfo.getCanonicalID();
-    const requestArn = authInfo.getArn();
     return metadataGetBucket(requestType, bucketName, log, (err, bucket) => {
         if (err) {
             return callback(err);
@@ -274,7 +272,7 @@ function metadataValidateBucket(params, log, callback) {
             return callback(errors.MethodNotAllowed, bucket);
         }
         // still return bucket for cors headers
-        if (!isBucketAuthorized(bucket, (preciseRequestType || requestType), canonicalID, requestArn, log)) {
+        if (!isBucketAuthorized(bucket, (preciseRequestType || requestType), canonicalID, authInfo, log)) {
             log.debug('access denied for user on bucket', { requestType });
             return callback(errors.AccessDenied, bucket);
         }

--- a/tests/unit/api/bucketPolicyAuth.js
+++ b/tests/unit/api/bucketPolicyAuth.js
@@ -3,20 +3,24 @@ const { BucketInfo, BucketPolicy } = require('arsenal').models;
 const constants = require('../../../constants');
 const { isBucketAuthorized, isObjAuthorized, validatePolicyResource }
     = require('../../../lib/api/apiUtils/authorization/permissionChecks');
-const { DummyRequestLogger } = require('../helpers');
+const { DummyRequestLogger, makeAuthInfo } = require('../helpers');
 
-const bucketOwnerCanonicalId = 'bucketOwnerCanonicalId';
+const accessKey = 'accessKey1';
+const altAccessKey = 'accessKey2';
+const authInfo = makeAuthInfo(accessKey);
+const user1AuthInfo = makeAuthInfo(accessKey, 'user');
+const user2AuthInfo = makeAuthInfo(accessKey, 'user2');
+const altAcctAuthInfo = makeAuthInfo(altAccessKey);
+const altAcctUserAuthInfo = makeAuthInfo(altAccessKey, 'user1');
+const bucketOwnerCanonicalId = authInfo.getCanonicalID();
+const objectOwnerCanonicalId = user1AuthInfo.getCanonicalID();
+const altAcctCanonicalId = altAcctAuthInfo.getCanonicalID();
+const accountId = authInfo.getShortid();
+const altAcctId = altAcctAuthInfo.getShortid();
 const creationDate = new Date().toJSON();
 const bucket = new BucketInfo('policyBucketAuthTester', bucketOwnerCanonicalId,
-    'iAmTheOwnerDisplayName', creationDate);
-const objectOwnerCanonicalId = 'objectOwnerCanonicalId';
+    authInfo.getAccountDisplayName(), creationDate);
 const object = { 'owner-id': objectOwnerCanonicalId };
-const canonicalIdToVet = 'canonicalIdToVet';
-const userArn = 'arn:aws:iam::123456789012:user/user';
-const otherUserArn = 'arn:aws:iam::123456789012:user/other';
-const otherAccountUserArn = 'arn:aws:iam:987654321098:user/other';
-const accountArn = 'arn:aws:iam::123456789012:root';
-const accountId = '123456789012';
 const bucAction = 'bucketHead';
 const objAction = 'objectPut';
 const basePolicyObj = {
@@ -34,35 +38,43 @@ const log = new DummyRequestLogger();
 const authTests = [
     {
         name: 'should allow access if canonical user principal matches non-',
-        bucketId: canonicalIdToVet,
-        objectId: canonicalIdToVet,
+        bucketId: altAcctCanonicalId,
+        bucketAuthInfo: altAcctAuthInfo,
+        objectId: altAcctCanonicalId,
+        objectAuthInfo: altAcctAuthInfo,
         keyToChange: 'Principal',
-        bucketValue: { CanonicalUser: [canonicalIdToVet] },
-        objectValue: { CanonicalUser: [canonicalIdToVet] },
+        bucketValue: { CanonicalUser: [altAcctCanonicalId] },
+        objectValue: { CanonicalUser: [altAcctCanonicalId] },
         expected: true,
     },
     {
         name: 'should allow access if user arn principal matches non-',
-        bucketId: userArn,
-        objectId: userArn,
+        bucketId: objectOwnerCanonicalId,
+        bucketAuthInfo: user1AuthInfo,
+        objectId: objectOwnerCanonicalId,
+        objectAuthInfo: user1AuthInfo,
         keyToChange: 'Principal',
-        bucketValue: { AWS: userArn },
-        objectValue: { AWS: userArn },
+        bucketValue: { AWS: user1AuthInfo.getArn() },
+        objectValue: { AWS: user1AuthInfo.getArn() },
         expected: true,
     },
     {
         name: 'should allow access if account arn principal matches non-',
-        bucketId: accountArn,
-        objectId: accountArn,
+        bucketId: bucketOwnerCanonicalId,
+        bucketAuthInfo: authInfo,
+        objectId: bucketOwnerCanonicalId,
+        objectAuthInfo: authInfo,
         keyToChange: 'Principal',
-        bucketValue: { AWS: accountArn },
-        objectValue: { AWS: accountArn },
+        bucketValue: { AWS: authInfo.getArn() },
+        objectValue: { AWS: authInfo.getArn() },
         expected: true,
     },
     {
         name: 'should allow access if account id principal matches non-',
-        bucketId: accountId,
-        objectId: accountId,
+        bucketId: bucketOwnerCanonicalId,
+        bucketAuthInfo: authInfo,
+        objectId: bucketOwnerCanonicalId,
+        objectAuthInfo: authInfo,
         keyToChange: 'Principal',
         bucketValue: { AWS: accountId },
         objectValue: { AWS: accountId },
@@ -71,8 +83,10 @@ const authTests = [
     {
         name: 'should allow access if account id principal is contained in ' +
             'user arn of non-',
-        bucketId: userArn,
-        objectId: userArn,
+        bucketId: objectOwnerCanonicalId,
+        bucketAuthInfo: user1AuthInfo,
+        objectId: objectOwnerCanonicalId,
+        objectAuthInfo: user1AuthInfo,
         keyToChange: 'Principal',
         bucketValue: { AWS: accountId },
         objectValue: { AWS: accountId },
@@ -81,47 +95,69 @@ const authTests = [
     {
         name: 'should allow access if account id principal is contained in ' +
             'account arn of non-',
-        bucketId: accountArn,
-        objectId: accountArn,
+        bucketId: altAcctCanonicalId,
+        bucketAuthInfo: altAcctAuthInfo,
+        objectId: altAcctCanonicalId,
+        objectAuthInfo: altAcctAuthInfo,
         keyToChange: 'Principal',
-        bucketValue: { AWS: accountId },
-        objectValue: { AWS: accountId },
+        bucketValue: { AWS: altAcctId },
+        objectValue: { AWS: altAcctId },
         expected: true,
     },
     {
         name: 'should allow access if account arn principal is contained in ' +
             'user arn of non-',
-        bucketId: userArn,
-        objectId: userArn,
+        bucketId: objectOwnerCanonicalId,
+        bucketAuthInfo: user1AuthInfo,
+        objectId: objectOwnerCanonicalId,
+        objectAuthInfo: user1AuthInfo,
         keyToChange: 'Principal',
-        bucketValue: { AWS: accountArn },
-        objectValue: { AWS: accountArn },
+        bucketValue: { AWS: authInfo.getArn() },
+        objectValue: { AWS: authInfo.getArn() },
+        expected: true,
+    },
+    {
+        name: 'should allow access even if user arn principal doesn\'t match ' +
+            'user arn of user in account of ',
+        bucketId: objectOwnerCanonicalId,
+        bucketAuthInfo: user1AuthInfo,
+        objectId: objectOwnerCanonicalId,
+        objectAuthInfo: user1AuthInfo,
+        keyToChange: 'Principal',
+        bucketValue: { AWS: altAcctUserAuthInfo.getArn() },
+        objectValue: { AWS: altAcctUserAuthInfo.getArn() },
         expected: true,
     },
     {
         name: 'should deny access if account arn principal doesn\'t match ' +
             'user arn of non-',
-        bucketId: otherAccountUserArn,
-        objectId: otherAccountUserArn,
+        bucketId: altAcctCanonicalId,
+        bucketAuthInfo: altAcctUserAuthInfo,
+        objectId: altAcctCanonicalId,
+        objectAuthInfo: altAcctUserAuthInfo,
         keyToChange: 'Principal',
-        bucketValue: { AWS: accountArn },
-        objectValue: { AWS: accountArn },
+        bucketValue: { AWS: authInfo.getArn() },
+        objectValue: { AWS: authInfo.getArn() },
         expected: false,
     },
     {
         name: 'should deny access if user arn principal doesn\'t match ' +
             'user arn of non-',
-        bucketId: userArn,
-        objectId: userArn,
+        bucketId: altAcctCanonicalId,
+        bucketAuthInfo: altAcctUserAuthInfo,
+        objectId: altAcctCanonicalId,
+        objectAuthInfo: altAcctUserAuthInfo,
         keyToChange: 'Principal',
-        bucketValue: { AWS: otherUserArn },
-        objectValue: { AWS: otherUserArn },
+        bucketValue: { AWS: user2AuthInfo.getArn() },
+        objectValue: { AWS: user2AuthInfo.getArn() },
         expected: false,
     },
     {
         name: 'should deny access if principal doesn\'t match non-',
-        bucketId: canonicalIdToVet,
-        objectId: canonicalIdToVet,
+        bucketId: altAcctAuthInfo,
+        bucketAuthInfo: altAcctAuthInfo,
+        objectId: altAcctAuthInfo,
+        objectAuthInfo: altAcctAuthInfo,
         keyToChange: 'Principal',
         bucketValue: { CanonicalUser: [bucketOwnerCanonicalId] },
         objectValue: { CanonicalUser: [objectOwnerCanonicalId] },
@@ -130,8 +166,10 @@ const authTests = [
     {
         name: 'should allow access if principal and action match policy for ' +
             'non-',
-        bucketId: canonicalIdToVet,
-        objectId: canonicalIdToVet,
+        bucketId: altAcctCanonicalId,
+        bucketAuthInfo: altAcctAuthInfo,
+        objectId: altAcctCanonicalId,
+        objectAuthInfo: altAcctAuthInfo,
         keyToChange: 'Action',
         bucketValue: ['s3:ListBucket'],
         objectValue: ['s3:PutObject'],
@@ -140,8 +178,10 @@ const authTests = [
     {
         name: 'should deny access if principal matches but action does not ' +
             'match policy for non-',
-        bucketId: canonicalIdToVet,
-        objectId: canonicalIdToVet,
+        bucketId: altAcctCanonicalId,
+        bucketAuthInfo: altAcctAuthInfo,
+        objectId: altAcctCanonicalId,
+        objectAuthInfo: altAcctAuthInfo,
         keyToChange: 'Action',
         bucketValue: ['s3:GetBucketLocation'],
         objectValue: ['s3:GetObject'],
@@ -150,11 +190,24 @@ const authTests = [
     {
         name: 'should allow access even if bucket policy denies for ',
         bucketId: bucketOwnerCanonicalId,
-        objectId: objectOwnerCanonicalId,
+        bucketAuthInfo: authInfo,
+        objectId: bucketOwnerCanonicalId,
+        objectAuthInfo: authInfo,
         keyToChange: 'Effect',
         bucketValue: 'Deny',
         objectValue: 'Deny',
         expected: true,
+    },
+    {
+        name: 'should deny access even for users in account of ',
+        bucketId: objectOwnerCanonicalId,
+        bucketAuthInfo: user1AuthInfo,
+        objectId: objectOwnerCanonicalId,
+        objectAuthInfo: user1AuthInfo,
+        keyToChange: 'Effect',
+        bucketValue: 'Deny',
+        objectValue: 'Deny',
+        expected: false,
     },
 ];
 
@@ -199,7 +252,7 @@ describe('bucket policy authorization', () => {
         it('should deny access to non-bucket owner',
         done => {
             const allowed = isBucketAuthorized(bucket, 'bucketPut',
-                canonicalIdToVet, null, log);
+                altAcctCanonicalId, null, log);
             assert.equal(allowed, false);
             done();
         });
@@ -215,7 +268,7 @@ describe('bucket policy authorization', () => {
         it('should allow access to non-bucket owner if principal is set to "*"',
         done => {
             const allowed = isBucketAuthorized(bucket, bucAction,
-                canonicalIdToVet, null, log);
+                altAcctCanonicalId, null, log);
             assert.equal(allowed, true);
             done();
         });
@@ -234,7 +287,7 @@ describe('bucket policy authorization', () => {
                 newPolicy.Statement[0][t.keyToChange] = t.bucketValue;
                 bucket.setBucketPolicy(newPolicy);
                 const allowed = isBucketAuthorized(bucket, bucAction,
-                    t.bucketId, t.bucketId, log);
+                    t.bucketId, t.bucketAuthInfo, log);
                 assert.equal(allowed, t.expected);
                 done();
             });
@@ -245,13 +298,13 @@ describe('bucket policy authorization', () => {
             const newPolicy = this.test.basePolicy;
             newPolicy.Statement[1] = {
                 Effect: 'Deny',
-                Principal: { CanonicalUser: [canonicalIdToVet] },
+                Principal: { CanonicalUser: [altAcctCanonicalId] },
                 Resource: `arn:aws:s3:::${bucket.getName()}`,
                 Action: 's3:*',
             };
             bucket.setBucketPolicy(newPolicy);
             const allowed = isBucketAuthorized(bucket, bucAction,
-                canonicalIdToVet, null, log);
+                altAcctCanonicalId, null, log);
             assert.equal(allowed, false);
             done();
         });
@@ -272,7 +325,7 @@ describe('bucket policy authorization', () => {
         it('should deny access to non-object owner',
         done => {
             const allowed = isObjAuthorized(bucket, object, objAction,
-                canonicalIdToVet, null, log);
+                altAcctCanonicalId, null, log);
             assert.equal(allowed, false);
             done();
         });
@@ -291,7 +344,7 @@ describe('bucket policy authorization', () => {
         it('should allow access to non-object owner if principal is set to "*"',
         done => {
             const allowed = isObjAuthorized(bucket, object, objAction,
-                canonicalIdToVet, null, log);
+                altAcctCanonicalId, null, log);
             assert.equal(allowed, true);
             done();
         });
@@ -310,7 +363,7 @@ describe('bucket policy authorization', () => {
                 newPolicy.Statement[0][t.keyToChange] = t.objectValue;
                 bucket.setBucketPolicy(newPolicy);
                 const allowed = isObjAuthorized(bucket, object, objAction,
-                    t.objectId, t.objectId, log);
+                    t.objectId, t.objectAuthInfo, log);
                 assert.equal(allowed, t.expected);
                 done();
             });
@@ -321,13 +374,13 @@ describe('bucket policy authorization', () => {
             const newPolicy = this.test.basePolicy;
             newPolicy.Statement[1] = {
                 Effect: 'Deny',
-                Principal: { CanonicalUser: [canonicalIdToVet] },
+                Principal: { CanonicalUser: [altAcctCanonicalId] },
                 Resource: `arn:aws:s3:::${bucket.getName()}/*`,
                 Action: 's3:*',
             };
             bucket.setBucketPolicy(newPolicy);
             const allowed = isObjAuthorized(bucket, object, objAction,
-                canonicalIdToVet, null, log);
+                altAcctCanonicalId, null, log);
             assert.equal(allowed, false);
             done();
         });

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -63,7 +63,7 @@ function timeDiff(startTime) {
     return milliseconds;
 }
 
-function makeAuthInfo(accessKey) {
+function makeAuthInfo(accessKey, userName) {
     const canIdMap = {
         accessKey1: '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7'
             + 'cd47ef2be',
@@ -72,13 +72,26 @@ function makeAuthInfo(accessKey) {
         default: crypto.randomBytes(32).toString('hex'),
     };
     canIdMap[constants.publicId] = constants.publicId;
-
-    return new AuthInfo({
+    const acctIdMap = {
+        accessKey1: '123456789098',
+        accessKey2: '234567890987',
+        default: 'shortid',
+    };
+    const shortid = acctIdMap[accessKey] || acctIdMap.default;
+    const params = {
         canonicalID: canIdMap[accessKey] || canIdMap.default,
-        shortid: 'shortid',
+        shortid,
         email: `${accessKey}@l.com`,
         accountDisplayName: `${accessKey}displayName`,
-    });
+        arn: `arn:aws:iam::${shortid}:root`,
+    };
+
+    if (userName) {
+        params.IAMdisplayName = `${accessKey}-${userName}-userDisplayName`;
+        params.arn = `arn:aws:iam::${shortid}:user/${userName}`;
+    }
+
+    return new AuthInfo(params);
 }
 
 class WebsiteConfig {


### PR DESCRIPTION
Previous behavior: Assumed that canonical ids were different for each IAM entity (i.e. users and accounts). Accordingly, every user within the bucket owner account was basically treated as the bucket owner and granted full permissions on an action, even if there was an explicit bucket policy denying it.

Current behavior: A user within the bucket owner's account will still be allowed all actions by default (this behavior assumes an IAM policy has already allowed the user), unless there is a bucket policy which denies the user, in which case they will receive an Access Denied error.