### PR TITLE
INTEGRATION [PR#2590 > development/7.8] feature: S3C-2946 extend get object for object lock

### DIFF
--- a/lib/utilities/collectResponseHeaders.js
+++ b/lib/utilities/collectResponseHeaders.js
@@ -75,8 +75,8 @@ function collectResponseHeaders(objectMD, corsHeaders, versioningCfg,
         responseMetaHeaders['x-amz-tagging-count'] =
           Object.keys(objectMD.tags).length;
     }
-    if (objectMD.retentionInfo && objectMD.retentionInfo.retainUntilDate
-        && objectMD.retentionInfo.mode) {
+    if (objectMD.retentionInfo && (objectMD.retentionInfo.retainUntilDate
+        && objectMD.retentionInfo.mode)) {
             responseMetaHeaders['x-amz-object-lock-retain-until-date']
                 = objectMD.retentionInfo.retainUntilDate;
             responseMetaHeaders['x-amz-object-lock-mode']

--- a/lib/utilities/collectResponseHeaders.js
+++ b/lib/utilities/collectResponseHeaders.js
@@ -75,6 +75,17 @@ function collectResponseHeaders(objectMD, corsHeaders, versioningCfg,
         responseMetaHeaders['x-amz-tagging-count'] =
           Object.keys(objectMD.tags).length;
     }
+    if (objectMD.retentionInfo && objectMD.retentionInfo.retainUntilDate
+        && objectMD.retentionInfo.mode) {
+            responseMetaHeaders['x-amz-object-lock-retain-until-date']
+                = objectMD.retentionInfo.retainUntilDate;
+            responseMetaHeaders['x-amz-object-lock-mode']
+                = objectMD.retentionInfo.mode;
+    }
+    if (objectMD.legalHold !== undefined) {
+        responseMetaHeaders['x-amz-object-lock-legal-hold']
+            = objectMD.legalHold ? 'ON' : 'OFF';
+    }
     if (objectMD.replicationInfo && objectMD.replicationInfo.status) {
         responseMetaHeaders['x-amz-replication-status'] =
             objectMD.replicationInfo.status;

--- a/tests/unit/api/objectGet.js
+++ b/tests/unit/api/objectGet.js
@@ -146,7 +146,6 @@ describe('objectGet API', () => {
                     objectGet(authInfo, testGetRequest, false, log,
                         (err, res, responseMetaHeaders) => {
                             assert.ifError(err);
-                            console.log(`\nresponseMetaHeaders:${JSON.stringify(responseMetaHeaders, null, 2)}\n`)
                             assert.strictEqual(
                                 responseMetaHeaders['x-amz-object-lock-legal-hold'],
                                 'ON');
@@ -168,7 +167,6 @@ describe('objectGet API', () => {
                     objectGet(authInfo, testGetRequest, false,
                         log, (err, res, responseMetaHeaders) => {
                             assert.ifError(err);
-                            console.log(`\nresponseMetaHeaders:${JSON.stringify(responseMetaHeaders, null, 2)}\n`)
                             assert.strictEqual(
                                 responseMetaHeaders.ObjectLockLegalHoldStatus,
                                 'OFF');


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2590.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.8/feature/S3C-2946_GetObjectApiSupportsObjectLock`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.8/feature/S3C-2946_GetObjectApiSupportsObjectLock
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.8/feature/S3C-2946_GetObjectApiSupportsObjectLock
```

Please always comment pull request #2590 instead of this one.