### PR TITLE
improvement: S3C-3653 add server ip, port to log

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -124,8 +124,9 @@ class S3Server {
                 address: ipAddress || '[::]',
                 port,
             };
-            logger.info('server started', { address: addr.address,
-                port: addr.port, pid: process.pid });
+            const { address } = addr;
+            logger.info('server started', { address, port,
+                pid: process.pid, serverIP: address, serverPort: port });
         });
         if (ipAddress !== undefined) {
             this.server.listen(port, ipAddress);


### PR DESCRIPTION
These fields are added to support transformation to LEEF log format
for S3C. It's redundant to the fields address and port but they are not
removed to maintain backwards compatibility.
