### PR TITLE
INTEGRATION [PR#3282 > development/8.1] bugfix: S3C-3860: object put write continue too early

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -128,12 +128,13 @@ const api = {
                     }
                 }
             }
-            // issue 100 Continue to the client
-            writeContinue(request, response);
             if (apiMethod === 'objectPut' || apiMethod === 'objectPutPart') {
+                request._response = response;
                 return this[apiMethod](userInfo, request, streamingV4Params,
                     log, callback);
             }
+            // issue 100 Continue to the client
+            writeContinue(request, response);
             const MAX_POST_LENGTH = request.method.toUpperCase() === 'POST' ?
                 1024 * 1024 : 1024 * 1024 / 2; // 1 MB or 512 KB
             const post = [];

--- a/lib/api/objectPut.js
+++ b/lib/api/objectPut.js
@@ -10,6 +10,7 @@ const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
 const kms = require('../kms/wrapper');
 
+const writeContinue = require('../utilities/writeContinue');
 const versionIdUtils = versioning.VersionID;
 
 /**
@@ -80,6 +81,7 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
                 return next(null, null);
             },
             function objectCreateAndStore(cipherBundle, next) {
+                writeContinue(request, request._response);
                 return createAndStoreObject(bucketName,
                 bucket, objectKey, objMD, authInfo, canonicalID, cipherBundle,
                 request, false, streamingV4Params, log, next);

--- a/lib/api/objectPutPart.js
+++ b/lib/api/objectPutPart.js
@@ -16,7 +16,7 @@ const { config } = require('../Config');
 const multipleBackendGateway = require('../data/multipleBackendGateway');
 const locationConstraintCheck
     = require('./apiUtils/object/locationConstraintCheck');
-
+const writeContinue = require('../utilities/writeContinue');
 const skipError = new Error('skip');
 
 // We pad the partNumbers so that the parts will be sorted in numerical order.
@@ -113,6 +113,7 @@ function objectPutPart(authInfo, request, streamingV4Params, log,
                 log.debug('access denied for user on bucket', { requestType });
                 return next(errors.AccessDenied, destinationBucket);
             }
+            writeContinue(request, request._response);
             return next(null, destinationBucket);
         },
         // Get bucket server-side encryption, if it exists.

--- a/tests/functional/aws-node-sdk/test/object/100-continue.js
+++ b/tests/functional/aws-node-sdk/test/object/100-continue.js
@@ -19,6 +19,7 @@ const describeSkipIfE2E = process.env.S3_END_TO_END ? describe.skip : describe;
 class ContinueRequestHandler {
     constructor(path) {
         this.path = path;
+        this.expectHeader = '100-continue';
         return this;
     }
 
@@ -40,7 +41,7 @@ class ContinueRequestHandler {
             method: 'PUT',
             headers: {
                 'content-length': body.length,
-                'Expect': this.expectHeader || '100-continue',
+                'Expect': this.expectHeader,
             },
         };
     }
@@ -49,11 +50,15 @@ class ContinueRequestHandler {
         const options = this.getRequestOptions();
         process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
         const req = transport.request(options, res => {
-            assert.strictEqual(res.statusCode, statusCode);
-            return cb();
+            res.on('data', () => {});
+            res.on('end', () => {
+                assert.strictEqual(res.statusCode, statusCode);
+                return cb();
+            });
         });
         // Send the body either on the continue event, or immediately.
         if (this.expectHeader === '100-continue') {
+            req.flushHeaders();
             req.on('continue', () => req.end(body));
         } else {
             req.end(body);
@@ -64,25 +69,50 @@ class ContinueRequestHandler {
         const options = this.getRequestOptions();
         process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
         const req = transport.request(options);
+        req.flushHeaders();
         // At this point we have only sent the header.
-        assert(req.output.length === 1);
-        const headerLen = req.output[0].length;
+        const headerLen = req._header.length;
         req.on('continue', () => {
             // Has only the header been sent?
             assert.strictEqual(req.socket.bytesWritten, headerLen);
             // Send the body since the continue event has been emitted.
             return req.end(body);
         });
-        req.on('close', () => {
-            const expected = body.length + headerLen;
-            // Has the entire body been sent?
-            assert.strictEqual(req.socket.bytesWritten, expected);
-            return cb();
+        req.on('response', res => {
+            res.on('data', () => {});
+            res.on('end', () => {
+                const expected = body.length + headerLen;
+                // Has the entire body been sent?
+                assert.strictEqual(req.socket.bytesWritten, expected);
+                return cb();
+            });
+            res.on('error', err => cb(err));
+        });
+        req.on('error', err => cb(err));
+    }
+
+    shouldNotGetContinue(cb) {
+        const options = this.getRequestOptions();
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+        const req = transport.request(options);
+        req.flushHeaders();
+        // At this point we have only sent the header.
+        const headerLen = req._header.length;
+        req.on('continue', () =>
+            cb('Continue beeing seen when 403 is expected'));
+        req.on('response', res => {
+            res.on('data', () => {});
+            res.on('end', () => {
+                const expected = headerLen;
+                assert.strictEqual(req.socket.bytesWritten, expected);
+                return cb();
+            });
+            res.on('error', err => cb(err));
         });
         req.on('error', err => cb(err));
     }
 }
-// TODO: S3C-3063
+
 describeSkipIfE2E('PUT public object with 100-continue header', () => {
     withV4(sigCfg => {
         let bucketUtil;
@@ -125,8 +155,8 @@ describeSkipIfE2E('PUT public object with 100-continue header', () => {
         it('should wait for continue event before sending body', done =>
             continueRequest.sendsBodyOnContinue(done));
 
-        it('should continue if a public user', done =>
+        it('should not send continue if denied for a public user', done =>
             continueRequest.setRequestPath(invalidSignedURL)
-                .sendsBodyOnContinue(done));
+                .shouldNotGetContinue(done));
     });
 });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3282.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-3860-put-object-continue-too-early`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-3860-put-object-continue-too-early
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-3860-put-object-continue-too-early
```

Please always comment pull request #3282 instead of this one.