### PR TITLE
INTEGRATION [PR#2804 > development/7.7] improvement: S3C-3120 bucket get object lock use setter

### DIFF
--- a/lib/api/bucketGetObjectLock.js
+++ b/lib/api/bucketGetObjectLock.js
@@ -44,10 +44,9 @@ function bucketGetObjectLock(authInfo, request, log, callback) {
             });
             return callback(err, null, corsHeaders);
         }
-        const objectLockEnabled = bucket._objectLockEnabled;
-        const objectLockConfig = bucket._objectLockConfiguration ?
-            bucket._objectLockConfiguration :
-            {};
+        const objectLockEnabled = bucket.isObjectLockEnabled();
+        const bucketObjLockConfig = bucket.getObjectLockConfiguration();
+        const objLockConfig = bucketObjLockConfig || {};
         if (!objectLockEnabled) {
             log.debug('object lock is not enabled', {
                 error: errors.ObjectLockConfigurationNotFoundError,
@@ -56,7 +55,7 @@ function bucketGetObjectLock(authInfo, request, log, callback) {
             return callback(errors.ObjectLockConfigurationNotFoundError, null,
                 corsHeaders);
         }
-        const xml = ObjectLockConfiguration.getConfigXML(objectLockConfig);
+        const xml = ObjectLockConfiguration.getConfigXML(objLockConfig);
         pushMetric('getBucketObjectLock', log, {
             authInfo,
             bucket: bucketName,


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2804.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.7/improvement/S3C-3120_updateBucketGetObjectLockApi`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.7/improvement/S3C-3120_updateBucketGetObjectLockApi
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.7/improvement/S3C-3120_updateBucketGetObjectLockApi
```

Please always comment pull request #2804 instead of this one.