### PR TITLE
bugfix: S3C-3778 prevent MPU with duplicate data keys

### DIFF
--- a/lib/api/apiUtils/object/locationKeysSanityCheck.js
+++ b/lib/api/apiUtils/object/locationKeysSanityCheck.js
@@ -4,7 +4,8 @@
 * instability from the metadata layer. The check returns true if there was no
 * match and false if at least one key from the previous list exists in the
 * current list
-* @param {array|string} prev - list of keys from the object being overwritten
+* @param {array|string|null} prev - list of keys from the object being
+* overwritten
 * @param {array} curr - list of keys to be used in composing current object
 * @returns {array} list of keys that can be deleted
 */

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -337,6 +337,46 @@ function completeMultipartUpload(authInfo, request, log, callback) {
             metaStoreParams, mpuBucket, keysToDelete, aggregateETag, objMD,
             extraPartLocations, pseudoCipherBundle, dataToDelete,
             completeObjData, next) {
+            if (objMD) {
+                // An object with the same key already exists, check
+                // if it has been created by the same MPU upload by
+                // checking if any of its internal location keys match
+                // the new keys. In such case, it must be a duplicate
+                // from a retry of a previous failed completion
+                // attempt, hence do the following:
+                //
+                // - skip writing the new metadata key to avoid
+                //   creating a new version pointing to the same data
+                //   keys
+                //
+                // - skip old data locations deletion since the old
+                //   data location keys overlap the new ones (in
+                //   principle they should be fully identical as there
+                //   is no reuse of previous versions' data keys in
+                //   the normal process) - note that the previous
+                //   failed completion attempt may have left orphan
+                //   data keys but we lost track of them so we cannot
+                //   delete them now
+                //
+                // - proceed to the deletion of overview and part
+                //   metadata keys, which are likely to have failed in
+                //   the previous MPU completion attempt
+                //
+                const onlyDifferentLocationKeys = locationKeysSanityCheck(
+                    objMD.location, dataLocations);
+                if (!onlyDifferentLocationKeys) {
+                    log.info('MPU complete request replay detected', {
+                        method: 'completeMultipartUpload.storeAsNewObj',
+                        bucketName: destinationBucket.getName(),
+                        objectKey: metaStoreParams.objectKey,
+                        uploadId: metaStoreParams.uploadId,
+                    });
+                    return next(null, mpuBucket, keysToDelete, aggregateETag,
+                        extraPartLocations, destinationBucket,
+                        // pass the original version ID as generatedVersionId
+                        objMD.versionId);
+                }
+            }
             return services.metadataStoreObject(destinationBucket.getName(),
                 dataLocations, pseudoCipherBundle, metaStoreParams,
                 (err, res) => {
@@ -350,31 +390,22 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     // unless the preexisting object and the completed mpu
                     // are on external backends
                     if (dataToDelete) {
-                        // check keys against accidental deletion, if any
-                        // existing key is found in the current object,
-                        // deletion is skipped
-                        const sanityCheckPassed =
-                            locationKeysSanityCheck(dataToDelete,
-                                dataLocations);
-
                         const newDataStoreName =
                             Array.isArray(dataLocations) && dataLocations[0] ?
                             dataLocations[0].dataStoreName : null;
-                        if (sanityCheckPassed) {
-                            const delLog =
-                                logger.newRequestLoggerFromSerializedUids(log
-                                .getSerializedUids());
-                            return data.batchDelete(dataToDelete,
-                                request.method,
-                                newDataStoreName, delLog, err => {
-                                    if (err) {
-                                        return next(err);
-                                    }
-                                    return next(null, mpuBucket, keysToDelete,
-                                        aggregateETag, extraPartLocations,
-                                        destinationBucket, generatedVersionId);
-                                });
-                        }
+                        const delLog =
+                            logger.newRequestLoggerFromSerializedUids(log
+                            .getSerializedUids());
+                        return data.batchDelete(dataToDelete,
+                            request.method,
+                            newDataStoreName, delLog, err => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                return next(null, mpuBucket, keysToDelete,
+                                    aggregateETag, extraPartLocations,
+                                    destinationBucket, generatedVersionId);
+                            });
                     }
                     return next(null, mpuBucket, keysToDelete, aggregateETag,
                         extraPartLocations, destinationBucket,

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -15,7 +15,6 @@ const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const constants = require('../../constants');
 const { versioningPreprocessing, checkQueryVersionId }
     = require('./apiUtils/object/versioning');
-const metadata = require('../metadata/wrapper');
 const services = require('../services');
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { skipMpuPartProcessing } = require('../data/external/utils');
@@ -126,43 +125,35 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                 oldByteLength = objMD['content-length'];
             }
             services.metadataValidateMultipart(metadataValParams,
-                (err, mpuBucket) => {
+                (err, mpuBucket, mpuOverview, storedMetadata) => {
                     if (err) {
                         return next(err, destBucket);
                     }
-                    return next(null, destBucket, objMD, mpuBucket);
+                    return next(null, destBucket, objMD, mpuBucket,
+                        storedMetadata);
                 });
         },
-        function parsePartsList(destBucket, objMD, mpuBucket, next) {
+        function parsePartsList(destBucket, objMD, mpuBucket,
+        storedMetadata, next) {
+            const location = storedMetadata.controllingLocationConstraint;
+            // BACKWARD: Remove to remove the old splitter
+            if (mpuBucket.getMdBucketModelVersion() < 2) {
+                splitter = constants.oldSplitter;
+            }
+            // Reconstruct mpuOverviewKey to point to metadata
+            // originally stored when mpu initiated
+            const mpuOverviewKey =
+                  `overview${splitter}${objectKey}${splitter}${uploadId}`;
             if (request.post) {
                 return parseXml(request.post, (err, jsonList) => {
                     if (err) {
                         return next(err, destBucket);
                     }
-                    return next(err, destBucket, objMD, mpuBucket, jsonList);
+                    return next(null, destBucket, objMD, mpuBucket,
+                        jsonList, storedMetadata, location, mpuOverviewKey);
                 });
             }
             return next(errors.MalformedXML, destBucket);
-        },
-        function getMPUMetadata(destBucket, objMD, mpuBucket, jsonList, next) {
-            // BACKWARD: Remove to remove the old splitter
-            if (mpuBucket.getMdBucketModelVersion() < 2) {
-                splitter = constants.oldSplitter;
-            }
-            // Reconstruct mpuOverviewKey to serve
-            // as key to pull metadata originally stored when mpu initiated
-            const mpuOverviewKey =
-                `overview${splitter}${objectKey}${splitter}${uploadId}`;
-
-            return metadata.getObjectMD(mpuBucket.getName(), mpuOverviewKey,
-            {}, log, (err, storedMetadata) => {
-                if (err) {
-                    return next(err, destBucket);
-                }
-                const location = storedMetadata.controllingLocationConstraint;
-                return next(null, destBucket, objMD, mpuBucket, jsonList,
-                storedMetadata, location, mpuOverviewKey);
-            });
         },
         function retrieveParts(destBucket, objMD, mpuBucket, jsonList,
         storedMetadata, location, mpuOverviewKey, next) {

--- a/lib/services.js
+++ b/lib/services.js
@@ -424,8 +424,11 @@ const services = {
      * bucket name, uploadId, authInfo etc.
      * @param {function} cb - callback containing error and
      * bucket reference for the next task
-     * @return {function} calls callback with arguments:
-     * error, bucket and the multipart upload metadata
+     * @return {undefined} calls callback with arguments:
+     * - error
+     * - bucket
+     * - the multipart upload metadata
+     * - the overview key stored metadata
      */
     metadataValidateMultipart(params, cb) {
         const { bucketName, uploadId, authInfo,
@@ -492,7 +495,7 @@ const services = {
                     // If access was provided by the destination bucket's
                     // bucket policies, go ahead.
                     if (requestType === 'bucketPolicyGoAhead') {
-                        return cb(null, mpuBucket, mpuOverview);
+                        return cb(null, mpuBucket, mpuOverview, storedMetadata);
                     }
 
                     const requesterID = authInfo.isRequesterAnIAMUser() ?
@@ -528,7 +531,7 @@ const services = {
                             return cb(errors.AccessDenied);
                         }
                     }
-                    return cb(null, mpuBucket, mpuOverview);
+                    return cb(null, mpuBucket, mpuOverview, storedMetadata);
                 });
             return undefined;
         });

--- a/lib/services.js
+++ b/lib/services.js
@@ -419,7 +419,7 @@ const services = {
 
     /**
      * Checks whether bucket exists, multipart upload
-     * has been initatied and the user is authorized
+     * has been initiated and the user is authorized
      * @param {object} params - custom built object containing
      * bucket name, uploadId, authInfo etc.
      * @param {function} cb - callback containing error and

--- a/tests/unit/api/apiUtils/locationKeysSanityCheck.js
+++ b/tests/unit/api/apiUtils/locationKeysSanityCheck.js
@@ -32,4 +32,10 @@ describe('Sanity check for location keys', () => {
         const curr = [{ key: 'ddd' }, { key: 'eee' }, { key: 'fff' }];
         assert.strictEqual(locationKeysSanityCheck(prev, curr), true);
     });
+
+    it('should return true if prev location is null', () => {
+        const prev = null;
+        const curr = [{ key: 'ddd' }, { key: 'eee' }, { key: 'fff' }];
+        assert.strictEqual(locationKeysSanityCheck(prev, curr), true);
+    });
 });

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -18,6 +18,7 @@ const { ds } = require('../../../lib/data/in_memory/backend');
 const initiateMultipartUpload
     = require('../../../lib/api/initiateMultipartUpload');
 const { metadata } = require('../../../lib/metadata/in_memory/metadata');
+const metadataBackend = require('../../../lib/metadata/in_memory/backend');
 const multipartDelete = require('../../../lib/api/multipartDelete');
 const objectPutPart = require('../../../lib/api/objectPutPart');
 const DummyRequest = require('../DummyRequest');
@@ -1695,28 +1696,9 @@ describe('complete mpu with versioning', () => {
         versioningTestUtils.createPutObjectRequest(bucketName, objectKey,
             data));
 
-    before(done => {
+    beforeEach(done => {
         cleanup();
-        async.series([
-            callback => bucketPut(authInfo, bucketPutRequest, log,
-                callback),
-            // putting null version: put obj before versioning configured
-            callback => objectPut(authInfo, testPutObjectRequests[0],
-                undefined, log, callback),
-            callback => bucketPutVersioning(authInfo,
-                enableVersioningRequest, log, callback),
-            // put another version:
-            callback => objectPut(authInfo, testPutObjectRequests[1],
-                undefined, log, callback),
-            callback => bucketPutVersioning(authInfo,
-                suspendVersioningRequest, log, callback),
-        ], err => {
-            if (err) {
-                return done(err);
-            }
-            versioningTestUtils.assertDataStoreValues(ds, objData.slice(0, 2));
-            return done();
-        });
+        bucketPut(authInfo, bucketPutRequest, log, done);
     });
 
     after(done => {
@@ -1727,8 +1709,21 @@ describe('complete mpu with versioning', () => {
     it('should delete null version when creating new null version, ' +
     'even when null version is not the latest version', done => {
         async.waterfall([
-            next =>
-                initiateMultipartUpload(authInfo, initiateRequest, log, next),
+            // putting null version: put obj before versioning configured
+            next => objectPut(authInfo, testPutObjectRequests[0],
+                undefined, log, err => next(err)),
+            next => bucketPutVersioning(authInfo,
+                enableVersioningRequest, log, err => next(err)),
+            // put another version:
+            next => objectPut(authInfo, testPutObjectRequests[1],
+                undefined, log, err => next(err)),
+            next => bucketPutVersioning(authInfo,
+                suspendVersioningRequest, log, err => next(err)),
+            next => {
+                versioningTestUtils.assertDataStoreValues(
+                    ds, objData.slice(0, 2));
+                initiateMultipartUpload(authInfo, initiateRequest, log, next);
+            },
             (result, corsHeaders, next) => parseString(result, next),
             (json, next) => {
                 const partBody = objData[2];
@@ -1752,6 +1747,76 @@ describe('complete mpu with versioning', () => {
                     objData[1], objData[2]]);
                 done(err);
             });
+        });
+    });
+
+    it('should finish deleting metadata on completeMultipartUpload retry',
+    done => {
+        let origDeleteObject;
+        async.waterfall([
+            next => bucketPutVersioning(authInfo,
+                enableVersioningRequest, log, err => next(err)),
+            next =>
+                initiateMultipartUpload(authInfo, initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
+            (json, next) => {
+                const partBody = objData[2];
+                const testUploadId =
+                    json.InitiateMultipartUploadResult.UploadId[0];
+                const partRequest = _createPutPartRequest(testUploadId, 1,
+                    partBody);
+                objectPutPart(authInfo, partRequest, undefined, log,
+                    (err, eTag) => next(err, eTag, testUploadId));
+            },
+            (eTag, testUploadId, next) => {
+                origDeleteObject = metadataBackend.deleteObject;
+                metadataBackend.deleteObject = (
+                    bucketName, objName, params, log, cb) => {
+                        // prevent deletions from MPU bucket only
+                    if (bucketName === mpuBucket) {
+                        return process.nextTick(
+                            () => cb(errors.InternalError));
+                    }
+                    return origDeleteObject(
+                        bucketName, objName, params, log, cb);
+                };
+                const parts = [{ partNumber: 1, eTag }];
+                const completeRequest = _createCompleteMpuRequest(
+                    testUploadId, parts);
+                completeMultipartUpload(authInfo, completeRequest, log, err => {
+                    // expect a failure here because we could not
+                    // remove the overview key
+                    assert.strictEqual(err, errors.InternalError);
+                    next(null, eTag, testUploadId);
+                });
+            },
+            (eTag, testUploadId, next) => {
+                // allow MPU bucket metadata deletions to happen again
+                metadataBackend.deleteObject = origDeleteObject;
+                // retry the completeMultipartUpload with the same
+                // metadata, as an application would normally do after
+                // a failure
+                const parts = [{ partNumber: 1, eTag }];
+                const completeRequest = _createCompleteMpuRequest(
+                    testUploadId, parts);
+                completeMultipartUpload(authInfo, completeRequest, log, next);
+            },
+        ], err => {
+            assert.ifError(err);
+            let nbVersions = 0;
+            for (const key of metadata.keyMaps.get(bucketName).keys()) {
+                if (key !== objectKey && key.startsWith(objectKey)) {
+                    nbVersions += 1;
+                }
+            }
+            // There should be only one version of the object, since
+            // the second call should not have created a new version
+            assert.strictEqual(nbVersions, 1);
+            for (const key of metadata.keyMaps.get(mpuBucket).keys()) {
+                assert.fail('There should be no more keys in MPU bucket, ' +
+                            `found "${key}"`);
+            }
+            done();
         });
     });
 });

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -1682,6 +1682,68 @@ describe('Multipart Upload API', () => {
             });
         });
     });
+
+    it('should not delete data locations on completeMultipartUpload retry',
+    done => {
+        const partBody = Buffer.from('foo', 'utf8');
+        let origDeleteObject;
+        async.waterfall([
+            next =>
+                bucketPut(authInfo, bucketPutRequest, log, err => next(err)),
+            next =>
+                initiateMultipartUpload(authInfo, initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
+            (json, next) => {
+                const testUploadId =
+                    json.InitiateMultipartUploadResult.UploadId[0];
+                const partRequest = _createPutPartRequest(testUploadId, 1,
+                    partBody);
+                objectPutPart(authInfo, partRequest, undefined, log,
+                    (err, eTag) => next(err, eTag, testUploadId));
+            },
+            (eTag, testUploadId, next) => {
+                origDeleteObject = metadataBackend.deleteObject;
+                metadataBackend.deleteObject = (
+                    bucketName, objName, params, log, cb) => {
+                        // prevent deletions from MPU bucket only
+                    if (bucketName === mpuBucket) {
+                        return process.nextTick(
+                            () => cb(errors.InternalError));
+                    }
+                    return origDeleteObject(
+                        bucketName, objName, params, log, cb);
+                };
+                const parts = [{ partNumber: 1, eTag }];
+                const completeRequest = _createCompleteMpuRequest(
+                    testUploadId, parts);
+                completeMultipartUpload(authInfo, completeRequest, log, err => {
+                    // expect a failure here because we could not
+                    // remove the overview key
+                    assert.strictEqual(err, errors.InternalError);
+                    next(null, eTag, testUploadId);
+                });
+            },
+            (eTag, testUploadId, next) => {
+                // allow MPU bucket metadata deletions to happen again
+                metadataBackend.deleteObject = origDeleteObject;
+                // retry the completeMultipartUpload with the same
+                // metadata, as an application would normally do after
+                // a failure
+                const parts = [{ partNumber: 1, eTag }];
+                const completeRequest = _createCompleteMpuRequest(
+                    testUploadId, parts);
+                completeMultipartUpload(authInfo, completeRequest, log, next);
+            },
+        ], err => {
+            assert.ifError(err);
+            // check that the original data has not been deleted
+            // during the replay
+            assert.strictEqual(ds[0], undefined);
+            assert.notStrictEqual(ds[1], undefined);
+            assert.deepStrictEqual(ds[1].value, partBody);
+            done();
+        });
+    });
 });
 
 describe('complete mpu with versioning', () => {


### PR DESCRIPTION
Sometimes, complete MPU request may be replayed due to a previous failure leaving the original MPU metadata untouched but with a valid completed object as well. This could lead to a new version of the object being created, pointing to the same data keys than the previous version, created from the same MPU that failed from the client perspective.

The fix consists of checking whether we are trying to update the metadata with the same data location keys than the existing ones, and skip the metadata update and data location deletions if this is the case.

It's a generalization of the previous fix S3C-1959 that consisted in skipping data deletions if they were already in the object metadata. It worked on non-versioned buckets because there, the keys to delete are the original master key locations because the master key gets overwritten, but it did not work on versioned buckets since there is no key to delete as we are creating a new version.
