### PR TITLE
INTEGRATION [PR#2964 > development/7.8] bf(S3C-1232): Validate passed account ids for list_metrics.js

### DIFF
--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -156,6 +156,20 @@ function listMetrics(metricType) {
         }
     });
 
+    // The string `commander[metric]` is a comma-separated list of resources
+    // given by the user.
+    const resources = commander[metric].split(',');
+
+    // Validate passed accounts to remove any canonicalids
+    if (metric === 'accounts') {
+        resources.forEach(r => {
+            if (!/^\d{12}$/.test(r)) {
+                logger.error(`${r} is not a valid account id`);
+                process.exit(1);
+            }
+        });
+    }
+
     const timeRange = [];
     // If recent listing, we disregard any start or end option given
     if (!recent) {
@@ -178,9 +192,7 @@ function listMetrics(metricType) {
             timeRange.push(numEnd);
         }
     }
-    // The string `commander[metric]` is a comma-separated list of resources
-    // given by the user.
-    const resources = commander[metric].split(',');
+
     _listMetrics(host, port, metric, resources, timeRange, accessKey, secretKey,
         verbose, recent, ssl);
 }


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2964.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.8/bugfix/S3C-1232_add_account_id_validation_for_list_metrics`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.8/bugfix/S3C-1232_add_account_id_validation_for_list_metrics
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.8/bugfix/S3C-1232_add_account_id_validation_for_list_metrics
```

Please always comment pull request #2964 instead of this one.