### PR TITLE
bugfix: S3C-3042 prevent suspending version on replication buckets

### DIFF
--- a/lib/api/bucketPutVersioning.js
+++ b/lib/api/bucketPutVersioning.js
@@ -12,7 +12,9 @@ const { config } = require('../Config');
 
 const externalVersioningErrorMessage = 'We do not currently support putting ' +
 'a versioned object to a location-constraint of type Azure.';
-
+const invalidBucketStateMessage = 'A replication configuration is present on ' +
+ 'this bucket, so you cannot change the versioning state. To change the ' +
+ 'versioning state, first delete the replication configuration.';
 /**
  * Format of xml request:
 
@@ -116,6 +118,18 @@ function bucketPutVersioning(authInfo, request, log, callback) {
             return next(null, bucket, versioningConfiguration);
         }),
         (bucket, versioningConfiguration, next) => {
+            // check if replication is enabled if versioning is being suspended
+            const replicationConfig = bucket.getReplicationConfiguration();
+            const invalidAction =
+                versioningConfiguration.Status === 'Suspended'
+                && replicationConfig
+                && replicationConfig.rules
+                && replicationConfig.rules.some(r => r.enabled);
+            if (invalidAction) {
+                next(errors.InvalidBucketState
+                    .customizeDescription(invalidBucketStateMessage));
+                return;
+            }
             bucket.setVersioningConfiguration(versioningConfiguration);
             // TODO all metadata updates of bucket should be using CAS
             metadata.updateBucket(bucket.getName(), bucket, log, err =>

--- a/tests/functional/aws-node-sdk/test/versioning/replicationBucket.js
+++ b/tests/functional/aws-node-sdk/test/versioning/replicationBucket.js
@@ -1,0 +1,80 @@
+const assert = require('assert');
+const async = require('async');
+
+const withV4 = require('../support/withV4');
+const BucketUtility = require('../../lib/utility/bucket-util');
+
+const bucketName = `versioning-bucket-${Date.now()}`;
+
+
+function checkError(err, code) {
+    assert.notEqual(err, null, 'Expected failure but got success');
+    assert.strictEqual(err.code, code);
+}
+
+function checkNoError(err) {
+    assert.ifError(err, `Expected success, got error ${JSON.stringify(err)}`);
+}
+
+function testVersioning(s3, versioningStatus, replicationStatus, cb) {
+    const versioningParams = { Bucket: bucketName,
+        VersioningConfiguration: { Status: versioningStatus } };
+    const replicationParams = {
+        Bucket: bucketName,
+        ReplicationConfiguration: {
+            Role: 'arn:aws:iam::123456789012:role/examplerole,' +
+            'arn:aws:iam::123456789012:role/examplerole',
+            Rules: [
+                {
+                    Destination: {
+                        Bucket: 'arn:aws:s3:::destinationbucket',
+                        StorageClass: 'STANDARD',
+                    },
+                    Prefix: '',
+                    Status: replicationStatus,
+                },
+            ],
+        },
+    };
+    async.waterfall([
+        cb => s3.putBucketReplication(replicationParams, e => cb(e)),
+        cb => s3.putBucketVersioning(versioningParams, e => cb(e)),
+    ], cb);
+}
+
+describe('Versioning on a replication source bucket', () => {
+    withV4(sigCfg => {
+        const bucketUtil = new BucketUtility('default', sigCfg);
+        const s3 = bucketUtil.s3;
+
+        beforeEach(done => {
+            async.waterfall([
+                cb => s3.createBucket({ Bucket: bucketName }, e => cb(e)),
+                cb => s3.putBucketVersioningPromise({
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    },
+                }, err => cb(err)),
+            ], done);
+        });
+
+        afterEach(done => s3.deleteBucket({ Bucket: bucketName }, done));
+
+        it('should not be able to disable versioning if replication enabled',
+        done => {
+            testVersioning(s3, 'Suspended', 'Enabled', err => {
+                checkError(err, 'InvalidBucketState');
+                done();
+            });
+        });
+
+        it('should be able to disable versioning if replication disabled',
+        done => {
+            testVersioning(s3, 'Suspended', 'Disabled', err => {
+                checkNoError(err);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
This fix which is compatibility with AWS S3, ensures that versioning cannot be suspended on buckets that have replication enabled