### PR TITLE
INTEGRATION [PR#2931 > development/8.2] bf: S3C-3246 getObject pushMetric missing key

### DIFF
--- a/lib/api/objectGet.js
+++ b/lib/api/objectGet.js
@@ -197,6 +197,7 @@ function objectGet(authInfo, request, returnTagCount, log, callback) {
             pushMetric('getObject', log, {
                 authInfo,
                 bucket: bucketName,
+                keys: [objectKey],
                 newByteLength:
                     Number.parseInt(responseMetaHeaders['Content-Length'], 10),
                 versionId: objMD.versionId,

--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -246,7 +246,7 @@ function pushMetric(action, log, metricObj) {
             incomingBytes: newByteLength,
             outgoingBytes: action === 'getObject' ? newByteLength : 0,
         };
-        if (action !== 'multiObjectDelete') {
+        if (action !== 'multiObjectDelete' && keys) {
             utapiObj.object = keys[0];
             if (versionId) {
                 utapiObj.versionId = versionId;


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2931.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/bugfix/S3C-3246-pushmetric-getobject`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/bugfix/S3C-3246-pushmetric-getobject
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/bugfix/S3C-3246-pushmetric-getobject
```

Please always comment pull request #2931 instead of this one.