### PR TITLE
INTEGRATION [PR#2590 > development/8.1] feature: S3C-2946 get and head object support object lock

### DIFF
--- a/lib/utilities/collectResponseHeaders.js
+++ b/lib/utilities/collectResponseHeaders.js
@@ -75,12 +75,14 @@ function collectResponseHeaders(objectMD, corsHeaders, versioningCfg,
         responseMetaHeaders['x-amz-tagging-count'] =
           Object.keys(objectMD.tags).length;
     }
-    if (objectMD.retentionInfo && (objectMD.retentionInfo.retainUntilDate
-        && objectMD.retentionInfo.mode)) {
-            responseMetaHeaders['x-amz-object-lock-retain-until-date']
-                = objectMD.retentionInfo.retainUntilDate;
-            responseMetaHeaders['x-amz-object-lock-mode']
-                = objectMD.retentionInfo.mode;
+    const hasRetentionInfo = objectMD.retentionInfo
+        && objectMD.retentionInfo.retainUntilDate
+        && objectMD.retentionInfo.mode;
+    if (hasRetentionInfo) {
+        responseMetaHeaders['x-amz-object-lock-retain-until-date']
+            = objectMD.retentionInfo.retainUntilDate;
+        responseMetaHeaders['x-amz-object-lock-mode']
+            = objectMD.retentionInfo.mode;
     }
     if (objectMD.legalHold !== undefined) {
         responseMetaHeaders['x-amz-object-lock-legal-hold']

--- a/lib/utilities/collectResponseHeaders.js
+++ b/lib/utilities/collectResponseHeaders.js
@@ -75,6 +75,17 @@ function collectResponseHeaders(objectMD, corsHeaders, versioningCfg,
         responseMetaHeaders['x-amz-tagging-count'] =
           Object.keys(objectMD.tags).length;
     }
+    if (objectMD.retentionInfo && (objectMD.retentionInfo.retainUntilDate
+        && objectMD.retentionInfo.mode)) {
+            responseMetaHeaders['x-amz-object-lock-retain-until-date']
+                = objectMD.retentionInfo.retainUntilDate;
+            responseMetaHeaders['x-amz-object-lock-mode']
+                = objectMD.retentionInfo.mode;
+    }
+    if (objectMD.legalHold !== undefined) {
+        responseMetaHeaders['x-amz-object-lock-legal-hold']
+            = objectMD.legalHold ? 'ON' : 'OFF';
+    }
     if (objectMD.replicationInfo && objectMD.replicationInfo.status) {
         responseMetaHeaders['x-amz-replication-status'] =
             objectMD.replicationInfo.status;

--- a/tests/unit/api/objectGet.js
+++ b/tests/unit/api/objectGet.js
@@ -85,7 +85,7 @@ describe('objectGet API', () => {
         url: `/${bucketName}`,
     };
 
-    const testPutObjectReqRetention = (date, mode) => new DummyRequest({
+    const createPutDummyRetention = (date, mode) => new DummyRequest({
         bucketName,
         namespace,
         objectKey: objectName,
@@ -102,24 +102,24 @@ describe('objectGet API', () => {
 
     it('should get the object metadata with valid retention info', done => {
         bucketPut(authInfo, testPutBucketRequestObjectLock, log, () => {
-            const request = testPutObjectReqRetention(testDate, 'GOVERNANCE');
+            const request = createPutDummyRetention(testDate, 'GOVERNANCE');
             objectPut(authInfo, request, undefined,
                 log, (err, headers) => {
                     assert.ifError(err);
                     assert.strictEqual(headers.ETag, `"${correctMD5}"`);
-                    objectGet(authInfo, testGetRequest, false, log,
-                        (err, res, headers) => {
-                            assert.ifError(err);
-                            assert.strictEqual(
-                                headers['x-amz-object-lock-retain-until-date'],
-                                testDate);
-                            assert.strictEqual(
-                                headers['x-amz-object-lock-mode'],
-                                'GOVERNANCE');
-                            assert.strictEqual(headers.ETag,
-                                `"${correctMD5}"`);
-                            done();
-                        });
+                    const req = testGetRequest;
+                    objectGet(authInfo, req, false, log, err, res, headers => {
+                        assert.ifError(err);
+                        assert.strictEqual(
+                            headers['x-amz-object-lock-retain-until-date'],
+                            testDate);
+                        assert.strictEqual(
+                            headers['x-amz-object-lock-mode'],
+                            'GOVERNANCE');
+                        assert.strictEqual(headers.ETag,
+                            `"${correctMD5}"`);
+                        done();
+                    });
                 });
         });
     });
@@ -160,7 +160,7 @@ describe('objectGet API', () => {
         });
     })
 
-    const testPutObjectReqRetentionAndLegalHold = (date, mode, status) => {
+    const createPutDummyRetentionAndLegalHold = (date, mode, status) => {
         return new DummyRequest({
             bucketName,
             namespace,
@@ -179,7 +179,7 @@ describe('objectGet API', () => {
     it('should get the object metadata with both retention and legal hold',
         done => {
             bucketPut(authInfo, testPutBucketRequestObjectLock, log, () => {
-                const request = testPutObjectReqRetentionAndLegalHold(
+                const request = createPutDummyRetentionAndLegalHold(
                     testDate, 'COMPLIANCE', 'ON');
                 objectPut(authInfo, request, undefined, log,
                     (err, resHeaders) => {

--- a/tests/unit/api/objectGet.js
+++ b/tests/unit/api/objectGet.js
@@ -75,6 +75,155 @@ describe('objectGet API', () => {
         });
     });
 
+    const testPutBucketRequestObjectLock = {
+        bucketName,
+        namespace,
+        headers: {
+            host: `${bucketName}.s3.amazonaws.com`,
+            'x-amz-object-lock-enabled': true,
+        },
+        url: `/${bucketName}`,
+    };
+
+    const testPutObjectReqRetention = (date, mode) => new DummyRequest({
+        bucketName,
+        namespace,
+        objectKey: objectName,
+        headers: {
+            'x-amz-object-lock-retain-until-date': date,
+            'x-amz-object-lock-mode': mode,
+            'content-length': '12',
+        },
+        parsedContentLength: 12,
+        url: `/${bucketName}/${objectName}`,
+    }, postBody);
+
+    const testDate = new Date(2022, 6, 3);
+
+    it('should get the object metadata with valid retention info', done => {
+        bucketPut(authInfo, testPutBucketRequestObjectLock, log, () => {
+            const request = testPutObjectReqRetention(testDate, 'GOVERNANCE');
+            objectPut(authInfo, request, undefined,
+                log, (err, headers) => {
+                    assert.ifError(err);
+                    assert.strictEqual(headers.ETag, `"${correctMD5}"`);
+                    objectGet(authInfo, testGetRequest, false, log,
+                        (err, res, headers) => {
+                            assert.ifError(err);
+                            assert.strictEqual(
+                                headers['x-amz-object-lock-retain-until-date'],
+                                testDate);
+                            assert.strictEqual(
+                                headers['x-amz-object-lock-mode'],
+                                'GOVERNANCE');
+                            assert.strictEqual(headers.ETag,
+                                `"${correctMD5}"`);
+                            done();
+                        });
+                });
+        });
+    });
+
+    const testPutObjectReqLegalHold = legalHold => new DummyRequest({
+        bucketName,
+        namespace,
+        objectKey: objectName,
+        headers: {
+            'x-amz-object-lock-legal-hold': legalHold,
+            'content-length': '12',
+        },
+        parsedContentLength: 12,
+        url: `/${bucketName}/${objectName}`,
+    }, postBody);
+
+    it('should get the object metadata with legal hold status ON', done => {
+        bucketPut(authInfo, testPutBucketRequestObjectLock, log, () => {
+            const request = testPutObjectReqLegalHold('ON');
+            objectPut(authInfo, request, undefined,
+                log, (err, resHeaders) => {
+                    assert.ifError(err);
+                    assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
+                    objectGet(authInfo, testGetRequest, false, log,
+                        (err, res, responseMetaHeaders) => {
+                            assert.ifError(err);
+                            assert.strictEqual(
+                                responseMetaHeaders['x-amz-object-lock-legal-hold'],
+                                'ON');
+                            assert.strictEqual(responseMetaHeaders.ETag,
+                                `"${correctMD5}"`);
+                            done();
+                        });
+                });
+        });
+    });
+
+    it('should get the object metadata with legal hold status OFF', done => {
+        bucketPut(authInfo, testPutBucketRequestObjectLock, log, () => {
+            const request = testPutObjectReqLegalHold('OFF');
+            objectPut(authInfo, request, undefined,
+                log, (err, resHeaders) => {
+                    assert.ifError(err);
+                    assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
+                    objectGet(authInfo, testGetRequest, false,
+                        log, (err, res, responseMetaHeaders) => {
+                            assert.ifError(err);
+                            assert.strictEqual(
+                                responseMetaHeaders.ObjectLockLegalHoldStatus,
+                                'OFF');
+                            assert.strictEqual(responseMetaHeaders.ETag,
+                                `"${correctMD5}"`);
+                            done();
+                        });
+                });
+        });
+    });
+
+    const testPutObjectReqRetentionAndLegalHold = (date, mode, status) => {
+        return new DummyRequest({
+            bucketName,
+            namespace,
+            objectKey: objectName,
+            headers: {
+                'x-amz-object-lock-retain-until-date': date,
+                'x-amz-object-lock-mode': mode,
+                'x-amz-object-lock-legal-hold': status,
+                'content-length': '12',
+            },
+            parsedContentLength: 12,
+            url: `/${bucketName}/${objectName}`,
+        }, postBody);
+    }
+
+    it('should get the object metadata with both retention and legal hold',
+        done => {
+            bucketPut(authInfo, testPutBucketRequestObjectLock, log, () => {
+                const request = testPutObjectReqRetentionAndLegalHold(
+                    testDate, 'COMPLIANCE', 'ON');
+                objectPut(authInfo, request, undefined,
+                    log, (err, resHeaders) => {
+                        assert.ifError(err);
+                        assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
+                        objectGet(authInfo, testGetRequest, false, log,
+                            (err, res, headers) => {
+                                assert.ifError(err);
+                                assert.strictEqual(
+                                    headers['x-amz-object-lock-legal-hold'],
+                                    'ON');
+                                assert.strictEqual(
+                                    /* eslint-disable next line */
+                                    headers['x-amz-object-lock-retain-until-date'],
+                                    testDate);
+                                assert.strictEqual(
+                                    headers['x-amz-object-lock-mode'],
+                                    'COMPLIANCE');
+                                assert.strictEqual(headers.ETag,
+                                    `"${correctMD5}"`);
+                                done();
+                        });
+                });
+            });
+    });
+
     it('should get the object data retrieval info', done => {
         bucketPut(authInfo, testPutBucketRequest, log, () => {
             objectPut(authInfo, testPutObjectRequest, undefined, log,

--- a/tests/unit/api/objectGet.js
+++ b/tests/unit/api/objectGet.js
@@ -124,7 +124,7 @@ describe('objectGet API', () => {
         });
     });
 
-    const testPutObjectReqLegalHold = legalHold => new DummyRequest({
+    const createPutDummyLegalHold = legalHold => new DummyRequest({
         bucketName,
         namespace,
         objectKey: objectName,
@@ -140,7 +140,7 @@ describe('objectGet API', () => {
     testStatuses.forEach(status => {
         it(`should get object metadata with legal hold ${status}`, done => {
             bucketPut(authInfo, testPutBucketRequestObjectLock, log, () => {
-                const request = testPutObjectReqLegalHold(status);
+                const request = createPutDummyLegalHold(status);
                 objectPut(authInfo, request, undefined, log,
                     (err, resHeaders) => {
                         assert.ifError(err);

--- a/tests/unit/api/objectGet.js
+++ b/tests/unit/api/objectGet.js
@@ -136,47 +136,29 @@ describe('objectGet API', () => {
         url: `/${bucketName}/${objectName}`,
     }, postBody);
 
-    it('should get the object metadata with legal hold status ON', done => {
-        bucketPut(authInfo, testPutBucketRequestObjectLock, log, () => {
-            const request = testPutObjectReqLegalHold('ON');
-            objectPut(authInfo, request, undefined,
-                log, (err, resHeaders) => {
-                    assert.ifError(err);
-                    assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
-                    objectGet(authInfo, testGetRequest, false, log,
-                        (err, res, responseMetaHeaders) => {
-                            assert.ifError(err);
-                            assert.strictEqual(
-                                responseMetaHeaders['x-amz-object-lock-legal-hold'],
-                                'ON');
-                            assert.strictEqual(responseMetaHeaders.ETag,
-                                `"${correctMD5}"`);
-                            done();
-                        });
-                });
+    const testStatuses = ['ON', 'OFF'];
+    testStatuses.forEach(status => {
+        it(`should get object metadata with legal hold ${status}`, done => {
+            bucketPut(authInfo, testPutBucketRequestObjectLock, log, () => {
+                const request = testPutObjectReqLegalHold(status);
+                objectPut(authInfo, request, undefined, log,
+                    (err, resHeaders) => {
+                        assert.ifError(err);
+                        assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
+                        objectGet(authInfo, testGetRequest, false, log,
+                            (err, res, headers) => {
+                                assert.ifError(err);
+                                assert.strictEqual(
+                                    headers['x-amz-object-lock-legal-hold'],
+                                    status);
+                                assert.strictEqual(headers.ETag,
+                                    `"${correctMD5}"`);
+                                done();
+                            });
+                    });
+            });
         });
-    });
-
-    it('should get the object metadata with legal hold status OFF', done => {
-        bucketPut(authInfo, testPutBucketRequestObjectLock, log, () => {
-            const request = testPutObjectReqLegalHold('OFF');
-            objectPut(authInfo, request, undefined,
-                log, (err, resHeaders) => {
-                    assert.ifError(err);
-                    assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
-                    objectGet(authInfo, testGetRequest, false,
-                        log, (err, res, responseMetaHeaders) => {
-                            assert.ifError(err);
-                            assert.strictEqual(
-                                responseMetaHeaders.ObjectLockLegalHoldStatus,
-                                'OFF');
-                            assert.strictEqual(responseMetaHeaders.ETag,
-                                `"${correctMD5}"`);
-                            done();
-                        });
-                });
-        });
-    });
+    })
 
     const testPutObjectReqRetentionAndLegalHold = (date, mode, status) => {
         return new DummyRequest({
@@ -199,8 +181,8 @@ describe('objectGet API', () => {
             bucketPut(authInfo, testPutBucketRequestObjectLock, log, () => {
                 const request = testPutObjectReqRetentionAndLegalHold(
                     testDate, 'COMPLIANCE', 'ON');
-                objectPut(authInfo, request, undefined,
-                    log, (err, resHeaders) => {
+                objectPut(authInfo, request, undefined, log,
+                    (err, resHeaders) => {
                         assert.ifError(err);
                         assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
                         objectGet(authInfo, testGetRequest, false, log,

--- a/tests/unit/api/objectHead.js
+++ b/tests/unit/api/objectHead.js
@@ -271,6 +271,7 @@ describe('objectHead API', () => {
             headers: {
                 'x-amz-object-lock-retain-until-date': '2050-10-10',
                 'x-amz-object-lock-mode': 'GOVERNANCE',
+                'x-amz-object-lock-legal-hold': 'ON',
             },
             url: `/${bucketName}/${objectName}`,
             calculatedHash: correctMD5,
@@ -298,8 +299,10 @@ describe('objectHead API', () => {
                         assert.strictEqual(
                             res['x-amz-object-lock-retain-until-date'],
                             expectedDate);
-                            assert.strictEqual(res['x-amz-object-lock-mode'],
+                        assert.strictEqual(res['x-amz-object-lock-mode'],
                             expectedMode);
+                        assert.strictEqual(res['x-amz-object-lock-legal-hold'],
+                            'ON');
                         done();
                     });
             });

--- a/tests/unit/api/objectHead.js
+++ b/tests/unit/api/objectHead.js
@@ -256,4 +256,53 @@ describe('objectHead API', () => {
                 });
         });
     });
+
+    it('should get the object metadata with object lock', done => {
+        const testPutBucketRequestLock = {
+            bucketName,
+            namespace,
+            headers: { 'x-amz-bucket-object-lock-enabled': true },
+            url: `/${bucketName}`,
+        };
+        const testPutObjectRequestLock = new DummyRequest({
+            bucketName,
+            namespace,
+            objectKey: objectName,
+            headers: {
+                'x-amz-object-lock-retain-until-date': '2050-10-10',
+                'x-amz-object-lock-mode': 'GOVERNANCE',
+            },
+            url: `/${bucketName}/${objectName}`,
+            calculatedHash: correctMD5,
+        }, postBody);
+        const testGetRequest = {
+            bucketName,
+            namespace,
+            objectKey: objectName,
+            headers: {},
+            url: `/${bucketName}/${objectName}`,
+        };
+
+        bucketPut(authInfo, testPutBucketRequestLock, log, () => {
+            objectPut(authInfo, testPutObjectRequestLock, undefined, log,
+                (err, resHeaders) => {
+                    assert.ifError(err);
+                    assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
+                    objectHead(authInfo, testGetRequest, log, (err, res) => {
+                        assert.ifError(err);
+                        const expectedDate = testPutObjectRequestLock
+                        .headers['x-amz-object-lock-retain-until-date'];
+                        const expectedMode = testPutObjectRequestLock
+                        .headers['x-amz-object-lock-mode'];
+                        assert.ifError(err);
+                        assert.strictEqual(
+                            res['x-amz-object-lock-retain-until-date'],
+                            expectedDate);
+                            assert.strictEqual(res['x-amz-object-lock-mode'],
+                            expectedMode);
+                        done();
+                    });
+            });
+        });
+    });
 });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2590.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/feature/S3C-2946_GetObjectApiSupportsObjectLock`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/feature/S3C-2946_GetObjectApiSupportsObjectLock
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/feature/S3C-2946_GetObjectApiSupportsObjectLock
```

Please always comment pull request #2590 instead of this one.