### PR TITLE
INTEGRATION [PR#2937 > development/8.2] bf: ZENKO-2729 remove .only from raw-node tests

### DIFF
--- a/tests/functional/raw-node/test/headObject.js
+++ b/tests/functional/raw-node/test/headObject.js
@@ -9,23 +9,25 @@ const authCredentials = {
 const bucket = 'rawnodeapibucket';
 
 describe('api tests', () => {
-    before(() => {
+    before(done => {
         makeS3Request({
             method: 'PUT',
             authCredentials,
             bucket,
         }, err => {
             assert.ifError(err);
+            done();
         });
     });
 
-    after(() => {
+    after(done => {
         makeS3Request({
             method: 'DELETE',
             authCredentials,
             bucket,
         }, err => {
             assert.ifError(err);
+            done();
         });
     });
 

--- a/tests/functional/raw-node/test/headObject.js
+++ b/tests/functional/raw-node/test/headObject.js
@@ -8,7 +8,7 @@ const authCredentials = {
 };
 const bucket = 'rawnodeapibucket';
 
-describe.only('api tests', () => {
+describe('api tests', () => {
     before(() => {
         makeS3Request({
             method: 'PUT',

--- a/tests/functional/raw-node/test/routes/routeBackbeat.js
+++ b/tests/functional/raw-node/test/routes/routeBackbeat.js
@@ -110,7 +110,7 @@ describeSkipIfAWS('backbeat routes:', () => {
         bucketUtil = new BucketUtility(
             'default', { signatureVersion: 'v4' });
         s3 = bucketUtil.s3;
-        return s3.createBucketPromise({ Bucket: TEST_BUCKET })
+        s3.createBucketPromise({ Bucket: TEST_BUCKET })
             .then(() => s3.putBucketVersioningPromise(
                 {
                     Bucket: TEST_BUCKET,


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2937.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/bugfix/ZENKO-2729-raw-node-tests-remove-only`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/bugfix/ZENKO-2729-raw-node-tests-remove-only
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/bugfix/ZENKO-2729-raw-node-tests-remove-only
```

Please always comment pull request #2937 instead of this one.