### PR TITLE
bugfix: S3C-2959 fix objectLockEnabled and NFSEnabled locations

### DIFF
--- a/lib/api/apiUtils/bucket/bucketCreation.js
+++ b/lib/api/apiUtils/bucket/bucketCreation.js
@@ -174,8 +174,8 @@ function createBucket(authInfo, bucketName, headers,
     const objectLockEnabled = headers['x-amz-bucket-object-lock-enabled'];
     const bucket = new BucketInfo(bucketName, canonicalID, ownerDisplayName,
         creationDate, BucketInfo.currentModelVersion(), null, null, null, null,
-        null, null, null, null, null, null, null, null, isNFSEnabled,
-        objectLockEnabled);
+        null, null, null, null, null, null, null, null, null, isNFSEnabled,
+        null, null, objectLockEnabled);
     let locationConstraintVal = null;
 
     if (locationConstraint) {


### PR DESCRIPTION
Fixes the locations of the `NFSEnabled` and `objectLockEnabled` params. 

I realized `NFSEnabled` is off by one while fixing the location of `objectLockEnabled`; now both should be correct according to model: https://github.com/scality/Arsenal/blob/development/8.1/lib/models/BucketInfo.js#L66  