### PR TITLE
feature: S3C-2946 get and head object support object lock

### DIFF
--- a/lib/utilities/collectResponseHeaders.js
+++ b/lib/utilities/collectResponseHeaders.js
@@ -75,6 +75,17 @@ function collectResponseHeaders(objectMD, corsHeaders, versioningCfg,
         responseMetaHeaders['x-amz-tagging-count'] =
           Object.keys(objectMD.tags).length;
     }
+    if (objectMD.retentionInfo && (objectMD.retentionInfo.retainUntilDate
+        && objectMD.retentionInfo.mode)) {
+            responseMetaHeaders['x-amz-object-lock-retain-until-date']
+                = objectMD.retentionInfo.retainUntilDate;
+            responseMetaHeaders['x-amz-object-lock-mode']
+                = objectMD.retentionInfo.mode;
+    }
+    if (objectMD.legalHold !== undefined) {
+        responseMetaHeaders['x-amz-object-lock-legal-hold']
+            = objectMD.legalHold ? 'ON' : 'OFF';
+    }
     if (objectMD.replicationInfo && objectMD.replicationInfo.status) {
         responseMetaHeaders['x-amz-replication-status'] =
             objectMD.replicationInfo.status;

--- a/tests/unit/api/objectGet.js
+++ b/tests/unit/api/objectGet.js
@@ -75,6 +75,155 @@ describe('objectGet API', () => {
         });
     });
 
+    const testPutBucketRequestObjectLock = {
+        bucketName,
+        namespace,
+        headers: {
+            host: `${bucketName}.s3.amazonaws.com`,
+            'x-amz-object-lock-enabled': true,
+        },
+        url: `/${bucketName}`,
+    };
+
+    const testPutObjectReqRetention = (date, mode) => new DummyRequest({
+        bucketName,
+        namespace,
+        objectKey: objectName,
+        headers: {
+            'x-amz-object-lock-retain-until-date': date,
+            'x-amz-object-lock-mode': mode,
+            'content-length': '12',
+        },
+        parsedContentLength: 12,
+        url: `/${bucketName}/${objectName}`,
+    }, postBody);
+
+    const testDate = new Date(2022, 6, 3);
+
+    it('should get the object metadata with valid retention info', done => {
+        bucketPut(authInfo, testPutBucketRequestObjectLock, log, () => {
+            const request = testPutObjectReqRetention(testDate, 'GOVERNANCE');
+            objectPut(authInfo, request, undefined,
+                log, (err, headers) => {
+                    assert.ifError(err);
+                    assert.strictEqual(headers.ETag, `"${correctMD5}"`);
+                    objectGet(authInfo, testGetRequest, false, log,
+                        (err, res, headers) => {
+                            assert.ifError(err);
+                            assert.strictEqual(
+                                headers['x-amz-object-lock-retain-until-date'],
+                                testDate);
+                            assert.strictEqual(
+                                headers['x-amz-object-lock-mode'],
+                                'GOVERNANCE');
+                            assert.strictEqual(headers.ETag,
+                                `"${correctMD5}"`);
+                            done();
+                        });
+                });
+        });
+    });
+
+    const testPutObjectReqLegalHold = legalHold => new DummyRequest({
+        bucketName,
+        namespace,
+        objectKey: objectName,
+        headers: {
+            'x-amz-object-lock-legal-hold': legalHold,
+            'content-length': '12',
+        },
+        parsedContentLength: 12,
+        url: `/${bucketName}/${objectName}`,
+    }, postBody);
+
+    it('should get the object metadata with legal hold status ON', done => {
+        bucketPut(authInfo, testPutBucketRequestObjectLock, log, () => {
+            const request = testPutObjectReqLegalHold('ON');
+            objectPut(authInfo, request, undefined,
+                log, (err, resHeaders) => {
+                    assert.ifError(err);
+                    assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
+                    objectGet(authInfo, testGetRequest, false, log,
+                        (err, res, responseMetaHeaders) => {
+                            assert.ifError(err);
+                            assert.strictEqual(
+                                responseMetaHeaders['x-amz-object-lock-legal-hold'],
+                                'ON');
+                            assert.strictEqual(responseMetaHeaders.ETag,
+                                `"${correctMD5}"`);
+                            done();
+                        });
+                });
+        });
+    });
+
+    it('should get the object metadata with legal hold status OFF', done => {
+        bucketPut(authInfo, testPutBucketRequestObjectLock, log, () => {
+            const request = testPutObjectReqLegalHold('OFF');
+            objectPut(authInfo, request, undefined,
+                log, (err, resHeaders) => {
+                    assert.ifError(err);
+                    assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
+                    objectGet(authInfo, testGetRequest, false,
+                        log, (err, res, responseMetaHeaders) => {
+                            assert.ifError(err);
+                            assert.strictEqual(
+                                responseMetaHeaders.ObjectLockLegalHoldStatus,
+                                'OFF');
+                            assert.strictEqual(responseMetaHeaders.ETag,
+                                `"${correctMD5}"`);
+                            done();
+                        });
+                });
+        });
+    });
+
+    const testPutObjectReqRetentionAndLegalHold = (date, mode, status) => {
+        return new DummyRequest({
+            bucketName,
+            namespace,
+            objectKey: objectName,
+            headers: {
+                'x-amz-object-lock-retain-until-date': date,
+                'x-amz-object-lock-mode': mode,
+                'x-amz-object-lock-legal-hold': status,
+                'content-length': '12',
+            },
+            parsedContentLength: 12,
+            url: `/${bucketName}/${objectName}`,
+        }, postBody);
+    }
+
+    it('should get the object metadata with both retention and legal hold',
+        done => {
+            bucketPut(authInfo, testPutBucketRequestObjectLock, log, () => {
+                const request = testPutObjectReqRetentionAndLegalHold(
+                    testDate, 'COMPLIANCE', 'ON');
+                objectPut(authInfo, request, undefined,
+                    log, (err, resHeaders) => {
+                        assert.ifError(err);
+                        assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
+                        objectGet(authInfo, testGetRequest, false, log,
+                            (err, res, headers) => {
+                                assert.ifError(err);
+                                assert.strictEqual(
+                                    headers['x-amz-object-lock-legal-hold'],
+                                    'ON');
+                                assert.strictEqual(
+                                    /* eslint-disable next line */
+                                    headers['x-amz-object-lock-retain-until-date'],
+                                    testDate);
+                                assert.strictEqual(
+                                    headers['x-amz-object-lock-mode'],
+                                    'COMPLIANCE');
+                                assert.strictEqual(headers.ETag,
+                                    `"${correctMD5}"`);
+                                done();
+                        });
+                });
+            });
+    });
+
     it('should get the object data retrieval info', done => {
         bucketPut(authInfo, testPutBucketRequest, log, () => {
             objectPut(authInfo, testPutObjectRequest, undefined, log,

--- a/tests/unit/api/objectGet.js
+++ b/tests/unit/api/objectGet.js
@@ -136,47 +136,29 @@ describe('objectGet API', () => {
         url: `/${bucketName}/${objectName}`,
     }, postBody);
 
-    it('should get the object metadata with legal hold status ON', done => {
-        bucketPut(authInfo, testPutBucketRequestObjectLock, log, () => {
-            const request = testPutObjectReqLegalHold('ON');
-            objectPut(authInfo, request, undefined,
-                log, (err, resHeaders) => {
-                    assert.ifError(err);
-                    assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
-                    objectGet(authInfo, testGetRequest, false, log,
-                        (err, res, responseMetaHeaders) => {
-                            assert.ifError(err);
-                            assert.strictEqual(
-                                responseMetaHeaders['x-amz-object-lock-legal-hold'],
-                                'ON');
-                            assert.strictEqual(responseMetaHeaders.ETag,
-                                `"${correctMD5}"`);
-                            done();
-                        });
-                });
+    const testStatuses = ['ON', 'OFF'];
+    testStatuses.forEach(status => {
+        it(`should get object metadata with legal hold ${status}`, done => {
+            bucketPut(authInfo, testPutBucketRequestObjectLock, log, () => {
+                const request = testPutObjectReqLegalHold(status);
+                objectPut(authInfo, request, undefined, log,
+                    (err, resHeaders) => {
+                        assert.ifError(err);
+                        assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
+                        objectGet(authInfo, testGetRequest, false, log,
+                            (err, res, headers) => {
+                                assert.ifError(err);
+                                assert.strictEqual(
+                                    headers['x-amz-object-lock-legal-hold'],
+                                    status);
+                                assert.strictEqual(headers.ETag,
+                                    `"${correctMD5}"`);
+                                done();
+                            });
+                    });
+            });
         });
-    });
-
-    it('should get the object metadata with legal hold status OFF', done => {
-        bucketPut(authInfo, testPutBucketRequestObjectLock, log, () => {
-            const request = testPutObjectReqLegalHold('OFF');
-            objectPut(authInfo, request, undefined,
-                log, (err, resHeaders) => {
-                    assert.ifError(err);
-                    assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
-                    objectGet(authInfo, testGetRequest, false,
-                        log, (err, res, responseMetaHeaders) => {
-                            assert.ifError(err);
-                            assert.strictEqual(
-                                responseMetaHeaders.ObjectLockLegalHoldStatus,
-                                'OFF');
-                            assert.strictEqual(responseMetaHeaders.ETag,
-                                `"${correctMD5}"`);
-                            done();
-                        });
-                });
-        });
-    });
+    })
 
     const testPutObjectReqRetentionAndLegalHold = (date, mode, status) => {
         return new DummyRequest({
@@ -199,8 +181,8 @@ describe('objectGet API', () => {
             bucketPut(authInfo, testPutBucketRequestObjectLock, log, () => {
                 const request = testPutObjectReqRetentionAndLegalHold(
                     testDate, 'COMPLIANCE', 'ON');
-                objectPut(authInfo, request, undefined,
-                    log, (err, resHeaders) => {
+                objectPut(authInfo, request, undefined, log,
+                    (err, resHeaders) => {
                         assert.ifError(err);
                         assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
                         objectGet(authInfo, testGetRequest, false, log,

--- a/tests/unit/api/objectHead.js
+++ b/tests/unit/api/objectHead.js
@@ -271,6 +271,7 @@ describe('objectHead API', () => {
             headers: {
                 'x-amz-object-lock-retain-until-date': '2050-10-10',
                 'x-amz-object-lock-mode': 'GOVERNANCE',
+                'x-amz-object-lock-legal-hold': 'ON',
             },
             url: `/${bucketName}/${objectName}`,
             calculatedHash: correctMD5,
@@ -298,8 +299,10 @@ describe('objectHead API', () => {
                         assert.strictEqual(
                             res['x-amz-object-lock-retain-until-date'],
                             expectedDate);
-                            assert.strictEqual(res['x-amz-object-lock-mode'],
+                        assert.strictEqual(res['x-amz-object-lock-mode'],
                             expectedMode);
+                        assert.strictEqual(res['x-amz-object-lock-legal-hold'],
+                            'ON');
                         done();
                     });
             });

--- a/tests/unit/api/objectHead.js
+++ b/tests/unit/api/objectHead.js
@@ -256,4 +256,53 @@ describe('objectHead API', () => {
                 });
         });
     });
+
+    it('should get the object metadata with object lock', done => {
+        const testPutBucketRequestLock = {
+            bucketName,
+            namespace,
+            headers: { 'x-amz-bucket-object-lock-enabled': true },
+            url: `/${bucketName}`,
+        };
+        const testPutObjectRequestLock = new DummyRequest({
+            bucketName,
+            namespace,
+            objectKey: objectName,
+            headers: {
+                'x-amz-object-lock-retain-until-date': '2050-10-10',
+                'x-amz-object-lock-mode': 'GOVERNANCE',
+            },
+            url: `/${bucketName}/${objectName}`,
+            calculatedHash: correctMD5,
+        }, postBody);
+        const testGetRequest = {
+            bucketName,
+            namespace,
+            objectKey: objectName,
+            headers: {},
+            url: `/${bucketName}/${objectName}`,
+        };
+
+        bucketPut(authInfo, testPutBucketRequestLock, log, () => {
+            objectPut(authInfo, testPutObjectRequestLock, undefined, log,
+                (err, resHeaders) => {
+                    assert.ifError(err);
+                    assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
+                    objectHead(authInfo, testGetRequest, log, (err, res) => {
+                        assert.ifError(err);
+                        const expectedDate = testPutObjectRequestLock
+                        .headers['x-amz-object-lock-retain-until-date'];
+                        const expectedMode = testPutObjectRequestLock
+                        .headers['x-amz-object-lock-mode'];
+                        assert.ifError(err);
+                        assert.strictEqual(
+                            res['x-amz-object-lock-retain-until-date'],
+                            expectedDate);
+                            assert.strictEqual(res['x-amz-object-lock-mode'],
+                            expectedMode);
+                        done();
+                    });
+            });
+        });
+    });
 });


### PR DESCRIPTION
Extends GET and HEAD Object APIs to return object lock related information for the object if any set on the object's metadata.

When an object version have object lock related information stored in its metadata, GET Object and HEAD Object APIs should return these in the response; sample GET/HEAD Object response for a locked object:

```
{   
    "AcceptRanges": "bytes",
    "LastModified": "2020-06-03T03:26:39+00:00",
    "ContentLength": 0,
    "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
    "VersionId": "39383430383834353230303133383939393939395247303031202030",
    "Metadata": {},
    "ObjectLockMode": "GOVERNANCE",
    "ObjectLockRetainUntilDate": "2021-12-12T00:00:34+00:00",
    "ObjectLockLegalHoldStatus": "ON"
}
```