### PR TITLE
ft: S3C-2785 extend put bucket api for object lock

### DIFF
--- a/lib/api/apiUtils/bucket/bucketCreation.js
+++ b/lib/api/apiUtils/bucket/bucketCreation.js
@@ -165,12 +165,22 @@ function createBucket(authInfo, bucketName, headers,
     const ownerDisplayName =
         authInfo.getAccountDisplayName();
     const creationDate = new Date().toJSON();
-    const bucket = new BucketInfo(bucketName,
-        canonicalID, ownerDisplayName, creationDate,
-        BucketInfo.currentModelVersion());
+    const objectLockEnabled = headers['x-amz-bucket-object-lock-enabled'];
+    const bucket = new BucketInfo(bucketName, canonicalID, ownerDisplayName,
+        creationDate, BucketInfo.currentModelVersion(), null, null, null, null,
+        null, null, null, null, null, null, null, objectLockEnabled);
 
     if (locationConstraint !== undefined) {
         bucket.setLocationConstraint(locationConstraint);
+    }
+    if (objectLockEnabled) {
+        // default versioning configuration AWS sets
+        // when a bucket is created with object lock
+        const versioningConfiguration = {
+            Status: 'Enabled',
+            MfaDelete: 'Disabled',
+        };
+        bucket.setVersioningConfiguration(versioningConfiguration);
     }
     const parseAclParams = {
         headers,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "github:scality/Arsenal#2b9ac57",
+    "arsenal": "github:scality/Arsenal#f988270",
     "async": "~2.5.0",
     "aws-sdk": "2.363.0",
     "azure-storage": "^2.1.0",

--- a/tests/functional/aws-node-sdk/test/bucket/put.js
+++ b/tests/functional/aws-node-sdk/test/bucket/put.js
@@ -192,6 +192,44 @@ describe('PUT Bucket - AWS.S3.createBucket', () => {
             it('should create bucket if name is an IP address with some suffix',
                 done => _test('192.168.5.4-suffix', done));
         });
+
+        describe('bucket creation success with object lock', () => {
+            function _testObjectLock(name, done) {
+                bucketUtil.s3.createBucket({
+                    Bucket: name,
+                    ObjectLockEnabledForBucket: true,
+                }, (err, res) => {
+                    assert.ifError(err);
+                    assert(res.Location, 'No Location in response');
+                    assert.strictEqual(res.Location, `/${name}`,
+                        'Wrong Location header');
+                    bucketUtil.deleteOne(name).then(() => done()).catch(done);
+                });
+            }
+            function _testVersioning(name, done) {
+                bucketUtil.s3.createBucket({
+                    Bucket: name,
+                    ObjectLockEnabledForBucket: true,
+                }, (err, res) => {
+                    assert.ifError(err);
+                    assert(res.Location, 'No Location in response');
+                    assert.strictEqual(res.Location, `/${name}`,
+                        'Wrong Location header');
+                    bucketUtil.s3.getBucketVersioning({ Bucket: name }, (err, res) => {
+                        assert.ifError(err);
+                        assert.strictEqual(res.Status, 'Enabled');
+                        assert.strictEqual(res.MFADelete, 'Disabled');
+                    });
+                    bucketUtil.deleteOne(name).then(() => done()).catch(done);
+                });
+            }
+            it('should create bucket without error', done =>
+            _testObjectLock('bucket-with-object-lock', done));
+
+            it('should create bucket with versioning enabled by default', done =>
+            _testVersioning('bucket-with-object-lock', done));
+        });
+
         Object.keys(locationConstraints).forEach(
         location => {
             describeSkipAWS(`bucket creation with location: ${location}`,

--- a/tests/unit/bucket/bucketCreation.js
+++ b/tests/unit/bucket/bucketCreation.js
@@ -70,3 +70,16 @@ describe('bucket creation', () => {
         });
     });
 });
+describe('bucket creation with object lock', () => {
+    it('should return 200 when creating a bucket with object lock', done => {
+        const bucketName = 'test-bucket-with-objectlock';
+        const headers = {
+            'x-amz-bucket-object-lock-enabled': true,
+        };
+        createBucket(authInfo, bucketName, headers,
+            normalBehaviorLocationConstraint, log, err => {
+                assert.ifError(err);
+                done();
+            });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -210,9 +210,9 @@ arraybuffer.slice@0.0.6:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz#f33b2159f0532a3f3107a272c0ccfbd1ad2979ca"
   integrity sha1-8zshWfBTKj8xB6JywMz70a0peco=
 
-"arsenal@github:scality/Arsenal#2b9ac57":
+"arsenal@github:scality/Arsenal#f988270":
   version "7.5.0"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/2b9ac57230ca7f9a1901a47e835ac87484eebc79"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/f988270a0c557f0d663cae5a6d3dc5b840ccc4ff"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
@@ -261,9 +261,10 @@ arsenal@scality/Arsenal#32c895b:
     ioctl "2.0.0"
 
 arsenal@scality/Arsenal#9f2e74e:
-  version "7.4.3"
+  version "7.5.0"
   resolved "https://codeload.github.com/scality/Arsenal/tar.gz/9f2e74ec6972527c2a9ca6ecb4155618f123fc19"
   dependencies:
+    "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
     ajv "4.10.0"
     async "~2.1.5"
@@ -271,7 +272,6 @@ arsenal@scality/Arsenal#9f2e74e:
     diskusage "^1.1.1"
     ioredis "4.9.5"
     ipaddr.js "1.2.0"
-    joi "^10.6"
     level "~5.0.1"
     level-sublevel "~6.6.5"
     node-forge "^0.7.1"
@@ -379,9 +379,9 @@ aws-sdk@2.363.0:
     xml2js "0.4.19"
 
 aws-sdk@^2.2.23:
-  version "2.676.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.676.0.tgz#add497d57438f450a95efe570a4fd55654d7c16e"
-  integrity sha512-+ftolB59dL+7M6hRihhlKSDKNPfm0AJe48gtkwVJYljYubz1Y7vAwveRgBc18L9aoRXH2obFC5Ivf3r0dcfF2A==
+  version "2.671.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.671.0.tgz#2c6e164a0f540d6fc428c123f2994ac081663ff5"
+  integrity sha512-i83+/TIOLlhAxvV2xVLz5+XGtNqJgQJwP/e8J49rzDkyMV6OE2FgxU8utujGrComrSJFpITqMFqug+ZfdHoLIQ==
   dependencies:
     buffer "4.9.1"
     events "1.1.1"
@@ -3143,9 +3143,9 @@ s3blaster@scality/s3blaster#7a836b6:
     utf8 "~2.1.1"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
+  integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
 
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -3640,9 +3640,9 @@ uc.micro@^1.0.0, uc.micro@^1.0.1:
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 uglify-js@^3.1.4:
-  version "3.9.3"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.9.3.tgz#4a285d1658b8a2ebaef9e51366b3a0f7acd79ec2"
-  integrity sha512-r5ImcL6QyzQGVimQoov3aL2ZScywrOgBXGndbWrdehKoSvGe/RmiE5Jpw/v+GvxODt6l2tpBXwA7n+qZVlHBMA==
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.9.2.tgz#012b74fb6a2e440d9ba1f79110a479d3b1f2d48d"
+  integrity sha512-zGVwKslUAD/EeqOrD1nQaBmXIHl1Vw371we8cvS8I6mYK9rmgX5tv8AAeJdfsQ3Kk5mGax2SVV/AizxdNGhl7Q==
   dependencies:
     commander "~2.20.3"
 


### PR DESCRIPTION
- Adds functionality to create a bucket with object lock if the 'x-amz-bucket-object-lock-enabled' header passed with the request.
* Enables versioning if object lock is enabled during bucket creation.
* Includes a functional test to verify that when a bucket with object lock gets created, that bucket is created with versioning enabled by default.
