### PR TITLE
ZENKO-2810 upload docker image with short version tag

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -433,6 +433,14 @@ stages:
           name: Set docker tag latest property
           property: docker_tag_latest
           value: "%(prop:registry_url)s:latest-%(prop:product_version)s"
+      - SetPropertyFromCommand: &short_version
+          name: Set short version
+          property: short_version
+          command: echo "%(prop:product_version)s" | grep -o '^[0-9]*\.[0-9]*'
+      - SetProperty: &docker_tag_short_version
+          name: Set docker tag latest short version property
+          property: docker_tag_short_version
+          value: "%(prop:registry_url)s:latest-%(prop:short_version)s"
       - ShellCommand:
           name: Build docker image
           command: >-
@@ -440,9 +448,11 @@ stages:
             --no-cache
             -t %(prop:docker_tag_revision)s
             -t %(prop:docker_tag_latest)s
+            -t %(prop:docker_tag_short_version)s
             .
       - ShellCommand:
           name: Push images
           command: |
             docker push %(prop:docker_tag_revision)s
             docker push %(prop:docker_tag_latest)s
+            docker push %(prop:docker_tag_short_version)s


### PR DESCRIPTION
The goal of this code is to allow us to obtain docker images tag
in our registry that look like the following: `registry.scality.com/zenko/cloudserver:latest-8.1` or `registry.scality.com/zenko/cloudserver:latest-8.2`

Those tags will match the content of the tip of a given development/x.y branch