### PR TITLE
INTEGRATION [PR#3014 > development/8.2] bugfix: S3C-2775 update logic for counting object replicas

### DIFF
--- a/lib/routes/utilities/pushReplicationMetric.js
+++ b/lib/routes/utilities/pushReplicationMetric.js
@@ -1,5 +1,3 @@
-const assert = require('assert');
-
 const { ObjectMD } = require('arsenal').models;
 const { pushMetric } = require('../../utapi/utilities');
 
@@ -8,18 +6,16 @@ function shouldPushMetric(prevObjectMD, newObjectMD) {
     if (newObjectMD.getReplicationStatus() !== 'REPLICA') {
         return false;
     }
-    try {
-        // Replication of object tags and ACLs should not increment metrics.
-        assert.deepStrictEqual(prevObjectMD.getAcl(), newObjectMD.getAcl());
-        assert.deepStrictEqual(prevObjectMD.getTags(), newObjectMD.getTags());
-    } catch (e) {
-        return false;
-    }
-    return true;
+    // The rule for a REPLICA is: push object metrics if it is a new
+    // object version i.e. there is no existing object of the same
+    // version. It is the case when updating ACLs and/or tags
+    // in-place, in which case we don't want to bump object metrics as
+    // the object is still there with the same data.
+    return !prevObjectMD;
 }
 
 function pushReplicationMetric(prevValue, newValue, bucket, key, log) {
-    const prevObjectMD = new ObjectMD(prevValue);
+    const prevObjectMD = prevValue ? new ObjectMD(prevValue) : null;
     const newObjectMD = new ObjectMD(newValue);
     if (!shouldPushMetric(prevObjectMD, newObjectMD)) {
         return undefined;

--- a/tests/functional/raw-node/test/routes/routeBackbeat.js
+++ b/tests/functional/raw-node/test/routes/routeBackbeat.js
@@ -82,6 +82,7 @@ function checkObjectData(s3, objectKey, dataValue, done) {
  * @param {object} params.authCredentials.accessKey - access key
  * @param {object} params.authCredentials.secretKey - secret key
  * @param {string} [params.requestBody] - request body contents
+ * @param {object} [params.queryObj] - query params
  * @param {function} callback - with error and response parameters
  * @return {undefined} - and call callback
  */
@@ -183,6 +184,10 @@ describeSkipIfAWS('backbeat routes:', () => {
                             method: 'PUT', bucket: TEST_BUCKET,
                             objectKey: testCase.encodedKey,
                             resourceType: 'metadata',
+                            queryObj: {
+                                versionId: versionIdUtils.encode(
+                                    testMd.versionId),
+                            },
                             authCredentials: backbeatAuthCredentials,
                             requestBody: JSON.stringify(newMd),
                         }, next);
@@ -220,6 +225,9 @@ describeSkipIfAWS('backbeat routes:', () => {
                     method: 'PUT', bucket: TEST_BUCKET,
                     objectKey: 'test-updatemd-key',
                     resourceType: 'metadata',
+                    queryObj: {
+                        versionId: versionIdUtils.encode(testMd.versionId),
+                    },
                     authCredentials: backbeatAuthCredentials,
                     requestBody: JSON.stringify(newMd),
                 }, next);
@@ -230,6 +238,9 @@ describeSkipIfAWS('backbeat routes:', () => {
                     method: 'PUT', bucket: TEST_BUCKET,
                     objectKey: 'test-updatemd-key',
                     resourceType: 'metadata',
+                    queryObj: {
+                        versionId: versionIdUtils.encode(testMd.versionId),
+                    },
                     headers: { 'x-scal-replication-content': 'METADATA' },
                     authCredentials: backbeatAuthCredentials,
                     requestBody: JSON.stringify(newMd),
@@ -264,6 +275,9 @@ describeSkipIfAWS('backbeat routes:', () => {
         done => makeBackbeatRequest({
             method: 'PUT', bucket: NONVERSIONED_BUCKET,
             objectKey: testKey, resourceType: 'metadata',
+            queryObj: {
+                versionId: versionIdUtils.encode(testMd.versionId),
+            },
             authCredentials: backbeatAuthCredentials,
             requestBody: JSON.stringify(testMd),
         },
@@ -312,6 +326,9 @@ describeSkipIfAWS('backbeat routes:', () => {
                     method: 'PUT', bucket: TEST_BUCKET,
                     objectKey: 'does-not-exist',
                     resourceType: 'metadata',
+                    queryObj: {
+                        versionId: versionIdUtils.encode(testMd.versionId),
+                    },
                     headers: { 'x-scal-replication-content': 'METADATA' },
                     authCredentials: backbeatAuthCredentials,
                     requestBody: JSON.stringify(newMd),


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3014.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/bugfix/S3C-2775-utapiCRRFix`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/bugfix/S3C-2775-utapiCRRFix
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/bugfix/S3C-2775-utapiCRRFix
```

Please always comment pull request #3014 instead of this one.