### PR TITLE
INTEGRATION [PR#2634 > development/8.1] Feature/s3 c 2974 object lock delete apis

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -39,6 +39,7 @@ const objectDeleteTagging = require('./objectDeleteTagging');
 const objectGet = require('./objectGet');
 const objectGetACL = require('./objectGetACL');
 const objectGetLegalHold = require('./objectGetLegalHold');
+const objectGetRetention = require('./objectGetRetention');
 const objectGetTagging = require('./objectGetTagging');
 const objectHead = require('./objectHead');
 const objectPut = require('./objectPut');
@@ -206,6 +207,7 @@ const api = {
     objectGet,
     objectGetACL,
     objectGetLegalHold,
+    objectGetRetention,
     objectGetTagging,
     objectCopy,
     objectHead,

--- a/lib/api/apiUtils/object/objectLockHelpers.js
+++ b/lib/api/apiUtils/object/objectLockHelpers.js
@@ -11,7 +11,7 @@ function calculateRetainUntilDate(retention) {
     // Calculate the number of days to retain the lock on the object
     const retainUntilDays = days || years * 365;
     const retainUntilDate
-        = date.add(retainUntilDays, 'Days');
+        = date.add(retainUntilDays, 'days');
     return retainUntilDate.toISOString();
 }
 /**
@@ -110,9 +110,43 @@ function setObjectLockInformation(headers, md, defaultRetention) {
     }
 }
 
+/**
+ * isObjectLocked - checks whether object is locked or not
+ * @param {obect} bucket - bucket metadata
+ * @param {object} objectMD - object metadata
+ * @param {array} headers - request headers
+ * @return {boolean} - indicates whether object is locked or not
+ */
+function isObjectLocked(bucket, objectMD, headers) {
+    if (bucket.isObjectLockEnabled()) {
+        const objectLegalHold = objectMD.legalHold;
+        if (objectLegalHold) {
+            return true;
+        }
+        const objectRetention = objectMD.retentionInfo;
+        if (!objectRetention) {
+            return false;
+        }
+        const objectMode = objectRetention.retention.mode;
+        if (objectMode === 'GOVERNANCE' &&
+        headers['x-amz-bypass-governance-retention']) {
+            return false;
+        }
+        const objectDate = moment(objectRetention.retention.retainUntilDate);
+        const now = moment();
+        // indicates retain until date has expired
+        if (now.isSameOrAfter(objectDate)) {
+            return false;
+        }
+        return true;
+    }
+    return false;
+}
+
 module.exports = {
     calculateRetainUntilDate,
     compareObjectLockInformation,
     setObjectLockInformation,
+    isObjectLocked,
     validateHeaders,
 };

--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -18,6 +18,7 @@ const { preprocessingVersioningDelete }
 const createAndStoreObject = require('./apiUtils/object/createAndStoreObject');
 const { metadataGetObject } = require('../metadata/metadataUtils');
 const { config } = require('../Config');
+const { isObjectLocked } = require('./apiUtils/object/objectLockHelpers');
 const requestUtils = policies.requestUtils;
 
 const versionIdUtils = versioning.VersionID;
@@ -225,6 +226,10 @@ function getObjMetadataAndDelete(authInfo, canonicalID, request,
                         // list and move on
                         successfullyDeleted.push({ entry });
                         return callback(skipError);
+                    }
+                    if (versionId && isObjectLocked(bucket, objMD, request.headers)) {
+                        log.debug('trying to delete locked object');
+                        return callback(errors.AccessDenied);
                     }
                     return callback(null, objMD, versionId);
                 }),

--- a/lib/api/objectDelete.js
+++ b/lib/api/objectDelete.js
@@ -8,6 +8,7 @@ const createAndStoreObject = require('./apiUtils/object/createAndStoreObject');
 const { decodeVersionId, preprocessingVersioningDelete }
     = require('./apiUtils/object/versioning');
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
+const { isObjectLocked } = require('./apiUtils/object/objectLockHelpers');
 
 const versionIdUtils = versioning.VersionID;
 
@@ -72,6 +73,13 @@ function objectDelete(authInfo, request, log, cb) {
                     // if trying to delete an object that does not exist when
                     // versioning has been configured
                     return next(null, bucketMD, objMD);
+                }
+                // AWS only returns an object lock error if a version id
+                // is specified, else continue to create a delete marker
+                if (reqVersionId &&
+                isObjectLocked(bucketMD, objMD, request.headers)) {
+                    log.debug('trying to delete locked object');
+                    return next(errors.AccessDenied, bucketMD);
                 }
                 if (reqVersionId && objMD.location &&
                     Array.isArray(objMD.location) && objMD.location[0]) {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "diskusage": "1.1.3",
     "google-auto-auth": "^0.9.1",
     "http-proxy": "^1.17.0",
+    "moment": "^2.26.0",
     "node-uuid": "^1.4.3",
     "npm-run-all": "~4.1.5",
     "sproxydclient": "scality/sproxydclient#44f025b",

--- a/tests/functional/aws-node-sdk/lib/utility/objectLock-util.js
+++ b/tests/functional/aws-node-sdk/lib/utility/objectLock-util.js
@@ -1,0 +1,28 @@
+const assert = require('assert');
+const async = require('async');
+const { versioning } = require('arsenal');
+
+const { metadataGetObject } = require('../../../../../lib/metadata/metadataUtils');
+const metadata = require('../../../../../lib/metadata/wrapper');
+const { DummyRequestLogger } = require('../../../../unit/helpers');
+const versionIdUtils = versioning.VersionID;
+
+const log = new DummyRequestLogger();
+
+function removeObjectLock(objects, cb) {
+    async.each(objects, (object, next) => {
+        const { bucket, key, versionId } = object;
+        metadataGetObject(bucket, key, versionIdUtils.decode(versionId), log, (err, objMD) => {
+            assert.ifError(err);
+            /* eslint-disable no-param-reassign */
+            objMD.retentionInfo = '';
+            objMD.legalHold = false;
+            metadata.putObjectMD(bucket, key, objMD, { versionId: objMD.versionId }, log, err => {
+                assert.ifError(err);
+                next();
+            });
+        });
+    }, cb);
+}
+
+module.exports = removeObjectLock;

--- a/tests/functional/aws-node-sdk/test/object/deleteObject.js
+++ b/tests/functional/aws-node-sdk/test/object/deleteObject.js
@@ -1,10 +1,13 @@
 const assert = require('assert');
+const moment = require('moment');
 const Promise = require('bluebird');
 const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
+const removeObjectLock = require('../../lib/utility/objectLock-util');
 
 const bucketName = 'testdeletempu';
 const objectName = 'key';
+const objectNameTwo = 'secondkey';
 
 describe('DELETE object', () => {
     withV4(sigCfg => {
@@ -13,70 +16,214 @@ describe('DELETE object', () => {
         const s3 = bucketUtil.s3;
         const testfile = Buffer.alloc(1024 * 1024 * 54, 0);
 
-        before(() => {
-            process.stdout.write('creating bucket\n');
-            return s3.createBucketPromise({ Bucket: bucketName })
-            .then(() => {
-                process.stdout.write('initiating multipart upload\n');
-                return s3.createMultipartUploadPromise({ Bucket: bucketName,
-                    Key: objectName });
-            })
-            .then(res => {
-                process.stdout.write('uploading parts\n');
-                uploadId = res.UploadId;
-                const uploads = [];
-                for (let i = 1; i <= 3; i++) {
-                    uploads.push(
-                        s3.uploadPartPromise({ Bucket: bucketName,
-                            Key: objectName, PartNumber: i, Body: testfile,
-                            UploadId: uploadId })
-                    );
-                }
-                return Promise.all(uploads);
-            })
-            .catch(err => {
-                process.stdout.write(`Error with uploadPart ${err}\n`);
-                throw err;
-            })
-            .then(res => {
-                process.stdout.write('about to complete multipart upload\n');
-                return s3.completeMultipartUploadPromise({
+        describe('with multipart upload', () => {
+            before(() => {
+                process.stdout.write('creating bucket\n');
+                return s3.createBucketPromise({ Bucket: bucketName })
+                .then(() => {
+                    process.stdout.write('initiating multipart upload\n');
+                    return s3.createMultipartUploadPromise({ Bucket: bucketName,
+                        Key: objectName });
+                })
+                .then(res => {
+                    process.stdout.write('uploading parts\n');
+                    uploadId = res.UploadId;
+                    const uploads = [];
+                    for (let i = 1; i <= 3; i++) {
+                        uploads.push(
+                            s3.uploadPartPromise({
+                                Bucket: bucketName,
+                                Key: objectName,
+                                PartNumber: i,
+                                Body: testfile,
+                                UploadId: uploadId,
+                            })
+                        );
+                    }
+                    return Promise.all(uploads);
+                })
+                .catch(err => {
+                    process.stdout.write(`Error with uploadPart ${err}\n`);
+                    throw err;
+                })
+                .then(res => {
+                    process.stdout.write('about to complete multipart ' +
+                        'upload\n');
+                    return s3.completeMultipartUploadPromise({
+                        Bucket: bucketName,
+                        Key: objectName,
+                        UploadId: uploadId,
+                        MultipartUpload: {
+                            Parts: [
+                                { ETag: res[0].ETag, PartNumber: 1 },
+                                { ETag: res[1].ETag, PartNumber: 2 },
+                                { ETag: res[2].ETag, PartNumber: 3 },
+                            ],
+                        },
+                    });
+                })
+                .catch(err => {
+                    process.stdout.write('completeMultipartUpload error: ' +
+                        `${err}\n`);
+                    throw err;
+                });
+            });
+
+            after(() => {
+                process.stdout.write('Emptying bucket\n');
+                return bucketUtil.empty(bucketName)
+                .then(() => {
+                    process.stdout.write('Deleting bucket\n');
+                    return bucketUtil.deleteOne(bucketName);
+                })
+                .catch(err => {
+                    process.stdout.write('Error in after\n');
+                    throw err;
+                });
+            });
+
+            it('should delete a object uploaded in parts successfully',
+            done => {
+                s3.deleteObject({ Bucket: bucketName, Key: objectName },
+                err => {
+                    assert.strictEqual(err, null,
+                        `Expected success, got error ${JSON.stringify(err)}`);
+                    done();
+                });
+            });
+        });
+
+        describe('with object lock', () => {
+            let versionIdOne;
+            let versionIdTwo;
+            const retainDate = moment().add(10, 'days').toISOString();
+            before(() => {
+                process.stdout.write('creating bucket\n');
+                return s3.createBucketPromise({
+                    Bucket: bucketName,
+                    ObjectLockEnabledForBucket: true,
+                })
+                .catch(err => {
+                    process.stdout.write(`Error creating bucket ${err}\n`);
+                    throw err;
+                })
+                .then(() => {
+                    process.stdout.write('putting object\n');
+                    return s3.putObjectPromise({
+                        Bucket: bucketName,
+                        Key: objectName,
+                    });
+                })
+                .catch(err => {
+                    process.stdout.write('Error putting object');
+                    throw err;
+                })
+                .then(res => {
+                    versionIdOne = res.VersionId;
+                    process.stdout.write('putting object retention\n');
+                    return s3.putObjectRetentionPromise({
+                        Bucket: bucketName,
+                        Key: objectName,
+                        Retention: {
+                            Mode: 'GOVERNANCE',
+                            RetainUntilDate: retainDate,
+                        },
+                    });
+                })
+                .catch(err => {
+                    process.stdout.write('Err putting object retention\n');
+                    throw err;
+                })
+                .then(() => {
+                    process.stdout.write('putting object\n');
+                    return s3.putObjectPromise({
+                        Bucket: bucketName,
+                        Key: objectNameTwo,
+                    });
+                })
+                .catch(err => {
+                    process.stdout.write(('Err putting second object\n'));
+                    throw err;
+                })
+                .then(res => {
+                    versionIdTwo = res.VersionId;
+                    process.stdout.write('putting object legal hold\n');
+                    return s3.putObjectLegalHoldPromise({
+                        Bucket: bucketName,
+                        Key: objectNameTwo,
+                        LegalHold: {
+                            Status: 'ON',
+                        },
+                    });
+                })
+                .catch(err => {
+                    process.stdout.write('Err putting object legal hold\n');
+                    throw err;
+                });
+            });
+
+            after(() => {
+                process.stdout.write('Emptying bucket\n');
+                return bucketUtil.empty(bucketName)
+                .then(() => {
+                    process.stdout.write('Deleting bucket\n');
+                    return bucketUtil.deleteOne(bucketName);
+                })
+                .catch(err => {
+                    process.stdout.write('Error in after\n');
+                    throw err;
+                });
+            });
+
+            it('should put delete marker if no version id specified', done => {
+                s3.deleteObject({
                     Bucket: bucketName,
                     Key: objectName,
-                    UploadId: uploadId,
-                    MultipartUpload: {
-                        Parts: [
-                            { ETag: res[0].ETag, PartNumber: 1 },
-                            { ETag: res[1].ETag, PartNumber: 2 },
-                            { ETag: res[2].ETag, PartNumber: 3 },
-                        ],
-                    },
+                }, err => {
+                    assert.ifError(err);
+                    done();
                 });
-            })
-            .catch(err => {
-                process.stdout.write(`completeMultipartUpload error: ${err}\n`);
-                throw err;
             });
-        });
 
-        after(() => {
-            process.stdout.write('Emptying bucket\n');
-            return bucketUtil.empty(bucketName)
-            .then(() => {
-                process.stdout.write('Deleting bucket\n');
-                return bucketUtil.deleteOne(bucketName);
-            })
-            .catch(err => {
-                process.stdout.write('Error in after\n');
-                throw err;
+            it('should not delete object version locked with object ' +
+            'retention', done => {
+                s3.deleteObject({
+                    Bucket: bucketName,
+                    Key: objectName,
+                    VersionId: versionIdOne,
+                }, err => {
+                    assert.strictEqual(err.code, 'AccessDenied');
+                    done();
+                });
             });
-        });
 
-        it('should delete a object uploaded in parts successfully', done => {
-            s3.deleteObject({ Bucket: bucketName, Key: objectName }, err => {
-                assert.strictEqual(err, null,
-                    `Expected success, got error ${JSON.stringify(err)}`);
-                done();
+            it('should delete locked object version with GOVERNANCE ' +
+            'retention mode and correct header', done => {
+                s3.deleteObject({
+                    Bucket: bucketName,
+                    Key: objectName,
+                    VersionId: versionIdOne,
+                    BypassGovernanceRetention: true,
+                }, err => {
+                    assert.ifError(err);
+                    done();
+                });
+            });
+
+            it('should not delete object locked with legal hold', done => {
+                s3.deleteObject({
+                    Bucket: bucketName,
+                    Key: objectNameTwo,
+                    VersionId: versionIdTwo,
+                }, err => {
+                    assert.strictEqual(err.code, 'AccessDenied');
+                    removeObjectLock(
+                        [{
+                            bucket: bucketName,
+                            key: objectNameTwo,
+                            versionId: versionIdTwo,
+                        }], done);
+                });
             });
         });
     });

--- a/tests/functional/aws-node-sdk/test/object/put.js
+++ b/tests/functional/aws-node-sdk/test/object/put.js
@@ -6,6 +6,7 @@ const provideRawOutput = require('../../lib/utility/provideRawOutput');
 const { taggingTests } = require('../../lib/utility/tagging');
 const genMaxSizeMetaHeaders
     = require('../../lib/utility/genMaxSizeMetaHeaders');
+const removeObjectLock = require('../../lib/utility/objectLock-util');
 
 const bucket = 'bucket2putstuffin4324242';
 const object = 'object2putstuffin';
@@ -316,13 +317,13 @@ describe('PUT object with object lock', () => {
             const date = new Date(2050, 10, 10);
             const params = {
                 Bucket: bucket,
-                Key: 'key',
+                Key: 'key1',
                 ObjectLockRetainUntilDate: date,
                 ObjectLockMode: 'COMPLIANCE',
             };
-            s3.putObject(params, err => {
+            s3.putObject(params, (err, res) => {
                 assert.ifError(err);
-                done();
+                removeObjectLock(bucket, 'key1', res.VersionId, done);
             });
         });
 
@@ -331,13 +332,13 @@ describe('PUT object with object lock', () => {
             const date = new Date(2050, 10, 10);
             const params = {
                 Bucket: bucket,
-                Key: 'key',
+                Key: 'key2',
                 ObjectLockRetainUntilDate: date,
                 ObjectLockMode: 'GOVERNANCE',
             };
-            s3.putObject(params, err => {
+            s3.putObject(params, (err, res) => {
                 assert.ifError(err);
-                done();
+                removeObjectLock(bucket, 'key2', res.VersionId, done);
             });
         });
 
@@ -345,7 +346,7 @@ describe('PUT object with object lock', () => {
             const date = new Date(2050, 10, 10);
             const params = {
                 Bucket: bucket,
-                Key: 'key',
+                Key: 'key3',
                 ObjectLockMode: 'Governance',
                 ObjectLockRetainUntilDate: date,
             };
@@ -359,19 +360,19 @@ describe('PUT object with object lock', () => {
         it('should put object with valid legal hold status ON', done => {
             const params = {
                 Bucket: bucket,
-                Key: 'key',
+                Key: 'key4',
                 ObjectLockLegalHoldStatus: 'ON',
             };
-            s3.putObject(params, err => {
+            s3.putObject(params, (err, res) => {
                 assert.ifError(err);
-                done();
+                removeObjectLock(bucket, 'key4', res.VersionId, done);
             });
         });
 
         it('should put object with valid legal hold status OFF', done => {
             const params = {
                 Bucket: bucket,
-                Key: 'key',
+                Key: 'key5',
                 ObjectLockLegalHoldStatus: 'OFF',
             };
             s3.putObject(params, err => {
@@ -383,7 +384,7 @@ describe('PUT object with object lock', () => {
         it('should error with invalid legal hold status', done => {
             const params = {
                 Bucket: bucket,
-                Key: 'key',
+                Key: 'key6',
                 ObjectLockLegalHoldStatus: 'on',
             };
             s3.putObject(params, err => {
@@ -399,7 +400,7 @@ describe('PUT object with object lock', () => {
             const date = new Date(2050, 10, 10);
             const params = {
                 Bucket: bucket,
-                Key: 'key',
+                Key: 'key7',
                 ObjectLockRetainUntilDate: date,
             };
             s3.putObject(params, err => {
@@ -416,7 +417,7 @@ describe('PUT object with object lock', () => {
             'but object lock retain until date header is missing', done => {
             const params = {
                 Bucket: bucket,
-                Key: 'key',
+                Key: 'key8',
                 ObjectLockMode: 'GOVERNANCE',
             };
             s3.putObject(params, err => {

--- a/tests/functional/aws-node-sdk/test/object/put.js
+++ b/tests/functional/aws-node-sdk/test/object/put.js
@@ -323,7 +323,8 @@ describe('PUT object with object lock', () => {
             };
             s3.putObject(params, (err, res) => {
                 assert.ifError(err);
-                removeObjectLock(bucket, 'key1', res.VersionId, done);
+                removeObjectLock(
+                    [{ bucket, key: 'key1', versionId: res.VersionId }], done);
             });
         });
 
@@ -338,7 +339,8 @@ describe('PUT object with object lock', () => {
             };
             s3.putObject(params, (err, res) => {
                 assert.ifError(err);
-                removeObjectLock(bucket, 'key2', res.VersionId, done);
+                removeObjectLock(
+                    [{ bucket, key: 'key2', versionId: res.VersionId }], done);
             });
         });
 
@@ -365,7 +367,8 @@ describe('PUT object with object lock', () => {
             };
             s3.putObject(params, (err, res) => {
                 assert.ifError(err);
-                removeObjectLock(bucket, 'key4', res.VersionId, done);
+                removeObjectLock(
+                    [{ bucket, key: 'key4', versionId: res.VersionId }], done);
             });
         });
 

--- a/tests/unit/api/objectGet.js
+++ b/tests/unit/api/objectGet.js
@@ -13,6 +13,8 @@ const initiateMultipartUpload
 const objectPut = require('../../../lib/api/objectPut');
 const objectGet = require('../../../lib/api/objectGet');
 const objectPutPart = require('../../../lib/api/objectPutPart');
+const removeObjectLock =
+    require('../../functional/aws-node-sdk/lib/utility/objectLock-util');
 
 const log = new DummyRequestLogger();
 const canonicalID = 'accessKey1';
@@ -118,7 +120,11 @@ describe('objectGet API', () => {
                             'GOVERNANCE');
                         assert.strictEqual(headers.ETag,
                             `"${correctMD5}"`);
-                        done();
+                        removeObjectLock([{
+                            bucket: bucketName,
+                            key: objectName,
+                            versionId: headers['x-amz-version-id'],
+                        }], done);
                     });
                 });
         });
@@ -153,7 +159,11 @@ describe('objectGet API', () => {
                                     status);
                                 assert.strictEqual(headers.ETag,
                                     `"${correctMD5}"`);
-                                done();
+                                removeObjectLock([{
+                                    bucket: bucketName,
+                                    key: objectName,
+                                    versionId: headers['x-amz-version-id'],
+                                }], done);
                             });
                     });
             });

--- a/tests/unit/api/objectHead.js
+++ b/tests/unit/api/objectHead.js
@@ -6,6 +6,8 @@ const { cleanup, DummyRequestLogger, makeAuthInfo } = require('../helpers');
 const objectPut = require('../../../lib/api/objectPut');
 const objectHead = require('../../../lib/api/objectHead');
 const DummyRequest = require('../DummyRequest');
+const removeObjectLock =
+    require('../../functional/aws-node-sdk/lib/utility/objectLock-util');
 
 const log = new DummyRequestLogger();
 const canonicalID = 'accessKey1';
@@ -303,7 +305,11 @@ describe('objectHead API', () => {
                             expectedMode);
                         assert.strictEqual(res['x-amz-object-lock-legal-hold'],
                             'ON');
-                        done();
+                        removeObjectLock([{
+                            bucket: bucketName,
+                            key: objectName,
+                            versionId: res['x-amz-version-id'],
+                        }], done);
                     });
                 });
         });

--- a/tests/unit/api/objectPut.js
+++ b/tests/unit/api/objectPut.js
@@ -256,7 +256,7 @@ describe('objectPut API', () => {
                                     const days
                                         = type === 'Days' ? val : val * 365;
                                     const expectedDate
-                                        = date.add(days, 'Days');
+                                        = date.add(days, 'days');
                                     assert.ifError(err);
                                     assert.strictEqual(mode, testMode);
                                     assert.strictEqual(formatTime(retainDate),

--- a/yarn.lock
+++ b/yarn.lock
@@ -261,10 +261,9 @@ arsenal@scality/Arsenal#32c895b:
     ioctl "2.0.0"
 
 arsenal@scality/Arsenal#9f2e74e:
-  version "7.5.0"
+  version "7.4.3"
   resolved "https://codeload.github.com/scality/Arsenal/tar.gz/9f2e74ec6972527c2a9ca6ecb4155618f123fc19"
   dependencies:
-    "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
     ajv "4.10.0"
     async "~2.1.5"
@@ -272,6 +271,7 @@ arsenal@scality/Arsenal#9f2e74e:
     diskusage "^1.1.1"
     ioredis "4.9.5"
     ipaddr.js "1.2.0"
+    joi "^10.6"
     level "~5.0.1"
     level-sublevel "~6.6.5"
     node-forge "^0.7.1"
@@ -379,9 +379,9 @@ aws-sdk@2.363.0:
     xml2js "0.4.19"
 
 aws-sdk@^2.2.23:
-  version "2.697.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.697.0.tgz#37320f50449a0d048fd34664dec023fdfeeab01f"
-  integrity sha512-aNrwiPRHQyzjJxpfgLwVOevuGTOMkU5uiP4VDIngfc/k4s2kQgLSyhLSKmNTjbubHCHfs1sQQkP3RXK2Oi8Rbw==
+  version "2.698.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.698.0.tgz#edb85a004f13ac002e59baf6639f9215dbbd1e3f"
+  integrity sha512-6S01wJMGwVLU7uld3sNXd1YuZab/Rha7qMFznxOHjkX/N+N0N1+Spd0T4NqXX9ebSai+OfeLT2H0IwyH4LAIZw==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -889,7 +889,7 @@ debug@^2.1.1, debug@^2.2.0, debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.1.0:
+debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -1387,11 +1387,9 @@ follow-redirects@1.5.10:
     debug "=3.1.0"
 
 follow-redirects@^1.0.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.11.0.tgz#afa14f08ba12a52963140fe43212658897bc0ecb"
-  integrity sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==
-  dependencies:
-    debug "^3.0.0"
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.12.0.tgz#ff0ccf85cf2c867c481957683b5f91b75b25e240"
+  integrity sha512-JgawlbfBQKjbKegPn8vUsvJqplE7KHJuhGO4yPcb+ZOIYKSr+xobMVlfRBToZwZUUxy7lFiKBdFNloz9ui368Q==
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -2544,7 +2542,7 @@ moment-timezone@^0.5.31:
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.9.0":
+"moment@>= 2.9.0", moment@^2.26.0:
   version "2.26.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.26.0.tgz#5e1f82c6bafca6e83e808b30c8705eed0dcbd39a"
   integrity sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw==


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2634.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/feature/S3C-2974-object-lock-delete-apis`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/feature/S3C-2974-object-lock-delete-apis
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/feature/S3C-2974-object-lock-delete-apis
```

Please always comment pull request #2634 instead of this one.