### PR TITLE
INTEGRATION [PR#2795 > development/8.2] improvement: S3C-3119 add functional test to get and head obj

### DIFF
--- a/tests/functional/aws-node-sdk/test/object/get.js
+++ b/tests/functional/aws-node-sdk/test/object/get.js
@@ -1,9 +1,14 @@
 const assert = require('assert');
 const async = require('async');
 const crypto = require('crypto');
+const moment = require('moment');
+const Promise = require('bluebird');
 
 const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
+const changeObjectLock = require('../../../../utilities/objectLock-util');
+
+const changeLockPromise = Promise.promisify(changeObjectLock);
 
 const bucketName = 'buckettestgetobject';
 const objectName = 'someObject';
@@ -44,7 +49,6 @@ function dateFromNow(diff) {
 function dateConvert(d) {
     return (new Date(d)).toISOString();
 }
-
 
 describe('GET object', () => {
     withV4(sigCfg => {
@@ -1012,6 +1016,81 @@ describe('GET object', () => {
                           undefined);
                       return done();
                   });
+            });
+        });
+    });
+});
+
+describe('GET object with object lock', () => {
+    withV4(sigCfg => {
+        const bucketUtil = new BucketUtility('default', sigCfg);
+        const s3 = bucketUtil.s3;
+        const bucket = 'bucket-with-lock';
+        const key = 'object-with-lock';
+        const formatDate = date => date.toString().slice(0, 20);
+        const mockDate = moment().add(1, 'days').toISOString();
+        const mockMode = 'GOVERNANCE';
+        let versionId;
+
+        beforeEach(() => {
+            const params = {
+                Bucket: bucket,
+                Key: key,
+                ObjectLockRetainUntilDate: mockDate,
+                ObjectLockMode: mockMode,
+                ObjectLockLegalHoldStatus: 'ON',
+            };
+            return s3.createBucketPromise(
+                { Bucket: bucket, ObjectLockEnabledForBucket: true })
+            .then(() => s3.putObjectPromise(params))
+            .then(() => s3.getObjectPromise({ Bucket: bucket, Key: key }))
+            /* eslint-disable no-return-assign */
+            .then(res => versionId = res.VersionId)
+            .catch(err => {
+                process.stdout.write('Error in before\n');
+                throw err;
+            });
+        });
+
+        afterEach(() => changeLockPromise([{ bucket, key, versionId }], '')
+            .then(() => s3.listObjectVersionsPromise({ Bucket: bucket }))
+            .then(res => res.Versions.forEach(object => {
+                const params = [
+                    {
+                        bucket,
+                        key: object.Key,
+                        versionId: object.VersionId,
+                    },
+                ];
+                changeLockPromise(params, '');
+            }))
+            .then(() => {
+                process.stdout.write('Emptying and deleting buckets\n');
+                return bucketUtil.empty(bucket);
+            })
+            .then(() => s3.deleteBucketPromise({ Bucket: bucket }))
+            .catch(err => {
+                process.stdout.write('Error in afterEach');
+                throw err;
+            }));
+
+        it('should return object lock headers if set on the object', done => {
+            s3.getObject({ Bucket: bucket, Key: key }, (err, res) => {
+                assert.ifError(err);
+                assert.strictEqual(res.ObjectLockMode, mockMode);
+                const responseDate
+                    = formatDate(res.ObjectLockRetainUntilDate.toISOString());
+                const expectedDate = formatDate(mockDate);
+                assert.strictEqual(responseDate, expectedDate);
+                assert.strictEqual(res.ObjectLockLegalHoldStatus, 'ON');
+                const objectWithLock = [
+                    {
+                        bucket,
+                        key,
+                        versionId: res.VersionId,
+                    },
+                ];
+                changeObjectLock(objectWithLock, '', done);
             });
         });
     });

--- a/tests/functional/aws-node-sdk/test/object/objectHead.js
+++ b/tests/functional/aws-node-sdk/test/object/objectHead.js
@@ -1,9 +1,13 @@
 const assert = require('assert');
 const { errors } = require('arsenal');
+const moment = require('moment');
+const Promise = require('bluebird');
 
-
+const changeObjectLock = require('../../../../utilities/objectLock-util');
 const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
+
+const changeLockPromise = Promise.promisify(changeObjectLock);
 
 const bucketName = 'alexbucketnottaken';
 const objectName = 'someObject';
@@ -439,6 +443,81 @@ describe('HEAD object, conditions', () => {
                 assert.strictEqual('WebsiteRedirectLocation' in data,
                   false, 'WebsiteRedirectLocation header is present.');
                 done();
+            });
+        });
+    });
+});
+
+describe('HEAD object with object lock', () => {
+    withV4(sigCfg => {
+        const bucketUtil = new BucketUtility('default', sigCfg);
+        const s3 = bucketUtil.s3;
+        const bucket = 'bucket-with-lock';
+        const key = 'object-with-lock';
+        const formatDate = date => date.toString().slice(0, 20);
+        const mockDate = moment().add(1, 'days').toISOString();
+        const mockMode = 'GOVERNANCE';
+        let versionId;
+
+        beforeEach(() => {
+            const params = {
+                Bucket: bucket,
+                Key: key,
+                ObjectLockRetainUntilDate: mockDate,
+                ObjectLockMode: mockMode,
+                ObjectLockLegalHoldStatus: 'ON',
+            };
+            return s3.createBucketPromise(
+                { Bucket: bucket, ObjectLockEnabledForBucket: true })
+            .then(() => s3.putObjectPromise(params))
+            .then(() => s3.getObjectPromise({ Bucket: bucket, Key: key }))
+            /* eslint-disable no-return-assign */
+            .then(res => versionId = res.VersionId)
+            .catch(err => {
+                process.stdout.write('Error in before\n');
+                throw err;
+            });
+        });
+
+        afterEach(() => changeLockPromise([{ bucket, key, versionId }], '')
+            .then(() => s3.listObjectVersionsPromise({ Bucket: bucket }))
+            .then(res => res.Versions.forEach(object => {
+                const params = [
+                    {
+                        bucket,
+                        key: object.Key,
+                        versionId: object.VersionId,
+                    },
+                ];
+                changeLockPromise(params, '');
+            }))
+            .then(() => {
+                process.stdout.write('Emptying and deleting buckets\n');
+                return bucketUtil.empty(bucket);
+            })
+            .then(() => s3.deleteBucketPromise({ Bucket: bucket }))
+            .catch(err => {
+                process.stdout.write('Error in afterEach');
+                throw err;
+            }));
+
+        it('should return object lock headers if set on the object', done => {
+            s3.headObject({ Bucket: bucket, Key: key }, (err, res) => {
+                assert.ifError(err);
+                assert.strictEqual(res.ObjectLockMode, mockMode);
+                const responseDate
+                    = formatDate(res.ObjectLockRetainUntilDate.toISOString());
+                const expectedDate = formatDate(mockDate);
+                assert.strictEqual(responseDate, expectedDate);
+                assert.strictEqual(res.ObjectLockLegalHoldStatus, 'ON');
+                const objectWithLock = [
+                    {
+                        bucket,
+                        key,
+                        versionId: res.VersionId,
+                    },
+                ];
+                changeObjectLock(objectWithLock, '', done);
             });
         });
     });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2795.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/improvement/S3C-3119_AddGetHeadObjFuncTests`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/improvement/S3C-3119_AddGetHeadObjFuncTests
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/improvement/S3C-3119_AddGetHeadObjFuncTests
```

Please always comment pull request #2795 instead of this one.