### PR TITLE
INTEGRATION [PR#3455 > development/7.9] bf(S3C-4166): putDeleteMarkerObject should increment numberOfObjects

### DIFF
--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -495,6 +495,9 @@ function multiObjectDelete(authInfo, request, log, callback) {
         const xml = _formatXML(quietSetting, errorResults,
             successfullyDeleted);
         const deletedKeys = successfullyDeleted.map(item => item.key);
+        const removedDeleteMarkers = successfullyDeleted
+            .filter(item => item.isDeleteMarker && item.entry && item.entry.versionId)
+            .length;
         pushMetric('multiObjectDelete', log, {
             authInfo,
             canonicalID: bucket ? bucket.getOwner() : '',
@@ -502,6 +505,7 @@ function multiObjectDelete(authInfo, request, log, callback) {
             keys: deletedKeys,
             byteLength: Number.parseInt(totalContentLengthDeleted, 10),
             numberOfObjects: numOfObjectsRemoved,
+            removedDeleteMarkers,
             isDelete: true,
         });
         return callback(null, xml, corsHeaders);

--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -276,11 +276,17 @@ function pushMetric(action, log, metricObj) {
             sizeDelta = -byteLength;
         }
 
+        let objectDelta = isDelete ? -numberOfObjects : numberOfObjects;
+        // putDeleteMarkerObject does not pass numberOfObjects
+        if (action === 'putDeleteMarkerObject') {
+            objectDelta = 1;
+        }
+
         const utapiObj = {
             operationId: action,
             bucket,
             location,
-            objectDelta: isDelete ? -numberOfObjects : numberOfObjects,
+            objectDelta,
             sizeDelta: isDelete ? -byteLength : sizeDelta,
             incomingBytes,
             outgoingBytes: action === 'getObject' ? newByteLength : 0,

--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -260,6 +260,7 @@ function pushMetric(action, log, metricObj) {
         canonicalID,
         location,
         isDelete,
+        removedDeleteMarkers,
     } = metricObj;
 
     if (utapiVersion === 2) {
@@ -280,6 +281,8 @@ function pushMetric(action, log, metricObj) {
         // putDeleteMarkerObject does not pass numberOfObjects
         if (action === 'putDeleteMarkerObject') {
             objectDelta = 1;
+        } else if (action === 'multiObjectDelete') {
+            objectDelta = -(numberOfObjects + removedDeleteMarkers)
         }
 
         const utapiObj = {

--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -282,7 +282,7 @@ function pushMetric(action, log, metricObj) {
         if (action === 'putDeleteMarkerObject') {
             objectDelta = 1;
         } else if (action === 'multiObjectDelete') {
-            objectDelta = -(numberOfObjects + removedDeleteMarkers)
+            objectDelta = -(numberOfObjects + removedDeleteMarkers);
         }
 
         const utapiObj = {

--- a/tests/utapi/awsNodeSdk.js
+++ b/tests/utapi/awsNodeSdk.js
@@ -330,6 +330,36 @@ describe('utapi v2 metrics incoming and outgoing bytes', function t() {
             next => deleteBucket(bucket, next),
         ], done);
     });
+    it('should set metrics for multiObjectDelete in a versioned bucket', done => {
+        const bucket = 'bucket5';
+        const objectSize = 1024 * 1024;
+        const obj1Size = objectSize * 2;
+        const obj2Size = objectSize * 1;
+        const key1 = '1.txt';
+        const key2 = '2.txt';
+        async.series([
+            next => createBucket(bucket, next),
+            next => enableVersioning(bucket, true, next),
+            next => putObject(bucket, key1, obj1Size, next),
+            next => wait(WAIT_MS, next),
+            next => putObject(bucket, key2, obj2Size, next),
+            next => wait(WAIT_MS, () => {
+                checkMetrics(obj1Size + obj2Size, 0, 2);
+                next();
+            }),
+            next => deleteObjects(bucket, [key1, key2], next),
+            next => wait(WAIT_MS, () => {
+                checkMetrics(obj1Size + obj2Size, 0, 4);
+                next();
+            }),
+            next => removeVersions([bucket], next),
+            next => wait(WAIT_MS, () => {
+                checkMetrics(0, 0, 0);
+                next();
+            }),
+            next => deleteBucket(bucket, next),
+        ], done);
+    });
     it('should set metrics for multiPartUpload', done => {
         const bucket = 'bucket6';
         const partSize = 1024 * 1024 * 6;
@@ -362,6 +392,11 @@ describe('utapi v2 metrics incoming and outgoing bytes', function t() {
             next => putObject(bucket, key, objectSize, next),
             next => wait(WAIT_MS, () => {
                 checkMetrics(objectSize * 2, 0, 2);
+                next();
+            }),
+            next => deleteObject(bucket, key, next),
+            next => wait(WAIT_MS, () => {
+                checkMetrics(objectSize * 2, 0, 3);
                 next();
             }),
             next => removeVersions([bucket], next),

--- a/tests/utapi/awsNodeSdk.js
+++ b/tests/utapi/awsNodeSdk.js
@@ -330,36 +330,6 @@ describe('utapi v2 metrics incoming and outgoing bytes', function t() {
             next => deleteBucket(bucket, next),
         ], done);
     });
-    it('should set metrics for multiObjectDelete in a versioned bucket', done => {
-        const bucket = 'bucket5';
-        const objectSize = 1024 * 1024;
-        const obj1Size = objectSize * 2;
-        const obj2Size = objectSize * 1;
-        const key1 = '1.txt';
-        const key2 = '2.txt';
-        async.series([
-            next => createBucket(bucket, next),
-            next => enableVersioning(bucket, true, next),
-            next => putObject(bucket, key1, obj1Size, next),
-            next => wait(WAIT_MS, next),
-            next => putObject(bucket, key2, obj2Size, next),
-            next => wait(WAIT_MS, () => {
-                checkMetrics(obj1Size + obj2Size, 0, 2);
-                next();
-            }),
-            next => deleteObjects(bucket, [key1, key2], next),
-            next => wait(WAIT_MS, () => {
-                checkMetrics(obj1Size + obj2Size, 0, 4);
-                next();
-            }),
-            next => removeVersions([bucket], next),
-            next => wait(WAIT_MS, () => {
-                checkMetrics(0, 0, 0);
-                next();
-            }),
-            next => deleteBucket(bucket, next),
-        ], done);
-    });
     it('should set metrics for multiPartUpload', done => {
         const bucket = 'bucket6';
         const partSize = 1024 * 1024 * 6;
@@ -464,6 +434,36 @@ describe('utapi v2 metrics incoming and outgoing bytes', function t() {
                 next();
             }),
             next => deleteObject(bucket, key, next),
+            next => wait(WAIT_MS, () => {
+                checkMetrics(0, 0, 0);
+                next();
+            }),
+            next => deleteBucket(bucket, next),
+        ], done);
+    });
+    it('should set metrics for multiObjectDelete in a versioned bucket', done => {
+        const bucket = 'bucket11';
+        const objectSize = 1024 * 1024;
+        const obj1Size = objectSize * 2;
+        const obj2Size = objectSize * 1;
+        const key1 = '1.txt';
+        const key2 = '2.txt';
+        async.series([
+            next => createBucket(bucket, next),
+            next => enableVersioning(bucket, true, next),
+            next => putObject(bucket, key1, obj1Size, next),
+            next => wait(WAIT_MS, next),
+            next => putObject(bucket, key2, obj2Size, next),
+            next => wait(WAIT_MS, () => {
+                checkMetrics(obj1Size + obj2Size, 0, 2);
+                next();
+            }),
+            next => deleteObjects(bucket, [key1, key2], next),
+            next => wait(WAIT_MS, () => {
+                checkMetrics(obj1Size + obj2Size, 0, 4);
+                next();
+            }),
+            next => removeVersions([bucket], next),
             next => wait(WAIT_MS, () => {
                 checkMetrics(0, 0, 0);
                 next();

--- a/tests/utapi/utilities.js
+++ b/tests/utapi/utilities.js
@@ -322,10 +322,11 @@ const testEvents = [{
         keys: [undefined],
         byteLength: 3,
         numberOfObjects: 1,
+        removedDeleteMarkers: 1,
         isDelete: true,
     },
     expected: {
-        objectDelta: -1,
+        objectDelta: -2,
         sizeDelta: -3,
         incomingBytes: undefined,
         outgoingBytes: 0,


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3455.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.9/bugfix/S3C-4166_putDeleteMarkerObject_increments_numberOfObjects`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.9/bugfix/S3C-4166_putDeleteMarkerObject_increments_numberOfObjects
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.9/bugfix/S3C-4166_putDeleteMarkerObject_increments_numberOfObjects
```

Please always comment pull request #3455 instead of this one.