### PR TITLE
bf: S3C-3301 bucket notif config fix

### DIFF
--- a/config.json
+++ b/config.json
@@ -82,9 +82,7 @@
         {
             "resource": "target1",
             "type": "dummy",
-            "host": "localhost",
-            "port": 6000,
-            "auth": { "user": "user", "password": "password" }
+            "host": "localhost:6000"
         }
     ]
 }

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -291,30 +291,13 @@ function bucketNotifAssert(bucketNotifConfig) {
             'bad config: bucket notification configuration type must be a string');
         assert(typeof host === 'string' && host !== '',
             'bad config: hostname must be a non-empty string');
-        assert(Number.isInteger(port) && port > 0,
-            'bad config: port must be a positive integer');
-        assert(typeof auth === 'object',
-            'bad config: bucket notification auth must be an object');
-        const { cert, user, password } = auth;
-        if ((cert && (user || password)) || (!cert && !user && !password)) {
-            throw new Error('bad config: bucket notification configuration ' +
-                'auth should contain either cert or user and password');
+        if (port) {
+            assert(Number.isInteger(port, 10) && port > 0,
+                'bad config: port must be a positive integer');
         }
-        if (cert) {
-            const certpath = (cert[0] === '/') ? cert : `${this._basePath}/${cert}`;
-            assert.doesNotThrow(() =>
-                fs.accessSync(certpath, fs.F_OK | fs.R_OK),
-                `File not found or unreachable: ${certpath}`);
-            // eslint-disable-next-line no-param-reassign
-            c.auth.cert = certpath;
-        } else if (!user || !password) {
-            throw new Error('bad config: bucket notification configuration ' +
-                'auth should contain both user and password if not using cert');
-        } else {
-            assert(typeof user === 'string',
-                'bad config: bucket notification configuration auth user should be a string');
-            assert(typeof password === 'string',
-                'bad config: bucket notification configuration auth password should be a string');
+        if (auth) {
+            assert(typeof auth === 'object',
+                'bad config: bucket notification auth must be an object');
         }
     });
     return bucketNotifConfig;

--- a/tests/unit/testConfigs/bucketNotifConfigTest.js
+++ b/tests/unit/testConfigs/bucketNotifConfigTest.js
@@ -21,7 +21,7 @@ describe('bucketNotifAssert', () => {
                 auth: { user: 'user', password: 'password' },
             });
         },
-        '/bad config: bucket notification configuration must be an array/');
+            '/bad config: bucket notification configuration must be an array/');
     });
     it('should throw an error if resource is not a string', () => {
         assert.throws(() => {
@@ -67,73 +67,6 @@ describe('bucketNotifAssert', () => {
             }]);
         }, '/bad config: port must be a positive integer/');
     });
-    it('should throw an error if auth is not an object', () => {
-        assert.throws(() => {
-            bucketNotifAssert([{
-                resource: 'target1',
-                type: 'kafka',
-                host: 'localhost',
-                port: 8000,
-                auth: 'yes',
-            }]);
-        }, '/bad config: bucket notification auth must be an object/');
-    });
-    it('should throw an error if auth is an empty object', () => {
-        assert.throws(() => {
-            bucketNotifAssert([{
-                resource: 'target1',
-                type: 'kafka',
-                host: 'localhost',
-                port: 8000,
-                auth: {},
-            }]);
-        }, '/bad config: bucket notification configuration ' +
-        'auth should contain either cert or user and password/');
-    });
-    it('should throw an error if auth includes cert, user, and password', () => {
-        assert.throws(() => {
-            bucketNotifAssert([{
-                resource: 'target1',
-                type: 'kafka',
-                host: 'localhost',
-                port: 8000,
-                auth: { user: 'user', password: 'password', cert: 'cert/path' },
-            }]);
-        }, '/bad config: bucket notification configuration ' +
-        'auth should contain either cert or user and password/');
-    });
-    it('should throw an error if auth includes user but no password', () => {
-        assert.throws(() => {
-            bucketNotifAssert([{
-                resource: 'target1',
-                type: 'kafka',
-                host: 'localhost',
-                port: 8000,
-                auth: { user: 'user' },
-            }]);
-        }, '/bad config: bucket notification configuration ' +
-        'auth should contain both user and password if not using cert/');
-    });
-    it('should throw an error if auth user is not a string', () => {
-        assert.throws(() => {
-            bucketNotifAssert([{
-                resource: 'target1',
-                type: 'kafka',
-                host: 'localhost',
-                port: 8000,
-                auth: { user: 1, password: 'password' },
-            }]);
-        }, '/bad config: bucket notification configuration auth user should be a string/');
-    });
-    it('should throw an error if auth password is not a string', () => {
-        assert.throws(() => {
-            bucketNotifAssert([{
-                resource: 'target1',
-                type: 'kafka',
-                host: 'localhost',
-                port: 8000,
-                auth: { user: 'user', password: 12345 },
-            }]);
-        }, '/bad config: bucket notification configuration auth password should be a string/');
-    });
+    // TODO: currently auth is fluid and once a concrete structure is
+    // established, add tests to auth part of the config
 });


### PR DESCRIPTION
Bucket notification configuration properties 'port' and 'auth' are optional and should not stop cloudserver to start. Corrected bucket notification configuration checks to allow optional 'port' and 'auth' properties. Necessary tests are updated.