### PR TITLE
ZENKO-3230: fix Orbit instance registration request

### DIFF
--- a/lib/management/credentials.js
+++ b/lib/management/credentials.js
@@ -37,7 +37,7 @@ function issueCredentials(managementEndpoint, instanceId, log, callback) {
     };
 
     request.post(`${managementEndpoint}/${instanceId}/register`,
-        { body: postData }, (error, response, body) => {
+        { body: postData, json: true }, (error, response, body) => {
             if (error) {
                 return callback(error);
             }

--- a/lib/management/poll.js
+++ b/lib/management/poll.js
@@ -66,12 +66,15 @@ function applyConfigurationOverlay(
     });
 }
 
-function postStats(managementEndpoint, instanceId, remoteToken, next) {
+function postStats(managementEndpoint, instanceId, remoteToken, report, next) {
     const toURL = `${managementEndpoint}/${instanceId}/stats`;
     const toOptions = {
+        json: true,
         headers: {
+            'content-type': 'application/json',
             'x-instance-authentication-token': remoteToken,
         },
+        body: report,
     };
     const toCallback = (err, response, body) => {
         if (err) {
@@ -87,26 +90,41 @@ function postStats(managementEndpoint, instanceId, remoteToken, next) {
             next(null, instanceId, remoteToken);
         }
     };
-    return request.post(toURL, toOptions, toCallback).json();
+    return request.post(toURL, toOptions, toCallback);
 }
 
-function getStats() {
+function getStats(next) {
     const fromURL = `http://localhost:${_config.port}/_/report`;
     const fromOptions = {
-        json: true,
         headers: {
             'x-scal-report-token': process.env.REPORT_TOKEN,
         },
     };
-    return request.get(fromURL, fromOptions);
+    return request.get(fromURL, fromOptions, next);
 }
 
 function pushStats(managementEndpoint, instanceId, remoteToken, next) {
     if (process.env.PUSH_STATS === 'false') {
         return;
     }
-    getStats().pipe(
-        postStats(managementEndpoint, instanceId, remoteToken, next));
+
+    getStats((err, res, report) => {
+        if (err) {
+            logger.info('could not retrieve stats', { error: err });
+            return;
+        }
+
+        logger.debug('report', { report });
+        postStats(
+            managementEndpoint,
+            instanceId,
+            remoteToken,
+            report,
+            next
+        );
+        return;
+    });
+
     setTimeout(pushStats, pushReportDelay,
         managementEndpoint, instanceId, remoteToken);
 }

--- a/tests/unit/utils/request.js
+++ b/tests/unit/utils/request.js
@@ -89,7 +89,7 @@ function handlePostRequest(req, res, expected) {
         if (rawData !== expected) {
             return respondWithError(req, res, 400, 'incorrect body value');
         }
-        res.write('post completed');
+        res.write('{"body": "post completed"}');
         return res.end();
     });
 }
@@ -300,7 +300,7 @@ function createTestServer(proto, hostname, port, handler, callback) {
                     (err, res, body) => {
                         assert.ifError(err);
                         assert.equal(res.statusCode, 200);
-                        assert.equal(body, 'post completed');
+                        assert.equal(body, '{"body": "post completed"}');
                         done();
                     });
             });
@@ -310,7 +310,7 @@ function createTestServer(proto, hostname, port, handler, callback) {
                     (err, res, body) => {
                         assert.ifError(err);
                         assert.equal(res.statusCode, 200);
-                        assert.equal(body, 'post completed');
+                        assert.equal(body, '{"body": "post completed"}');
                         done();
                     });
             });
@@ -320,7 +320,20 @@ function createTestServer(proto, hostname, port, handler, callback) {
                     (err, res, body) => {
                         assert.ifError(err);
                         assert.equal(res.statusCode, 200);
-                        assert.equal(body, 'post completed');
+                        assert.equal(body, '{"body": "post completed"}');
+                        done();
+                    });
+            });
+
+            it('should post with json data (json response)', done => {
+                request.post(`${host}/postjson`,
+                    { body: { key: 'value' }, json: true },
+                    (err, res, body) => {
+                        assert.ifError(err);
+                        assert.equal(res.statusCode, 200);
+                        assert.deepStrictEqual(body, {
+                            body: 'post completed',
+                        });
                         done();
                     });
             });


### PR DESCRIPTION
fixes issue where the registration response is stored as a string; add
`json` option to registration request in order parse response body as an
object.

# Pull request template

## Description

### Motivation and context

Why is this change required? What problem does it solve?

### Related issues

Please use the following link syntaxes #600 to reference issues in the
current repository

## Checklist

### Add tests to cover the changes

New tests added or existing tests modified to cover all changes

### Code conforms with the [style guide](https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#coding-style-guidelines)

### Sign your work

In order to contribute to the project, you must sign your work
https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#sign-your-work

Thank you again for contributing! We will try to test and integrate the change
as soon as we can.
