### PR TITLE
bugfix: S3C-4324 bucket policy allows notification actions

### DIFF
--- a/lib/api/apiUtils/authorization/permissionChecks.js
+++ b/lib/api/apiUtils/authorization/permissionChecks.js
@@ -1,45 +1,6 @@
-const { evaluators } = require('arsenal').policies;
+const { evaluators, actionMaps } = require('arsenal').policies;
 const constants = require('../../../../constants');
 
-const actionMap = {
-    multipartDelete: 's3:AbortMultipartUpload',
-    bucketDelete: 's3:DeleteBucket',
-    bucketDeletePolicy: 's3:DeleteBucketPolicy',
-    bucketDeleteWebsite: 's3:DeleteBucketWebsite',
-    objectDelete: 's3:DeleteObject',
-    objectDeleteTagging: 's3:DeleteObjectTagging',
-    bucketGetACL: 's3:GetBucketAcl',
-    bucketGetCors: 's3:GetBucketCORS',
-    bucketGetLocation: 's3:GetBucketLocation',
-    bucketGetObjectLock: 's3:GetBucketObjectLockConfiguration',
-    bucketGetPolicy: 's3:GetBucketPolicy',
-    bucketGetVersioning: 's3:GetBucketVersioning',
-    bucketGetWebsite: 's3:GetBucketWebsite',
-    bucketGetLifecycle: 's3:GetLifecycleConfiguration',
-    objectGet: 's3:GetObject',
-    objectGetACL: 's3:GetObjectAcl',
-    objectGetLegalHold: 's3:GetObjectLegalHold',
-    objectGetRetention: 's3:GetObjectRetention',
-    objectGetTagging: 's3:GetObjectTagging',
-    bucketGetReplication: 's3:GetReplicationConfiguration',
-    bucketHead: 's3:ListBucket',
-    bucketGet: 's3:ListBucket',
-    listMultipartUploads: 's3:ListBucketMultipartUploads',
-    listParts: 's3:ListMultipartUploadParts',
-    bucketPutACL: 's3:PutBucketAcl',
-    bucketPutCors: 's3:PutBucketCORS',
-    bucketPutObjectLock: 's3:PutBucketObjectLockConfiguration',
-    bucketPutPolicy: 's3:PutBucketPolicy',
-    bucketPutVersioning: 's3:PutBucketVersioning',
-    bucketPutWebsite: 's3:PutBucketWebsite',
-    bucketPutLifecycle: 's3:PutLifecycleConfiguration',
-    objectPut: 's3:PutObject',
-    objectPutACL: 's3:PutObjectAcl',
-    objectPutTagging: 's3:PutObjectTagging',
-    objectPutLegalHold: 's3:PutObjectLegalHold',
-    objectPutRetention: 's3:PutObjectRetention',
-    bucketPutReplication: 's3:PutReplicationConfiguration',
-};
 const { allAuthedUsersId, bucketOwnerActions, logId, publicId } = constants;
 
 // whitelist buckets to allow public read on objects
@@ -212,8 +173,8 @@ function checkObjectAcls(bucket, objectMD, requestType, canonicalID) {
     return false;
 }
 
-function _checkActions(requestType, actions, log) {
-    const mappedAction = actionMap[requestType];
+function _checkBucketPolicyActions(requestType, actions, log) {
+    const mappedAction = actionMaps.actionMapBP[requestType];
     // Deny any action that isn't in list of controlled actions
     if (!mappedAction) {
         return false;
@@ -276,7 +237,7 @@ function checkBucketPolicy(policy, requestType, canonicalID, arn, bucketOwner, l
     while (copiedStatement.length > 0) {
         const s = copiedStatement[0];
         const principalMatch = _checkPrincipals(canonicalID, arn, s.Principal);
-        const actionMatch = _checkActions(requestType, s.Action, log);
+        const actionMatch = _checkBucketPolicyActions(requestType, s.Action, log);
 
         if (principalMatch && actionMatch && s.Effect === 'Deny') {
             // explicit deny trumps any allows, so return immediately

--- a/lib/api/apiUtils/authorization/permissionChecks.js
+++ b/lib/api/apiUtils/authorization/permissionChecks.js
@@ -214,9 +214,9 @@ function checkObjectAcls(bucket, objectMD, requestType, canonicalID) {
 
 function _checkActions(requestType, actions, log) {
     const mappedAction = actionMap[requestType];
-    // if requestType isn't in list of controlled actions
+    // Deny any action that isn't in list of controlled actions
     if (!mappedAction) {
-        return true;
+        return false;
     }
     return evaluators.isActionApplicable(mappedAction, actions, log);
 }

--- a/tests/unit/api/bucketPolicyAuth.js
+++ b/tests/unit/api/bucketPolicyAuth.js
@@ -308,6 +308,14 @@ describe('bucket policy authorization', () => {
             assert.equal(allowed, false);
             done();
         });
+
+        it('should deny access to non-bucket owner with an unsupported action type',
+        done => {
+            const allowed = isBucketAuthorized(bucket, 'unsupportedAction',
+                altAcctCanonicalId, null, log);
+            assert.equal(allowed, false);
+            done();
+        });
     });
 
     describe('isObjAuthorized with no policy set', () => {
@@ -380,6 +388,14 @@ describe('bucket policy authorization', () => {
             };
             bucket.setBucketPolicy(newPolicy);
             const allowed = isObjAuthorized(bucket, object, objAction,
+                altAcctCanonicalId, null, log);
+            assert.equal(allowed, false);
+            done();
+        });
+
+        it('should deny access to non-object owner with an unsupported action type',
+        done => {
+            const allowed = isObjAuthorized(bucket, object, 'unsupportedAction',
                 altAcctCanonicalId, null, log);
             assert.equal(allowed, false);
             done();


### PR DESCRIPTION
* bugfix: S3C-4324 shared action map to check bucket policy actions

  When checking bucket policy actions, instead of using a hard-coded local action map which was missing a few items, check against the shared bucket policy action map in arsenal.

* bugfix: S3C-4324 deny any unsupported action

  As a security feature rather than a functional change, all action types that are not explicitly known are denied instead of allowed (or subject to further non-action policy controls).

Integration run: https://eve.devsca.com/github/scality/integration/#/builders/11/builds/3432 (fails on node5 due to a known issue in backbeat, unrelated)