### PR TITLE
INTEGRATION [PR#3682 > development/7.10] add x-amz-bucket-region header on bucket HEAD response

### DIFF
--- a/lib/api/bucketHead.js
+++ b/lib/api/bucketHead.js
@@ -12,7 +12,7 @@ const { pushMetric } = require('../utapi/utilities');
  *  with either error code or success
  * @return {undefined}
  */
- function bucketHead(authInfo, request, log, callback) {
+function bucketHead(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'bucketHead' });
     const bucketName = request.bucketName;
     const metadataValParams = {

--- a/lib/api/bucketHead.js
+++ b/lib/api/bucketHead.js
@@ -30,9 +30,8 @@ const { pushMetric } = require('../utapi/utilities');
             authInfo,
             bucket: bucketName,
         });
-        
-        const headers = { 'x-amz-bucket-region': bucket._locationConstraint }
-        return callback(null, {...corsHeaders, ...headers});
+        const headers = { 'x-amz-bucket-region': bucket._locationConstraint };
+        return callback(null, Object.assign(corsHeaders, headers));
     });
 }
 

--- a/lib/api/bucketHead.js
+++ b/lib/api/bucketHead.js
@@ -12,7 +12,7 @@ const { pushMetric } = require('../utapi/utilities');
  *  with either error code or success
  * @return {undefined}
  */
-function bucketHead(authInfo, request, log, callback) {
+ function bucketHead(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'bucketHead' });
     const bucketName = request.bucketName;
     const metadataValParams = {
@@ -30,7 +30,9 @@ function bucketHead(authInfo, request, log, callback) {
             authInfo,
             bucket: bucketName,
         });
-        return callback(null, corsHeaders);
+        
+        const headers = { 'x-amz-bucket-region': bucket._locationConstraint }
+        return callback(null, {...corsHeaders, ...headers});
     });
 }
 

--- a/tests/unit/api/bucketHead.js
+++ b/tests/unit/api/bucketHead.js
@@ -52,7 +52,7 @@ describe('bucketHead API', () => {
             bucketHead(authInfo, testRequest, log, (err, headers) => {
                 assert.strictEqual(headers['x-amz-bucket-region'], 'us-east-1');
                 done();
-            })
+            });
         });
     });
 });

--- a/tests/unit/api/bucketHead.js
+++ b/tests/unit/api/bucketHead.js
@@ -46,4 +46,13 @@ describe('bucketHead API', () => {
             });
         });
     });
+
+    it('should return expected header value for x-amz-bucket-region', done => {
+        bucketPut(authInfo, testRequest, log, () => {
+            bucketHead(authInfo, testRequest, log, (err, headers) => {
+                assert.strictEqual(headers['x-amz-bucket-region'], 'us-east-1');
+                done();
+            })
+        });
+    });
 });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3682.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/feature/S3C-4569_x-amz-bucket-region_header`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/feature/S3C-4569_x-amz-bucket-region_header
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/feature/S3C-4569_x-amz-bucket-region_header
```

Please always comment pull request #3682 instead of this one.