### PR TITLE
Bugfix/s3 c 3106 multiobj delete obj lock error

### DIFF
--- a/tests/functional/aws-node-sdk/test/object/deleteObject.js
+++ b/tests/functional/aws-node-sdk/test/object/deleteObject.js
@@ -3,7 +3,7 @@ const moment = require('moment');
 const Promise = require('bluebird');
 const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
-const removeObjectLock = require('../../lib/utility/objectLock-util');
+const changeObjectLock = require('../../../../utilities/objectLock-util');
 
 const bucketName = 'testdeletempu';
 const objectName = 'key';
@@ -217,12 +217,12 @@ describe('DELETE object', () => {
                     VersionId: versionIdTwo,
                 }, err => {
                     assert.strictEqual(err.code, 'AccessDenied');
-                    removeObjectLock(
+                    changeObjectLock(
                         [{
                             bucket: bucketName,
                             key: objectNameTwo,
                             versionId: versionIdTwo,
-                        }], done);
+                        }], '', done);
                 });
             });
         });

--- a/tests/functional/aws-node-sdk/test/object/getObjectLegalHold.js
+++ b/tests/functional/aws-node-sdk/test/object/getObjectLegalHold.js
@@ -4,9 +4,9 @@ const Promise = require('bluebird');
 const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
 const checkError = require('../../lib/utility/checkError');
-const removeObjectLock = require('../../lib/utility/objectLock-util');
+const changeObjectLock = require('../../../../utilities/objectLock-util');
 
-const removeLockPromise = Promise.promisify(removeObjectLock);
+const changeLockPromise = Promise.promisify(changeObjectLock);
 
 const bucket = 'mock-bucket-lock';
 const unlockedBucket = 'mock-bucket-no-lock';
@@ -46,7 +46,7 @@ describe('GET object legal hold', () => {
 
         afterEach(() => {
             process.stdout.write('Removing object lock\n');
-            return removeLockPromise([{ bucket, key, versionId }])
+            return changeLockPromise([{ bucket, key, versionId }], '')
             .then(() => {
                 process.stdout.write('Emptying and deleting buckets\n');
                 return bucketUtil.empty(bucket);
@@ -133,7 +133,7 @@ describe('GET object legal hold', () => {
             }, (err, res) => {
                 assert.ifError(err);
                 assert.deepStrictEqual(res.LegalHold, { Status: 'ON' });
-                removeObjectLock([{ bucket, key, versionId }], done);
+                changeObjectLock([{ bucket, key, versionId }], '', done);
             });
         });
     });

--- a/tests/functional/aws-node-sdk/test/object/getRetention.js
+++ b/tests/functional/aws-node-sdk/test/object/getRetention.js
@@ -5,9 +5,9 @@ const moment = require('moment');
 const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
 const checkError = require('../../lib/utility/checkError');
-const removeObjectLock = require('../../lib/utility/objectLock-util');
+const changeObjectLock = require('../../../../utilities/objectLock-util');
 
-const removeLockPromise = Promise.promisify(removeObjectLock);
+const changeLockPromise = Promise.promisify(changeObjectLock);
 
 const bucketName = 'lockenabledbucket';
 const unlockedBucket = 'locknotenabledbucket';
@@ -66,7 +66,7 @@ describe('GET object retention', () => {
 
         afterEach(() => {
             process.stdout.write('Removing object lock\n');
-            return removeLockPromise([{ bucket: bucketName, key: objectName, versionId }])
+            return changeLockPromise([{ bucket: bucketName, key: objectName, versionId }], '')
             .then(() => {
                 process.stdout.write('Emptying and deleting buckets\n');
                 return bucketUtil.empty(bucketName);
@@ -155,8 +155,8 @@ describe('GET object retention', () => {
             }, (err, res) => {
                 assert.ifError(err);
                 assert.deepStrictEqual(res.Retention, expectedConfig);
-                removeObjectLock([
-                    { bucket: bucketName, key: objectName, versionId }], done);
+                changeObjectLock([
+                    { bucket: bucketName, key: objectName, versionId }], '', done);
             });
         });
     });

--- a/tests/functional/aws-node-sdk/test/object/multiObjectDelete.js
+++ b/tests/functional/aws-node-sdk/test/object/multiObjectDelete.js
@@ -3,6 +3,7 @@ const Promise = require('bluebird');
 
 const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
+const changeObjectLock = require('../../../../utilities/objectLock-util');
 
 const otherAccountBucketUtility = new BucketUtility('lisa', {});
 const otherAccountS3 = otherAccountBucketUtility.s3;

--- a/tests/functional/aws-node-sdk/test/object/objectCopy.js
+++ b/tests/functional/aws-node-sdk/test/object/objectCopy.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
-const removeObjectLock = require('../../lib/utility/objectLock-util');
+const changeObjectLock = require('../../../../utilities/objectLock-util');
 
 const { taggingTests } = require('../../lib/utility/tagging');
 const genMaxSizeMetaHeaders
@@ -1304,7 +1304,7 @@ describe('Object Copy with object lock enabled on both destination ' +
                                     versionId: res.VersionId,
                                 },
                             ];
-                            removeObjectLock(removeLockObjs, done);
+                            changeObjectLock(removeLockObjs, '', done);
                         });
                 });
             });
@@ -1335,7 +1335,7 @@ describe('Object Copy with object lock enabled on both destination ' +
                                     versionId,
                                 },
                             ];
-                            removeObjectLock(removeLockObjs, done);
+                            changeObjectLock(removeLockObjs, '', done);
                         });
                 });
             });
@@ -1369,7 +1369,7 @@ describe('Object Copy with object lock enabled on both destination ' +
                                     versionId: res.VersionId,
                                 },
                             ];
-                            removeObjectLock(removeLockObjs, done);
+                            changeObjectLock(removeLockObjs, '', done);
                         });
                 });
             });

--- a/tests/functional/aws-node-sdk/test/object/put.js
+++ b/tests/functional/aws-node-sdk/test/object/put.js
@@ -6,7 +6,7 @@ const provideRawOutput = require('../../lib/utility/provideRawOutput');
 const { taggingTests } = require('../../lib/utility/tagging');
 const genMaxSizeMetaHeaders
     = require('../../lib/utility/genMaxSizeMetaHeaders');
-const removeObjectLock = require('../../lib/utility/objectLock-util');
+const changeObjectLock = require('../../../../utilities/objectLock-util');
 
 const bucket = 'bucket2putstuffin4324242';
 const object = 'object2putstuffin';
@@ -323,8 +323,8 @@ describe('PUT object with object lock', () => {
             };
             s3.putObject(params, (err, res) => {
                 assert.ifError(err);
-                removeObjectLock(
-                    [{ bucket, key: 'key1', versionId: res.VersionId }], done);
+                changeObjectLock(
+                    [{ bucket, key: 'key1', versionId: res.VersionId }], '', done);
             });
         });
 
@@ -339,8 +339,8 @@ describe('PUT object with object lock', () => {
             };
             s3.putObject(params, (err, res) => {
                 assert.ifError(err);
-                removeObjectLock(
-                    [{ bucket, key: 'key2', versionId: res.VersionId }], done);
+                changeObjectLock(
+                    [{ bucket, key: 'key2', versionId: res.VersionId }], '', done);
             });
         });
 
@@ -367,8 +367,8 @@ describe('PUT object with object lock', () => {
             };
             s3.putObject(params, (err, res) => {
                 assert.ifError(err);
-                removeObjectLock(
-                    [{ bucket, key: 'key4', versionId: res.VersionId }], done);
+                changeObjectLock(
+                    [{ bucket, key: 'key4', versionId: res.VersionId }], '', done);
             });
         });
 

--- a/tests/functional/aws-node-sdk/test/object/putObjectLegalHold.js
+++ b/tests/functional/aws-node-sdk/test/object/putObjectLegalHold.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
 const checkError = require('../../lib/utility/checkError');
-const removeObjectLock = require('../../lib/utility/objectLock-util');
+const changeObjectLock = require('../../../../utilities/objectLock-util');
 
 const bucket = 'mock-bucket-lock';
 const unlockedBucket = 'mock-bucket-no-lock';
@@ -120,7 +120,7 @@ describe('PUT object legal hold', () => {
             const params = createLegalHoldParams(bucket, key, 'ON');
             s3.putObjectLegalHold(params, err => {
                 assert.ifError(err);
-                removeObjectLock([{ bucket, key, versionId }], done);
+                changeObjectLock([{ bucket, key, versionId }], '', done);
             });
         });
 
@@ -128,7 +128,7 @@ describe('PUT object legal hold', () => {
             const params = createLegalHoldParams(bucket, key, 'OFF');
             s3.putObjectLegalHold(params, err => {
                 assert.ifError(err);
-                removeObjectLock([{ bucket, key, versionId }], done);
+                changeObjectLock([{ bucket, key, versionId }], '', done);
             });
         });
 
@@ -136,7 +136,7 @@ describe('PUT object legal hold', () => {
             const params = createLegalHoldParams(bucket, key, '');
             s3.putObjectLegalHold(params, err => {
                 checkError(err, 'MalformedXML', 400);
-                removeObjectLock([{ bucket, key, versionId }], done);
+                changeObjectLock([{ bucket, key, versionId }], '', done);
             });
         });
 
@@ -147,7 +147,7 @@ describe('PUT object legal hold', () => {
                 LegalHold: {},
             }, err => {
                 checkError(err, 'MalformedXML', 400);
-                removeObjectLock([{ bucket, key, versionId }], done);
+                changeObjectLock([{ bucket, key, versionId }], '', done);
             });
         });
 
@@ -155,7 +155,7 @@ describe('PUT object legal hold', () => {
             const params = createLegalHoldParams(bucket, key, true);
             s3.putObjectLegalHold(params, err => {
                 checkError(err, 'InvalidParameterType');
-                removeObjectLock([{ bucket, key, versionId }], done);
+                changeObjectLock([{ bucket, key, versionId }], '', done);
             });
         });
 
@@ -163,7 +163,7 @@ describe('PUT object legal hold', () => {
             const params = createLegalHoldParams(bucket, key, 'on');
             s3.putObjectLegalHold(params, err => {
                 checkError(err, 'MalformedXML', 400);
-                removeObjectLock([{ bucket, key, versionId }], done);
+                changeObjectLock([{ bucket, key, versionId }], '', done);
             });
         });
     });

--- a/tests/functional/aws-node-sdk/test/object/putRetention.js
+++ b/tests/functional/aws-node-sdk/test/object/putRetention.js
@@ -4,7 +4,7 @@ const moment = require('moment');
 const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
 const checkError = require('../../lib/utility/checkError');
-const removeObjectLock = require('../../lib/utility/objectLock-util');
+const changeObjectLock = require('../../../../utilities/objectLock-util');
 
 const bucketName = 'lockenabledputbucket';
 const unlockedBucket = 'locknotenabledputbucket';
@@ -119,8 +119,8 @@ describe('PUT object retention', () => {
                 Retention: retentionConfig,
             }, err => {
                 assert.ifError(err);
-                removeObjectLock([
-                    { bucket: bucketName, key: objectName, versionId }], done);
+                changeObjectLock([
+                    { bucket: bucketName, key: objectName, versionId }], '', done);
             });
         });
     });

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -23,8 +23,7 @@ const { metadata } = require('../../../lib/metadata/in_memory/metadata');
 const multipartDelete = require('../../../lib/api/multipartDelete');
 const objectPutPart = require('../../../lib/api/objectPutPart');
 const DummyRequest = require('../DummyRequest');
-const removeObjectLock =
-    require('../../functional/aws-node-sdk/lib/utility/objectLock-util');
+const changeObjectLock = require('../../utilities/objectLock-util');
 
 const log = new DummyRequestLogger();
 
@@ -1838,8 +1837,8 @@ describe('multipart upload with object lock', () => {
         ], (err, json) => {
             assert.ifError(err);
             assert.deepStrictEqual(json.Retention, expectedRetentionConfig);
-            removeObjectLock(
-                [{ bucket: lockedBucket, key: objectKey, versionId }], done);
+            changeObjectLock(
+                [{ bucket: lockedBucket, key: objectKey, versionId }], '', done);
         });
     });
 
@@ -1877,8 +1876,8 @@ describe('multipart upload with object lock', () => {
         ], (err, json) => {
             assert.ifError(err);
             assert.deepStrictEqual(json.LegalHold, expectedLegalHold);
-            removeObjectLock(
-                [{ bucket: lockedBucket, key: objectKey, versionId }], done);
+            changeObjectLock(
+                [{ bucket: lockedBucket, key: objectKey, versionId }], '', done);
         });
     });
 });

--- a/tests/unit/api/objectGet.js
+++ b/tests/unit/api/objectGet.js
@@ -13,8 +13,7 @@ const initiateMultipartUpload
 const objectPut = require('../../../lib/api/objectPut');
 const objectGet = require('../../../lib/api/objectGet');
 const objectPutPart = require('../../../lib/api/objectPutPart');
-const removeObjectLock =
-    require('../../functional/aws-node-sdk/lib/utility/objectLock-util');
+const changeObjectLock = require('../../utilities/objectLock-util');
 
 const log = new DummyRequestLogger();
 const canonicalID = 'accessKey1';
@@ -120,11 +119,11 @@ describe('objectGet API', () => {
                             'GOVERNANCE');
                         assert.strictEqual(headers.ETag,
                             `"${correctMD5}"`);
-                        removeObjectLock([{
+                        changeObjectLock([{
                             bucket: bucketName,
                             key: objectName,
                             versionId: headers['x-amz-version-id'],
-                        }], done);
+                        }], '', done);
                     });
                 });
         });
@@ -159,11 +158,11 @@ describe('objectGet API', () => {
                                     status);
                                 assert.strictEqual(headers.ETag,
                                     `"${correctMD5}"`);
-                                removeObjectLock([{
+                                changeObjectLock([{
                                     bucket: bucketName,
                                     key: objectName,
                                     versionId: headers['x-amz-version-id'],
-                                }], done);
+                                }], '', done);
                             });
                     });
             });

--- a/tests/unit/api/objectHead.js
+++ b/tests/unit/api/objectHead.js
@@ -6,8 +6,7 @@ const { cleanup, DummyRequestLogger, makeAuthInfo } = require('../helpers');
 const objectPut = require('../../../lib/api/objectPut');
 const objectHead = require('../../../lib/api/objectHead');
 const DummyRequest = require('../DummyRequest');
-const removeObjectLock =
-    require('../../functional/aws-node-sdk/lib/utility/objectLock-util');
+const changeObjectLock = require('../../utilities/objectLock-util');
 
 const log = new DummyRequestLogger();
 const canonicalID = 'accessKey1';
@@ -305,11 +304,11 @@ describe('objectHead API', () => {
                             expectedMode);
                         assert.strictEqual(res['x-amz-object-lock-legal-hold'],
                             'ON');
-                        removeObjectLock([{
+                        changeObjectLock([{
                             bucket: bucketName,
                             key: objectName,
                             versionId: res['x-amz-version-id'],
-                        }], done);
+                        }], '', done);
                     });
                 });
         });

--- a/tests/utilities/objectLock-util.js
+++ b/tests/utilities/objectLock-util.js
@@ -2,21 +2,22 @@ const assert = require('assert');
 const async = require('async');
 const { versioning } = require('arsenal');
 
-const { metadataGetObject } = require('../../../../../lib/metadata/metadataUtils');
-const metadata = require('../../../../../lib/metadata/wrapper');
-const { DummyRequestLogger } = require('../../../../unit/helpers');
+const { metadataGetObject } = require('../../lib/metadata/metadataUtils');
+const metadata = require('../../lib/metadata/wrapper');
+const { DummyRequestLogger } = require('../unit/helpers');
 const versionIdUtils = versioning.VersionID;
 
 const log = new DummyRequestLogger();
 
-function removeObjectLock(objects, cb) {
+function changeObjectLock(objects, newConfig, cb) {
     async.each(objects, (object, next) => {
         const { bucket, key, versionId } = object;
         metadataGetObject(bucket, key, versionIdUtils.decode(versionId), log, (err, objMD) => {
             assert.ifError(err);
+            // set newConfig as empty string to remove object lock
             /* eslint-disable no-param-reassign */
-            objMD.retentionMode = '';
-            objMD.retentionDate = '';
+            objMD.retentionMode = newConfig.mode;
+            objMD.retentionDate = newConfig.date;
             objMD.legalHold = false;
             metadata.putObjectMD(bucket, key, objMD, { versionId: objMD.versionId }, log, err => {
                 assert.ifError(err);
@@ -26,4 +27,4 @@ function removeObjectLock(objects, cb) {
     }, cb);
 }
 
-module.exports = removeObjectLock;
+module.exports = changeObjectLock;


### PR DESCRIPTION
First commit changes a helper function for object lock tests and updates all the tests using it. Second commit fixes a bug with a missing reference and adds tests. 