### PR TITLE
ft: S3C-2767 bucket policy not implemented error

### DIFF
--- a/lib/api/bucketPutPolicy.js
+++ b/lib/api/bucketPutPolicy.js
@@ -9,6 +9,20 @@ const { validatePolicyResource } =
 const { BucketPolicy } = models;
 
 /**
+ * _checkNotImplementedPolicy - some bucket policy features have not been
+ * implemented and should return NotImplemented error
+ * @param {string} policyString - string bucket policy
+ * @return {boolean} - returns true if policy contains not implemented elements
+ */
+function _checkNotImplementedPolicy(policyString) {
+    // bucket names and key names cannot include "", so including those
+    // isolates not implemented keys
+    return policyString.includes('"Condition"')
+    || policyString.includes('"Service"')
+    || policyString.includes('"Federated"');
+}
+
+/**
  * bucketPutPolicy - create or update a bucket policy
  * @param {AuthInfo} authInfo - Instance of AuthInfo class with requester's info
  * @param {object} request - http request object
@@ -33,6 +47,11 @@ function bucketPutPolicy(authInfo, request, log, callback) {
             // returned policyObj will contain 'error' key
             process.nextTick(() => {
                 const policyObj = bucketPolicy.getBucketPolicy();
+                if (_checkNotImplementedPolicy(request.post)) {
+                    const err = errors.NotImplemented.customizeDescription(
+                        'Bucket policy contains element not yet implemented');
+                    return next(err);
+                }
                 if (policyObj.error) {
                     const err = errors.MalformedPolicy.customizeDescription(
                         policyObj.error.description);

--- a/tests/unit/api/bucketPutPolicy.js
+++ b/tests/unit/api/bucketPutPolicy.js
@@ -17,18 +17,7 @@ const testBucketPutRequest = {
     url: '/',
 };
 
-const expectedBucketPolicy = {
-    Version: '2012-10-17',
-    Statement: [
-        {
-            Effect: 'Allow',
-            Resource: `arn:aws:s3:::${bucketName}`,
-            Principal: '*',
-            Action: ['s3:GetBucketLocation'],
-        },
-    ],
-};
-
+let expectedBucketPolicy = {};
 function getPolicyRequest(policy) {
     return {
         bucketName,
@@ -41,7 +30,20 @@ function getPolicyRequest(policy) {
 
 describe('putBucketPolicy API', () => {
     before(() => cleanup());
-    beforeEach(done => bucketPut(authInfo, testBucketPutRequest, log, done));
+    beforeEach(done => {
+        expectedBucketPolicy = {
+            Version: '2012-10-17',
+            Statement: [
+                {
+                    Effect: 'Allow',
+                    Resource: `arn:aws:s3:::${bucketName}`,
+                    Principal: '*',
+                    Action: ['s3:GetBucketLocation'],
+                },
+            ],
+        };
+        bucketPut(authInfo, testBucketPutRequest, log, done);
+    });
     afterEach(() => cleanup());
 
     it('should update a bucket\'s metadata with bucket policy obj', done => {
@@ -71,6 +73,35 @@ describe('putBucketPolicy API', () => {
             assert.strictEqual(err.MalformedPolicy, true);
             assert.strictEqual(err.description, 'Policy has invalid resource');
             return done();
+        });
+    });
+
+    it('should return error if policy contains conditions', done => {
+        expectedBucketPolicy.Statement[0].Condition =
+            { StringEquals: { 's3:x-amz-acl': ['public-read'] } };
+        bucketPutPolicy(authInfo, getPolicyRequest(expectedBucketPolicy), log,
+        err => {
+            assert.strictEqual(err.NotImplemented, true);
+            done();
+        });
+    });
+
+    it('should return error if policy contains service principal', done => {
+        expectedBucketPolicy.Statement[0].Principal = { Service: ['test.com'] };
+        bucketPutPolicy(authInfo, getPolicyRequest(expectedBucketPolicy), log,
+        err => {
+            assert.strictEqual(err.NotImplemented, true);
+            done();
+        });
+    });
+
+    it('should return error if policy contains federated principal', done => {
+        expectedBucketPolicy.Statement[0].Principal =
+            { Federated: 'www.test.com' };
+        bucketPutPolicy(authInfo, getPolicyRequest(expectedBucketPolicy), log,
+        err => {
+            assert.strictEqual(err.NotImplemented, true);
+            done();
         });
     });
 });


### PR DESCRIPTION
Makes PutBucketPolicy API return a NotImplemented error if the user attempts to put a condition, federated principal, or service principal in the bucket policy instead of MalformedXML.

Not the absolute most elegant solution, but this way nothing in Arsenal is impacted (which would have required enough work that we could have just implemented conditions x) ), and it will be easy to remove once those keys are implemented.