### PR TITLE
INTEGRATION [PR#3455 > development/7.9] bf(S3C-4166): putDeleteMarkerObject should increment numberOfObjects

### DIFF
--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -276,11 +276,17 @@ function pushMetric(action, log, metricObj) {
             sizeDelta = -byteLength;
         }
 
+        let objectDelta = isDelete ? -numberOfObjects : numberOfObjects;
+        // putDeleteMarkerObject does not pass numberOfObjects
+        if (action === 'putDeleteMarkerObject') {
+            objectDelta = 1;
+        }
+
         const utapiObj = {
             operationId: action,
             bucket,
             location,
-            objectDelta: isDelete ? -numberOfObjects : numberOfObjects,
+            objectDelta,
             sizeDelta: isDelete ? -byteLength : sizeDelta,
             incomingBytes,
             outgoingBytes: action === 'getObject' ? newByteLength : 0,


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3455.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.9/bugfix/S3C-4166_putDeleteMarkerObject_increments_numberOfObjects`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.9/bugfix/S3C-4166_putDeleteMarkerObject_increments_numberOfObjects
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.9/bugfix/S3C-4166_putDeleteMarkerObject_increments_numberOfObjects
```

Please always comment pull request #3455 instead of this one.