### PR TITLE
S3C-2663: fix missing object access error response

### DIFF
--- a/lib/api/apiUtils/authorization/aclChecks.js
+++ b/lib/api/apiUtils/authorization/aclChecks.js
@@ -86,11 +86,56 @@ function isBucketAuthorized(bucket, requestType, canonicalID) {
     requestType === 'objectGet' || requestType === 'objectHead');
 }
 
+function _isPermissionGranted(permissionList, canonicalID) {
+    if (permissionList.indexOf(publicId) > -1) {
+        return true;
+    }
+
+    if (permissionList.indexOf(allAuthedUsersId) > -1 &&
+        canonicalID !== publicId) {
+        return true;
+    }
+
+    if (permissionList.indexOf(canonicalID) > -1) {
+        return true;
+    }
+
+    return false;
+}
+
+function hasBucketReadAccess(bucket, requestType, canonicalID) {
+    const bucketAcl = bucket.getAcl();
+    const bucketOwner = bucket.getOwner();
+
+    if (canonicalID === bucketOwner ||
+        _isPermissionGranted(bucketAcl.FULL_CONTROL, canonicalID) ||
+        _isPermissionGranted(bucketAcl.READ, canonicalID)) {
+        return true;
+    }
+
+    if (bucketAcl.Canned === 'public-read' ||
+        bucketAcl.Canned === 'public-read-write' ||
+        (bucketAcl.Canned === 'authenticated-read' &&
+         canonicalID !== publicId)) {
+        return true;
+    }
+
+    return false;
+}
+
 function isObjAuthorized(bucket, objectMD, requestType, canonicalID) {
     const bucketOwner = bucket.getOwner();
     if (!objectMD) {
-        return false;
+        if (requestType === 'objectPut' || requestType === 'objectDelete') {
+            return true;
+        }
+
+        // if read access is granted, return true to have the api handler
+        // respond accordingly to the missing object metadata
+        // if read access is not granted, return false for AccessDenied
+        return hasBucketReadAccess(bucket, requestType, canonicalID);
     }
+
     if (objectMD['owner-id'] === canonicalID) {
         return true;
     }

--- a/lib/metadata/metadataUtils.js
+++ b/lib/metadata/metadataUtils.js
@@ -196,9 +196,6 @@ function metadataValidateBucketAndObj(params, log, callback) {
             return next(null, bucket, objMD);
         },
         function checkObjectAuth(bucket, objMD, next) {
-            if (!objMD) {
-                return next(null, bucket);
-            }
             if (!isObjAuthorized(bucket, objMD, requestType, canonicalID)) {
                 log.debug('access denied for user on object', { requestType });
                 return next(errors.AccessDenied, bucket);

--- a/tests/unit/api/objectACLauth.js
+++ b/tests/unit/api/objectACLauth.js
@@ -207,3 +207,98 @@ describe('object authorization for objectPutACL and objectGetACL', () => {
         assert.strictEqual(authorizedResult, true);
     });
 });
+
+describe('without object metadata', () => {
+    afterEach(() => {
+        bucket.setFullAcl({
+            Canned: 'private',
+            FULL_CONTROL: [],
+            WRITE: [],
+            WRITE_ACP: [],
+            READ: [],
+            READ_ACP: [],
+        });
+    });
+
+    const requestTypes = [
+        'objectGet',
+        'objectHead',
+        'objectPutACL',
+        'objectGetACL',
+    ];
+
+    const allowedAccess = [true, true, true, true];
+    const deniedAccess = [false, false, false, false];
+
+    const tests = [
+        {
+            it: 'should allow bucket owner',
+            canned: 'private', id: bucketOwnerCanonicalId,
+            aclParam: null,
+            response: allowedAccess,
+        },
+        {
+            it: 'should not allow public if canned private',
+            canned: 'private', id: constants.publicId,
+            aclParam: null,
+            response: deniedAccess,
+        },
+        {
+            it: 'should not allow other accounts if canned private',
+            canned: 'private', id: accountToVet,
+            aclParam: null,
+            response: deniedAccess,
+        },
+        {
+            it: 'should allow public if bucket is canned public-read',
+            canned: 'public-read', id: constants.publicId,
+            aclParam: null,
+            response: allowedAccess,
+        },
+        {
+            it: 'should allow public if bucket is canned public-read-write',
+            canned: 'public-read-write', id: constants.publicId,
+            aclParam: null,
+            response: allowedAccess,
+        },
+        {
+            it: 'should not allow public if bucket is canned ' +
+            'authenticated-read',
+            canned: 'authenticated-read', id: constants.publicId,
+            aclParam: null,
+            response: deniedAccess,
+        },
+        {
+            it: 'should allow authenticated users if bucket is canned ' +
+            'authenticated-read',
+            canned: 'authenticated-read', id: accountToVet,
+            aclParam: null,
+            response: allowedAccess,
+        },
+        {
+            it: 'should allow account if granted bucket READ',
+            canned: '', id: accountToVet,
+            aclParam: ['READ', accountToVet],
+            response: allowedAccess,
+        },
+        {
+            it: 'should allow account if granted bucket FULL_CONTROL',
+            canned: '', id: accountToVet,
+            aclParam: ['FULL_CONTROL', accountToVet],
+            response: allowedAccess,
+        },
+    ];
+
+    tests.forEach(value => {
+        it(value.it, done => {
+            if (value.aclParam) {
+                bucket.setSpecificAcl(value.aclParam[1], value.aclParam[0]);
+            }
+            bucket.setCannedAcl(value.canned);
+            const results = requestTypes.map(type =>
+                isObjAuthorized(bucket, null, type, value.id));
+            assert.deepStrictEqual(results, value.response);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Add checks to return proper error response in the case of object 404s; `AccessDenied` when not granted bucket read vs `NoSuchKey` when granted bucket read.

note for reviewers: another PR will be created to handle bucket policies in development/7.10 (https://github.com/scality/cloudserver/pull/3622)