### PR TITLE
INTEGRATION [PR#2826 > development/7.8] bugfix: S3C-3121 fix put bucket api to create unlocked bucket

### DIFF
--- a/lib/api/apiUtils/bucket/bucketCreation.js
+++ b/lib/api/apiUtils/bucket/bucketCreation.js
@@ -165,7 +165,9 @@ function createBucket(authInfo, bucketName, headers,
     const ownerDisplayName =
         authInfo.getAccountDisplayName();
     const creationDate = new Date().toJSON();
-    const objectLockEnabled = headers['x-amz-bucket-object-lock-enabled'];
+    const headerObjectLock = headers['x-amz-bucket-object-lock-enabled'];
+    const objectLockEnabled
+        = headerObjectLock && headerObjectLock.toLowerCase() === 'true';
     const bucket = new BucketInfo(bucketName, canonicalID, ownerDisplayName,
         creationDate, BucketInfo.currentModelVersion(), null, null, null, null,
         null, null, null, null, null, null, null, objectLockEnabled);

--- a/tests/functional/aws-node-sdk/test/bucket/put.js
+++ b/tests/functional/aws-node-sdk/test/bucket/put.js
@@ -207,7 +207,7 @@ describe('PUT Bucket - AWS.S3.createBucket', () => {
                         assert.deepStrictEqual(res.ObjectLockConfiguration,
                             { ObjectLockEnabled: 'Enabled' });
                     });
-                    bucketUtil.deleteOne(name).then(done).catch(done);
+                    bucketUtil.deleteOne(name).then(() => done()).catch(done);
                 });
             }
             function _testObjectLockDisabled(name, done) {

--- a/tests/unit/api/bucketGetObjectLock.js
+++ b/tests/unit/api/bucketGetObjectLock.js
@@ -20,7 +20,7 @@ const testBucketPutReqWithObjLock = {
     bucketName,
     headers: {
         'host': `${bucketName}.s3.amazonaws.com`,
-        'x-amz-bucket-object-lock-enabled': true,
+        'x-amz-bucket-object-lock-enabled': 'True',
     },
     url: '/',
 };
@@ -30,7 +30,7 @@ function getObjectLockConfigRequest(bucketName, xml) {
         bucketName,
         headers: {
             'host': `${bucketName}.s3.amazonaws.com`,
-            'x-amz-bucket-object-lock-enabled': true,
+            'x-amz-bucket-object-lock-enabled': 'true',
         },
         url: '/?object-lock',
     };

--- a/tests/unit/api/bucketPutObjectLock.js
+++ b/tests/unit/api/bucketPutObjectLock.js
@@ -56,7 +56,7 @@ describe('putBucketObjectLock API', () => {
 
     describe('with Object Lock enabled on bucket', () => {
         const bucketObjLockRequest = Object.assign({}, bucketPutRequest,
-            { headers: { 'x-amz-bucket-object-lock-enabled': true } });
+            { headers: { 'x-amz-bucket-object-lock-enabled': 'true' } });
 
         beforeEach(done => bucketPut(authInfo, bucketObjLockRequest, log, done));
         afterEach(() => cleanup());

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -51,7 +51,7 @@ const lockEnabledBucketRequest = Object.assign({}, bucketPutRequest);
 lockEnabledBucketRequest.bucketName = lockedBucket;
 lockEnabledBucketRequest.headers = {
     'host': `${lockedBucket}.s3.amazonaws.com`,
-    'x-amz-bucket-object-lock-enabled': true,
+    'x-amz-bucket-object-lock-enabled': 'true',
 };
 const initiateRequest = {
     bucketName,

--- a/tests/unit/api/objectGet.js
+++ b/tests/unit/api/objectGet.js
@@ -81,7 +81,7 @@ describe('objectGet API', () => {
         namespace,
         headers: {
             'host': `${bucketName}.s3.amazonaws.com`,
-            'x-amz-bucket-object-lock-enabled': true,
+            'x-amz-bucket-object-lock-enabled': 'true',
         },
         url: `/${bucketName}`,
     };

--- a/tests/unit/api/objectGetLegalHold.js
+++ b/tests/unit/api/objectGetLegalHold.js
@@ -69,7 +69,7 @@ describe('getObjectLegalHold API', () => {
 
     describe('with Object Lock enabled on bucket', () => {
         const bucketObjectLockRequest = Object.assign({}, bucketPutRequest,
-            { headers: { 'x-amz-bucket-object-lock-enabled': true } });
+            { headers: { 'x-amz-bucket-object-lock-enabled': 'true' } });
 
         beforeEach(done => {
             bucketPut(authInfo, bucketObjectLockRequest, log, err => {

--- a/tests/unit/api/objectGetRetention.js
+++ b/tests/unit/api/objectGetRetention.js
@@ -72,7 +72,7 @@ describe('getObjectRetention API', () => {
 
     describe('with Object Lock enabled on bucket', () => {
         const bucketObjLockRequest = Object.assign({}, bucketPutRequest,
-            { headers: { 'x-amz-bucket-object-lock-enabled': true } });
+            { headers: { 'x-amz-bucket-object-lock-enabled': 'true' } });
 
         beforeEach(done => {
             bucketPut(authInfo, bucketObjLockRequest, log, err => {

--- a/tests/unit/api/objectHead.js
+++ b/tests/unit/api/objectHead.js
@@ -262,7 +262,7 @@ describe('objectHead API', () => {
         const testPutBucketRequestLock = {
             bucketName,
             namespace,
-            headers: { 'x-amz-bucket-object-lock-enabled': true },
+            headers: { 'x-amz-bucket-object-lock-enabled': 'true' },
             url: `/${bucketName}`,
         };
         const testPutObjectRequestLock = new DummyRequest({

--- a/tests/unit/api/objectPut.js
+++ b/tests/unit/api/objectPut.js
@@ -35,7 +35,7 @@ const testPutBucketRequestLock = new DummyRequest({
     namespace,
     headers: {
         'host': `${bucketName}.s3.amazonaws.com`,
-        'x-amz-bucket-object-lock-enabled': true,
+        'x-amz-bucket-object-lock-enabled': 'true',
     },
     url: '/',
 });

--- a/tests/unit/api/objectPutLegalHold.js
+++ b/tests/unit/api/objectPutLegalHold.js
@@ -63,7 +63,7 @@ describe('putObjectLegalHold API', () => {
 
     describe('with Object Lock enabled on bucket', () => {
         const bucketObjLockRequest = Object.assign({}, putBucketRequest,
-            { headers: { 'x-amz-bucket-object-lock-enabled': true } });
+            { headers: { 'x-amz-bucket-object-lock-enabled': 'true' } });
 
         beforeEach(done => {
             bucketPut(authInfo, bucketObjLockRequest, log, err => {

--- a/tests/unit/api/objectPutRetention.js
+++ b/tests/unit/api/objectPutRetention.js
@@ -69,7 +69,7 @@ describe('putObjectRetention API', () => {
 
     describe('with Object Lock enabled on bucket', () => {
         const bucketObjLockRequest = Object.assign({}, bucketPutRequest,
-            { headers: { 'x-amz-bucket-object-lock-enabled': true } });
+            { headers: { 'x-amz-bucket-object-lock-enabled': 'true' } });
 
         beforeEach(done => {
             bucketPut(authInfo, bucketObjLockRequest, log, err => {

--- a/tests/unit/bucket/bucketCreation.js
+++ b/tests/unit/bucket/bucketCreation.js
@@ -74,7 +74,7 @@ describe('bucket creation with object lock', () => {
     it('should return 200 when creating a bucket with object lock', done => {
         const bucketName = 'test-bucket-with-objectlock';
         const headers = {
-            'x-amz-bucket-object-lock-enabled': true,
+            'x-amz-bucket-object-lock-enabled': 'true',
         };
         createBucket(authInfo, bucketName, headers,
             normalBehaviorLocationConstraint, log, err => {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2826.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.8/bugfix/S3C-3121_fixPutBucketApiObjLock`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.8/bugfix/S3C-3121_fixPutBucketApiObjLock
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.8/bugfix/S3C-3121_fixPutBucketApiObjLock
```

Please always comment pull request #2826 instead of this one.