### PR TITLE
INTEGRATION [PR#3443 > development/7.9] bf(S3C-4138): Decrement storage counter when abortMultipartUpload is …

### DIFF
--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -272,6 +272,8 @@ function pushMetric(action, log, metricObj) {
             // If this is a non-versioned bucket we need to decrement
             // the sizeDelta added by uploadPart when completeMPU is called.
             sizeDelta = -oldByteLength;
+        } else if (action === 'abortMultipartUpload' && byteLength) {
+            sizeDelta = -byteLength;
         }
 
         const utapiObj = {

--- a/tests/utapi/utilities.js
+++ b/tests/utapi/utilities.js
@@ -100,7 +100,7 @@ const testEvents = [{
     },
     expected: {
         objectDelta: undefined,
-        sizeDelta: undefined,
+        sizeDelta: -26,
         incomingBytes: undefined,
         outgoingBytes: 0,
     },


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3443.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.9/bugfix/S3C-4138_fix_aborted_mpu_metrics`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.9/bugfix/S3C-4138_fix_aborted_mpu_metrics
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.9/bugfix/S3C-4138_fix_aborted_mpu_metrics
```

Please always comment pull request #3443 instead of this one.