### PR TITLE
bf(S3C-4134): Prevent NaN sizeDelta from completeMultipartUpload

### DIFF
--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -264,8 +264,16 @@ function pushMetric(action, log, metricObj) {
 
     if (utapiVersion === 2) {
         const incomingBytes = action === 'getObject' ? 0 : newByteLength;
-        const sizeDelta = oldByteLength ? newByteLength - oldByteLength :
-            incomingBytes;
+        let sizeDelta = incomingBytes;
+        if (Number.isInteger(oldByteLength) && Number.isInteger(newByteLength)) {
+            sizeDelta = newByteLength - oldByteLength;
+            // Include oldByteLength in conditional so we don't end up with `-0`
+        } else if (action === 'completeMultipartUpload' && !versionId && oldByteLength) {
+            // If this is a non-versioned bucket we need to decrement
+            // the sizeDelta added by uploadPart when completeMPU is called.
+            sizeDelta = -oldByteLength;
+        }
+
         const utapiObj = {
             operationId: action,
             bucket,

--- a/tests/utapi/awsNodeSdk.js
+++ b/tests/utapi/awsNodeSdk.js
@@ -372,4 +372,68 @@ describe('utapi v2 metrics incoming and outgoing bytes', function t() {
             next => deleteBucket(bucket, next),
         ], done);
     });
+    it('should set metrics for multipartUpload in a versioned bucket', done => {
+        const bucket = 'bucket8';
+        const partSize = 1024 * 1024 * 6;
+        const parts = 2;
+        const key = '8.txt';
+        async.series([
+            next => createBucket(bucket, next),
+            next => enableVersioning(bucket, true, next),
+            next => objectMPU(bucket, key, parts, partSize, next),
+            next => wait(WAIT_MS, () => {
+                checkMetrics(partSize * parts, 0, 1);
+                next();
+            }),
+            next => removeVersions([bucket], next),
+            next => wait(WAIT_MS, () => {
+                checkMetrics(0, 0, 0);
+                next();
+            }),
+            next => deleteBucket(bucket, next),
+        ], done);
+    });
+    it('should set metrics for multipartUpload overwrite in a versioned bucket', done => {
+        const bucket = 'bucket9';
+        const partSize = 1024 * 1024 * 6;
+        const parts = 2;
+        const key = '9.txt';
+        async.series([
+            next => createBucket(bucket, next),
+            next => enableVersioning(bucket, true, next),
+            next => objectMPU(bucket, key, parts, partSize, next),
+            next => objectMPU(bucket, key, parts, partSize, next),
+            next => wait(WAIT_MS, () => {
+                checkMetrics(partSize * parts * 2, 0, 2);
+                next();
+            }),
+            next => removeVersions([bucket], next),
+            next => wait(WAIT_MS, () => {
+                checkMetrics(0, 0, 0);
+                next();
+            }),
+            next => deleteBucket(bucket, next),
+        ], done);
+    });
+    it('should set metrics for multiPartUpload overwrite', done => {
+        const bucket = 'bucket10';
+        const partSize = 1024 * 1024 * 6;
+        const parts = 2;
+        const key = '10.txt';
+        async.series([
+            next => createBucket(bucket, next),
+            next => objectMPU(bucket, key, parts, partSize, next),
+            next => objectMPU(bucket, key, parts, partSize, next),
+            next => wait(WAIT_MS, () => {
+                checkMetrics(partSize * parts, 0, 1);
+                next();
+            }),
+            next => deleteObject(bucket, key, next),
+            next => wait(WAIT_MS, () => {
+                checkMetrics(0, 0, 0);
+                next();
+            }),
+            next => deleteBucket(bucket, next),
+        ], done);
+    });
 });


### PR DESCRIPTION
completeMultipartUpload does not pass a value for `newByteSize` leading to a `NaN` value for `sizeDelta` being computed, which cause a validation error on metric push.