### PR TITLE
bugfix: ZENKO-3294 use correctly formatted utapi local cache sentinel…

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -963,7 +963,7 @@ class Config extends EventEmitter {
                 // config duplication.
                 assert(config.localCache, 'missing required property of utapi ' +
                     'configuration: localCache');
-                this.utapi.localCache = config.localCache;
+                this.utapi.localCache = this.localCache;
                 assert(config.redis, 'missing required property of utapi ' +
                     'configuration: redis');
                 if (config.utapi.redis) {

--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -10,7 +10,11 @@ const { suppressedUtapiEventFields: suppressedEventFields } = require('../../con
 let utapiConfig;
 
 if (utapiVersion === 1 && _config.utapi) {
-    utapiConfig = Object.assign({}, _config.utapi, { redis: _config.redis });
+    if (_config.utapi.redis === undefined) {
+        utapiConfig = Object.assign({}, _config.utapi, { redis: _config.redis });
+    } else {
+        utapiConfig = Object.assign({}, _config.utapi);
+    }
 } else if (utapiVersion === 2) {
     utapiConfig = Object.assign({
         tls: _config.https,

--- a/tests/unit/Config.js
+++ b/tests/unit/Config.js
@@ -1,3 +1,5 @@
+const assert = require('assert');
+
 describe('Config', () => {
     it('should load default config.json without errors', done => {
         require('../../lib/Config');
@@ -16,5 +18,47 @@ describe('Config', () => {
             return done();
         }
         return done(new Error('authdata-update event was not emitted'));
+    });
+
+    describe('utapi option setup', () => {
+        let oldConfig;
+
+        before(() => {
+            oldConfig = process.env.S3_CONFIG_FILE;
+            process.env.S3_CONFIG_FILE =
+                'tests/unit/testConfigs/allOptsConfig/config.json';
+        });
+
+        after(() => {
+            process.env.S3_CONFIG_FILE = oldConfig;
+        });
+
+        it('should set up utapi local cache', () => {
+            const { ConfigObject } = require('../../lib/Config');
+            const config = new ConfigObject();
+
+            assert.deepStrictEqual(
+                config.localCache,
+                { name: 'zenko', sentinels: [{ host: 'localhost', port: 6379 }] },
+            );
+            assert.deepStrictEqual(
+                config.utapi.localCache,
+                config.localCache,
+            );
+        });
+
+        it('should set up utapi redis', () => {
+            const { ConfigObject } = require('../../lib/Config');
+            const config = new ConfigObject();
+
+            assert.deepStrictEqual(
+                config.redis,
+                { name: 'zenko', sentinels: [{ host: 'localhost', port: 6379 }] },
+            );
+            assert.deepStrictEqual(
+                config.utapi.redis,
+                { host: 'localhost', port: 6379 },
+            );
+        });
     });
 });

--- a/tests/unit/testConfigs/allOptsConfig/config.json
+++ b/tests/unit/testConfigs/allOptsConfig/config.json
@@ -91,5 +91,19 @@
         "caBundle": "tests/unit/testConfigs/allOptsConfig/caBundle.txt",
         "key": "tests/unit/testConfigs/allOptsConfig/key.txt",
         "cert": "tests/unit/testConfigs/allOptsConfig/cert.txt"
+    },
+    "localCache": {
+        "name": "zenko",
+        "sentinels": "localhost:6379"
+    },
+    "redis": {
+        "name": "zenko",
+        "sentinels": "localhost:6379"
+    },
+    "utapi": {
+        "redis": {
+            "host": "localhost",
+            "port": 6379
+        }
     }
 }


### PR DESCRIPTION
# Pull request template

## Description

Fixes utapi `localCache` option where `sentinel` is not correctly formatted.

### Motivation and context

Why is this change required? What problem does it solve?

fixes ZENKO-3294

### Related issues

Please use the following link syntaxes #600 to reference issues in the
current repository

## Checklist

### Add tests to cover the changes

New tests added or existing tests modified to cover all changes

### Code conforms with the [style guide](https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#coding-style-guidelines)

### Sign your work

In order to contribute to the project, you must sign your work
https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#sign-your-work

Thank you again for contributing! We will try to test and integrate the change
as soon as we can.
