### PR TITLE
bf: S3C-3018 multiobject delete error

### DIFF
--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -486,7 +486,7 @@ function multiObjectDelete(authInfo, request, log, callback) {
         const deletedKeys = successfullyDeleted.map(item => item.key);
         pushMetric('multiObjectDelete', log, {
             authInfo,
-            canonicalID: bucket.getOwner(),
+            canonicalID: bucket ? bucket.getOwner() : '',
             bucket: bucketName,
             keys: deletedKeys,
             byteLength: Number.parseInt(totalContentLengthDeleted, 10),


### PR DESCRIPTION
Resolves error thrown if `multiObject Delete` fulfills this condition: https://github.com/scality/cloudserver/blob/stabilization/7.4.6/lib/api/multiObjectDelete.js#L432
Test for the fix is: https://github.com/scality/Integration/blob/stabilization/7.4.6/genericStaas/policies/tests/multiObjectDelete-versioning.js#L102