### PR TITLE
INTEGRATION [PR#2849 > development/8.1] bf: S3C-3145 - add objectLocked field to AccessDenied errors

### DIFF
--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -187,6 +187,7 @@ function getObjMetadataAndDelete(authInfo, canonicalID, request,
     let totalContentLengthDeleted = 0;
     let numOfObjectsRemoved = 0;
     const skipError = new Error('skip');
+    const objectLockedError = new Error('object locked');
 
     // doing 5 requests at a time. note that the data wrapper
     // will do 5 parallel requests to data backend to delete parts
@@ -229,7 +230,7 @@ function getObjMetadataAndDelete(authInfo, canonicalID, request,
                     }
                     if (versionId && isObjectLocked(bucket, objMD, request.headers)) {
                         log.debug('trying to delete locked object');
-                        return callback(errors.AccessDenied);
+                        return callback(objectLockedError);
                     }
                     return callback(null, objMD, versionId);
                 }),
@@ -254,6 +255,9 @@ function getObjMetadataAndDelete(authInfo, canonicalID, request,
             },
         ], (err, objMD, deleteInfo, versionId) => {
             if (err === skipError) {
+                return moveOn();
+            } else if (err === objectLockedError) {
+                errorResults.push({ entry, error: errors.AccessDenied, objectLocked: true });
                 return moveOn();
             } else if (err) {
                 log.error('error deleting object', { error: err, entry });

--- a/lib/api/objectDelete.js
+++ b/lib/api/objectDelete.js
@@ -11,6 +11,7 @@ const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { isObjectLocked } = require('./apiUtils/object/objectLockHelpers');
 
 const versionIdUtils = versioning.VersionID;
+const objectLockedError = new Error('object locked');
 
 /**
  * objectDelete - DELETE an object from a bucket
@@ -79,7 +80,7 @@ function objectDelete(authInfo, request, log, cb) {
                 if (reqVersionId &&
                 isObjectLocked(bucketMD, objMD, request.headers)) {
                     log.debug('trying to delete locked object');
-                    return next(errors.AccessDenied, bucketMD);
+                    return next(objectLockedError, bucketMD);
                 }
                 if (reqVersionId && objMD.location &&
                     Array.isArray(objMD.location) && objMD.location[0]) {
@@ -140,6 +141,11 @@ function objectDelete(authInfo, request, log, cb) {
             if (deleteInfo && deleteInfo.removeDeleteMarker) {
                 resHeaders['x-amz-delete-marker'] = true;
             }
+        }
+        if (err === objectLockedError) {
+            log.error('error deleting object', { error: errors.AccessDenied,
+                objectLocked: true, method: 'objectDelete' });
+            return cb(errors.AccessDenied, resHeaders);
         }
         if (err) {
             log.debug('error processing request', { error: err,


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2849.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-3145-obj-lock-delete-log-fix`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-3145-obj-lock-delete-log-fix
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-3145-obj-lock-delete-log-fix
```

Please always comment pull request #2849 instead of this one.