### PR TITLE
bf: S3C-2801 mpu tagging tests

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -367,6 +367,14 @@ const services = {
             params.controllingLocationConstraint;
         multipartObjectMD.dataStoreName = params.dataStoreName;
         if (params.tagging) {
+            const validationTagRes = parseTagFromQuery(params.tagging);
+            if (validationTagRes instanceof Error) {
+                log.debug('tag validation failed', {
+                    error: validationTagRes,
+                    method: 'metadataStoreObject',
+                });
+                process.nextTick(() => cb(validationTagRes));
+            }
             multipartObjectMD['x-amz-tagging'] = params.tagging;
         }
         Object.keys(params.metaHeaders).forEach(val => {

--- a/tests/functional/aws-node-sdk/lib/utility/tagging.js
+++ b/tests/functional/aws-node-sdk/lib/utility/tagging.js
@@ -12,6 +12,15 @@ const taggingTests = [
     },
 ];
 
+function generateMultipleTagQuery(numberOfTag) {
+    const tagsArray = [];
+    for (let i = 0; i < numberOfTag; i++) {
+        tagsArray.push(`key${i}=value${i}`);
+    }
+    return tagsArray.join('&');
+}
+
 module.exports = {
     taggingTests,
+    generateMultipleTagQuery,
 };

--- a/tests/functional/aws-node-sdk/test/object/initiateMPU.js
+++ b/tests/functional/aws-node-sdk/test/object/initiateMPU.js
@@ -5,6 +5,7 @@ const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
 const genMaxSizeMetaHeaders
     = require('../../lib/utility/genMaxSizeMetaHeaders');
+const { generateMultipleTagQuery } = require('../../lib/utility/tagging');
 
 const bucket = `initiatempubucket${Date.now()}`;
 const key = 'key';
@@ -63,6 +64,119 @@ describe('Initiate MPU', () => {
                 assert.strictEqual(err.code, 'MetadataTooLarge');
                 assert.strictEqual(err.statusCode, 400);
                 done();
+            });
+        });
+
+        describe('with tag set', () => {
+            it('should be able to put object with 10 tags',
+            done => {
+                const taggingConfig = generateMultipleTagQuery(10);
+                s3.createMultipartUpload({
+                    Bucket: bucket,
+                    Key: key,
+                    Tagging: taggingConfig,
+                }, err => {
+                    assert.ifError(err);
+                    done();
+                });
+            });
+
+            it('should allow putting 50 tags', done => {
+                const taggingConfig = generateMultipleTagQuery(50);
+                s3.createMultipartUpload({
+                    Bucket: bucket,
+                    Key: key,
+                    Tagging: taggingConfig,
+                }, err => {
+                    assert.ifError(err);
+                    done();
+                });
+            });
+
+            it('should return BadRequest if putting more that 50 tags',
+            done => {
+                const taggingConfig = generateMultipleTagQuery(51);
+                s3.createMultipartUpload({
+                    Bucket: bucket,
+                    Key: key,
+                    Tagging: taggingConfig,
+                }, err => {
+                    assert(err, 'Expected err but did not find one');
+                    assert.strictEqual(err.code, 'BadRequest');
+                    assert.strictEqual(err.statusCode, 400);
+                    done();
+                });
+            });
+
+            it('should return InvalidArgument creating mpu tag with ' +
+            'invalid characters: %', done => {
+                const value = 'value1%';
+                s3.createMultipartUpload({
+                    Bucket: bucket,
+                    Key: key,
+                    Tagging: `key1=${value}`,
+                }, err => {
+                    assert(err, 'Expected err but did not find one');
+                    assert.strictEqual(err.code, 'InvalidArgument');
+                    assert.strictEqual(err.statusCode, 400);
+                    done();
+                });
+            });
+
+            it('should return InvalidArgument creating mpu with ' +
+            'bad encoded tags', done => {
+                s3.createMultipartUpload({
+                    Bucket: bucket,
+                    Key: key,
+                    Tagging: 'key1==value1',
+                }, err => {
+                    assert(err, 'Expected err but did not find one');
+                    assert.strictEqual(err.code, 'InvalidArgument');
+                    assert.strictEqual(err.statusCode, 400);
+                    done();
+                });
+            });
+
+            it('should return InvalidArgument if tag with no key', done => {
+                s3.createMultipartUpload({
+                    Bucket: bucket,
+                    Key: key,
+                    Tagging: '=value1',
+                }, err => {
+                    assert(err, 'Expected err but did not find one');
+                    assert.strictEqual(err.code, 'InvalidArgument');
+                    assert.strictEqual(err.statusCode, 400);
+                    done();
+                });
+            });
+
+            it('should return InvalidArgument if using the same key twice',
+            done => {
+                s3.createMultipartUpload({
+                    Bucket: bucket,
+                    Key: key,
+                    Tagging: 'key1=value1&key1=value2',
+                }, err => {
+                    assert(err, 'Expected err but did not find one');
+                    assert.strictEqual(err.code, 'InvalidArgument');
+                    assert.strictEqual(err.statusCode, 400);
+                    done();
+                });
+            });
+
+            it('should return InvalidArgument if using the same key twice ' +
+            'and empty tags', done => {
+                s3.putObject({
+                    Bucket: bucket,
+                    Key: key,
+                    Tagging: '&&&&&&&&&&&&&&&&&key1=value1&key1=value2',
+                },
+                err => {
+                    assert(err, 'Expected err but did not find one');
+                    assert.strictEqual(err.code, 'InvalidArgument');
+                    assert.strictEqual(err.statusCode, 400);
+                    done();
+                });
             });
         });
     });

--- a/tests/functional/aws-node-sdk/test/object/put.js
+++ b/tests/functional/aws-node-sdk/test/object/put.js
@@ -3,7 +3,8 @@ const assert = require('assert');
 const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
 const provideRawOutput = require('../../lib/utility/provideRawOutput');
-const { taggingTests } = require('../../lib/utility/tagging');
+const { taggingTests, generateMultipleTagQuery }
+    = require('../../lib/utility/tagging');
 const genMaxSizeMetaHeaders
     = require('../../lib/utility/genMaxSizeMetaHeaders');
 
@@ -14,18 +15,6 @@ function _checkError(err, code, statusCode) {
     assert(err, 'Expected error but found none');
     assert.strictEqual(err.code, code);
     assert.strictEqual(err.statusCode, statusCode);
-}
-
-function generateMultipleTagQuery(numberOfTag) {
-    let tags = '';
-    let and = '';
-    for (let i = 0; i < numberOfTag; i++) {
-        if (i !== 0) {
-            and = '&';
-        }
-        tags = `key${i}=value${i}${and}${tags}`;
-    }
-    return tags;
 }
 
 describe('PUT object', () => {


### PR DESCRIPTION
Adds correct error handling for tags put with initiate mpu (previously, tags were evaluated on mpu completion), and adds tests.