### PR TITLE
INTEGRATION [PR#2414 > development/8.1] bf(S3C-2542): add default logger fields for backbeat routes

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -272,6 +272,9 @@ function putData(request, response, bucketInfo, objMd, log, callback) {
                 key,
                 dataStoreName,
             }];
+            log.info('successfully put data', {
+                method: 'routeBackbeat:putData',
+            });
             return _respond(response, dataRetrievalInfo, log, callback);
         });
 }
@@ -647,10 +650,16 @@ function routeBackbeat(clientIP, request, response, log) {
                             !request.objectKey ||
                             !request.resourceType ||
                             (!request.query.operation && useMultipleBackend));
+    log.addDefaultFields({
+        bucketName: request.bucketName,
+        objectKey: request.objectKey,
+        bytesReceived: request.parsedContentLength || 0,
+        bodyLength: parseInt(request.headers['content-length'], 10) || 0,
+    });
     if (invalidRequest) {
         log.debug('invalid request', {
-            method: request.method, bucketName: request.bucketName,
-            objectKey: request.objectKey, resourceType: request.resourceType,
+            method: request.method,
+            resourceType: request.resourceType,
             query: request.query,
         });
         return responseJSONBody(errors.MethodNotAllowed, null, response, log);


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2414.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-2542_add_default_logger_fields_for_backbeat_routes`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-2542_add_default_logger_fields_for_backbeat_routes
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-2542_add_default_logger_fields_for_backbeat_routes
```

Please always comment pull request #2414 instead of this one.