### PR TITLE
INTEGRATION [PR#2723 > development/7.7] ft: S3C-3112 update arsenal for object lock setter

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "github:scality/Arsenal#6530f0a",
+    "arsenal": "github:scality/Arsenal#55b6cea",
     "async": "~2.5.0",
     "aws-sdk": "2.363.0",
     "azure-storage": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -210,9 +210,9 @@ arraybuffer.slice@0.0.6:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz#f33b2159f0532a3f3107a272c0ccfbd1ad2979ca"
   integrity sha1-8zshWfBTKj8xB6JywMz70a0peco=
 
-"arsenal@github:scality/Arsenal#6530f0a":
+"arsenal@github:scality/Arsenal#55b6cea":
   version "7.5.0"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/6530f0ace443ec6f553ea4832c8bf3d044e5f66e"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/55b6ceadabca9686eff8fb1ae7794a5b536ec52e"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
@@ -264,6 +264,7 @@ arsenal@scality/Arsenal#9f2e74e:
   version "7.4.3"
   resolved "https://codeload.github.com/scality/Arsenal/tar.gz/9f2e74ec6972527c2a9ca6ecb4155618f123fc19"
   dependencies:
+    "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
     ajv "4.10.0"
     async "~2.1.5"
@@ -271,7 +272,6 @@ arsenal@scality/Arsenal#9f2e74e:
     diskusage "^1.1.1"
     ioredis "4.9.5"
     ipaddr.js "1.2.0"
-    joi "^10.6"
     level "~5.0.1"
     level-sublevel "~6.6.5"
     node-forge "^0.7.1"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2723.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.7/feature/S3C-3112_updateArsenalForObjLockSetter`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.7/feature/S3C-3112_updateArsenalForObjLockSetter
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.7/feature/S3C-3112_updateArsenalForObjLockSetter
```

Please always comment pull request #2723 instead of this one.