### PR TITLE
INTEGRATION [PR#3205 > development/8.2] bf: S3C-3313 add canonicalid for abortmpu metric

### DIFF
--- a/lib/api/apiUtils/bucket/bucketDeletion.js
+++ b/lib/api/apiUtils/bucket/bucketDeletion.js
@@ -23,7 +23,7 @@ function _deleteMPUbucket(destinationBucketName, log, cb) {
     });
 }
 
-function _deleteOngoingMPUs(authInfo, bucketName, mpus, log, cb) {
+function _deleteOngoingMPUs(authInfo, bucketName, bucketMD, mpus, log, cb) {
     async.mapLimit(mpus, 1, (mpu, next) => {
         const splitterChar = mpu.key.includes(oldSplitter) ?
             oldSplitter : splitter;
@@ -33,6 +33,7 @@ function _deleteOngoingMPUs(authInfo, bucketName, mpus, log, cb) {
             (err, destBucket, partSizeSum) => {
                 pushMetric('abortMultipartUpload', log, {
                     authInfo,
+                    canonicalID: bucketMD.getOwner(),
                     bucket: bucketName,
                     keys: [objectKey],
                     byteLength: partSizeSum,
@@ -98,7 +99,7 @@ function deleteBucket(authInfo, bucketMD, bucketName, canonicalID, log, cb) {
                     }
                     if (objectsListRes.Contents.length) {
                         return _deleteOngoingMPUs(authInfo, bucketName,
-                            objectsListRes.Contents, log, err => {
+                            bucketMD, objectsListRes.Contents, log, err => {
                                 if (err) {
                                     return next(err);
                                 }


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3205.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/bugfix/S3C-3313-fix-bucketdel-abortmpu`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/bugfix/S3C-3313-fix-bucketdel-abortmpu
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/bugfix/S3C-3313-fix-bucketdel-abortmpu
```

Please always comment pull request #3205 instead of this one.