### PR TITLE
INTEGRATION [PR#3238 > development/8.1] ft(S3C-3772): Add support for Utapiv2 client to communicate over TLS

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -13,6 +13,7 @@ const validateAuthConfig = require('arsenal').auth.inMemory.validateAuthConfig;
 const { buildAuthDataAccount } = require('./auth/in_memory/builder');
 const externalBackends = require('../constants').externalBackends;
 const { azureAccountNameRegex, base64Regex } = require('../constants');
+const { utapiVersion } = require('utapi');
 
 // whitelist IP, CIDR for health checks
 const defaultHealthChecks = { allowFrom: ['127.0.0.1/8', '::1'] };
@@ -737,137 +738,144 @@ class Config extends EventEmitter {
         }
         if (config.utapi) {
             this.utapi = { component: 's3' };
+            if (config.utapi.host) {
+                assert(typeof config.utapi.host === 'string',
+                    'bad config: utapi host must be a string');
+                this.utapi.host = config.utapi.host;
+            }
             if (config.utapi.port) {
                 assert(Number.isInteger(config.utapi.port)
                     && config.utapi.port > 0,
                     'bad config: utapi port must be a positive integer');
                 this.utapi.port = config.utapi.port;
             }
-            if (config.utapi.workers !== undefined) {
-                assert(Number.isInteger(config.utapi.workers)
-                    && config.utapi.workers > 0,
-                    'bad config: utapi workers must be a positive integer');
-                this.utapi.workers = config.utapi.workers;
-            }
-            // Utapi uses the same localCache config defined for S3 to avoid
-            // config duplication.
-            assert(config.localCache, 'missing required property of utapi ' +
-                'configuration: localCache');
-            this.utapi.localCache = config.localCache;
-            assert(config.utapi.redis, 'missing required property of utapi ' +
-                'configuration: redis');
-            if (config.utapi.redis.sentinels) {
-                this.utapi.redis = { sentinels: [], name: null };
+            if (utapiVersion === 1) {
+                if (config.utapi.workers !== undefined) {
+                    assert(Number.isInteger(config.utapi.workers)
+                        && config.utapi.workers > 0,
+                        'bad config: utapi workers must be a positive integer');
+                    this.utapi.workers = config.utapi.workers;
+                }
+                // Utapi uses the same localCache config defined for S3 to avoid
+                // config duplication.
+                assert(config.localCache, 'missing required property of utapi ' +
+                    'configuration: localCache');
+                this.utapi.localCache = config.localCache;
+                assert(config.utapi.redis, 'missing required property of utapi ' +
+                    'configuration: redis');
+                if (config.utapi.redis.sentinels) {
+                    this.utapi.redis = { sentinels: [], name: null };
 
-                assert(typeof config.utapi.redis.name === 'string',
-                    'bad config: redis sentinel name must be a string');
-                this.utapi.redis.name = config.utapi.redis.name;
+                    assert(typeof config.utapi.redis.name === 'string',
+                        'bad config: redis sentinel name must be a string');
+                    this.utapi.redis.name = config.utapi.redis.name;
 
-                assert(Array.isArray(config.utapi.redis.sentinels),
-                    'bad config: redis sentinels must be an array');
-                config.utapi.redis.sentinels.forEach(item => {
-                    const { host, port } = item;
-                    assert(typeof host === 'string',
-                        'bad config: redis sentinel host must be a string');
-                    assert(typeof port === 'number',
-                        'bad config: redis sentinel port must be a number');
-                    this.utapi.redis.sentinels.push({ host, port });
-                });
-            } else {
-                // check for standalone configuration
-                this.utapi.redis = {};
-                assert(typeof config.utapi.redis.host === 'string',
-                    'bad config: redis.host must be a string');
-                assert(typeof config.utapi.redis.port === 'number',
-                    'bad config: redis.port must be a number');
-                this.utapi.redis.host = config.utapi.redis.host;
-                this.utapi.redis.port = config.utapi.redis.port;
-            }
-            if (config.utapi.redis.password !== undefined) {
-                assert(
-                    this._verifyRedisPassword(config.utapi.redis.password),
-                    'config: invalid password for utapi redis. password' +
-                    ' must be a string');
-                this.utapi.redis.password = config.utapi.redis.password;
-            }
-            if (config.utapi.redis.sentinelPassword !== undefined) {
-                assert(
-                this._verifyRedisPassword(config.utapi.redis.sentinelPassword),
-                    'config: invalid password for utapi redis. password' +
-                    ' must be a string');
-                this.utapi.redis.sentinelPassword =
-                    config.utapi.redis.sentinelPassword;
-            }
-            if (config.utapi.metrics) {
-                this.utapi.metrics = config.utapi.metrics;
-            }
-            this.utapi.enabledOperationCounters = [];
-            if (config.utapi.enabledOperationCounters !== undefined) {
-                const { enabledOperationCounters } = config.utapi;
-                assert(Array.isArray(enabledOperationCounters),
-                    'bad config: utapi.enabledOperationCounters must be an ' +
-                    'array');
-                assert(enabledOperationCounters.length > 0,
-                    'bad config: utapi.enabledOperationCounters cannot be ' +
-                    'empty');
-                this.utapi.enabledOperationCounters = enabledOperationCounters;
-            }
-            this.utapi.disableOperationCounters = false;
-            if (config.utapi.disableOperationCounters !== undefined) {
-                const { disableOperationCounters } = config.utapi;
-                assert(typeof disableOperationCounters === 'boolean',
-                    'bad config: utapi.disableOperationCounters must be a ' +
-                    'boolean');
-                this.utapi.disableOperationCounters = disableOperationCounters;
-            }
-            if (config.utapi.disableOperationCounters !== undefined &&
-                config.utapi.enabledOperationCounters !== undefined) {
-                assert(config.utapi.disableOperationCounters === false,
-                    'bad config: conflicting rules: ' +
-                    'utapi.disableOperationCounters and ' +
-                    'utapi.enabledOperationCounters cannot both be ' +
-                    'specified');
-            }
-            if (config.utapi.component) {
-                this.utapi.component = config.utapi.component;
-            }
-            // (optional) The value of the replay schedule should be cron-style
-            // scheduling. For example, every five minutes: '*/5 * * * *'.
-            if (config.utapi.replaySchedule) {
-                assert(typeof config.utapi.replaySchedule === 'string', 'bad' +
-                    'config: utapi.replaySchedule must be a string');
-                this.utapi.replaySchedule = config.utapi.replaySchedule;
-            }
-            // (optional) The number of elements processed by each call to the
-            // Redis local cache during a replay. For example, 50.
-            if (config.utapi.batchSize) {
-                assert(typeof config.utapi.batchSize === 'number', 'bad' +
-                    'config: utapi.batchSize must be a number');
-                assert(config.utapi.batchSize > 0, 'bad config:' +
-                    'utapi.batchSize must be a number greater than 0');
-                this.utapi.batchSize = config.utapi.batchSize;
-            }
+                    assert(Array.isArray(config.utapi.redis.sentinels),
+                        'bad config: redis sentinels must be an array');
+                    config.utapi.redis.sentinels.forEach(item => {
+                        const { host, port } = item;
+                        assert(typeof host === 'string',
+                            'bad config: redis sentinel host must be a string');
+                        assert(typeof port === 'number',
+                            'bad config: redis sentinel port must be a number');
+                        this.utapi.redis.sentinels.push({ host, port });
+                    });
+                } else {
+                    // check for standalone configuration
+                    this.utapi.redis = {};
+                    assert(typeof config.utapi.redis.host === 'string',
+                        'bad config: redis.host must be a string');
+                    assert(typeof config.utapi.redis.port === 'number',
+                        'bad config: redis.port must be a number');
+                    this.utapi.redis.host = config.utapi.redis.host;
+                    this.utapi.redis.port = config.utapi.redis.port;
+                }
+                if (config.utapi.redis.password !== undefined) {
+                    assert(
+                        this._verifyRedisPassword(config.utapi.redis.password),
+                        'config: invalid password for utapi redis. password' +
+                        ' must be a string');
+                    this.utapi.redis.password = config.utapi.redis.password;
+                }
+                if (config.utapi.redis.sentinelPassword !== undefined) {
+                    assert(
+                    this._verifyRedisPassword(config.utapi.redis.sentinelPassword),
+                        'config: invalid password for utapi redis. password' +
+                        ' must be a string');
+                    this.utapi.redis.sentinelPassword =
+                        config.utapi.redis.sentinelPassword;
+                }
+                if (config.utapi.metrics) {
+                    this.utapi.metrics = config.utapi.metrics;
+                }
+                this.utapi.enabledOperationCounters = [];
+                if (config.utapi.enabledOperationCounters !== undefined) {
+                    const { enabledOperationCounters } = config.utapi;
+                    assert(Array.isArray(enabledOperationCounters),
+                        'bad config: utapi.enabledOperationCounters must be an ' +
+                        'array');
+                    assert(enabledOperationCounters.length > 0,
+                        'bad config: utapi.enabledOperationCounters cannot be ' +
+                        'empty');
+                    this.utapi.enabledOperationCounters = enabledOperationCounters;
+                }
+                this.utapi.disableOperationCounters = false;
+                if (config.utapi.disableOperationCounters !== undefined) {
+                    const { disableOperationCounters } = config.utapi;
+                    assert(typeof disableOperationCounters === 'boolean',
+                        'bad config: utapi.disableOperationCounters must be a ' +
+                        'boolean');
+                    this.utapi.disableOperationCounters = disableOperationCounters;
+                }
+                if (config.utapi.disableOperationCounters !== undefined &&
+                    config.utapi.enabledOperationCounters !== undefined) {
+                    assert(config.utapi.disableOperationCounters === false,
+                        'bad config: conflicting rules: ' +
+                        'utapi.disableOperationCounters and ' +
+                        'utapi.enabledOperationCounters cannot both be ' +
+                        'specified');
+                }
+                if (config.utapi.component) {
+                    this.utapi.component = config.utapi.component;
+                }
+                // (optional) The value of the replay schedule should be cron-style
+                // scheduling. For example, every five minutes: '*/5 * * * *'.
+                if (config.utapi.replaySchedule) {
+                    assert(typeof config.utapi.replaySchedule === 'string', 'bad' +
+                        'config: utapi.replaySchedule must be a string');
+                    this.utapi.replaySchedule = config.utapi.replaySchedule;
+                }
+                // (optional) The number of elements processed by each call to the
+                // Redis local cache during a replay. For example, 50.
+                if (config.utapi.batchSize) {
+                    assert(typeof config.utapi.batchSize === 'number', 'bad' +
+                        'config: utapi.batchSize must be a number');
+                    assert(config.utapi.batchSize > 0, 'bad config:' +
+                        'utapi.batchSize must be a number greater than 0');
+                    this.utapi.batchSize = config.utapi.batchSize;
+                }
 
-            // (optional) Expire bucket level metrics on delete bucket
-            // Disabled by default
-            this.utapi.expireMetrics = false;
-            if (config.utapi.expireMetrics !== undefined) {
-                assert(typeof config.utapi.expireMetrics === 'boolean', 'bad' +
-                    'config: utapi.expireMetrics must be a boolean');
-                this.utapi.expireMetrics = config.utapi.expireMetrics;
-            }
-            // (optional) TTL controlling the expiry for bucket level metrics
-            // keys when expireMetrics is enabled
-            this.utapi.expireMetricsTTL = 0;
-            if (config.utapi.expireMetricsTTL !== undefined) {
-                assert(typeof config.utapi.expireMetricsTTL === 'number',
-                    'bad config: utapi.expireMetricsTTL must be a number');
-                this.utapi.expireMetricsTTL = config.utapi.expireMetricsTTL;
-            }
+                // (optional) Expire bucket level metrics on delete bucket
+                // Disabled by default
+                this.utapi.expireMetrics = false;
+                if (config.utapi.expireMetrics !== undefined) {
+                    assert(typeof config.utapi.expireMetrics === 'boolean', 'bad' +
+                        'config: utapi.expireMetrics must be a boolean');
+                    this.utapi.expireMetrics = config.utapi.expireMetrics;
+                }
+                // (optional) TTL controlling the expiry for bucket level metrics
+                // keys when expireMetrics is enabled
+                this.utapi.expireMetricsTTL = 0;
+                if (config.utapi.expireMetricsTTL !== undefined) {
+                    assert(typeof config.utapi.expireMetricsTTL === 'number',
+                        'bad config: utapi.expireMetricsTTL must be a number');
+                    this.utapi.expireMetricsTTL = config.utapi.expireMetricsTTL;
+                }
 
-            if (config.utapi && config.utapi.reindex) {
-                parseUtapiReindex(config.utapi.reindex);
-                this.utapi.reindex = config.utapi.reindex;
+                if (config.utapi && config.utapi.reindex) {
+                    parseUtapiReindex(config.utapi.reindex);
+                    this.utapi.reindex = config.utapi.reindex;
+                }
             }
         }
 

--- a/lib/utapi/utapi.js
+++ b/lib/utapi/utapi.js
@@ -1,8 +1,8 @@
-const utapiServer = require('utapi').UtapiServer;
 const _config = require('../Config').config;
+const { utapiVersion, UtapiServer: utapiServer } = require('utapi');
 
 // start utapi server
-if (_config.utapi) {
+if (utapiVersion === 1 && _config.utapi) {
     const fullConfig = Object.assign({}, _config.utapi);
     if (_config.vaultd) {
         Object.assign(fullConfig, { vaultd: _config.vaultd });

--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -6,7 +6,15 @@ const { UtapiClient, utapiVersion } = require('utapi');
 const logger = require('../utilities/logger');
 const _config = require('../Config').config;
 // setup utapi client
-const utapi = new UtapiClient(_config.utapi);
+let utapiConfig;
+
+if (utapiVersion === 1 && _config.utapi) {
+    utapiConfig = Object.assign({}, _config.utapi);
+} else if (utapiVersion === 2) {
+    utapiConfig = Object.assign({ tls: _config.https }, _config.utapi || {});
+}
+
+const utapi = new UtapiClient(utapiConfig);
 
 const bucketOwnerMetrics = [
     'completeMultipartUpload',


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3238.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/feature/S3C-3772_add_utapiv2_client_tls_config_support`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/feature/S3C-3772_add_utapiv2_client_tls_config_support
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/feature/S3C-3772_add_utapiv2_client_tls_config_support
```

Please always comment pull request #3238 instead of this one.