### PR TITLE
INTEGRATION [PR#3496 > development/7.10] bugfix: S3C-4263 limit concurrent operations during versioning tests

### DIFF
--- a/tests/functional/aws-node-sdk/test/versioning/objectHead.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectHead.js
@@ -386,10 +386,10 @@ describe('put and head object with versioning', function testSuite() {
                 const keycount = 50;
                 const versioncount = 20;
                 const value = '{"foo":"bar"}';
-                async.times(keycount, (i, next1) => {
+                async.timesLimit(keycount, 10, (i, next1) => {
                     const key = `foo${i}`;
                     const params = { Bucket: bucket, Key: key, Body: value };
-                    async.times(versioncount, (j, next2) =>
+                    async.timesLimit(versioncount, 10, (j, next2) =>
                         s3.putObject(params, (err, data) => {
                             assert.strictEqual(err, null);
                             assert(data.VersionId, 'invalid versionId');

--- a/tests/functional/aws-node-sdk/test/versioning/objectPut.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectPut.js
@@ -522,10 +522,10 @@ describe('put and get object with versioning', function testSuite() {
                 const keycount = 50;
                 const versioncount = 20;
                 const value = '{"foo":"bar"}';
-                async.times(keycount, (i, next1) => {
+                async.timesLimit(keycount, 10, (i, next1) => {
                     const key = `foo${i}`;
                     const params = { Bucket: bucket, Key: key, Body: value };
-                    async.times(versioncount, (j, next2) =>
+                    async.timesLimit(versioncount, 10, (j, next2) =>
                         s3.putObject(params, (err, data) => {
                             assert.strictEqual(err, null);
                             assert(data.VersionId, 'invalid versionId');

--- a/tests/functional/aws-node-sdk/test/versioning/versioningGeneral1.js
+++ b/tests/functional/aws-node-sdk/test/versioning/versioningGeneral1.js
@@ -53,11 +53,11 @@ describe('aws-node-sdk test bucket versioning listing', function testSuite() {
         const keycount = 20;
         const versioncount = 20;
         const value = '{"foo":"bar"}';
-        async.times(keycount, (i, next1) => {
+        async.timesLimit(keycount, 10, (i, next1) => {
             const key = `foo${i}`;
             masterVersions.push(key);
             const params = { Bucket: bucket, Key: key, Body: value };
-            async.times(versioncount, (j, next2) =>
+            async.timesLimit(versioncount, 10, (j, next2) =>
                 s3.putObject(params, (err, data) => {
                     assert.strictEqual(err, null);
                     assert(data.VersionId, 'invalid versionId');

--- a/tests/functional/aws-node-sdk/test/versioning/versioningGeneral2.js
+++ b/tests/functional/aws-node-sdk/test/versioning/versioningGeneral2.js
@@ -317,10 +317,10 @@ describe('aws-node-sdk test bucket versioning', function testSuite() {
         const keycount = 50;
         const versioncount = 20;
         const value = '{"foo":"bar"}';
-        async.times(keycount, (i, next1) => {
+        async.timesLimit(keycount, 10, (i, next1) => {
             const key = `foo${i}`;
             const params = { Bucket: bucket, Key: key, Body: value };
-            async.times(versioncount, (j, next2) =>
+            async.timesLimit(versioncount, 10, (j, next2) =>
                 s3.putObject(params, (err, data) => {
                     assert.strictEqual(err, null);
                     assert(data.VersionId, 'invalid versionId');


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3496.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/bugfix/S3C-4263-limitConcurrentOpsInTest`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/bugfix/S3C-4263-limitConcurrentOpsInTest
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/bugfix/S3C-4263-limitConcurrentOpsInTest
```

Please always comment pull request #3496 instead of this one.