### PR TITLE
INTEGRATION [PR#2690 > development/8.2] ft: S3C-2960 update utapi for object lock metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node-uuid": "^1.4.3",
     "npm-run-all": "~4.1.5",
     "sproxydclient": "scality/sproxydclient#44f025b",
-    "utapi": "scality/utapi#2bc5d07",
+    "utapi": "scality/utapi#89ede12",
     "utf8": "~2.1.1",
     "uuid": "^3.0.1",
     "vaultclient": "scality/vaultclient#21d03b1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -379,9 +379,9 @@ aws-sdk@2.363.0:
     xml2js "0.4.19"
 
 aws-sdk@^2.2.23:
-  version "2.698.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.698.0.tgz#edb85a004f13ac002e59baf6639f9215dbbd1e3f"
-  integrity sha512-6S01wJMGwVLU7uld3sNXd1YuZab/Rha7qMFznxOHjkX/N+N0N1+Spd0T4NqXX9ebSai+OfeLT2H0IwyH4LAIZw==
+  version "2.699.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.699.0.tgz#e77b6ffa4c860882e2779c060b74fab33d42f554"
+  integrity sha512-EC431z/+i/cJgOgnDpOJ8Fa6+p7Oo1vIvdm/uJqP9tJX3+pxi/M/tvQavfz4yAlLBFqjQwxa8nrPisby0Mr5MQ==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -3677,9 +3677,9 @@ user-home@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
 
-utapi@scality/utapi#2bc5d07:
+utapi@scality/utapi#89ede12:
   version "7.5.0"
-  resolved "https://codeload.github.com/scality/utapi/tar.gz/2bc5d07f85ba6d0e1ec230efe579b23386c99fa7"
+  resolved "https://codeload.github.com/scality/utapi/tar.gz/89ede12a609cb4de2e9d42a69d858c4c19aa4343"
   dependencies:
     arsenal scality/Arsenal#32c895b
     async "^2.0.1"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2690.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/feature/S3C-2960-update-utapi`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/feature/S3C-2960-update-utapi
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/feature/S3C-2960-update-utapi
```

Please always comment pull request #2690 instead of this one.