### PR TITLE
improvement: build dependabot pull requests

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -2,7 +2,7 @@
 version: 0.2
 
 branches:
-  feature/*, improvement/*, bugfix/*, w/*, q/*, hotfix/*:
+  feature/*, improvement/*, bugfix/*, w/*, q/*, hotfix/*, dependabot/*:
     stage: pre-merge
   development/*:
     stage: post-merge

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -149,7 +149,7 @@ stages:
             yarn run --silent lint -- --max-warnings 0
             yarn run --silent lint_md
             flake8 $(git ls-files "*.py")
-            yamllint $(git ls-files "*.yml")
+            yamllint -c yamllint.yml $(git ls-files "*.yml")
       - ShellCommand:
           name: Unit Coverage
           command: |

--- a/yamllint.yml
+++ b/yamllint.yml
@@ -1,0 +1,8 @@
+---
+
+extends: default
+
+rules:
+  truthy: disable
+  line-length:
+    max: 120


### PR DESCRIPTION

## Description

### Motivation and context

Dependabot makes PRs for out of date dependencies. This change allows eve to start the CI stage when dependabot opens PRs.

### Additional changes
yaml lint rule for max-len is updated to 120 characters to accommodate changes in upstream branches
