### PR TITLE
bf(S3C-2542): add default logger fields for backbeat routes

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -272,6 +272,9 @@ function putData(request, response, bucketInfo, objMd, log, callback) {
                 key,
                 dataStoreName,
             }];
+            log.info('successfully put data', {
+                method: 'routeBackbeat:putData',
+            });
             return _respond(response, dataRetrievalInfo, log, callback);
         });
 }
@@ -647,10 +650,16 @@ function routeBackbeat(clientIP, request, response, log) {
                             !request.objectKey ||
                             !request.resourceType ||
                             (!request.query.operation && useMultipleBackend));
+    log.addDefaultFields({
+        bucketName: request.bucketName,
+        objectKey: request.objectKey,
+        bytesReceived: request.parsedContentLength || 0,
+        bodyLength: parseInt(request.headers['content-length'], 10) || 0,
+    });
     if (invalidRequest) {
         log.debug('invalid request', {
-            method: request.method, bucketName: request.bucketName,
-            objectKey: request.objectKey, resourceType: request.resourceType,
+            method: request.method,
+            resourceType: request.resourceType,
             query: request.query,
         });
         return responseJSONBody(errors.MethodNotAllowed, null, response, log);


### PR DESCRIPTION
# Pull request template

## Description

### Motivation and context

Why is this change required? What problem does it solve?
Currently cloudserver does not include the default log fields in the backbeat routes. We would like to be able to monitor CRR bandwidth using the bytesRecieved field. This PR add adss the aforementioned fields and a info log to the putData route
