### PR TITLE
INTEGRATION [PR#3739 > development/7.10] bugfix: CLDSRV-5 Remove extra headers from 304 responses

### DIFF
--- a/tests/functional/aws-node-sdk/test/object/get.js
+++ b/tests/functional/aws-node-sdk/test/object/get.js
@@ -658,13 +658,19 @@ describe('GET object', () => {
             it('If-None-Match & If-Modified-Since: returns NotModified when ' +
                 'Etag does not match and lastModified is greater',
                 done => {
-                    requestGet({
+                    const req = s3.getObject({
+                        Bucket: bucketName,
+                        Key: objectName,
                         IfNoneMatch: etagTrim,
                         IfModifiedSince: dateFromNow(-1),
                     }, err => {
                         checkError(err, 'NotModified');
                         done();
                     });
+                    req.on('httpHeaders', (code, headers, response, status) => {
+                        assert(!headers.hasOwnProperty('content-type'));
+                        assert(!headers.hasOwnProperty('content-length'));
+                    })
                 });
 
             it('If-None-Match not match & If-Modified-Since not match',


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3739.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/bugfix/CLDSRV-5_RemoveExtraHeadersFrom304Responses`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/bugfix/CLDSRV-5_RemoveExtraHeadersFrom304Responses
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/bugfix/CLDSRV-5_RemoveExtraHeadersFrom304Responses
```

Please always comment pull request #3739 instead of this one.