### PR TITLE
feature: S3C-2946 get and head object support object lock

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -131,7 +131,7 @@ const services = {
             md.setRedirectLocation(headers['x-amz-website-redirect-location']);
         }
         if (headers) {
-            // Stores retention information if object either has its own retention
+            // Stores retention information if object has its own retention
             // configuration or default retention configuration from its bucket
             const headerMode = headers['x-amz-object-lock-mode'];
             const headerDate = headers['x-amz-object-lock-retain-until-date'];

--- a/lib/utilities/collectResponseHeaders.js
+++ b/lib/utilities/collectResponseHeaders.js
@@ -75,6 +75,19 @@ function collectResponseHeaders(objectMD, corsHeaders, versioningCfg,
         responseMetaHeaders['x-amz-tagging-count'] =
           Object.keys(objectMD.tags).length;
     }
+    const hasRetentionInfo = objectMD.retentionInfo
+        && objectMD.retentionInfo.retainUntilDate
+        && objectMD.retentionInfo.mode;
+    if (hasRetentionInfo) {
+        responseMetaHeaders['x-amz-object-lock-retain-until-date']
+            = objectMD.retentionInfo.retainUntilDate;
+        responseMetaHeaders['x-amz-object-lock-mode']
+            = objectMD.retentionInfo.mode;
+    }
+    if (objectMD.legalHold !== undefined) {
+        responseMetaHeaders['x-amz-object-lock-legal-hold']
+            = objectMD.legalHold ? 'ON' : 'OFF';
+    }
     if (objectMD.replicationInfo && objectMD.replicationInfo.status) {
         responseMetaHeaders['x-amz-replication-status'] =
             objectMD.replicationInfo.status;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "github:scality/Arsenal#b77199b",
+    "arsenal": "github:scality/Arsenal#6530f0a",
     "async": "~2.5.0",
     "aws-sdk": "2.363.0",
     "azure-storage": "^2.1.0",

--- a/tests/unit/api/apiUtils/objectLockHelpers.js
+++ b/tests/unit/api/apiUtils/objectLockHelpers.js
@@ -157,10 +157,10 @@ describe('objectLockHelpers: calculateRetainUntilDate', () => {
         };
         const date = moment();
         const expectedRetainUntilDate
-            = date.add(mockConfigWithDays.days, 'Days');
+            = date.add(mockConfigWithDays.days, 'days');
         const retainUntilDate = calculateRetainUntilDate(mockConfigWithDays);
-        assert.strictEqual(retainUntilDate.slice(0, 21),
-            expectedRetainUntilDate.toISOString().slice(0, 21));
+        assert.strictEqual(retainUntilDate.slice(0, 20),
+            expectedRetainUntilDate.toISOString().slice(0, 20));
     });
 
     it('should calculate retainUntilDate for config with years', () => {
@@ -170,9 +170,9 @@ describe('objectLockHelpers: calculateRetainUntilDate', () => {
         };
         const date = moment();
         const expectedRetainUntilDate
-            = date.add(mockConfigWithYears.years * 365, 'Days');
+            = date.add(mockConfigWithYears.years * 365, 'days');
         const retainUntilDate = calculateRetainUntilDate(mockConfigWithYears);
-        assert.strictEqual(retainUntilDate.slice(0, 21),
-            expectedRetainUntilDate.toISOString().slice(0, 21));
+        assert.strictEqual(retainUntilDate.slice(0, 20),
+            expectedRetainUntilDate.toISOString().slice(0, 20));
     });
 });

--- a/tests/unit/api/objectGet.js
+++ b/tests/unit/api/objectGet.js
@@ -75,6 +75,136 @@ describe('objectGet API', () => {
         });
     });
 
+    const testPutBucketRequestObjectLock = {
+        bucketName,
+        namespace,
+        headers: {
+            'host': `${bucketName}.s3.amazonaws.com`,
+            'x-amz-bucket-object-lock-enabled': true,
+        },
+        url: `/${bucketName}`,
+    };
+
+    const createPutDummyRetention = (date, mode) => new DummyRequest({
+        bucketName,
+        namespace,
+        objectKey: objectName,
+        headers: {
+            'x-amz-object-lock-retain-until-date': date,
+            'x-amz-object-lock-mode': mode,
+            'content-length': '12',
+        },
+        parsedContentLength: 12,
+        url: `/${bucketName}/${objectName}`,
+    }, postBody);
+
+    const testDate = new Date(2022, 6, 3).toISOString();
+
+    it('should get the object metadata with valid retention info', done => {
+        bucketPut(authInfo, testPutBucketRequestObjectLock, log, () => {
+            const request = createPutDummyRetention(testDate, 'GOVERNANCE');
+            objectPut(authInfo, request, undefined,
+                log, (err, headers) => {
+                    assert.ifError(err);
+                    assert.strictEqual(headers.ETag, `"${correctMD5}"`);
+                    const req = testGetRequest;
+                    objectGet(authInfo, req, false, log, (err, r, headers) => {
+                        assert.ifError(err);
+                        assert.strictEqual(
+                            headers['x-amz-object-lock-retain-until-date'],
+                            testDate);
+                        assert.strictEqual(
+                            headers['x-amz-object-lock-mode'],
+                            'GOVERNANCE');
+                        assert.strictEqual(headers.ETag,
+                            `"${correctMD5}"`);
+                        done();
+                    });
+                });
+        });
+    });
+
+    const createPutDummyLegalHold = legalHold => new DummyRequest({
+        bucketName,
+        namespace,
+        objectKey: objectName,
+        headers: {
+            'x-amz-object-lock-legal-hold': legalHold,
+            'content-length': '12',
+        },
+        parsedContentLength: 12,
+        url: `/${bucketName}/${objectName}`,
+    }, postBody);
+
+    const testStatuses = ['ON', 'OFF'];
+    testStatuses.forEach(status => {
+        it(`should get object metadata with legal hold ${status}`, done => {
+            bucketPut(authInfo, testPutBucketRequestObjectLock, log, () => {
+                const request = createPutDummyLegalHold(status);
+                objectPut(authInfo, request, undefined, log,
+                    (err, resHeaders) => {
+                        assert.ifError(err);
+                        assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
+                        objectGet(authInfo, testGetRequest, false, log,
+                            (err, res, headers) => {
+                                assert.ifError(err);
+                                assert.strictEqual(
+                                    headers['x-amz-object-lock-legal-hold'],
+                                    status);
+                                assert.strictEqual(headers.ETag,
+                                    `"${correctMD5}"`);
+                                done();
+                            });
+                    });
+            });
+        });
+    });
+
+    const createPutDummyRetentionAndLegalHold = (date, mode, status) =>
+        new DummyRequest({
+            bucketName,
+            namespace,
+            objectKey: objectName,
+            headers: {
+                'x-amz-object-lock-retain-until-date': date,
+                'x-amz-object-lock-mode': mode,
+                'x-amz-object-lock-legal-hold': status,
+                'content-length': '12',
+            },
+            parsedContentLength: 12,
+            url: `/${bucketName}/${objectName}`,
+        }, postBody);
+
+    it('should get the object metadata with both retention and legal hold',
+        done => {
+            bucketPut(authInfo, testPutBucketRequestObjectLock, log, () => {
+                const request = createPutDummyRetentionAndLegalHold(
+                    testDate, 'COMPLIANCE', 'ON');
+                objectPut(authInfo, request, undefined, log,
+                    (err, resHeaders) => {
+                        assert.ifError(err);
+                        assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
+                        const auth = authInfo;
+                        const req = testGetRequest;
+                        objectGet(auth, req, false, log, (err, r, headers) => {
+                            assert.ifError(err);
+                            assert.strictEqual(
+                                headers['x-amz-object-lock-legal-hold'],
+                                'ON');
+                            assert.strictEqual(
+                                headers['x-amz-object-lock-retain-until-date'],
+                                testDate);
+                            assert.strictEqual(
+                                headers['x-amz-object-lock-mode'],
+                                'COMPLIANCE');
+                            assert.strictEqual(headers.ETag,
+                                `"${correctMD5}"`);
+                            done();
+                        });
+                    });
+            });
+        });
+
     it('should get the object data retrieval info', done => {
         bucketPut(authInfo, testPutBucketRequest, log, () => {
             objectPut(authInfo, testPutObjectRequest, undefined, log,

--- a/tests/unit/api/objectGetRetention.js
+++ b/tests/unit/api/objectGetRetention.js
@@ -31,11 +31,11 @@ const putObjectRequest = new DummyRequest({
     url: `/${bucketName}/${objectName}`,
 }, postBody);
 
-const objectRetentionXml = '<ObjectRetention ' +
+const objectRetentionXml = '<Retention ' +
     'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
     '<Mode>GOVERNANCE</Mode>' +
     `<RetainUntilDate>${date.toISOString()}</RetainUntilDate>` +
-    '</ObjectRetention>';
+    '</Retention>';
 
 const putObjRetRequest = {
     bucketName,

--- a/tests/unit/api/objectHead.js
+++ b/tests/unit/api/objectHead.js
@@ -256,4 +256,56 @@ describe('objectHead API', () => {
                 });
         });
     });
+
+    it('should get the object metadata with object lock', done => {
+        const testPutBucketRequestLock = {
+            bucketName,
+            namespace,
+            headers: { 'x-amz-bucket-object-lock-enabled': true },
+            url: `/${bucketName}`,
+        };
+        const testPutObjectRequestLock = new DummyRequest({
+            bucketName,
+            namespace,
+            objectKey: objectName,
+            headers: {
+                'x-amz-object-lock-retain-until-date': '2050-10-10',
+                'x-amz-object-lock-mode': 'GOVERNANCE',
+                'x-amz-object-lock-legal-hold': 'ON',
+            },
+            url: `/${bucketName}/${objectName}`,
+            calculatedHash: correctMD5,
+        }, postBody);
+        const testGetRequest = {
+            bucketName,
+            namespace,
+            objectKey: objectName,
+            headers: {},
+            url: `/${bucketName}/${objectName}`,
+        };
+
+        bucketPut(authInfo, testPutBucketRequestLock, log, () => {
+            objectPut(authInfo, testPutObjectRequestLock, undefined, log,
+                (err, resHeaders) => {
+                    assert.ifError(err);
+                    assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
+                    objectHead(authInfo, testGetRequest, log, (err, res) => {
+                        assert.ifError(err);
+                        const expectedDate = testPutObjectRequestLock
+                        .headers['x-amz-object-lock-retain-until-date'];
+                        const expectedMode = testPutObjectRequestLock
+                        .headers['x-amz-object-lock-mode'];
+                        assert.ifError(err);
+                        assert.strictEqual(
+                            res['x-amz-object-lock-retain-until-date'],
+                            expectedDate);
+                        assert.strictEqual(res['x-amz-object-lock-mode'],
+                            expectedMode);
+                        assert.strictEqual(res['x-amz-object-lock-legal-hold'],
+                            'ON');
+                        done();
+                    });
+                });
+        });
+    });
 });

--- a/tests/unit/api/objectPutRetention.js
+++ b/tests/unit/api/objectPutRetention.js
@@ -31,11 +31,11 @@ const putObjectRequest = new DummyRequest({
     url: `/${bucketName}/${objectName}`,
 }, postBody);
 
-const objectRetentionXml = '<ObjectRetention ' +
+const objectRetentionXml = '<Retention ' +
     'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
     '<Mode>GOVERNANCE</Mode>' +
     `<RetainUntilDate>${date.toISOString()}</RetainUntilDate>` +
-    '</ObjectRetention>';
+    '</Retention>';
 
 const putObjRetRequest = {
     bucketName,

--- a/yarn.lock
+++ b/yarn.lock
@@ -210,9 +210,9 @@ arraybuffer.slice@0.0.6:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz#f33b2159f0532a3f3107a272c0ccfbd1ad2979ca"
   integrity sha1-8zshWfBTKj8xB6JywMz70a0peco=
 
-"arsenal@github:scality/Arsenal#b77199b":
+"arsenal@github:scality/Arsenal#6530f0a":
   version "7.5.0"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/b77199b085ae3c1e9121592e5f84090e188cf248"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/6530f0ace443ec6f553ea4832c8bf3d044e5f66e"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
@@ -261,9 +261,10 @@ arsenal@scality/Arsenal#32c895b:
     ioctl "2.0.0"
 
 arsenal@scality/Arsenal#9f2e74e:
-  version "7.4.3"
+  version "7.5.0"
   resolved "https://codeload.github.com/scality/Arsenal/tar.gz/9f2e74ec6972527c2a9ca6ecb4155618f123fc19"
   dependencies:
+    "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
     ajv "4.10.0"
     async "~2.1.5"
@@ -271,7 +272,6 @@ arsenal@scality/Arsenal#9f2e74e:
     diskusage "^1.1.1"
     ioredis "4.9.5"
     ipaddr.js "1.2.0"
-    joi "^10.6"
     level "~5.0.1"
     level-sublevel "~6.6.5"
     node-forge "^0.7.1"


### PR DESCRIPTION
Extends GET and HEAD Object APIs to return object lock related information for the object if any set on the object's metadata.

When an object version have object lock related information stored in its metadata, GET Object and HEAD Object APIs should return these in the response; sample GET/HEAD Object response for a locked object:
```
{   
    "AcceptRanges": "bytes",
    "LastModified": "2020-06-03T03:26:39+00:00",
    "ContentLength": 0,
    "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
    "VersionId": "39383430383834353230303133383939393939395247303031202030",
    "Metadata": {},
    "ObjectLockMode": "GOVERNANCE",
    "ObjectLockRetainUntilDate": "2021-12-12T00:00:34+00:00",
    "ObjectLockLegalHoldStatus": "ON"
}
```