### PR TITLE
bf: S3C-3416: data backend uuid when delete

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -251,7 +251,9 @@ const services = {
                         return cb(err, res);
                     }
                     log.trace('deleteObject: metadata delete OK');
-                    const deleteLog = logger.newRequestLogger();
+                    const deleteLog =
+                        logger.newRequestLoggerFromSerializedUids(
+                            log.getSerializedUids());
                     if (objectMD.location === null) {
                         return cb(null, res);
                     } else if (!Array.isArray(objectMD.location)) {


### PR DESCRIPTION
## Description
A new logger was created for service delete
operations without propagating logger uuid,
leading to some issue with tracking the
further requests.

### Motivation and context
Better track of requests

### Related issues
S3C-3416
