### PR TITLE
bf(S3C-3460): Increment numberOfObjects only on MPU completion

### DIFF
--- a/lib/api/initiateMultipartUpload.js
+++ b/lib/api/initiateMultipartUpload.js
@@ -161,7 +161,6 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
                             bucket: bucketName,
                             keys: [objectKey],
                             location: locConstraint,
-                            numberOfObjects: 1,
                         });
                         return callback(null, xml, corsHeaders);
                     });


### PR DESCRIPTION
`numberOfObjects` should only be incremented when `completeMultipartUpload` is called. Removes this to avoid double counting
