### PR TITLE
Feature/s3 c 2797 put bucket notification

### DIFF
--- a/config.json
+++ b/config.json
@@ -77,5 +77,14 @@
         "viaProxy": false,
         "trustedProxyCIDRs": [],
         "extractClientIPFromHeader": ""
-    }
+    },
+    "bucketNotificationDestinations": [
+        {
+            "resource": "target1",
+            "type": "dummy",
+            "host": "localhost",
+            "port": 6000,
+            "auth": { "user": "user", "password": "password" }
+        }
+    ]
 }

--- a/constants.js
+++ b/constants.js
@@ -91,7 +91,6 @@ const constants = {
         'inventory',
         'logging',
         'metrics',
-        'notification',
         'policyStatus',
         'publicAccessBlock',
         'requestPayment',

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1100,8 +1100,8 @@ class Config extends EventEmitter {
             requestsConfigAssert(config.requests);
             this.requests = config.requests;
         }
-        if (config.bucketNotificationTargets) {
-            this.bucketNotificationTargets = bucketNotifAssert(config.bucketNotificationTargets);
+        if (config.bucketNotificationDestinations) {
+            this.bucketNotificationDestinations = bucketNotifAssert(config.bucketNotificationDestinations);
         }
     }
 

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -22,6 +22,7 @@ const bucketPutVersioning = require('./bucketPutVersioning');
 const bucketPutWebsite = require('./bucketPutWebsite');
 const bucketPutReplication = require('./bucketPutReplication');
 const bucketPutLifecycle = require('./bucketPutLifecycle');
+const bucketPutNotification = require('./bucketPutNotification');
 const bucketPutPolicy = require('./bucketPutPolicy');
 const bucketPutObjectLock = require('./bucketPutObjectLock');
 const bucketGetReplication = require('./bucketGetReplication');
@@ -195,6 +196,7 @@ const api = {
     bucketGetPolicy,
     bucketDeletePolicy,
     bucketPutObjectLock,
+    bucketPutNotification,
     corsPreflight,
     completeMultipartUpload,
     initiateMultipartUpload,

--- a/lib/api/apiUtils/bucket/getNotificationConfiguration.js
+++ b/lib/api/apiUtils/bucket/getNotificationConfiguration.js
@@ -1,0 +1,25 @@
+const { errors, models } = require('arsenal');
+const { NotificationConfiguration } = models;
+
+const { config } = require('../../../Config');
+
+function getNotificationConfiguration(parsedXml) {
+    const notifConfig = new NotificationConfiguration(parsedXml).getValidatedNotificationConfiguration();
+    if (notifConfig.error) {
+        return notifConfig;
+    }
+    if (!config.bucketNotificationDestinations) {
+        return { error: errors.InvalidArgument.customizeDescription(
+            'Unable to validate the following destination configurations') };
+    }
+    const targets = new Set(config.bucketNotificationDestinations.map(t => t.resource));
+    const notifConfigTargets = notifConfig.queueConfig.map(t => t.queueArn.split(':')[5]);
+    if (!notifConfigTargets.every(t => targets.has(t))) {
+        return { error: errors.MalformedXML.customizeDescription(
+            'queue arn target is not included in Cloudserver bucket notification config'),
+        };
+    }
+    return notifConfig;
+}
+
+module.exports = getNotificationConfiguration;

--- a/lib/api/bucketPutNotification.js
+++ b/lib/api/bucketPutNotification.js
@@ -1,0 +1,58 @@
+const async = require('async');
+
+const parseXML = require('../utilities/parseXML');
+const collectCorsHeaders = require('../utilities/collectCorsHeaders');
+const getNotificationConfiguration = require('./apiUtils/bucket/getNotificationConfiguration');
+const metadata = require('../metadata/wrapper');
+const { metadataValidateBucket } = require('../metadata/metadataUtils');
+const { pushMetric } = require('../utapi/utilities');
+
+/**
+ * Bucket Put Notification - Create or update bucket notification configuration
+ * @param {AuthInfo} authInfo - Instance of AuthInfo class with requester's info
+ * @param {object} request - http request object
+ * @param {object} log - Werelogs logger
+ * @param {function} callback - callback to server
+ * @return {undefined}
+ */
+
+function bucketPutNotification(authInfo, request, log, callback) {
+    log.debug('processing request', { method: 'bucketPutNotification' });
+
+    const bucketName = request.bucketName;
+    const metadataValParams = {
+        authInfo,
+        bucketName,
+        requestType: 'bucketPutNotification',
+    };
+
+    return async.waterfall([
+        next => parseXML(request.post, log, next),
+        (parsedXml, next) => {
+            const notificationConfig = getNotificationConfiguration(parsedXml);
+            process.nextTick(() => next(notificationConfig.error, notificationConfig));
+        },
+        (notifConfig, next) => metadataValidateBucket(metadataValParams, log,
+            (err, bucket) => next(err, bucket, notifConfig)),
+        (bucket, notifConfig, next) => {
+            bucket.setNotificationConfiguration(notifConfig);
+            metadata.updateBucket(bucket.getName(), bucket, log,
+                err => next(err, bucket));
+        },
+    ], (err, bucket) => {
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, bucket);
+        if (err) {
+            log.trace('error processing request', { error: err,
+                method: 'bucketPutNotification' });
+            return callback(err, corsHeaders);
+        }
+        pushMetric('putBucketNotification', log, {
+            authInfo,
+            bucket: bucketName,
+        });
+        return callback(null, corsHeaders);
+    });
+}
+
+module.exports = bucketPutNotification;

--- a/lib/metadata/ModelVersion.md
+++ b/lib/metadata/ModelVersion.md
@@ -94,3 +94,15 @@ this._objectLockConfiguration = objectLockConfiguration || null;
 
 Used to determine whether object lock capabilities are enabled on a bucket and
 to store the object lock configuration of the bucket
+
+## Model version 8
+
+### Properties Added
+
+```javascript
+this._notificationConfiguration = notificationConfiguration || null;
+```
+
+### Usage
+
+Used to store the bucket notification configuration info

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "github:scality/Arsenal#6fff00d",
+    "arsenal": "github:scality/Arsenal#aa9c9e5",
     "async": "~2.5.0",
     "aws-sdk": "2.363.0",
     "azure-storage": "^2.1.0",

--- a/tests/functional/aws-node-sdk/test/bucket/putBucketNotification.js
+++ b/tests/functional/aws-node-sdk/test/bucket/putBucketNotification.js
@@ -1,0 +1,110 @@
+const assert = require('assert');
+const { S3 } = require('aws-sdk');
+
+const checkError = require('../../lib/utility/checkError');
+const getConfig = require('../support/config');
+const BucketUtility = require('../../lib/utility/bucket-util');
+
+const bucket = 'mock-notification-bucket';
+
+function getNotificationParams(events, arn, id, filter) {
+    const notifConfig = {
+        QueueConfigurations: [
+            {
+                Events: events || ['s3:ObjectCreated:*'],
+                QueueArn: arn || 'arn:scality:bucketnotif:::target1',
+            },
+        ],
+    };
+    if (id) {
+        notifConfig.QueueConfigurations[0].Id = id;
+    }
+    if (filter) {
+        notifConfig.QueueConfigurations[0].Filter = filter;
+    }
+    return {
+        Bucket: bucket,
+        NotificationConfiguration: notifConfig,
+    };
+}
+
+describe('aws-sdk test put notification configuration', () => {
+    let s3;
+    let otherAccountS3;
+
+    before(() => {
+        const config = getConfig('default', { signatureVersion: 'v4' });
+        s3 = new S3(config);
+        otherAccountS3 = new BucketUtility('lisa', {}).s3;
+    });
+
+    it('should return NoSuchBucket error if bucket does not exist', done => {
+        const params = getNotificationParams();
+        s3.putBucketNotificationConfiguration(params, err => {
+            checkError(err, 'NoSuchBucket', 404);
+            done();
+        });
+    });
+
+    describe('config rules', () => {
+        beforeEach(done => s3.createBucket({
+            Bucket: bucket,
+        }, done));
+
+        afterEach(done => s3.deleteBucket({ Bucket: bucket }, done));
+
+        it('should return AccessDenied if user is not bucket owner', done => {
+            const params = getNotificationParams();
+            otherAccountS3.putBucketNotificationConfiguration(params, err => {
+                checkError(err, 'AccessDenied', 403);
+                done();
+            });
+        });
+
+        it('should put notification configuration on bucket with basic config',
+            done => {
+                const params = getNotificationParams();
+                s3.putBucketNotificationConfiguration(params, err => {
+                    assert.ifError(err);
+                    done();
+                });
+            });
+
+        it('should put notification configuration on bucket with multiple events',
+            done => {
+                const params = getNotificationParams(
+                    ['s3:ObjectCreated:*', 's3:ObjectRemoved:*']);
+                s3.putBucketNotificationConfiguration(params, err => {
+                    assert.ifError(err);
+                    done();
+                });
+            });
+
+        it('should put notification configuration on bucket with id',
+            done => {
+                const params = getNotificationParams(null, null, 'notification-id');
+                s3.putBucketNotificationConfiguration(params, err => {
+                    assert.ifError(err);
+                    done();
+                });
+            });
+
+        it('should not allow notification config request with invalid arn',
+            done => {
+                const params = getNotificationParams(null, 'invalidArn');
+                s3.putBucketNotificationConfiguration(params, err => {
+                    checkError(err, 'MalformedXML', 400);
+                    done();
+                });
+            });
+
+        it('should not allow notification config request with invalid event',
+            done => {
+                const params = getNotificationParams(['s3:NotAnEvent']);
+                s3.putBucketNotificationConfiguration(params, err => {
+                    checkError(err, 'MalformedXML', 400);
+                    done();
+                });
+            });
+    });
+});

--- a/tests/unit/api/bucketPutNotification.js
+++ b/tests/unit/api/bucketPutNotification.js
@@ -1,0 +1,64 @@
+const assert = require('assert');
+
+const { bucketPut } = require('../../../lib/api/bucketPut');
+const bucketPutNotification = require('../../../lib/api/bucketPutNotification');
+const { cleanup,
+    DummyRequestLogger,
+    makeAuthInfo }
+    = require('../helpers');
+const metadata = require('../../../lib/metadata/wrapper');
+
+const log = new DummyRequestLogger();
+const authInfo = makeAuthInfo('accessKey1');
+const bucketName = 'bucketname';
+const bucketPutRequest = {
+    bucketName,
+    headers: { host: `${bucketName}.s3.amazonaws.com` },
+    url: '/',
+};
+
+const expectedNotifConfig = {
+    queueConfig: [
+        {
+            id: 'notification-id',
+            events: ['s3:ObjectCreated:*'],
+            queueArn: 'arn:scality:bucketnotif:::target1',
+            filterRules: [],
+        },
+    ],
+};
+
+const notifXml = '<NotificationConfiguration>' +
+    '<QueueConfiguration>' +
+    '<Id>notification-id</Id>' +
+    '<Queue>arn:scality:bucketnotif:::target1</Queue>' +
+    '<Event>s3:ObjectCreated:*</Event>' +
+    '</QueueConfiguration>' +
+    '</NotificationConfiguration>';
+
+const putNotifConfigRequest = {
+    bucketName,
+    headers: {
+        host: `${bucketName}.s3.amazonaws.com`,
+    },
+    post: notifXml,
+};
+
+describe('putBucketNotification API', () => {
+    before(cleanup);
+    beforeEach(done => bucketPut(authInfo, bucketPutRequest, log, done));
+    afterEach(cleanup);
+
+    it('should update a bucket\'s metadata with bucket notification obj',
+    done => {
+        bucketPutNotification(authInfo, putNotifConfigRequest, log, err => {
+            assert.ifError(err);
+            return metadata.getBucket(bucketName, log, (err, bucket) => {
+                assert.ifError(err);
+                const bucketNotifConfig = bucket.getNotificationConfiguration();
+                assert.deepStrictEqual(bucketNotifConfig, expectedNotifConfig);
+                return done();
+            });
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -130,22 +130,23 @@
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
 "@sindresorhus/is@^3.0.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-3.1.0.tgz#d8735532635bea69ad39119df5f0f10099bd09dc"
-  integrity sha512-n4J+zu52VdY43kdi/XdI9DzuMr1Mur8zFL5ZRG2opCans9aiFwkPxHYFEb5Xgy7n1Z4K6WfI4FpqUqsh3E8BPQ==
-
-"@snyk/cli-interface@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@snyk/cli-interface/-/cli-interface-1.5.0.tgz#b9dbe6ebfb86e67ffabf29d4e0d28a52670ac456"
-  integrity sha512-+Qo+IO3YOXWgazlo+CKxOuWFLQQdaNCJ9cSfhFQd687/FuesaIxWdInaAdfpsLScq0c6M1ieZslXgiZELSzxbg==
-  dependencies:
-    tslib "^1.9.3"
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-3.1.1.tgz#6e39e4222add8b362da35720c9dd5d53345d5851"
+  integrity sha512-tLnujxFtfH7F+i5ghUfgGlJsvyCKvUnSMFMlWybFdX9/DdX8svb4Zwx1gV0gkkVCHXtmPSetoAR3QlKfOld6Tw==
 
 "@snyk/cli-interface@2.3.2":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@snyk/cli-interface/-/cli-interface-2.3.2.tgz#e93afa82de15b912e657f1ba86f9d7963983e594"
   integrity sha512-jmZyxVHqzYU1GfdnWCGdd68WY/lAzpPVyqalHazPj4tFJehrSfEFc82RMTYAMgXEJuvFRFIwhsvXh3sWUhIQmg==
   dependencies:
+    tslib "^1.9.3"
+
+"@snyk/cli-interface@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@snyk/cli-interface/-/cli-interface-2.6.1.tgz#1e4e7acf5f9aca1267ddf3c1bb98a469011c907a"
+  integrity sha512-3X+OwwwT9j0r2ObqxYIiAgdaHsTW71b92PN3wawGAxl4YgPRrRVw8Fouhe41I4WJsn7OlKUNedylZguvpYg9qw==
+  dependencies:
+    "@snyk/graphlib" "2.1.9-patch"
     tslib "^1.9.3"
 
 "@snyk/cli-interface@2.8.0":
@@ -166,13 +167,13 @@
     "@snyk/graphlib" "2.1.9-patch"
     tslib "^1.9.3"
 
-"@snyk/cocoapods-lockfile-parser@3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@snyk/cocoapods-lockfile-parser/-/cocoapods-lockfile-parser-3.4.0.tgz#e5a02e458b2db67de929936398565b22724ba2de"
-  integrity sha512-mAWgKIHFv0QEGpRvocVMxLAdJx7BmXtVOyQN/VtsGBoGFKqhO0jbtKUUVJC4b0jyKfVmEF2puo94i+1Uqz5q6A==
+"@snyk/cocoapods-lockfile-parser@3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@snyk/cocoapods-lockfile-parser/-/cocoapods-lockfile-parser-3.5.1.tgz#572907ae12abf77c1ea3dd497f7d1ced31104aa7"
+  integrity sha512-0bzajH/HdP3k5cOZKUmT/xqmHZFuWN124c/lrqh+U6Q1Z9Bt7TLOB2ifLKL+1I4rq+IgOesGWJYG1KhxBy3RLw==
   dependencies:
-    "@snyk/dep-graph" "1.18.4"
-    "@snyk/ruby-semver" "^2.0.4"
+    "@snyk/dep-graph" "1.19.3"
+    "@snyk/ruby-semver" "^3.0.0"
     "@types/js-yaml" "^3.12.1"
     js-yaml "^3.13.1"
     source-map-support "^0.5.7"
@@ -184,30 +185,6 @@
   integrity sha512-ga4YTRjJUuP0Ufr+t1IucwVjEFAv66JSBB/zVHP2zy/jmfA3l3ZjlGQSjsRC6Me9P2Z0esQ83AYNZvmIf9pq2w==
   dependencies:
     "@snyk/lodash" "^4.17.15-patch"
-
-"@snyk/dep-graph@1.18.3":
-  version "1.18.3"
-  resolved "https://registry.yarnpkg.com/@snyk/dep-graph/-/dep-graph-1.18.3.tgz#7bf675f694ecbc329f67cca6456ae67f3f45f516"
-  integrity sha512-7qWRTIJdZuc5VzDjdV2+03AHElyAZmhq7eV9BRu+jqrYjo9ohWBGEZgYslrTdvfqfJ8rkdrG3j0/0Aa25IxJcg==
-  dependencies:
-    "@snyk/graphlib" "2.1.9-patch"
-    "@snyk/lodash" "4.17.15-patch"
-    object-hash "^2.0.3"
-    semver "^7.3.2"
-    source-map-support "^0.5.19"
-    tslib "^1.11.1"
-
-"@snyk/dep-graph@1.18.4":
-  version "1.18.4"
-  resolved "https://registry.yarnpkg.com/@snyk/dep-graph/-/dep-graph-1.18.4.tgz#4dfb1681d56090ca1f04a3bcd6593cbb8bf1a576"
-  integrity sha512-SePWsDyD7qrLxFifIieEl4GqyOODfOnP0hmUweTG5YcMroAV5nARGAUcjxREGzbXMcUpPfZhAaqFjYgzUDH8dQ==
-  dependencies:
-    "@snyk/graphlib" "2.1.9-patch"
-    "@snyk/lodash" "4.17.15-patch"
-    object-hash "^2.0.3"
-    semver "^7.3.2"
-    source-map-support "^0.5.19"
-    tslib "^1.11.1"
 
 "@snyk/dep-graph@1.19.0":
   version "1.19.0"
@@ -221,7 +198,7 @@
     source-map-support "^0.5.19"
     tslib "^2.0.0"
 
-"@snyk/dep-graph@1.19.3", "@snyk/dep-graph@^1.17.0", "@snyk/dep-graph@^1.18.2":
+"@snyk/dep-graph@1.19.3", "@snyk/dep-graph@^1.17.0", "@snyk/dep-graph@^1.19.0":
   version "1.19.3"
   resolved "https://registry.yarnpkg.com/@snyk/dep-graph/-/dep-graph-1.19.3.tgz#f20521baf060f83f052fd6b55fad8b377833418d"
   integrity sha512-WJLUFKBokoFK5imi0t8Dkyj+uqtS/5Ziuf4oE/OOFX30UqP1ffMDkv9/3sqBJQVQ9FjdgsX3Cm8JZMtMlYRc6w==
@@ -331,23 +308,24 @@
   dependencies:
     "@snyk/lodash" "4.17.15-patch"
 
-"@snyk/ruby-semver@^2.0.4":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/@snyk/ruby-semver/-/ruby-semver-2.2.2.tgz#69efa5fc3a884ccc7f6a053c37a25b616ef7ce8b"
-  integrity sha512-zhWqr31fwU+kwh12X6LTWNMWp7QqpO6Z4qTqh/ItmCj/ImN1wO0Rv6AE1RafEbiAmTxG6kguCW3a9jzwLSWuBQ==
+"@snyk/ruby-semver@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@snyk/ruby-semver/-/ruby-semver-3.0.0.tgz#592e648343a88eccb7d787a97d3ad6c9df1dd61f"
+  integrity sha512-GoSRcwNuJ/mK3Q+tqelRJlylPh8K3RZRWh3ZpkOKm1gQPdG+z0wt+LipSIHxGR8yBDl5bQjwTrPLkL49/N1V6Q==
   dependencies:
     lodash.escaperegexp "^4.1.0"
     lodash.flatten "^4.4.0"
     lodash.uniq "^4.5.0"
+    tslib "^1.13.0"
 
-"@snyk/snyk-cocoapods-plugin@2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@snyk/snyk-cocoapods-plugin/-/snyk-cocoapods-plugin-2.3.0.tgz#e228f9eb42c94ef7309d98471768838f30e3274a"
-  integrity sha512-4V1xJMqsK6J3jHu9UufKySorzA8O1vNLRIK1JgJf5KcXQCP44SJI5dk9Xr9iFGXXtGo8iI9gmokQcHlGpkPSJg==
+"@snyk/snyk-cocoapods-plugin@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@snyk/snyk-cocoapods-plugin/-/snyk-cocoapods-plugin-2.5.0.tgz#8dedb9d3165e5c8cd72ab13fdb49397083a15866"
+  integrity sha512-arK4VHzNh/D9vCFQFeAiSP+rMRXwLbzaRoIKucodf8Q/3KftIo/byeDmoc2Cc7awR1HPo5E391bwBNH5ra8UqA==
   dependencies:
-    "@snyk/cli-interface" "1.5.0"
-    "@snyk/cocoapods-lockfile-parser" "3.4.0"
-    "@snyk/dep-graph" "^1.18.2"
+    "@snyk/cli-interface" "2.6.1"
+    "@snyk/cocoapods-lockfile-parser" "3.5.1"
+    "@snyk/dep-graph" "^1.19.0"
     source-map-support "^0.5.7"
     tslib "^2.0.0"
 
@@ -436,9 +414,9 @@
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*":
-  version "14.0.27"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"
-  integrity sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
+  version "14.6.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.0.tgz#7d4411bf5157339337d7cff864d9ff45f177b499"
+  integrity sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA==
 
 "@types/node@^13.7.0":
   version "13.13.15"
@@ -719,9 +697,9 @@ ajv@^4.7.0:
     json-stable-stringify "^1.0.1"
 
 ajv@^6.12.3:
-  version "6.12.3"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.3.tgz#18c5af38a111ddeb4f2697bd78d68abc1cabd706"
-  integrity sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==
+  version "6.12.4"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.4.tgz#0614facc4522127fa713445c6bfd3ebd376e2234"
+  integrity sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -839,9 +817,9 @@ arraybuffer.slice@~0.0.7:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
   integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
 
-"arsenal@github:scality/Arsenal#6fff00d":
+"arsenal@github:scality/Arsenal#aa9c9e5":
   version "7.7.0"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/6fff00d0883eb58a03baeeb1ea84c52ce0473468"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/aa9c9e54ff27211131ec823a34a3d8d77dc55cf2"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
@@ -1028,9 +1006,9 @@ aws-sdk@2.363.0:
     xml2js "0.4.19"
 
 aws-sdk@^2.2.23:
-  version "2.730.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.730.0.tgz#5b2775bb0c3cd7764031a17a9bcac3f1aafc385e"
-  integrity sha512-hYHplsbgUDP0XuaVJaHx2L/nC0E1i+4dGlkAQpkJz3qQ4NDfLnrbUFsA2g3AyWAsrnjrBNCkexPvwnV82Qng1g==
+  version "2.738.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.738.0.tgz#37e4b75ab1acf9bc01bea5d4f83ebb937842de6a"
+  integrity sha512-oO1odRT4DGssivoP6lHO3yB6I+5sU0uqpj6UJ0kS5wrHQ9J9EGrictLVKA9y6XhN0sNW+XPNLD9jMMY/A+gXWA==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -1048,9 +1026,9 @@ aws-sign2@~0.7.0:
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
 aws4@^1.8.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.0.tgz#a17b3a8ea811060e74d47d306122400ad4497ae2"
-  integrity sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.1.tgz#e1e82e4f3e999e2cfd61b161280d16a111f86428"
+  integrity sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==
 
 axios@^0.18.0:
   version "0.18.1"
@@ -4334,9 +4312,9 @@ lodash.values@^4.3.0:
   integrity sha1-o6bCsOvsxcLLocF+bmIP6BtT00c=
 
 lodash@^4.0.0, lodash@^4.14.0, lodash@^4.16.4, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.4, lodash@^4.3.0:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 lodash@~2.4.1:
   version "2.4.2"
@@ -5912,7 +5890,7 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.1.2, semver@^7.3.2:
+semver@^7.1.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
@@ -6064,10 +6042,17 @@ snyk-config@^3.0.0:
     lodash.merge "^4.6.2"
     nconf "^0.10.0"
 
-snyk-docker-plugin@3.16.0:
-  version "3.16.0"
-  resolved "https://registry.yarnpkg.com/snyk-docker-plugin/-/snyk-docker-plugin-3.16.0.tgz#2280c4b1f457eaa746b1156f634b0354e445522a"
-  integrity sha512-i11WxMhsZxcFKn123LeA+u77NN7uWqWgPfQ6dvkACJnvouWHZidkOAxBOmYU49x8VS7dEQSe2Ym0bgr6EHn4cQ==
+snyk-cpp-plugin@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/snyk-cpp-plugin/-/snyk-cpp-plugin-1.2.0.tgz#1e554eece61d40288bbc745f040c2ca54ec7e08a"
+  integrity sha512-zc2h0IAAjcxJwxWp4rauliwEUXZahmC3WoCgjTmRi36UhzwlxWJf8QpIeSOKJnc3t0NhlKzUc1YFkaQGJ2dXVQ==
+  dependencies:
+    tslib "^2.0.0"
+
+snyk-docker-plugin@3.17.0:
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/snyk-docker-plugin/-/snyk-docker-plugin-3.17.0.tgz#9f48f9d4455b15dc15fdfc37137c567e9c9e24e2"
+  integrity sha512-Pq0xr/NQQUss3bLb0rTfVtsot/9ID6TzZCWlF9nMrj9JFrJRrJPQxi/KO/uqfX0Nbwz4VysXDzwdWNtrxpaabg==
   dependencies:
     "@snyk/rpm-parser" "^2.0.0"
     "@snyk/snyk-docker-pull" "^3.2.0"
@@ -6311,18 +6296,18 @@ snyk-try-require@1.3.1, snyk-try-require@^1.1.1, snyk-try-require@^1.3.1:
     then-fs "^2.0.0"
 
 snyk@^1.342.2:
-  version "1.372.0"
-  resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.372.0.tgz#d650c254b63ec6e4d93f54ceab90b33981562f40"
-  integrity sha512-5eX7cEmbPtpZ9w+vQIEIf9tlb3FOEN36cnSFpla4bTim2biGTx50lWPKYAclX3z1tlLt654rdJfpTt5tOqWxUQ==
+  version "1.381.1"
+  resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.381.1.tgz#e2f5be0eeb87c8da8e232a48cca40146fffc83e2"
+  integrity sha512-CSTBkUNYaOZgaXnFOxsQsHT9x0Wifsg4Fm0ahceliEhjRuKTFkOBTt/TTtRjXlHZ+/DZ9uDRivYxomJaSlgpMQ==
   dependencies:
     "@snyk/cli-interface" "2.8.1"
-    "@snyk/dep-graph" "1.18.3"
+    "@snyk/dep-graph" "1.19.3"
     "@snyk/gemfile" "1.2.0"
     "@snyk/graphlib" "2.1.9-patch"
     "@snyk/inquirer" "6.2.2-patch"
     "@snyk/lodash" "^4.17.15-patch"
     "@snyk/ruby-semver" "2.2.0"
-    "@snyk/snyk-cocoapods-plugin" "2.3.0"
+    "@snyk/snyk-cocoapods-plugin" "2.5.0"
     abbrev "^1.1.1"
     ansi-escapes "3.2.0"
     chalk "^2.4.2"
@@ -6338,7 +6323,8 @@ snyk@^1.342.2:
     proxy-from-env "^1.0.0"
     semver "^6.0.0"
     snyk-config "3.1.0"
-    snyk-docker-plugin "3.16.0"
+    snyk-cpp-plugin "1.2.0"
+    snyk-docker-plugin "3.17.0"
     snyk-go-plugin "1.16.0"
     snyk-gradle-plugin "3.5.1"
     snyk-module "3.1.0"
@@ -7011,7 +6997,7 @@ tslib@1.11.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
-tslib@^1, tslib@^1.10.0, tslib@^1.11.1, tslib@^1.11.2, tslib@^1.13.0, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1, tslib@^1.10.0, tslib@^1.11.2, tslib@^1.13.0, tslib@^1.9.0, tslib@^1.9.3:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
@@ -7069,9 +7055,9 @@ type@^1.0.1:
   integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
 
 type@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/type/-/type-2.0.0.tgz#5f16ff6ef2eb44f260494dae271033b29c09a9c3"
-  integrity sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/type/-/type-2.1.0.tgz#9bdc22c648cf8cf86dd23d32336a41cfb6475e3f"
+  integrity sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==
 
 typedarray-to-buffer@^3.1.5, typedarray-to-buffer@~3.1.5:
   version "3.1.5"
@@ -7145,9 +7131,9 @@ unpipe@1.0.0, unpipe@~1.0.0:
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
 update-notifier@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-4.1.0.tgz#4866b98c3bc5b5473c020b1250583628f9a328f3"
-  integrity sha512-w3doE1qtI0/ZmgeoDoARmI5fjDoT93IfKgEGqm26dGUOh8oNpaSTsGNdYRN/SjOuo10jcJGwkEL3mroKzktkew==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-4.1.1.tgz#895fc8562bbe666179500f9f2cebac4f26323746"
+  integrity sha512-9y+Kds0+LoLG6yN802wVXoIfxYEwh3FlZwzMwpCZp62S2i1/Jzeqb9Eeeju3NSHccGGasfGlK5/vEHbAifYRDg==
   dependencies:
     boxen "^4.2.0"
     chalk "^3.0.0"


### PR DESCRIPTION
Adds `putBucketNotification` API.
Requires https://github.com/scality/cloudserver/pull/2934 and https://github.com/scality/Arsenal/pull/1231
to be merged before.
The new `bucketNotificationTargets` field in the config is needed to run the tests.
There was also an attempt to make this API an async function using current node async/await and promise practices, but it would require more refactoring outside the scope of this PR. 