### PR TITLE
bf: S3C-3246 getObject pushMetric missing key

### DIFF
--- a/lib/api/objectGet.js
+++ b/lib/api/objectGet.js
@@ -197,6 +197,7 @@ function objectGet(authInfo, request, returnTagCount, log, callback) {
             pushMetric('getObject', log, {
                 authInfo,
                 bucket: bucketName,
+                keys: [objectKey],
                 newByteLength:
                     Number.parseInt(responseMetaHeaders['Content-Length'], 10),
                 versionId: objMD.versionId,

--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -246,7 +246,7 @@ function pushMetric(action, log, metricObj) {
             incomingBytes: newByteLength,
             outgoingBytes: action === 'getObject' ? newByteLength : 0,
         };
-        if (action !== 'multiObjectDelete') {
+        if (action !== 'multiObjectDelete' && keys) {
             utapiObj.object = keys[0];
             if (versionId) {
                 utapiObj.versionId = versionId;


### PR DESCRIPTION
Adds missing `keys` to pushMetric call in getObject, and adds check in conditional so similar error is not thrown for operations that do not include `keys`.