### PR TITLE
bugfix:S3C-2571 enable accept ranges header

### DIFF
--- a/lib/api/objectHead.js
+++ b/lib/api/objectHead.js
@@ -1,5 +1,6 @@
 const { errors, s3middleware } = require('arsenal');
 const validateHeaders = s3middleware.validateConditionalHeaders;
+const { parseRange } = require('arsenal/lib/network/http/utils');
 
 const { decodeVersionId } = require('./apiUtils/object/versioning');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
@@ -77,8 +78,47 @@ function objectHead(authInfo, request, log, callback) {
             if (headerValResult.error) {
                 return callback(headerValResult.error, corsHeaders);
             }
+            const responseHeaders = collectResponseHeaders(objMD, corsHeaders,
+                verCfg);
+
+            const objLength = (objMD.location === null ?
+                0 : parseInt(objMD['content-length'], 10));
+
+            let byteRange;
+            const streamingParams = {};
+            if (request.headers.range) {
+                const { range, error } = parseRange(request.headers.range,
+                                                    objLength);
+                if (error) {
+                    return callback(error, corsHeaders);
+                }
+                responseHeaders['accept-ranges'] = 'bytes';
+                if (range) {
+                    byteRange = range;
+                    // End of range should be included so + 1
+                    responseHeaders['content-length'] =
+                        range[1] - range[0] + 1;
+                    responseHeaders['content-range'] =
+                        `bytes ${range[0]}-${range[1]}/${objLength}`;
+                    streamingParams.rangeStart = range[0] ?
+                    range[0].toString() : undefined;
+                    streamingParams.rangeEnd = range[1] ?
+                    range[1].toString() : undefined;
+                }
+            }
             const partNumber = getPartNumber(request.query);
             if (partNumber !== undefined) {
+                if (byteRange) {
+                    const error = errors.InvalidRequest
+                        .customizeDescription('Cannot specify both Range ' +
+                            'header and partNumber query parameter.');
+                    return callback(error, corsHeaders);
+                }
+                if (Number.isNaN(partNumber)) {
+                    const error = errors.InvalidArgument
+                        .customizeDescription('Part number must be a number.');
+                    return callback(error, corsHeaders);
+                }
                 if (partNumber < 1 || partNumber > maximumAllowedPartCount) {
                     return callback(errors.BadRequest, corsHeaders);
                 }
@@ -86,11 +126,8 @@ function objectHead(authInfo, request, log, callback) {
                 if (!partSize) {
                     return callback(errors.InvalidRange, corsHeaders);
                 }
-                // eslint-disable-next-line no-param-reassign
-                objMD['content-length'] = partSize;
+                responseHeaders['content-length'] = partSize;
             }
-            const responseHeaders =
-                collectResponseHeaders(objMD, corsHeaders, verCfg);
             pushMetric('headObject', log, { authInfo, bucket: bucketName });
             return callback(null, responseHeaders);
         });

--- a/lib/utilities/collectResponseHeaders.js
+++ b/lib/utilities/collectResponseHeaders.js
@@ -45,6 +45,9 @@ function collectResponseHeaders(objectMD, corsHeaders, versioningCfg,
         responseMetaHeaders['x-amz-server-side-encryption-aws-kms-key-id']
             = objectMD['x-amz-server-side-encryption-aws-kms-key-id'];
     }
+
+    responseMetaHeaders['Accept-Ranges'] = 'bytes';
+
     if (objectMD['cache-control']) {
         responseMetaHeaders['Cache-Control'] = objectMD['cache-control'];
     }

--- a/tests/unit/api/objectHead.js
+++ b/tests/unit/api/objectHead.js
@@ -137,6 +137,102 @@ describe('objectHead API', () => {
         });
     });
 
+    it('should return Accept-Ranges header if request includes "Range" ' +
+       'header with specified range bytes of an object', done => {
+        const testGetRequest = {
+            bucketName,
+            namespace,
+            objectKey: objectName,
+            headers: { range: 'bytes=1-9' },
+            url: `/${bucketName}/${objectName}`,
+        };
+
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log, err => {
+                assert.strictEqual(err, null, `Error copying: ${err}`);
+                objectHead(authInfo, testGetRequest, log, (err, res) => {
+                    assert.strictEqual(res['accept-ranges'], 'bytes');
+                    done();
+                });
+            });
+        });
+    });
+
+    it('should return InvalidRequest error when both the Range header and ' +
+       'the partNumber query parameter specified', done => {
+        const testGetRequest = {
+            bucketName,
+            namespace,
+            objectKey: objectName,
+            headers: { range: 'bytes=1-9' },
+            url: `/${bucketName}/${objectName}`,
+            query: {
+                partNumber: '1',
+            },
+        };
+        const customizedInvalidRequestError = errors.InvalidRequest
+            .customizeDescription('Cannot specify both Range header and ' +
+                'partNumber query parameter.');
+
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log, err => {
+                assert.strictEqual(err, null, `Error objectPut: ${err}`);
+                objectHead(authInfo, testGetRequest, log, err => {
+                    assert.deepStrictEqual(err, customizedInvalidRequestError);
+                    assert.deepStrictEqual(err.InvalidRequest, true);
+                    done();
+                });
+            });
+        });
+    });
+
+    it('should return InvalidArgument error if partNumber is nan', done => {
+        const testGetRequest = {
+            bucketName,
+            namespace,
+            objectKey: objectName,
+            headers: {},
+            url: `/${bucketName}/${objectName}`,
+            query: {
+                partNumber: 'nan',
+            },
+        };
+        const customizedInvalidArgumentError = errors.InvalidArgument
+            .customizeDescription('Part number must be a number.');
+
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log, err => {
+                assert.strictEqual(err, null, `Error objectPut: ${err}`);
+                objectHead(authInfo, testGetRequest, log, err => {
+                    assert.deepStrictEqual(err, customizedInvalidArgumentError);
+                    assert.deepStrictEqual(err.InvalidArgument, true);
+                    done();
+                });
+            });
+        });
+    });
+
+    it('should not return Accept-Ranges header if request does not include ' +
+       '"Range" header with specified range bytes of an object', done => {
+        const testGetRequest = {
+            bucketName,
+            namespace,
+            objectKey: objectName,
+            headers: {},
+            url: `/${bucketName}/${objectName}`,
+        };
+
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log, err => {
+                assert.strictEqual(err, null, `Error objectPut: ${err}`);
+                objectHead(authInfo, testGetRequest, log, (err, res) => {
+                    assert.strictEqual(res['accept-ranges'], undefined);
+                    done();
+                });
+            });
+        });
+    });
+
     it('should get the object metadata', done => {
         const testGetRequest = {
             bucketName,


### PR DESCRIPTION
HeadObject supports "Accept-ranges" header for request with `Range` (String | i.e. "bytes=0-9") param.