### PR TITLE
bugfix: report currently running overlay version

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1399,6 +1399,9 @@ class Config extends EventEmitter {
         if (config.bucketNotificationDestinations) {
             this.bucketNotificationDestinations = bucketNotifAssert(config.bucketNotificationDestinations);
         }
+
+        // Version of the configuration we're running under
+        this.overlayVersion = config.overlayVersion || 0;
     }
 
     _getAuthData() {

--- a/tests/unit/Config.js
+++ b/tests/unit/Config.js
@@ -61,4 +61,9 @@ describe('Config', () => {
             );
         });
     });
+
+    it('should have a default overlay version', () => {
+        const { config } = require('../../lib/Config');
+        assert.strictEqual(config.overlayVersion, 0);
+    });
 });

--- a/tests/unit/testConfigs/allOptsConfig/config.json
+++ b/tests/unit/testConfigs/allOptsConfig/config.json
@@ -105,5 +105,6 @@
             "host": "localhost",
             "port": 6379
         }
-    }
+    },
+    "overlayVersion": 4
 }

--- a/tests/unit/testConfigs/allOptsConfig/testConfig.js
+++ b/tests/unit/testConfigs/allOptsConfig/testConfig.js
@@ -37,4 +37,8 @@ describe('Config with all possible options', () => {
         };
         assert.deepStrictEqual(expectedObj, config.outboundProxy);
     });
+
+    it('should read overlay version', () => {
+        assert.strictEqual(config.overlayVersion, 4);
+    });
 });


### PR DESCRIPTION
Report `config.overlayVersion` even if using config files and not websocket push, so that UIs can know when it's up-to-date or still updating.