### PR TITLE
RELENG-3697 add an hashicorp vault/kmip worker

### DIFF
--- a/eve/workers/hashicorp_vault_kmip/Dockerfile
+++ b/eve/workers/hashicorp_vault_kmip/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:bionic
+
+RUN apt-get update
+
+# install requirements
+RUN apt-get install --no-install-recommends --assume-yes \
+    ca-certificates \
+    curl \
+    jq \
+    iproute2 \
+    net-tools \
+    nginx \
+    unzip
+
+# install vault
+RUN curl -s -o /tmp/vault.zip https://releases.hashicorp.com/vault/1.3.4+ent/vault_1.3.4+ent_linux_amd64.zip
+RUN unzip -p /tmp/vault.zip > /usr/local/bin/vault && chmod u+x /usr/local/bin/vault
+
+# use a volume for vault server data
+VOLUME "/mnt/vault/data"
+
+# run
+COPY vault.cfg /etc/vault.cfg.template
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY setup.sh /setup.sh
+COPY start.sh /start.sh
+CMD ["/start.sh"]

--- a/eve/workers/hashicorp_vault_kmip/README
+++ b/eve/workers/hashicorp_vault_kmip/README
@@ -1,0 +1,16 @@
+This docker container spawns a hashicorp vault/kmip server for integration
+test purpose.
+
+Please note, the server does not setup TLS communication with the clients.
+
+The kmip scope and role are defined at the beginning of the setup.sh script:
+SCOPE="scality-s3c"
+ROLE="admin"
+
+When running this container, you have to set an environment variable called
+"LICENSE" containing the hashicorp vault license. The license value is
+available in the CI secrets with the key "hashicorp_vault_license".
+
+The whole container is setup and ready when it is also listening on HTTP. This
+should be used to coordinate test start. On this web server, the tester can get
+the kmip ca.pem, cert.pem, and key.pem at /ca.pem /cert.pem and /key.pem URIs.

--- a/eve/workers/hashicorp_vault_kmip/nginx.conf
+++ b/eve/workers/hashicorp_vault_kmip/nginx.conf
@@ -1,0 +1,24 @@
+worker_processes 1;
+
+events {
+  worker_connections 256;
+}
+
+http {
+  access_log /dev/null;
+  error_log /dev/null;
+
+  server {
+    listen 80;
+
+    root /var/www/html;
+
+    index index.html index.htm index.nginx-debian.html;
+
+    server_name _;
+
+    location / {
+      try_files $uri $uri/ =404;
+    }
+  }
+}

--- a/eve/workers/hashicorp_vault_kmip/setup.sh
+++ b/eve/workers/hashicorp_vault_kmip/setup.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+SCOPE="scality-s3c"
+ROLE="admin"
+
+# wait vault server to be up
+while true
+do
+  netstat -plnt | grep -q ':8200' && break
+  sleep 0.1
+done
+
+ipv4=$(ip -4 addr show eth0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')
+
+# find vault server address
+export VAULT_ADDR="http://"${ipv4}":8200"
+
+# init vault
+vault operator init --format json > /root/operator_init
+
+# unseal
+for i in $(seq 0 2); do
+  key=$(jq -r ".unseal_keys_b64[$i]" /root/operator_init)
+  vault operator unseal "$key"
+done
+
+# set root token
+export VAULT_TOKEN=$(jq -r ".root_token" /root/operator_init)
+
+# set license
+cat << EOF > /root/license.json
+{
+  "text": "$LICENSE"
+}
+EOF
+curl \
+ --silent \
+ --fail \
+ --show-error \
+ --header "X-Vault-Token: ${VAULT_TOKEN}" \
+ --request PUT \
+ --data @/root/license.json  \
+ ${VAULT_ADDR}/v1/sys/license
+
+# enable kmip
+vault secrets enable kmip
+
+# configure kmip
+vault write kmip/config listen_addrs=0.0.0.0:5696
+vault write -f kmip/scope/${SCOPE}
+vault write kmip/scope/${SCOPE}/role/${ROLE} operation_all=true
+
+# generate pem files for the client
+vault write kmip/config server_ips=${ipv4}
+vault read -format=json kmip/ca | jq -r .data.ca_pem > /var/www/html/ca.pem
+vault write -format=json kmip/scope/${SCOPE}/role/${ROLE}/credential/generate cert_format=pem > /root/creds.json
+jq -r .data.certificate /root/creds.json > /var/www/html/cert.pem
+jq -r .data.private_key /root/creds.json > /var/www/html/key.pem
+
+# make the pem files available for the tester
+exec /usr/sbin/nginx

--- a/eve/workers/hashicorp_vault_kmip/start.sh
+++ b/eve/workers/hashicorp_vault_kmip/start.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+ipv4=$(ip -4 addr show eth0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')
+
+sed -e "s/__IP_ADDRESS__/${ipv4}/g"  /etc/vault.cfg.template > /etc/vault.cfg
+
+/setup.sh &
+
+exec /usr/local/bin/vault server -config /etc/vault.cfg

--- a/eve/workers/hashicorp_vault_kmip/vault.cfg
+++ b/eve/workers/hashicorp_vault_kmip/vault.cfg
@@ -1,0 +1,27 @@
+# set it to true, otherwise vault server complains when running inside a docker container
+disable_mlock = true
+
+# fix warning
+api_addr = "http://__IP_ADDRESS__:8200/"
+
+ui = true
+
+listener "tcp" {
+    address = "__IP_ADDRESS__:8200"
+    #tls_disable = false
+    #log = debug
+    tls_disable = 1
+    tls_skip_verify = 1
+    tls_cert_file = "/root/hashicorp/server/ca.crt"
+    tls_key_file = "/root/hashicorp/server/ca.key"
+    tls_client_ca_file = "/root/hashicorp/server/cacert.pem"
+}
+
+storage "file" {
+    path = "/mnt/vault/data"
+}
+
+telemetry {
+    prometheus_retention_time = "30s"
+    disable_hostname = true
+}


### PR DESCRIPTION
# Pull request template

## Description

### Motivation and context

Adding a docker worker running hashicorp vault kmip for the CI tests.

### Related issues

Please use the following link syntaxes #600 to reference issues in the
current repository

## Checklist

### Add tests to cover the changes

New tests added or existing tests modified to cover all changes

### Code conforms with the [style guide](https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#coding-style-guidelines)

### Sign your work

In order to contribute to the project, you must sign your work
https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#sign-your-work

Thank you again for contributing! We will try to test and integrate the change
as soon as we can.
