### PR TITLE
INTEGRATION [PR#3676 > development/8.2] bf(S3C-4610): Add missing content-length header to utapi util

### DIFF
--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -59,6 +59,11 @@ function _listMetrics(host,
     recent,
     ssl) {
     const listAction = recent ? 'ListRecentMetrics' : 'ListMetrics';
+    // If recent listing, we do not provide `timeRange` in the request
+    const requestObj = recent
+        ? { [metric]: metricType }
+        : { timeRange, [metric]: metricType };
+    const requestBody = JSON.stringify(requestObj);
     const options = {
         host,
         port,
@@ -67,6 +72,7 @@ function _listMetrics(host,
         headers: {
             'content-type': 'application/json',
             'cache-control': 'no-cache',
+            'content-length': Buffer.byteLength(requestBody),
         },
         rejectUnauthorized: false,
     };
@@ -104,10 +110,8 @@ function _listMetrics(host,
     if (verbose) {
         logger.info('request headers', { headers: request._headers });
     }
-    // If recent listing, we do not provide `timeRange` in the request
-    const requestObj = recent ? {} : { timeRange };
-    requestObj[metric] = metricType;
-    request.write(JSON.stringify(requestObj));
+
+    request.write(requestBody);
     request.end();
 }
 


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3676.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/bugfix/S3C-4610_add_missing_utapi_header`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/bugfix/S3C-4610_add_missing_utapi_header
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/bugfix/S3C-4610_add_missing_utapi_header
```

Please always comment pull request #3676 instead of this one.