### PR TITLE
INTEGRATION [PR#3715 > development/8.2] bugfix: S3C-4533 prevent suspending version on locked buckets

### DIFF
--- a/lib/api/bucketPutVersioning.js
+++ b/lib/api/bucketPutVersioning.js
@@ -15,6 +15,10 @@ const externalVersioningErrorMessage = 'We do not currently support putting ' +
 const invalidBucketStateMessage = 'A replication configuration is present on ' +
  'this bucket, so you cannot change the versioning state. To change the ' +
  'versioning state, first delete the replication configuration.';
+
+const objectLockErrorMessage = 'An Object Lock configuration is present on ' +
+  'this bucket, so the versioning state cannot be changed.';
+
 /**
  * Format of xml request:
 
@@ -128,6 +132,12 @@ function bucketPutVersioning(authInfo, request, log, callback) {
             if (invalidAction) {
                 next(errors.InvalidBucketState
                     .customizeDescription(invalidBucketStateMessage));
+                return;
+            }
+            const objectLockEnabled = bucket.isObjectLockEnabled();
+            if (objectLockEnabled) {
+                next(errors.InvalidBucketState
+                    .customizeDescription(objectLockErrorMessage));
                 return;
             }
             bucket.setVersioningConfiguration(versioningConfiguration);


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3715.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/bugfix/S3C-4533-prevent-suspending-versioning-locked-bucket`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/bugfix/S3C-4533-prevent-suspending-versioning-locked-bucket
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/bugfix/S3C-4533-prevent-suspending-versioning-locked-bucket
```

Please always comment pull request #3715 instead of this one.