### PR TITLE
INTEGRATION [PR#3322 > development/8.1] bugfix: S3C-3904: better s3 action logs

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -51,15 +51,20 @@ const validateQueryAndHeaders = require('../utilities/validateQueryAndHeaders');
 const parseCopySource = require('./apiUtils/object/parseCopySource');
 
 const actionMap = policies.actionMaps.actionMapS3;
+const monitoringMap = policies.actionMaps.actionMonitoringMapS3;
 
 auth.setHandler(vault);
 
 /* eslint-disable no-param-reassign */
 const api = {
     callApiMethod(apiMethod, request, response, log, callback) {
+        let actionLog = actionMap[apiMethod];
+        if (monitoringMap[apiMethod]) {
+            actionLog = monitoringMap[apiMethod];
+        }
         log.addDefaultFields({
             service: 's3',
-            action: actionMap[apiMethod],
+            action: actionLog,
             bucketName: request.bucketName,
         });
         if (request.objectKey) {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "github:scality/Arsenal#7358bd1",
+    "arsenal": "github:scality/Arsenal#9484366",
     "async": "~2.5.0",
     "aws-sdk": "2.831.0",
     "azure-storage": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -308,6 +308,32 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "2.0.0"
 
+"arsenal@github:scality/Arsenal#9484366":
+  version "7.5.0"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/9484366844d99280356854a385f4b6f5c2807948"
+  dependencies:
+    "@hapi/joi" "^15.1.0"
+    JSONStream "^1.0.0"
+    agentkeepalive "^4.1.3"
+    ajv "6.12.2"
+    async "~2.1.5"
+    debug "~2.6.9"
+    diskusage "^1.1.1"
+    ioredis "4.9.5"
+    ipaddr.js "1.9.1"
+    level "~5.0.1"
+    level-sublevel "~6.6.5"
+    node-forge "^0.7.1"
+    simple-glob "^0.2"
+    socket.io "~2.3.0"
+    socket.io-client "~2.3.0"
+    utf8 "2.1.2"
+    uuid "^3.0.1"
+    werelogs scality/werelogs#0ff7ec82
+    xml2js "~0.4.23"
+  optionalDependencies:
+    ioctl "2.0.0"
+
 arsenal@scality/Arsenal#9f2e74e:
   version "7.4.3"
   resolved "https://codeload.github.com/scality/Arsenal/tar.gz/9f2e74ec6972527c2a9ca6ecb4155618f123fc19"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3322.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-3904-better-s3-action-logs`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-3904-better-s3-action-logs
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-3904-better-s3-action-logs
```

Please always comment pull request #3322 instead of this one.