### PR TITLE
INTEGRATION [PR#2784 > development/8.1] Bugfix/s3 c 3106 multiobj delete obj lock error

### DIFF
--- a/tests/functional/aws-node-sdk/lib/utility/objectLock-util.js
+++ b/tests/functional/aws-node-sdk/lib/utility/objectLock-util.js
@@ -9,14 +9,15 @@ const versionIdUtils = versioning.VersionID;
 
 const log = new DummyRequestLogger();
 
-function removeObjectLock(objects, cb) {
+function changeObjectLock(objects, newConfig, cb) {
     async.each(objects, (object, next) => {
         const { bucket, key, versionId } = object;
         metadataGetObject(bucket, key, versionIdUtils.decode(versionId), log, (err, objMD) => {
             assert.ifError(err);
+            // set newConfig as empty string to remove object lock
             /* eslint-disable no-param-reassign */
-            objMD.retentionMode = '';
-            objMD.retentionDate = '';
+            objMD.retentionMode = newConfig.mode;
+            objMD.retentionDate = newConfig.date;
             objMD.legalHold = false;
             metadata.putObjectMD(bucket, key, objMD, { versionId: objMD.versionId }, log, err => {
                 assert.ifError(err);
@@ -26,4 +27,4 @@ function removeObjectLock(objects, cb) {
     }, cb);
 }
 
-module.exports = removeObjectLock;
+module.exports = changeObjectLock;

--- a/tests/functional/aws-node-sdk/test/object/deleteObject.js
+++ b/tests/functional/aws-node-sdk/test/object/deleteObject.js
@@ -3,7 +3,7 @@ const moment = require('moment');
 const Promise = require('bluebird');
 const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
-const removeObjectLock = require('../../lib/utility/objectLock-util');
+const changeObjectLock = require('../../lib/utility/objectLock-util');
 
 const bucketName = 'testdeletempu';
 const objectName = 'key';
@@ -217,12 +217,12 @@ describe('DELETE object', () => {
                     VersionId: versionIdTwo,
                 }, err => {
                     assert.strictEqual(err.code, 'AccessDenied');
-                    removeObjectLock(
+                    changeObjectLock(
                         [{
                             bucket: bucketName,
                             key: objectNameTwo,
                             versionId: versionIdTwo,
-                        }], done);
+                        }], '', done);
                 });
             });
         });

--- a/tests/functional/aws-node-sdk/test/object/getObjectLegalHold.js
+++ b/tests/functional/aws-node-sdk/test/object/getObjectLegalHold.js
@@ -4,9 +4,9 @@ const Promise = require('bluebird');
 const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
 const checkError = require('../../lib/utility/checkError');
-const removeObjectLock = require('../../lib/utility/objectLock-util');
+const changeObjectLock = require('../../lib/utility/objectLock-util');
 
-const removeLockPromise = Promise.promisify(removeObjectLock);
+const changeLockPromise = Promise.promisify(changeObjectLock);
 
 const bucket = 'mock-bucket-lock';
 const unlockedBucket = 'mock-bucket-no-lock';
@@ -46,7 +46,7 @@ describe('GET object legal hold', () => {
 
         afterEach(() => {
             process.stdout.write('Removing object lock\n');
-            return removeLockPromise([{ bucket, key, versionId }])
+            return changeLockPromise([{ bucket, key, versionId }], '')
             .then(() => {
                 process.stdout.write('Emptying and deleting buckets\n');
                 return bucketUtil.empty(bucket);
@@ -133,7 +133,7 @@ describe('GET object legal hold', () => {
             }, (err, res) => {
                 assert.ifError(err);
                 assert.deepStrictEqual(res.LegalHold, { Status: 'ON' });
-                removeObjectLock([{ bucket, key, versionId }], done);
+                changeObjectLock([{ bucket, key, versionId }], '', done);
             });
         });
     });

--- a/tests/functional/aws-node-sdk/test/object/getRetention.js
+++ b/tests/functional/aws-node-sdk/test/object/getRetention.js
@@ -5,9 +5,9 @@ const moment = require('moment');
 const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
 const checkError = require('../../lib/utility/checkError');
-const removeObjectLock = require('../../lib/utility/objectLock-util');
+const changeObjectLock = require('../../lib/utility/objectLock-util');
 
-const removeLockPromise = Promise.promisify(removeObjectLock);
+const changeLockPromise = Promise.promisify(changeObjectLock);
 
 const bucketName = 'lockenabledbucket';
 const unlockedBucket = 'locknotenabledbucket';
@@ -66,7 +66,7 @@ describe('GET object retention', () => {
 
         afterEach(() => {
             process.stdout.write('Removing object lock\n');
-            return removeLockPromise([{ bucket: bucketName, key: objectName, versionId }])
+            return changeLockPromise([{ bucket: bucketName, key: objectName, versionId }], '')
             .then(() => {
                 process.stdout.write('Emptying and deleting buckets\n');
                 return bucketUtil.empty(bucketName);
@@ -155,8 +155,8 @@ describe('GET object retention', () => {
             }, (err, res) => {
                 assert.ifError(err);
                 assert.deepStrictEqual(res.Retention, expectedConfig);
-                removeObjectLock([
-                    { bucket: bucketName, key: objectName, versionId }], done);
+                changeObjectLock([
+                    { bucket: bucketName, key: objectName, versionId }], '', done);
             });
         });
     });

--- a/tests/functional/aws-node-sdk/test/object/multiObjectDelete.js
+++ b/tests/functional/aws-node-sdk/test/object/multiObjectDelete.js
@@ -1,11 +1,14 @@
 const assert = require('assert');
+const moment = require('moment');
 const Promise = require('bluebird');
 
 const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
+const changeObjectLock = require('../../lib/utility/objectLock-util');
 
 const otherAccountBucketUtility = new BucketUtility('lisa', {});
 const otherAccountS3 = otherAccountBucketUtility.s3;
+const changeLockPromise = Promise.promisify(changeObjectLock);
 
 const bucketName = 'multi-object-delete-234-634';
 const key = 'key';
@@ -32,11 +35,17 @@ function sortList(list) {
     });
 }
 
-function createObjectsList(size) {
+function createObjectsList(size, versionIds) {
     const objects = [];
     for (let i = 1; i < (size + 1); i++) {
         objects.push({
             Key: `${key}${i}`,
+        });
+    }
+    if (versionIds) {
+        objects.forEach((obj, index) => {
+            // eslint-disable-next-line no-param-reassign
+            obj.VersionId = versionIds[index];
         });
     }
     return objects;
@@ -262,6 +271,104 @@ describe('Multi-Object Delete Access', function access() {
             },
         }).then(res => {
             assert.strictEqual(res.Deleted.length, 500);
+            assert.strictEqual(res.Errors.length, 0);
+        }).catch(err => {
+            checkNoError(err);
+        });
+    });
+});
+
+describe('Multi-Object Delete with Object Lock', () => {
+    let bucketUtil;
+    let s3;
+    const versionIds = [];
+
+    before(() => {
+        const createObjects = [];
+        bucketUtil = new BucketUtility('default', {
+            signatureVersion: 'v4',
+        });
+        s3 = bucketUtil.s3;
+        return s3.createBucketPromise({
+            Bucket: bucketName,
+            ObjectLockEnabledForBucket: true,
+        })
+        .then(() => s3.putObjectLockConfigurationPromise({
+            Bucket: bucketName,
+            ObjectLockConfiguration: {
+                ObjectLockEnabled: 'Enabled',
+                Rule: {
+                    DefaultRetention: {
+                        Days: 1,
+                        Mode: 'GOVERNANCE',
+                    },
+                },
+            },
+        }))
+        .catch(err => {
+            process.stdout.write(`Error creating bucket: ${err}\n`);
+            throw err;
+        })
+        .then(() => {
+            for (let i = 1; i < 6; i++) {
+                createObjects.push(s3.putObjectPromise({
+                    Bucket: bucketName,
+                    Key: `${key}${i}`,
+                    Body: 'somebody',
+                }));
+            }
+            return Promise.all(createObjects)
+            .then(res => {
+                res.forEach(r => {
+                    versionIds.push(r.VersionId);
+                });
+            })
+            .catch(err => {
+                process.stdout.write(`Error creating objects: ${err}\n`);
+                throw err;
+            });
+        });
+    });
+
+    after(() => s3.deleteBucketPromise({ Bucket: bucketName }));
+
+    it('should not delete locked objects', () => {
+        const objects = createObjectsList(5, versionIds);
+        return s3.deleteObjectsPromise({
+            Bucket: bucketName,
+            Delete: {
+                Objects: objects,
+                Quiet: false,
+            },
+        }).then(res => {
+            assert.strictEqual(res.Errors.length, 5);
+            res.Errors.forEach(err => assert.strictEqual(err.Code, 'AccessDenied'));
+        });
+    });
+
+    it('should delete locked objects after retention period has expired', () => {
+        const objects = createObjectsList(5, versionIds);
+        const objectsCopy = JSON.parse(JSON.stringify(objects));
+        for (let i = 0; i < objectsCopy.length; i++) {
+            objectsCopy[i].key = objectsCopy[i].Key;
+            objectsCopy[i].versionId = objectsCopy[i].VersionId;
+            objectsCopy[i].bucket = bucketName;
+            delete objectsCopy[i].Key;
+            delete objectsCopy[i].VersionId;
+        }
+        const newRetention = {
+            mode: 'GOVERNANCE',
+            date: moment().subtract(10, 'days').toISOString(),
+        };
+        return changeLockPromise(objectsCopy, newRetention)
+        .then(() => s3.deleteObjectsPromise({
+            Bucket: bucketName,
+            Delete: {
+                Objects: objects,
+                Quiet: false,
+            },
+        })).then(res => {
+            assert.strictEqual(res.Deleted.length, 5);
             assert.strictEqual(res.Errors.length, 0);
         }).catch(err => {
             checkNoError(err);

--- a/tests/functional/aws-node-sdk/test/object/objectCopy.js
+++ b/tests/functional/aws-node-sdk/test/object/objectCopy.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
-const removeObjectLock = require('../../lib/utility/objectLock-util');
+const changeObjectLock = require('../../lib/utility/objectLock-util');
 
 const { taggingTests } = require('../../lib/utility/tagging');
 const genMaxSizeMetaHeaders
@@ -1304,7 +1304,7 @@ describe('Object Copy with object lock enabled on both destination ' +
                                     versionId: res.VersionId,
                                 },
                             ];
-                            removeObjectLock(removeLockObjs, done);
+                            changeObjectLock(removeLockObjs, '', done);
                         });
                 });
             });
@@ -1335,7 +1335,7 @@ describe('Object Copy with object lock enabled on both destination ' +
                                     versionId,
                                 },
                             ];
-                            removeObjectLock(removeLockObjs, done);
+                            changeObjectLock(removeLockObjs, '', done);
                         });
                 });
             });
@@ -1369,7 +1369,7 @@ describe('Object Copy with object lock enabled on both destination ' +
                                     versionId: res.VersionId,
                                 },
                             ];
-                            removeObjectLock(removeLockObjs, done);
+                            changeObjectLock(removeLockObjs, '', done);
                         });
                 });
             });

--- a/tests/functional/aws-node-sdk/test/object/put.js
+++ b/tests/functional/aws-node-sdk/test/object/put.js
@@ -6,7 +6,7 @@ const provideRawOutput = require('../../lib/utility/provideRawOutput');
 const { taggingTests } = require('../../lib/utility/tagging');
 const genMaxSizeMetaHeaders
     = require('../../lib/utility/genMaxSizeMetaHeaders');
-const removeObjectLock = require('../../lib/utility/objectLock-util');
+const changeObjectLock = require('../../lib/utility/objectLock-util');
 
 const bucket = 'bucket2putstuffin4324242';
 const object = 'object2putstuffin';
@@ -323,8 +323,8 @@ describe('PUT object with object lock', () => {
             };
             s3.putObject(params, (err, res) => {
                 assert.ifError(err);
-                removeObjectLock(
-                    [{ bucket, key: 'key1', versionId: res.VersionId }], done);
+                changeObjectLock(
+                    [{ bucket, key: 'key1', versionId: res.VersionId }], '', done);
             });
         });
 
@@ -339,8 +339,8 @@ describe('PUT object with object lock', () => {
             };
             s3.putObject(params, (err, res) => {
                 assert.ifError(err);
-                removeObjectLock(
-                    [{ bucket, key: 'key2', versionId: res.VersionId }], done);
+                changeObjectLock(
+                    [{ bucket, key: 'key2', versionId: res.VersionId }], '', done);
             });
         });
 
@@ -367,8 +367,8 @@ describe('PUT object with object lock', () => {
             };
             s3.putObject(params, (err, res) => {
                 assert.ifError(err);
-                removeObjectLock(
-                    [{ bucket, key: 'key4', versionId: res.VersionId }], done);
+                changeObjectLock(
+                    [{ bucket, key: 'key4', versionId: res.VersionId }], '', done);
             });
         });
 

--- a/tests/functional/aws-node-sdk/test/object/putObjectLegalHold.js
+++ b/tests/functional/aws-node-sdk/test/object/putObjectLegalHold.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
 const checkError = require('../../lib/utility/checkError');
-const removeObjectLock = require('../../lib/utility/objectLock-util');
+const changeObjectLock = require('../../lib/utility/objectLock-util');
 
 const bucket = 'mock-bucket-lock';
 const unlockedBucket = 'mock-bucket-no-lock';
@@ -120,7 +120,7 @@ describe('PUT object legal hold', () => {
             const params = createLegalHoldParams(bucket, key, 'ON');
             s3.putObjectLegalHold(params, err => {
                 assert.ifError(err);
-                removeObjectLock([{ bucket, key, versionId }], done);
+                changeObjectLock([{ bucket, key, versionId }], '', done);
             });
         });
 
@@ -128,7 +128,7 @@ describe('PUT object legal hold', () => {
             const params = createLegalHoldParams(bucket, key, 'OFF');
             s3.putObjectLegalHold(params, err => {
                 assert.ifError(err);
-                removeObjectLock([{ bucket, key, versionId }], done);
+                changeObjectLock([{ bucket, key, versionId }], '', done);
             });
         });
 
@@ -136,7 +136,7 @@ describe('PUT object legal hold', () => {
             const params = createLegalHoldParams(bucket, key, '');
             s3.putObjectLegalHold(params, err => {
                 checkError(err, 'MalformedXML', 400);
-                removeObjectLock([{ bucket, key, versionId }], done);
+                changeObjectLock([{ bucket, key, versionId }], '', done);
             });
         });
 
@@ -147,7 +147,7 @@ describe('PUT object legal hold', () => {
                 LegalHold: {},
             }, err => {
                 checkError(err, 'MalformedXML', 400);
-                removeObjectLock([{ bucket, key, versionId }], done);
+                changeObjectLock([{ bucket, key, versionId }], '', done);
             });
         });
 
@@ -155,7 +155,7 @@ describe('PUT object legal hold', () => {
             const params = createLegalHoldParams(bucket, key, true);
             s3.putObjectLegalHold(params, err => {
                 checkError(err, 'InvalidParameterType');
-                removeObjectLock([{ bucket, key, versionId }], done);
+                changeObjectLock([{ bucket, key, versionId }], '', done);
             });
         });
 
@@ -163,7 +163,7 @@ describe('PUT object legal hold', () => {
             const params = createLegalHoldParams(bucket, key, 'on');
             s3.putObjectLegalHold(params, err => {
                 checkError(err, 'MalformedXML', 400);
-                removeObjectLock([{ bucket, key, versionId }], done);
+                changeObjectLock([{ bucket, key, versionId }], '', done);
             });
         });
     });

--- a/tests/functional/aws-node-sdk/test/object/putRetention.js
+++ b/tests/functional/aws-node-sdk/test/object/putRetention.js
@@ -4,7 +4,7 @@ const moment = require('moment');
 const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
 const checkError = require('../../lib/utility/checkError');
-const removeObjectLock = require('../../lib/utility/objectLock-util');
+const changeObjectLock = require('../../lib/utility/objectLock-util');
 
 const bucketName = 'lockenabledputbucket';
 const unlockedBucket = 'locknotenabledputbucket';
@@ -119,8 +119,8 @@ describe('PUT object retention', () => {
                 Retention: retentionConfig,
             }, err => {
                 assert.ifError(err);
-                removeObjectLock([
-                    { bucket: bucketName, key: objectName, versionId }], done);
+                changeObjectLock([
+                    { bucket: bucketName, key: objectName, versionId }], '', done);
             });
         });
     });

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -23,7 +23,7 @@ const { metadata } = require('../../../lib/metadata/in_memory/metadata');
 const multipartDelete = require('../../../lib/api/multipartDelete');
 const objectPutPart = require('../../../lib/api/objectPutPart');
 const DummyRequest = require('../DummyRequest');
-const removeObjectLock =
+const changeObjectLock =
     require('../../functional/aws-node-sdk/lib/utility/objectLock-util');
 
 const log = new DummyRequestLogger();
@@ -1838,8 +1838,8 @@ describe('multipart upload with object lock', () => {
         ], (err, json) => {
             assert.ifError(err);
             assert.deepStrictEqual(json.Retention, expectedRetentionConfig);
-            removeObjectLock(
-                [{ bucket: lockedBucket, key: objectKey, versionId }], done);
+            changeObjectLock(
+                [{ bucket: lockedBucket, key: objectKey, versionId }], '', done);
         });
     });
 
@@ -1877,8 +1877,8 @@ describe('multipart upload with object lock', () => {
         ], (err, json) => {
             assert.ifError(err);
             assert.deepStrictEqual(json.LegalHold, expectedLegalHold);
-            removeObjectLock(
-                [{ bucket: lockedBucket, key: objectKey, versionId }], done);
+            changeObjectLock(
+                [{ bucket: lockedBucket, key: objectKey, versionId }], '', done);
         });
     });
 });

--- a/tests/unit/api/objectGet.js
+++ b/tests/unit/api/objectGet.js
@@ -13,7 +13,7 @@ const initiateMultipartUpload
 const objectPut = require('../../../lib/api/objectPut');
 const objectGet = require('../../../lib/api/objectGet');
 const objectPutPart = require('../../../lib/api/objectPutPart');
-const removeObjectLock =
+const changeObjectLock =
     require('../../functional/aws-node-sdk/lib/utility/objectLock-util');
 
 const log = new DummyRequestLogger();
@@ -120,11 +120,11 @@ describe('objectGet API', () => {
                             'GOVERNANCE');
                         assert.strictEqual(headers.ETag,
                             `"${correctMD5}"`);
-                        removeObjectLock([{
+                        changeObjectLock([{
                             bucket: bucketName,
                             key: objectName,
                             versionId: headers['x-amz-version-id'],
-                        }], done);
+                        }], '', done);
                     });
                 });
         });
@@ -159,11 +159,11 @@ describe('objectGet API', () => {
                                     status);
                                 assert.strictEqual(headers.ETag,
                                     `"${correctMD5}"`);
-                                removeObjectLock([{
+                                changeObjectLock([{
                                     bucket: bucketName,
                                     key: objectName,
                                     versionId: headers['x-amz-version-id'],
-                                }], done);
+                                }], '', done);
                             });
                     });
             });

--- a/tests/unit/api/objectHead.js
+++ b/tests/unit/api/objectHead.js
@@ -6,7 +6,7 @@ const { cleanup, DummyRequestLogger, makeAuthInfo } = require('../helpers');
 const objectPut = require('../../../lib/api/objectPut');
 const objectHead = require('../../../lib/api/objectHead');
 const DummyRequest = require('../DummyRequest');
-const removeObjectLock =
+const changeObjectLock =
     require('../../functional/aws-node-sdk/lib/utility/objectLock-util');
 
 const log = new DummyRequestLogger();
@@ -305,11 +305,11 @@ describe('objectHead API', () => {
                             expectedMode);
                         assert.strictEqual(res['x-amz-object-lock-legal-hold'],
                             'ON');
-                        removeObjectLock([{
+                        changeObjectLock([{
                             bucket: bucketName,
                             key: objectName,
                             versionId: res['x-amz-version-id'],
-                        }], done);
+                        }], '', done);
                     });
                 });
         });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2784.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-3106-multiobj-delete-obj-lock-error`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-3106-multiobj-delete-obj-lock-error
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-3106-multiobj-delete-obj-lock-error
```

Please always comment pull request #2784 instead of this one.