### PR TITLE
INTEGRATION [PR#3100 > development/7.9] bf: S3C-3428 skip obj copy tests in e2e

### DIFF
--- a/tests/functional/aws-node-sdk/test/object/objectCopy.js
+++ b/tests/functional/aws-node-sdk/test/object/objectCopy.js
@@ -43,6 +43,8 @@ const content = 'I am the best content ever';
 const otherAccountBucketUtility = new BucketUtility('lisa', {});
 const otherAccountS3 = otherAccountBucketUtility.s3;
 
+const itSkipIfE2E = process.env.S3_END_TO_END ? it.skip : it;
+
 function checkNoError(err) {
     assert.equal(err, null,
         `Expected success, got error ${JSON.stringify(err)}`);
@@ -348,7 +350,8 @@ describe('Object Copy', () => {
                     );
             });
 
-        it('should not return error if copying object w/ > ' +
+        // TODO: see S3C-3482, figure out why this test fails in Integration builds
+        itSkipIfE2E('should not return error if copying object w/ > ' +
         '2KB user-defined md and COPY directive',
             done => {
                 const metadata = genMaxSizeMetaHeaders();
@@ -370,7 +373,8 @@ describe('Object Copy', () => {
                 });
             });
 
-        it('should return error if copying object w/ > 2KB ' +
+        // TODO: see S3C-3482, figure out why this test fails in Integration builds
+        itSkipIfE2E('should return error if copying object w/ > 2KB ' +
         'user-defined md and REPLACE directive',
             done => {
                 const metadata = genMaxSizeMetaHeaders();


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3100.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.9/bugfix/S3C-3428-skip-obj-copy-tests-e2e`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.9/bugfix/S3C-3428-skip-obj-copy-tests-e2e
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.9/bugfix/S3C-3428-skip-obj-copy-tests-e2e
```

Please always comment pull request #3100 instead of this one.