### PR TITLE
bf: S3C-3330 bucket policy action mapping

### DIFF
--- a/lib/api/apiUtils/authorization/permissionChecks.js
+++ b/lib/api/apiUtils/authorization/permissionChecks.js
@@ -2,42 +2,43 @@ const { evaluators } = require('arsenal').policies;
 const constants = require('../../../../constants');
 
 const actionMap = {
-    's3:AbortMultipartUpload': 'multipartDelete',
-    's3:DeleteBucket': 'bucketDelete',
-    's3:DeleteBucketPolicy': 'bucketDeletePolicy',
-    's3:DeleteBucketWebsite': 'bucketDeleteWebsite',
-    's3:DeleteObject': 'objectDelete',
-    's3:DeleteObjectTagging': 'objectDeleteTagging',
-    's3:GetBucketAcl': 'bucketGetACL',
-    's3:GetBucketCORS': 'bucketGetCors',
-    's3:GetBucketLocation': 'bucketGetLocation',
-    's3:GetBucketObjectLockConfiguration': 'bucketGetObjectLock',
-    's3:GetBucketPolicy': 'bucketGetPolicy',
-    's3:GetBucketVersioning': 'bucketGetVersioning',
-    's3:GetBucketWebsite': 'bucketGetWebsite',
-    's3:GetLifecycleConfiguration': 'bucketGetLifecycle',
-    's3:GetObject': 'objectGet',
-    's3:GetObjectAcl': 'objectGetACL',
-    's3:GetObjectLegalHold': 'objectGetLegalHold',
-    's3:GetObjectRetention': 'objectGetRetention',
-    's3:GetObjectTagging': 'objectGetTagging',
-    's3:GetReplicationConfiguration': 'bucketGetReplication',
-    's3:ListBucket': 'bucketHead',
-    's3:ListBucketMultipartUploads': 'listMultipartUploads',
-    's3:ListMultipartUploadParts': 'listParts',
-    's3:PutBucketAcl': 'bucketPutACL',
-    's3:PutBucketCORS': 'bucketPutCors',
-    's3:PutBucketObjectLockConfiguration': 'bucketPutObjectLock',
-    's3:PutBucketPolicy': 'bucketPutPolicy',
-    's3:PutBucketVersioning': 'bucketPutVersioning',
-    's3:PutBucketWebsite': 'bucketPutWebsite',
-    's3:PutLifecycleConfiguration': 'bucketPutLifecycle',
-    's3:PutObject': 'objectPut',
-    's3:PutObjectAcl': 'objectPutACL',
-    's3:PutObjectTagging': 'objectPutTagging',
-    's3:PutObjectLegalHold': 'objectPutLegalHold',
-    's3:PutObjectRetention': 'objectPutRetention',
-    's3:PutReplicationConfiguration': 'bucketPutReplication',
+    multipartDelete: 's3:AbortMultipartUpload',
+    bucketDelete: 's3:DeleteBucket',
+    bucketDeletePolicy: 's3:DeleteBucketPolicy',
+    bucketDeleteWebsite: 's3:DeleteBucketWebsite',
+    objectDelete: 's3:DeleteObject',
+    objectDeleteTagging: 's3:DeleteObjectTagging',
+    bucketGetACL: 's3:GetBucketAcl',
+    bucketGetCors: 's3:GetBucketCORS',
+    bucketGetLocation: 's3:GetBucketLocation',
+    bucketGetObjectLock: 's3:GetBucketObjectLockConfiguration',
+    bucketGetPolicy: 's3:GetBucketPolicy',
+    bucketGetVersioning: 's3:GetBucketVersioning',
+    bucketGetWebsite: 's3:GetBucketWebsite',
+    bucketGetLifecycle: 's3:GetLifecycleConfiguration',
+    objectGet: 's3:GetObject',
+    objectGetACL: 's3:GetObjectAcl',
+    objectGetLegalHold: 's3:GetObjectLegalHold',
+    objectGetRetention: 's3:GetObjectRetention',
+    objectGetTagging: 's3:GetObjectTagging',
+    bucketGetReplication: 's3:GetReplicationConfiguration',
+    bucketHead: 's3:ListBucket',
+    bucketGet: 's3:ListBucket',
+    listMultipartUploads: 's3:ListBucketMultipartUploads',
+    listParts: 's3:ListMultipartUploadParts',
+    bucketPutACL: 's3:PutBucketAcl',
+    bucketPutCors: 's3:PutBucketCORS',
+    bucketPutObjectLock: 's3:PutBucketObjectLockConfiguration',
+    bucketPutPolicy: 's3:PutBucketPolicy',
+    bucketPutVersioning: 's3:PutBucketVersioning',
+    bucketPutWebsite: 's3:PutBucketWebsite',
+    bucketPutLifecycle: 's3:PutLifecycleConfiguration',
+    objectPut: 's3:PutObject',
+    objectPutACL: 's3:PutObjectAcl',
+    objectPutTagging: 's3:PutObjectTagging',
+    objectPutLegalHold: 's3:PutObjectLegalHold',
+    objectPutRetention: 's3:PutObjectRetention',
+    bucketPutReplication: 's3:PutReplicationConfiguration',
 };
 
 // whitelist buckets to allow public read on objects
@@ -169,12 +170,11 @@ function checkObjectAcls(bucket, objectMD, requestType, canonicalID) {
 }
 
 function _checkActions(requestType, actions, log) {
+    const mappedAction = actionMap[requestType];
     // if requestType isn't in list of controlled actions
-    if (!Object.values(actionMap).includes(requestType)) {
+    if (!mappedAction) {
         return true;
     }
-    const mappedAction = Object.keys(actionMap)
-        [Object.values(actionMap).indexOf(requestType)];
     return evaluators.isActionApplicable(mappedAction, actions, log);
 }
 


### PR DESCRIPTION
Fixes bug caused by incorrect action mapping. `s3:ListBuckets` action corresponds to 2 APIs, `headBucket` and `listObjects`, so I reversed the map to allow for that. Tests in integration PR https://github.com/scality/Integration/pull/817