### PR TITLE
INTEGRATION [PR#3455 > development/8.2] bf(S3C-4166): putDeleteMarkerObject should increment numberOfObjects

### DIFF
--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -495,6 +495,9 @@ function multiObjectDelete(authInfo, request, log, callback) {
         const xml = _formatXML(quietSetting, errorResults,
             successfullyDeleted);
         const deletedKeys = successfullyDeleted.map(item => item.key);
+        const removedDeleteMarkers = successfullyDeleted
+            .filter(item => item.isDeleteMarker && item.entry && item.entry.versionId)
+            .length;
         pushMetric('multiObjectDelete', log, {
             authInfo,
             canonicalID: bucket ? bucket.getOwner() : '',
@@ -502,6 +505,7 @@ function multiObjectDelete(authInfo, request, log, callback) {
             keys: deletedKeys,
             byteLength: Number.parseInt(totalContentLengthDeleted, 10),
             numberOfObjects: numOfObjectsRemoved,
+            removedDeleteMarkers,
             isDelete: true,
         });
         return callback(null, xml, corsHeaders);

--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -260,6 +260,7 @@ function pushMetric(action, log, metricObj) {
         canonicalID,
         location,
         isDelete,
+        removedDeleteMarkers,
     } = metricObj;
 
     if (utapiVersion === 2) {
@@ -276,11 +277,19 @@ function pushMetric(action, log, metricObj) {
             sizeDelta = -byteLength;
         }
 
+        let objectDelta = isDelete ? -numberOfObjects : numberOfObjects;
+        // putDeleteMarkerObject does not pass numberOfObjects
+        if (action === 'putDeleteMarkerObject') {
+            objectDelta = 1;
+        } else if (action === 'multiObjectDelete') {
+            objectDelta = -(numberOfObjects + removedDeleteMarkers);
+        }
+
         const utapiObj = {
             operationId: action,
             bucket,
             location,
-            objectDelta: isDelete ? -numberOfObjects : numberOfObjects,
+            objectDelta,
             sizeDelta: isDelete ? -byteLength : sizeDelta,
             incomingBytes,
             outgoingBytes: action === 'getObject' ? newByteLength : 0,

--- a/tests/utapi/utilities.js
+++ b/tests/utapi/utilities.js
@@ -322,10 +322,11 @@ const testEvents = [{
         keys: [undefined],
         byteLength: 3,
         numberOfObjects: 1,
+        removedDeleteMarkers: 1,
         isDelete: true,
     },
     expected: {
-        objectDelta: -1,
+        objectDelta: -2,
         sizeDelta: -3,
         incomingBytes: undefined,
         outgoingBytes: 0,


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3455.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/bugfix/S3C-4166_putDeleteMarkerObject_increments_numberOfObjects`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/bugfix/S3C-4166_putDeleteMarkerObject_increments_numberOfObjects
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/bugfix/S3C-4166_putDeleteMarkerObject_increments_numberOfObjects
```

Please always comment pull request #3455 instead of this one.