### PR TITLE
INTEGRATION [PR#2843 > development/7.8] bf: S3C-3130 handle object lock disabled case for bucket

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "github:scality/Arsenal#b585307",
+    "arsenal": "github:scality/Arsenal#33216e4",
     "async": "~2.5.0",
     "aws-sdk": "2.363.0",
     "azure-storage": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "github:scality/Arsenal#33216e4",
+    "arsenal": "github:scality/Arsenal#e6622df",
     "async": "~2.5.0",
     "aws-sdk": "2.363.0",
     "azure-storage": "^2.1.0",

--- a/tests/functional/aws-node-sdk/test/bucket/putBucketObjectLock.js
+++ b/tests/functional/aws-node-sdk/test/bucket/putBucketObjectLock.js
@@ -61,6 +61,19 @@ describe('aws-sdk test put object lock configuration', () => {
                 done();
             });
         });
+
+        it('should return InvalidBucketState error without Rule', done => {
+            const params = {
+                Bucket: bucket,
+                ObjectLockConfiguration: {
+                    ObjectLockEnabled: 'Enabled',
+                },
+            };
+            s3.putObjectLockConfiguration(params, err => {
+                checkError(err, 'InvalidBucketState', 409);
+                done();
+            });
+        });
     });
 
     describe('config rules', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -210,9 +210,9 @@ arraybuffer.slice@0.0.6:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz#f33b2159f0532a3f3107a272c0ccfbd1ad2979ca"
   integrity sha1-8zshWfBTKj8xB6JywMz70a0peco=
 
-"arsenal@github:scality/Arsenal#b585307":
+"arsenal@github:scality/Arsenal#33216e4":
   version "7.5.0"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/b5853078c666c39d532d2a133e3dedc4a68bd566"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/33216e4b2f1ccff501ccd3d26dbb4cee401e5c48"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -210,9 +210,9 @@ arraybuffer.slice@0.0.6:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz#f33b2159f0532a3f3107a272c0ccfbd1ad2979ca"
   integrity sha1-8zshWfBTKj8xB6JywMz70a0peco=
 
-"arsenal@github:scality/Arsenal#33216e4":
+"arsenal@github:scality/Arsenal#e6622df":
   version "7.5.0"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/33216e4b2f1ccff501ccd3d26dbb4cee401e5c48"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/e6622dfdcec30ba95fef9a978007f5796680b01b"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2843.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.8/bugfix/S3C-3130_handleObjectLockDisabledCaseForBucket`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.8/bugfix/S3C-3130_handleObjectLockDisabledCaseForBucket
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.8/bugfix/S3C-3130_handleObjectLockDisabledCaseForBucket
```

Please always comment pull request #2843 instead of this one.