### PR TITLE
INTEGRATION [PR#3238 > development/8.2] ft(S3C-3772): Add support for Utapiv2 client to communicate over TLS

### DIFF
--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -6,7 +6,12 @@ const { UtapiClient, utapiVersion } = require('utapi');
 const logger = require('../utilities/logger');
 const _config = require('../Config').config;
 // setup utapi client
-const utapi = new UtapiClient(_config.utapi);
+const enableClient = utapiVersion === 2 || !!_config.utapi;
+const utapi = new UtapiClient({
+    ..._config.utapi,
+    tls: _config.certFilePaths,
+    enableClient
+});
 
 const bucketOwnerMetrics = [
     'completeMultipartUpload',


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3238.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/feature/S3C-3772_add_utapiv2_client_tls_config_support`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/feature/S3C-3772_add_utapiv2_client_tls_config_support
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/feature/S3C-3772_add_utapiv2_client_tls_config_support
```

Please always comment pull request #3238 instead of this one.