### PR TITLE
Integration: S3C-2729 Update arsenal version for 7.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "github:scality/Arsenal#c848d1f",
+    "arsenal": "github:scality/Arsenal#97bc429",
     "async": "~2.5.0",
     "aws-sdk": "2.178.0",
     "azure-storage": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -197,9 +197,9 @@ arraybuffer.slice@0.0.6:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz#f33b2159f0532a3f3107a272c0ccfbd1ad2979ca"
   integrity sha1-8zshWfBTKj8xB6JywMz70a0peco=
 
-"arsenal@github:scality/Arsenal#c848d1f":
+"arsenal@github:scality/Arsenal#97bc429":
   version "7.5.0"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/c848d1f13d027215e394ff25fbf686598a9df796"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/97bc42926d85f228ee44168f4b3e69712ab5a16e"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
@@ -248,9 +248,10 @@ arsenal@scality/Arsenal#32c895b:
     ioctl "2.0.0"
 
 arsenal@scality/Arsenal#9f2e74e:
-  version "7.4.3"
+  version "7.5.0"
   resolved "https://codeload.github.com/scality/Arsenal/tar.gz/9f2e74ec6972527c2a9ca6ecb4155618f123fc19"
   dependencies:
+    "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
     ajv "4.10.0"
     async "~2.1.5"
@@ -258,7 +259,6 @@ arsenal@scality/Arsenal#9f2e74e:
     diskusage "^1.1.1"
     ioredis "4.9.5"
     ipaddr.js "1.2.0"
-    joi "^10.6"
     level "~5.0.1"
     level-sublevel "~6.6.5"
     node-forge "^0.7.1"
@@ -3766,13 +3766,13 @@ utapi@scality/utapi#72aedba:
   version "7.4.5"
   resolved "https://codeload.github.com/scality/utapi/tar.gz/72aedba8bab198cf682bcfc7ffca7ac9e2afe6c0"
   dependencies:
-    arsenal scality/Arsenal#32c895b
+    arsenal scality/Arsenal#dd6fde6
     async "^2.0.1"
     ioredis "^4.9.5"
     node-schedule "1.2.0"
     uuid "^3.3.2"
-    vaultclient scality/vaultclient#478710c
-    werelogs scality/werelogs#0a4c576
+    vaultclient scality/vaultclient#cc9ba34
+    werelogs scality/werelogs#4e0d97c
 
 utf8@2.1.2, utf8@~2.1.1:
   version "2.1.2"


### PR DESCRIPTION
Updating arsenal version for cloudserver development/8.1 branch based on https://github.com/scality/Arsenal/pull/966