### PR TITLE
bf: S3C-2697 acl permissions regression

### DIFF
--- a/lib/api/apiUtils/authorization/permissionChecks.js
+++ b/lib/api/apiUtils/authorization/permissionChecks.js
@@ -39,6 +39,9 @@ const publicReadBuckets = process.env.ALLOW_PUBLIC_READ_BUCKETS ?
     process.env.ALLOW_PUBLIC_READ_BUCKETS.split(',') : [];
 
 function checkBucketAcls(bucket, requestType, canonicalID) {
+    if (bucket.getOwner() === canonicalID) {
+        return true;
+    }
     if (constants.bucketOwnerActions.includes(requestType)) {
         // only bucket owner can modify or retrieve this property of a bucket
         return false;
@@ -94,6 +97,9 @@ function checkBucketAcls(bucket, requestType, canonicalID) {
 }
 
 function checkObjectAcls(bucket, objectMD, requestType, canonicalID) {
+    if (objectMD['owner-id'] === canonicalID) {
+        return true;
+    }
     if (!objectMD.acl) {
         return false;
     }

--- a/tests/unit/api/bucketACLauth.js
+++ b/tests/unit/api/bucketACLauth.js
@@ -3,13 +3,19 @@ const BucketInfo = require('arsenal').models.BucketInfo;
 const constants = require('../../../constants');
 const { isBucketAuthorized }
     = require('../../../lib/api/apiUtils/authorization/permissionChecks');
-const { DummyRequestLogger } = require('../helpers');
+const { DummyRequestLogger, makeAuthInfo } = require('../helpers');
 
-const ownerCanonicalId = 'ownerCanonicalId';
 const creationDate = new Date().toJSON();
+const accessKey = 'accessKey1';
+const altAccessKey = 'accessKey2';
+const authInfo = makeAuthInfo(accessKey);
+const userAuthInfo = makeAuthInfo(accessKey, 'user');
+const ownerCanonicalId = authInfo.getCanonicalID();
+const altAcctAuthInfo = makeAuthInfo(altAccessKey);
+const accountToVet = altAcctAuthInfo.getCanonicalID();
+
 const bucket = new BucketInfo('niftyBucket', ownerCanonicalId,
-    'iAmTheOwnerDisplayName', creationDate);
-const accountToVet = 'accountToVetId';
+    authInfo.getAccountDisplayName(), creationDate);
 const log = new DummyRequestLogger();
 
 describe('bucket authorization for bucketGet, bucketHead, ' +
@@ -37,53 +43,59 @@ describe('bucket authorization for bucketGet, bucketHead, ' +
     const orders = [
         {
             it: 'should allow access to bucket owner', canned: '',
-            id: ownerCanonicalId, response: trueArray,
+            id: ownerCanonicalId, response: trueArray, auth: authInfo,
+        },
+        {
+            it: 'should allow access to user in bucket owner account', canned: '',
+            id: ownerCanonicalId, response: trueArray, auth: userAuthInfo,
         },
         {
             it: 'should allow access to anyone if canned public-read ACL',
             canned: 'public-read', id: accountToVet, response: trueArray,
+            auth: altAcctAuthInfo,
         },
         {
             it: 'should allow access to anyone if canned public-read-write ACL',
             canned: 'public-read-write', id: accountToVet, response: trueArray,
+            auth: altAcctAuthInfo,
         },
         {
             it: 'should not allow request on the bucket (bucketGet, bucketHead)'
             + ' but should allow request on the object (objectGet, objectHead)'
             + ' to public user if authenticated-read  ACL',
             canned: 'authenticated-read', id: constants.publicId,
-            response: falseArrayBucketTrueArrayObject,
+            response: falseArrayBucketTrueArrayObject, auth: altAcctAuthInfo,
         },
         {
             it: 'should allow access to any authenticated user if authenticated'
             + '-read ACL', canned: 'authenticated-read', id: accountToVet,
-            response: trueArray,
+            response: trueArray, auth: altAcctAuthInfo,
         },
         {
             it: 'should not allow request on the bucket (bucketGet, bucketHead)'
             + ' but should allow request on the object (objectGet, objectHead)'
             + ' to public user if private canned ACL',
             canned: '', id: accountToVet,
-            response: falseArrayBucketTrueArrayObject,
+            response: falseArrayBucketTrueArrayObject, auth: altAcctAuthInfo,
         },
         {
             it: 'should not allow request on the bucket (bucketGet, bucketHead)'
             + ' but should allow request on the object (objectGet, objectHead)'
             + ' to just any user if private canned ACL',
             canned: '', id: accountToVet,
-            response: falseArrayBucketTrueArrayObject,
+            response: falseArrayBucketTrueArrayObject, auth: altAcctAuthInfo,
         },
         {
             it: 'should allow access to user if account was granted'
             + ' FULL_CONTROL',
             canned: '', id: accountToVet, response: trueArray,
-            aclParam: ['FULL_CONTROL', accountToVet],
+            aclParam: ['FULL_CONTROL', accountToVet], auth: altAcctAuthInfo,
         },
         {
             it: 'should not allow access to just any user if private'
             + ' canned ACL',
             canned: '', id: accountToVet, response: trueArray,
-            aclParam: ['READ', accountToVet],
+            aclParam: ['READ', accountToVet], auth: altAcctAuthInfo,
         },
     ];
 
@@ -94,7 +106,7 @@ describe('bucket authorization for bucketGet, bucketHead, ' +
             }
             bucket.setCannedAcl(value.canned);
             const results = requestTypes.map(type =>
-                isBucketAuthorized(bucket, type, value.id, null, log));
+                isBucketAuthorized(bucket, type, value.id, value.auth, log));
             assert.deepStrictEqual(results, value.response);
             done();
         });
@@ -116,22 +128,30 @@ describe('bucket authorization for bucketGetACL', () => {
 
     it('should allow access to bucket owner', () => {
         const result = isBucketAuthorized(bucket, 'bucketGetACL',
-            ownerCanonicalId);
+            ownerCanonicalId, authInfo);
+        assert.strictEqual(result, true);
+    });
+
+    it('should allow access to user in bucket owner account', () => {
+        const result = isBucketAuthorized(bucket, 'bucketGetACL',
+            ownerCanonicalId, userAuthInfo);
         assert.strictEqual(result, true);
     });
 
     const orders = [
         {
             it: 'log group only if canned log-delivery-write acl',
-            id: constants.logId, canned: 'log-delivery-write',
+            id: constants.logId, canned: 'log-delivery-write', auth: null,
         },
         {
             it: 'account only if account was granted FULL_CONTROL right',
             id: accountToVet, aclParam: ['FULL_CONTROL', accountToVet],
+            auth: altAcctAuthInfo,
         },
         {
             it: 'account only if account was granted READ_ACP right',
             id: accountToVet, aclParam: ['READ_ACP', accountToVet],
+            auth: altAcctAuthInfo,
         },
     ];
     orders.forEach(value => {
@@ -145,7 +165,7 @@ describe('bucket authorization for bucketGetACL', () => {
                 bucket.setCannedAcl(value.canned);
             }
             const authorizedResult = isBucketAuthorized(bucket, 'bucketGetACL',
-                                                        value.id);
+                value.id, value.auth);
             assert.strictEqual(authorizedResult, true);
             done();
         });
@@ -167,7 +187,13 @@ describe('bucket authorization for bucketPutACL', () => {
 
     it('should allow access to bucket owner', () => {
         const result = isBucketAuthorized(bucket, 'bucketPutACL',
-            ownerCanonicalId);
+            ownerCanonicalId, authInfo);
+        assert.strictEqual(result, true);
+    });
+
+    it('should allow access to user in bucket owner account', () => {
+        const result = isBucketAuthorized(bucket, 'bucketPutACL',
+            ownerCanonicalId, userAuthInfo);
         assert.strictEqual(result, true);
     });
 
@@ -176,11 +202,11 @@ describe('bucket authorization for bucketPutACL', () => {
         it('should allow access to account if ' +
            `account was granted ${value} right`, done => {
             const noAuthResult = isBucketAuthorized(bucket, 'bucketPutACL',
-                accountToVet);
+                accountToVet, altAcctAuthInfo);
             assert.strictEqual(noAuthResult, false);
             bucket.setSpecificAcl(accountToVet, value);
             const authorizedResult = isBucketAuthorized(bucket, 'bucketPutACL',
-                accountToVet);
+                accountToVet, altAcctAuthInfo);
             assert.strictEqual(authorizedResult, true);
             done();
         });
@@ -202,19 +228,25 @@ describe('bucket authorization for bucketOwnerAction', () => {
 
     it('should allow access to bucket owner', () => {
         const result = isBucketAuthorized(bucket, 'bucketDeleteCors',
-            ownerCanonicalId);
+            ownerCanonicalId, authInfo);
         assert.strictEqual(result, true);
+    });
+
+    it('should not allow access to user in bucket owner account', () => {
+        const result = isBucketAuthorized(bucket, 'bucketDeleteCors',
+            ownerCanonicalId, userAuthInfo);
+        assert.strictEqual(result, false);
     });
 
     const orders = [
         {
             it: 'other account (even if other account has FULL_CONTROL rights'
             + ' in bucket)', id: accountToVet, canned: '',
-            aclParam: ['FULL_CONTROL', accountToVet],
+            aclParam: ['FULL_CONTROL', accountToVet], auth: altAcctAuthInfo,
         },
         {
             it: 'public user (even if bucket is public read write)',
-            id: constants.publicId, canned: 'public-read-write',
+            id: constants.publicId, canned: 'public-read-write', auth: altAcctAuthInfo,
         },
     ];
     orders.forEach(value => {
@@ -224,7 +256,7 @@ describe('bucket authorization for bucketOwnerAction', () => {
             }
             bucket.setCannedAcl(value.canned);
             const result = isBucketAuthorized(bucket, 'bucketDeleteCors',
-                value.id);
+                value.id, value.auth);
             assert.strictEqual(result, false);
             done();
         });
@@ -246,7 +278,13 @@ describe('bucket authorization for bucketDelete', () => {
 
     it('should allow access to bucket owner', () => {
         const result = isBucketAuthorized(bucket, 'bucketDelete',
-            ownerCanonicalId);
+            ownerCanonicalId, authInfo);
+        assert.strictEqual(result, true);
+    });
+
+    it('should allow access to user in bucket owner account', () => {
+        const result = isBucketAuthorized(bucket, 'bucketDelete',
+            ownerCanonicalId, userAuthInfo);
         assert.strictEqual(result, true);
     });
 
@@ -254,11 +292,11 @@ describe('bucket authorization for bucketDelete', () => {
         {
             it: 'other account (even if other account has FULL_CONTROL rights '
             + 'in bucket)', id: accountToVet, canned: '',
-            aclParam: ['FULL_CONTROL', accountToVet],
+            aclParam: ['FULL_CONTROL', accountToVet], auth: altAcctAuthInfo,
         },
         {
             it: 'public user (even if bucket is public read write)',
-            id: constants.publicId, canned: 'public-read-write',
+            id: constants.publicId, canned: 'public-read-write', auth: null,
         },
     ];
     orders.forEach(value => {
@@ -267,7 +305,7 @@ describe('bucket authorization for bucketDelete', () => {
                 bucket.setSpecificAcl(value.aclParam[1], value.aclParam[0]);
             }
             bucket.setCannedAcl(value.canned);
-            const result = isBucketAuthorized(bucket, 'bucketDelete', value.id);
+            const result = isBucketAuthorized(bucket, 'bucketDelete', value.id, value.auth);
             assert.strictEqual(result, false);
             done();
         });
@@ -291,7 +329,13 @@ describe('bucket authorization for objectDelete and objectPut', () => {
 
     it('should allow access to bucket owner', () => {
         const results = requestTypes.map(type =>
-            isBucketAuthorized(bucket, type, ownerCanonicalId));
+            isBucketAuthorized(bucket, type, ownerCanonicalId, authInfo));
+        assert.deepStrictEqual(results, [true, true]);
+    });
+
+    it('should allow access to user in bucket owner account', () => {
+        const results = requestTypes.map(type =>
+            isBucketAuthorized(bucket, type, ownerCanonicalId, userAuthInfo));
         assert.deepStrictEqual(results, [true, true]);
     });
 
@@ -304,25 +348,25 @@ describe('bucket authorization for objectDelete and objectPut', () => {
         {
             it: 'user if account was granted FULL_CONTROL', canned: '',
             id: accountToVet, response: [false, false],
-            aclParam: ['FULL_CONTROL', accountToVet],
+            aclParam: ['FULL_CONTROL', accountToVet], auth: altAcctAuthInfo,
         },
         {
             it: 'user if account was granted WRITE right', canned: '',
             id: accountToVet, response: [false, false],
-            aclParam: ['WRITE', accountToVet],
+            aclParam: ['WRITE', accountToVet], auth: altAcctAuthInfo,
         },
     ];
     orders.forEach(value => {
         it(`should allow access to ${value.it}`, done => {
             bucket.setCannedAcl(value.canned);
             const noAuthResults = requestTypes.map(type =>
-                isBucketAuthorized(bucket, type, value.id));
+                isBucketAuthorized(bucket, type, value.id, value.auth));
             assert.deepStrictEqual(noAuthResults, value.response);
             if (value.aclParam) {
                 bucket.setSpecificAcl(value.aclParam[1], value.aclParam[0]);
             }
             const authResults = requestTypes.map(type =>
-                isBucketAuthorized(bucket, type, accountToVet));
+                isBucketAuthorized(bucket, type, accountToVet, altAcctAuthInfo));
             assert.deepStrictEqual(authResults, [true, true]);
             done();
         });
@@ -334,7 +378,7 @@ describe('bucket authorization for objectPutACL and objectGetACL', () => {
         'are done at object level', done => {
         const requestTypes = ['objectPutACL', 'objectGetACL'];
         const results = requestTypes.map(type =>
-            isBucketAuthorized(bucket, type, accountToVet));
+            isBucketAuthorized(bucket, type, accountToVet, altAcctAuthInfo));
         assert.deepStrictEqual(results, [true, true]);
         const publicUserResults = requestTypes.map(type =>
             isBucketAuthorized(bucket, type, constants.publicId));

--- a/tests/unit/api/objectACLauth.js
+++ b/tests/unit/api/objectACLauth.js
@@ -4,14 +4,20 @@ const BucketInfo = require('arsenal').models.BucketInfo;
 const constants = require('../../../constants');
 const { isObjAuthorized }
     = require('../../../lib/api/apiUtils/authorization/permissionChecks');
-const { DummyRequestLogger } = require('../helpers');
+const { DummyRequestLogger, makeAuthInfo } = require('../helpers');
 
-const bucketOwnerCanonicalId = 'bucketOwnerCanonicalId';
+const accessKey = 'accessKey1';
+const altAccessKey = 'accessKey2';
+const authInfo = makeAuthInfo(accessKey);
+const bucketOwnerCanonicalId = authInfo.getCanonicalID();
 const creationDate = new Date().toJSON();
+const userAuthInfo = makeAuthInfo(accessKey, 'user');
+const altAcctAuthInfo = makeAuthInfo(altAccessKey);
+const accountToVet = altAcctAuthInfo.getCanonicalID();
+
 const bucket = new BucketInfo('niftyBucket', bucketOwnerCanonicalId,
     'iAmTheOwnerDisplayName', creationDate);
-const accountToVet = 'accountToVetId';
-const objectOwnerCanonicalId = 'objectOwnerCanonicalId';
+const objectOwnerCanonicalId = userAuthInfo.getCanonicalID();
 const object = {
     'owner-id': objectOwnerCanonicalId,
     'acl': {
@@ -40,22 +46,36 @@ describe('object acl authorization for objectGet and objectHead', () => {
 
     it('should allow access to object owner', () => {
         const results = requestTypes.map(type =>
-                isObjAuthorized(bucket, object, type, objectOwnerCanonicalId,
-                    null, log));
+            isObjAuthorized(bucket, object, type, objectOwnerCanonicalId,
+                authInfo, log));
+        assert.deepStrictEqual(results, [true, true]);
+    });
+
+    it('should allow access to user in object owner account', () => {
+        const results = requestTypes.map(type =>
+            isObjAuthorized(bucket, object, type, objectOwnerCanonicalId,
+                userAuthInfo, log));
+        assert.deepStrictEqual(results, [true, true]);
+    });
+
+    it('should allow access to bucket owner if same account as object owner', () => {
+        const results = requestTypes.map(type =>
+            isObjAuthorized(bucket, object, type, bucketOwnerCanonicalId,
+                authInfo, log));
         assert.deepStrictEqual(results, [true, true]);
     });
 
     it('should allow access to anyone if canned public-read ACL', () => {
         object.acl.Canned = 'public-read';
         const results = requestTypes.map(type =>
-            isObjAuthorized(bucket, object, type, accountToVet, null, log));
+            isObjAuthorized(bucket, object, type, accountToVet, altAcctAuthInfo, log));
         assert.deepStrictEqual(results, [true, true]);
     });
 
     it('should allow access to anyone if canned public-read-write ACL', () => {
         object.acl.Canned = 'public-read-write';
         const results = requestTypes.map(type =>
-            isObjAuthorized(bucket, object, type, accountToVet, null, log));
+            isObjAuthorized(bucket, object, type, accountToVet, altAcctAuthInfo, log));
         assert.deepStrictEqual(results, [true, true]);
     });
 
@@ -71,32 +91,52 @@ describe('object acl authorization for objectGet and objectHead', () => {
         'authenticated-read ACL', () => {
         object.acl.Canned = 'authenticated-read';
         const results = requestTypes.map(type =>
-            isObjAuthorized(bucket, object, type, accountToVet, null, log));
+            isObjAuthorized(bucket, object, type, accountToVet, altAcctAuthInfo, log));
         assert.deepStrictEqual(results, [true, true]);
     });
 
-    it('should allow access to bucker owner if ' +
+    it('should allow access to bucker owner when object owner is alt account if ' +
         'bucket-owner-read ACL', () => {
+        const altAcctObj = {
+            'owner-id': accountToVet,
+            'acl': {
+                Canned: 'private',
+                FULL_CONTROL: [],
+                WRITE_ACP: [],
+                READ: [],
+                READ_ACP: [],
+            },
+        };
         const noAuthResults = requestTypes.map(type =>
-            isObjAuthorized(bucket, object, type, bucketOwnerCanonicalId, null,
+            isObjAuthorized(bucket, altAcctObj, type, bucketOwnerCanonicalId, authInfo,
                 log));
         assert.deepStrictEqual(noAuthResults, [false, false]);
-        object.acl.Canned = 'bucket-owner-read';
+        altAcctObj.acl.Canned = 'bucket-owner-read';
         const authResults = requestTypes.map(type =>
-            isObjAuthorized(bucket, object, type, bucketOwnerCanonicalId, null,
+            isObjAuthorized(bucket, altAcctObj, type, bucketOwnerCanonicalId, authInfo,
                 log));
         assert.deepStrictEqual(authResults, [true, true]);
     });
 
-    it('should allow access to bucker owner if ' +
+    it('should allow access to bucker owner when object owner is alt account if ' +
         'bucket-owner-full-control ACL', () => {
+        const altAcctObj = {
+            'owner-id': accountToVet,
+            'acl': {
+                Canned: 'private',
+                FULL_CONTROL: [],
+                WRITE_ACP: [],
+                READ: [],
+                READ_ACP: [],
+            },
+        };
         const noAuthResults = requestTypes.map(type =>
-            isObjAuthorized(bucket, object, type, bucketOwnerCanonicalId, null,
+            isObjAuthorized(bucket, altAcctObj, type, bucketOwnerCanonicalId, authInfo,
                 log));
         assert.deepStrictEqual(noAuthResults, [false, false]);
-        object.acl.Canned = 'bucket-owner-full-control';
+        altAcctObj.acl.Canned = 'bucket-owner-full-control';
         const authResults = requestTypes.map(type =>
-            isObjAuthorized(bucket, object, type, bucketOwnerCanonicalId, null,
+            isObjAuthorized(bucket, altAcctObj, type, bucketOwnerCanonicalId, authInfo,
                 log));
         assert.deepStrictEqual(authResults, [true, true]);
     });
@@ -104,34 +144,34 @@ describe('object acl authorization for objectGet and objectHead', () => {
     it('should allow access to account if ' +
         'account was granted FULL_CONTROL', () => {
         const noAuthResults = requestTypes.map(type =>
-            isObjAuthorized(bucket, object, type, accountToVet, null, log));
+            isObjAuthorized(bucket, object, type, accountToVet, altAcctAuthInfo, log));
         assert.deepStrictEqual(noAuthResults, [false, false]);
         object.acl.FULL_CONTROL = [accountToVet];
         const authResults = requestTypes.map(type =>
-            isObjAuthorized(bucket, object, type, accountToVet, null, log));
+            isObjAuthorized(bucket, object, type, accountToVet, altAcctAuthInfo, log));
         assert.deepStrictEqual(authResults, [true, true]);
     });
 
     it('should allow access to account if ' +
         'account was granted READ right', () => {
         const noAuthResults = requestTypes.map(type =>
-            isObjAuthorized(bucket, object, type, accountToVet, null, log));
+            isObjAuthorized(bucket, object, type, accountToVet, altAcctAuthInfo, log));
         assert.deepStrictEqual(noAuthResults, [false, false]);
         object.acl.READ = [accountToVet];
         const authResults = requestTypes.map(type =>
-            isObjAuthorized(bucket, object, type, accountToVet, null, log));
+            isObjAuthorized(bucket, object, type, accountToVet, altAcctAuthInfo, log));
         assert.deepStrictEqual(authResults, [true, true]);
     });
 
     it('should not allow access to public user if private canned ACL', () => {
         const results = requestTypes.map(type =>
-            isObjAuthorized(bucket, object, type, accountToVet, null, log));
+            isObjAuthorized(bucket, object, type, accountToVet, altAcctAuthInfo, log));
         assert.deepStrictEqual(results, [false, false]);
     });
 
     it('should not allow access to just any user if private canned ACL', () => {
         const results = requestTypes.map(type =>
-            isObjAuthorized(bucket, object, type, accountToVet, null, log));
+            isObjAuthorized(bucket, object, type, accountToVet, altAcctAuthInfo, log));
         assert.deepStrictEqual(results, [false, false]);
     });
 });
@@ -141,7 +181,7 @@ describe('object authorization for objectPut and objectDelete', () => {
         'are done at bucket level', () => {
         const requestTypes = ['objectPut', 'objectDelete'];
         const results = requestTypes.map(type =>
-            isObjAuthorized(bucket, object, type, accountToVet, null, log));
+            isObjAuthorized(bucket, object, type, accountToVet, altAcctAuthInfo, log));
         assert.deepStrictEqual(results, [true, true]);
         const publicUserResults = requestTypes.map(type =>
             isObjAuthorized(bucket, object, type, constants.publicId, null,
@@ -168,19 +208,36 @@ describe('object authorization for objectPutACL and objectGetACL', () => {
     it('should allow access to object owner', () => {
         const results = requestTypes.map(type =>
             isObjAuthorized(bucket, object, type, objectOwnerCanonicalId,
-                null, log));
+                authInfo, log));
         assert.deepStrictEqual(results, [true, true]);
     });
 
-    it('should allow access to bucket owner if ' +
+    it('should allow access to user in object owner account', () => {
+        const results = requestTypes.map(type =>
+            isObjAuthorized(bucket, object, type, objectOwnerCanonicalId,
+                userAuthInfo, log));
+        assert.deepStrictEqual(results, [true, true]);
+    });
+
+    it('should allow access to bucket owner when object owner is alt account if ' +
         'bucket-owner-full-control canned ACL set on object', () => {
+        const altAcctObj = {
+            'owner-id': accountToVet,
+            'acl': {
+                Canned: 'private',
+                FULL_CONTROL: [],
+                WRITE_ACP: [],
+                READ: [],
+                READ_ACP: [],
+            },
+        };
         const noAuthResults = requestTypes.map(type =>
-            isObjAuthorized(bucket, object, type, bucketOwnerCanonicalId, null,
+            isObjAuthorized(bucket, altAcctObj, type, bucketOwnerCanonicalId, authInfo,
                 log));
         assert.deepStrictEqual(noAuthResults, [false, false]);
-        object.acl.Canned = 'bucket-owner-full-control';
+        altAcctObj.acl.Canned = 'bucket-owner-full-control';
         const authorizedResults = requestTypes.map(type =>
-            isObjAuthorized(bucket, object, type, bucketOwnerCanonicalId,
+            isObjAuthorized(bucket, altAcctObj, type, bucketOwnerCanonicalId, authInfo,
                 null, log));
         assert.deepStrictEqual(authorizedResults, [true, true]);
     });
@@ -188,33 +245,33 @@ describe('object authorization for objectPutACL and objectGetACL', () => {
     it('should allow access to account if ' +
         'account was granted FULL_CONTROL right', () => {
         const noAuthResults = requestTypes.map(type =>
-            isObjAuthorized(bucket, object, type, accountToVet, null, log));
+            isObjAuthorized(bucket, object, type, accountToVet, altAcctAuthInfo, log));
         assert.deepStrictEqual(noAuthResults, [false, false]);
         object.acl.FULL_CONTROL = [accountToVet];
         const authorizedResults = requestTypes.map(type =>
-            isObjAuthorized(bucket, object, type, accountToVet, null, log));
+            isObjAuthorized(bucket, object, type, accountToVet, altAcctAuthInfo, log));
         assert.deepStrictEqual(authorizedResults, [true, true]);
     });
 
     it('should allow objectPutACL access to account if ' +
         'account was granted WRITE_ACP right', () => {
         const noAuthResult = isObjAuthorized(bucket, object, 'objectPutACL',
-            accountToVet, null, log);
+            accountToVet, altAcctAuthInfo, log);
         assert.strictEqual(noAuthResult, false);
         object.acl.WRITE_ACP = [accountToVet];
         const authorizedResult = isObjAuthorized(bucket, object, 'objectPutACL',
-            accountToVet, null, log);
+            accountToVet, altAcctAuthInfo, log);
         assert.strictEqual(authorizedResult, true);
     });
 
     it('should allow objectGetACL access to account if ' +
         'account was granted READ_ACP right', () => {
         const noAuthResult = isObjAuthorized(bucket, object, 'objectGetACL',
-            accountToVet, null, log);
+            accountToVet, altAcctAuthInfo, log);
         assert.strictEqual(noAuthResult, false);
         object.acl.READ_ACP = [accountToVet];
         const authorizedResult = isObjAuthorized(bucket, object, 'objectGetACL',
-            accountToVet, null, log);
+            accountToVet, altAcctAuthInfo, log);
         assert.strictEqual(authorizedResult, true);
     });
 });


### PR DESCRIPTION
The fix for https://scality.atlassian.net/browse/S3C-2597 introduced a regression in the logic for ACL permissions. Found while doing manual Integration testing on 7.6.0-RC4