### PR TITLE
INTEGRATION [PR#3024 > development/8.1] build(deps): bump google-auto-auth from 0.9.7 to 0.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "commander": "^2.9.0",
     "cron-parser": "^2.11.0",
     "diskusage": "1.1.3",
-    "google-auto-auth": "^0.9.1",
+    "google-auto-auth": "^0.10.1",
     "http-proxy": "^1.17.0",
     "node-uuid": "^1.4.3",
     "npm-run-all": "~4.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1577,10 +1577,10 @@ google-auth-library@^1.3.1:
     lru-cache "^4.1.3"
     retry-axios "^0.3.2"
 
-google-auto-auth@^0.9.1:
-  version "0.9.7"
-  resolved "https://registry.yarnpkg.com/google-auto-auth/-/google-auto-auth-0.9.7.tgz#70b357ec9ec8e2368cf89a659309a15a1472596b"
-  integrity sha512-Nro7aIFrL2NP0G7PoGrJqXGMZj8AjdBOcbZXRRm/8T3w08NUHIiNN3dxpuUYzDsZizslH+c8e+7HXL8vh3JXTQ==
+google-auto-auth@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/google-auto-auth/-/google-auto-auth-0.10.1.tgz#68834a6f3da59a6cb27fce56f76e3d99ee49d0a2"
+  integrity sha512-iIqSbY7Ypd32mnHGbYctp80vZzXoDlvI9gEfvtl3kmyy5HzOcrZCIGCBdSlIzRsg7nHpQiHE3Zl6Ycur6TSodQ==
   dependencies:
     async "^2.3.0"
     gcp-metadata "^0.6.1"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3024.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/dependabot/npm_and_yarn/development/7.4/google-auto-auth-0.10.1`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/dependabot/npm_and_yarn/development/7.4/google-auto-auth-0.10.1
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/dependabot/npm_and_yarn/development/7.4/google-auto-auth-0.10.1
```

Please always comment pull request #3024 instead of this one.