### PR TITLE
INTEGRATION [PR#3087 > development/8.2] bugfix: S3C-3465 fix unit test errors in ms due to extra digits

### DIFF
--- a/tests/unit/api/apiUtils/objectLockHelpers.js
+++ b/tests/unit/api/apiUtils/objectLockHelpers.js
@@ -159,8 +159,8 @@ describe('objectLockHelpers: calculateRetainUntilDate', () => {
         const expectedRetainUntilDate
             = date.add(mockConfigWithDays.days, 'days');
         const retainUntilDate = calculateRetainUntilDate(mockConfigWithDays);
-        assert.strictEqual(retainUntilDate.slice(0, 20),
-            expectedRetainUntilDate.toISOString().slice(0, 20));
+        assert.strictEqual(retainUntilDate.slice(0, 16),
+            expectedRetainUntilDate.toISOString().slice(0, 16));
     });
 
     it('should calculate retainUntilDate for config with years', () => {
@@ -172,7 +172,7 @@ describe('objectLockHelpers: calculateRetainUntilDate', () => {
         const expectedRetainUntilDate
             = date.add(mockConfigWithYears.years * 365, 'days');
         const retainUntilDate = calculateRetainUntilDate(mockConfigWithYears);
-        assert.strictEqual(retainUntilDate.slice(0, 20),
-            expectedRetainUntilDate.toISOString().slice(0, 20));
+        assert.strictEqual(retainUntilDate.slice(0, 16),
+            expectedRetainUntilDate.toISOString().slice(0, 16));
     });
 });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3087.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/bugfix/S3C-3465-remove-extra-ms-digits`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/bugfix/S3C-3465-remove-extra-ms-digits
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/bugfix/S3C-3465-remove-extra-ms-digits
```

Please always comment pull request #3087 instead of this one.