### PR TITLE
Improvement/s3 c 4363 remove node UUID

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const url = require('url');
 
-const uuid = require('node-uuid');
+const { v4: uuidv4 } = require('uuid');
 const cronParser = require('cron-parser');
 const joi = require('@hapi/joi');
 
@@ -923,7 +923,7 @@ class Config extends EventEmitter {
         this.reportToken =
             process.env.REPORT_TOKEN ||
             config.reportToken ||
-            uuid.v4().toString();
+            uuidv4();
 
         // requests-proxy configuration
         this.requests = {

--- a/lib/api/initiateMultipartUpload.js
+++ b/lib/api/initiateMultipartUpload.js
@@ -1,4 +1,4 @@
-const UUID = require('node-uuid');
+const { v4: uuidv4 } = require('uuid');
 const { errors, s3middleware } = require('arsenal');
 const getMetaHeaders = s3middleware.userMetadata.getMetaHeaders;
 const convertToXml = s3middleware.convertToXml;
@@ -211,14 +211,14 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
                     // handles mpu
                     uploadId = dataBackendResObj.UploadId;
                 } else {
-                    uploadId = UUID.v4().replace(/-/g, '');
+                    uploadId = uuidv4().replace(/-/g, '');
                 }
                 return _getMPUBucket(destinationBucket, log, corsHeaders,
                 uploadId, cipherBundle, callback);
             });
         }
         // Generate uniqueID without dashes so that routing not messed up
-        uploadId = UUID.v4().replace(/-/g, '');
+        uploadId = uuidv4().replace(/-/g, '');
 
         return _getMPUBucket(destinationBucket, log, corsHeaders,
         uploadId, cipherBundle, callback);

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "sproxydclient": "scality/sproxydclient#77a2de0",
     "utapi": "scality/utapi#45d7e26",
     "utf8": "~2.1.1",
-    "uuid": "^3.0.1",
+    "uuid": "^8.3.2",
     "vaultclient": "scality/vaultclient#4636126",
     "werelogs": "scality/werelogs#0a4c576",
     "xml2js": "~0.4.16"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "diskusage": "1.1.3",
     "google-auto-auth": "^0.9.1",
     "http-proxy": "^1.17.0",
-    "node-uuid": "^1.4.3",
     "npm-run-all": "~4.1.5",
     "sproxydclient": "scality/sproxydclient#77a2de0",
     "utapi": "scality/utapi#45d7e26",

--- a/tests/functional/aws-node-sdk/test/object/abortMPU.js
+++ b/tests/functional/aws-node-sdk/test/object/abortMPU.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const uuid = require('uuid/v4');
+const { v4: uuidv4 } = require('uuid');
 const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
 
@@ -82,7 +82,7 @@ describe('Abort MPU - No Such Upload', () => {
             s3.abortMultipartUpload({
                 Bucket: bucket,
                 Key: key,
-                UploadId: uuid().replace(/-/g, '') },
+                UploadId: uuidv4().replace(/-/g, '') },
             err => {
                 assert.notEqual(err, null, 'Expected failure but got success');
                 assert.strictEqual(err.code, 'NoSuchUpload');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2907,11 +2907,6 @@ node-schedule@1.2.0:
     cron-parser "1.1.0"
     long-timeout "0.0.2"
 
-node-uuid@^1.4.3:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
-  integrity sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=
-
 nopt@3.x:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -282,32 +282,6 @@ arraybuffer.slice@~0.0.7:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
   integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
 
-"arsenal@github:scality/Arsenal#b3080e9":
-  version "7.5.0"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/b3080e9ac66cf828f30f0df58095f96ed62ef21d"
-  dependencies:
-    "@hapi/joi" "^15.1.0"
-    JSONStream "^1.0.0"
-    agentkeepalive "^4.1.3"
-    ajv "6.12.2"
-    async "~2.1.5"
-    debug "~2.6.9"
-    diskusage "^1.1.1"
-    ioredis "4.9.5"
-    ipaddr.js "1.9.1"
-    level "~5.0.1"
-    level-sublevel "~6.6.5"
-    node-forge "^0.7.1"
-    simple-glob "^0.2"
-    socket.io "~2.3.0"
-    socket.io-client "~2.3.0"
-    utf8 "2.1.2"
-    uuid "^3.0.1"
-    werelogs scality/werelogs#0ff7ec82
-    xml2js "~0.4.23"
-  optionalDependencies:
-    ioctl "2.0.0"
-
 "arsenal@github:scality/Arsenal#f17006b":
   version "7.5.0"
   resolved "https://codeload.github.com/scality/Arsenal/tar.gz/f17006b91eaefce2be00c2600ae55e4d63265333"
@@ -4080,6 +4054,11 @@ uuid@^3.0.0, uuid@^3.0.1, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"


### PR DESCRIPTION
## Description

### Motivation and context

Removing deprecated `node-uuid` in favor of `uuid`
Upgrade `uuid` to latest version and adapt breaking changes

### Related issues

N/A
