### PR TITLE
INTEGRATION [PR#3105 > development/7.8] bf(S3C-3460): Increment numberOfObjects only on MPU completion

### DIFF
--- a/lib/api/initiateMultipartUpload.js
+++ b/lib/api/initiateMultipartUpload.js
@@ -161,7 +161,6 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
                             bucket: bucketName,
                             keys: [objectKey],
                             location: locConstraint,
-                            numberOfObjects: 1,
                         });
                         return callback(null, xml, corsHeaders);
                     });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3105.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.8/bugfix/S3C-3460_increment_objDelta_only_on_mpu_completion`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.8/bugfix/S3C-3460_increment_objDelta_only_on_mpu_completion
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.8/bugfix/S3C-3460_increment_objDelta_only_on_mpu_completion
```

Please always comment pull request #3105 instead of this one.