### PR TITLE
INTEGRATION [PR#2542 > development/8.2] bugfix: S3C-2959 fix objectLockEnabled and NFSEnabled locations

### DIFF
--- a/lib/api/apiUtils/bucket/bucketCreation.js
+++ b/lib/api/apiUtils/bucket/bucketCreation.js
@@ -174,8 +174,8 @@ function createBucket(authInfo, bucketName, headers,
     const objectLockEnabled = headers['x-amz-bucket-object-lock-enabled'];
     const bucket = new BucketInfo(bucketName, canonicalID, ownerDisplayName,
         creationDate, BucketInfo.currentModelVersion(), null, null, null, null,
-        null, null, null, null, null, null, null, null, isNFSEnabled,
-        objectLockEnabled);
+        null, null, null, null, null, null, null, null, null, isNFSEnabled,
+        null, null, objectLockEnabled);
     let locationConstraintVal = null;
 
     if (locationConstraint) {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2542.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/bugfix/S3C-2959_ObjectLockAndNFSEnabledLocations`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/bugfix/S3C-2959_ObjectLockAndNFSEnabledLocations
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/bugfix/S3C-2959_ObjectLockAndNFSEnabledLocations
```

Please always comment pull request #2542 instead of this one.