### PR TITLE
Bugfix/s3 c 2714 fix permissions

### DIFF
--- a/lib/api/apiUtils/authorization/permissionChecks.js
+++ b/lib/api/apiUtils/authorization/permissionChecks.js
@@ -42,11 +42,10 @@ function checkBucketAcls(bucket, requestType, canonicalID) {
     if (bucket.getOwner() === canonicalID) {
         return true;
     }
-    if (constants.bucketOwnerActions.includes(requestType)) {
-        // only bucket owner can modify or retrieve this property of a bucket
-        return false;
-    }
 
+    // any requestType outside of those checked in this function is
+    // outside the scope of ACL permissions and will be denied unless
+    // allowed by a different permissions granter
     const bucketAcl = bucket.getAcl();
     if (requestType === 'bucketGet' || requestType === 'bucketHead') {
         if (bucketAcl.Canned === 'public-read'
@@ -97,13 +96,18 @@ function checkBucketAcls(bucket, requestType, canonicalID) {
 }
 
 function checkObjectAcls(bucket, objectMD, requestType, canonicalID) {
+    const bucketOwner = bucket.getOwner();
+    // acls don't distinguish between users and accounts, so both should be allowed
+    if (constants.bucketOwnerActions.includes(requestType)
+    && (bucketOwner === canonicalID)) {
+        return true;
+    }
     if (objectMD['owner-id'] === canonicalID) {
         return true;
     }
     if (!objectMD.acl) {
         return false;
     }
-    const bucketOwner = bucket.getOwner();
 
     if (requestType === 'objectGet' || requestType === 'objectHead') {
         if (objectMD.acl.Canned === 'public-read'
@@ -254,9 +258,6 @@ function isBucketAuthorized(bucket, requestType, canonicalID, authInfo, log) {
     const aclPermission = checkBucketAcls(bucket, requestType, canonicalID);
     const bucketPolicy = bucket.getBucketPolicy();
     if (!bucketPolicy) {
-        if (constants.bucketOwnerActions.includes(requestType)) {
-            return false;
-        }
         return aclPermission;
     }
     const bucketPolicyPermission = checkBucketPolicy(bucketPolicy, requestType,

--- a/tests/unit/api/bucketACLauth.js
+++ b/tests/unit/api/bucketACLauth.js
@@ -232,10 +232,10 @@ describe('bucket authorization for bucketOwnerAction', () => {
         assert.strictEqual(result, true);
     });
 
-    it('should not allow access to user in bucket owner account', () => {
+    it('should allow access to user in bucket owner account', () => {
         const result = isBucketAuthorized(bucket, 'bucketDeleteCors',
             ownerCanonicalId, userAuthInfo);
-        assert.strictEqual(result, false);
+        assert.strictEqual(result, true);
     });
 
     const orders = [


### PR DESCRIPTION
The bucketOwnerActions checks in the bucket authorization path are redundant.
The bucketOwnerActions checks in the object authorization path were not precise enough.