### PR TITLE
Bugfix/s3 c 2687 acl invalid

### DIFF
--- a/lib/utilities/aclUtils.js
+++ b/lib/utilities/aclUtils.js
@@ -188,7 +188,7 @@ aclUtils.parseGrant = function parseGrant(grantHeader, grantType) {
 };
 
 aclUtils.isValidCanonicalId = function isValidCanonicalId(canonicalID) {
-    return /^[A-Za-z0-9]{64}$/.test(canonicalID);
+    return /^(?=.*?[a-f])(?=.*?[0-9])[a-f0-9]{64}$/.test(canonicalID);
 };
 
 aclUtils.reconstructUsersIdentifiedByEmail =


### PR DESCRIPTION
Tightens up our canonical id regex evaluation.