### PR TITLE
bugfix: S3C-3465 fix unit test errors in ms due to extra digits

### DIFF
--- a/tests/unit/api/apiUtils/objectLockHelpers.js
+++ b/tests/unit/api/apiUtils/objectLockHelpers.js
@@ -159,8 +159,8 @@ describe('objectLockHelpers: calculateRetainUntilDate', () => {
         const expectedRetainUntilDate
             = date.add(mockConfigWithDays.days, 'days');
         const retainUntilDate = calculateRetainUntilDate(mockConfigWithDays);
-        assert.strictEqual(retainUntilDate.slice(0, 20),
-            expectedRetainUntilDate.toISOString().slice(0, 20));
+        assert.strictEqual(retainUntilDate.slice(0, 16),
+            expectedRetainUntilDate.toISOString().slice(0, 16));
     });
 
     it('should calculate retainUntilDate for config with years', () => {
@@ -172,7 +172,7 @@ describe('objectLockHelpers: calculateRetainUntilDate', () => {
         const expectedRetainUntilDate
             = date.add(mockConfigWithYears.years * 365, 'days');
         const retainUntilDate = calculateRetainUntilDate(mockConfigWithYears);
-        assert.strictEqual(retainUntilDate.slice(0, 20),
-            expectedRetainUntilDate.toISOString().slice(0, 20));
+        assert.strictEqual(retainUntilDate.slice(0, 16),
+            expectedRetainUntilDate.toISOString().slice(0, 16));
     });
 });


### PR DESCRIPTION
Fixes falsely failing unit test I noticed a short while ago by getting rid of the extra digits which used to be taking the millisecond into account.

![Screen Shot 2020-10-09 at 7 03 30 PM](https://user-images.githubusercontent.com/62902974/97061251-18ef5280-154b-11eb-8a05-d4d9d206fc2f.png)
