### PR TITLE
INTEGRATION [PR#3739 > development/7.10] bugfix: CLDSRV-5 Remove extra headers from 304 responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "github:scality/Arsenal#f17006b",
+    "arsenal": "github:scality/Arsenal#836c65e",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/tests/functional/aws-node-sdk/test/object/get.js
+++ b/tests/functional/aws-node-sdk/test/object/get.js
@@ -658,13 +658,19 @@ describe('GET object', () => {
             it('If-None-Match & If-Modified-Since: returns NotModified when ' +
                 'Etag does not match and lastModified is greater',
                 done => {
-                    requestGet({
+                    const req = s3.getObject({
+                        Bucket: bucketName,
+                        Key: objectName,
                         IfNoneMatch: etagTrim,
                         IfModifiedSince: dateFromNow(-1),
                     }, err => {
                         checkError(err, 'NotModified');
                         done();
                     });
+                    req.on('httpHeaders', (code, headers, response, status) => {
+                        assert(!headers.hasOwnProperty('content-type'));
+                        assert(!headers.hasOwnProperty('content-length'));
+                    })
                 });
 
             it('If-None-Match not match & If-Modified-Since not match',

--- a/tests/functional/aws-node-sdk/test/object/get.js
+++ b/tests/functional/aws-node-sdk/test/object/get.js
@@ -662,15 +662,15 @@ describe('GET object', () => {
                         Bucket: bucketName,
                         Key: objectName,
                         IfNoneMatch: etagTrim,
-                        IfModifiedSince: dateFromNow(-1),
+                        IfModifiedSince: dateFromNow(1),
                     }, err => {
                         checkError(err, 'NotModified');
                         done();
                     });
-                    req.on('httpHeaders', (code, headers, response, status) => {
-                        assert(!headers.hasOwnProperty('content-type'));
-                        assert(!headers.hasOwnProperty('content-length'));
-                    })
+                    req.on('httpHeaders', (code, headers) => {
+                        assert(!headers['content-type']);
+                        assert(!headers['content-length']);
+                    });
                 });
 
             it('If-None-Match not match & If-Modified-Since not match',

--- a/yarn.lock
+++ b/yarn.lock
@@ -282,9 +282,9 @@ arraybuffer.slice@~0.0.7:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
   integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
 
-"arsenal@github:scality/Arsenal#f17006b":
+"arsenal@github:scality/Arsenal#836c65e":
   version "7.5.0"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/f17006b91eaefce2be00c2600ae55e4d63265333"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/836c65e91eddad7682a807fa79d77b993cdfd367"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
@@ -298,6 +298,7 @@ arraybuffer.slice@~0.0.7:
     level "~5.0.1"
     level-sublevel "~6.6.5"
     node-forge "^0.7.1"
+    prom-client "10.2.3"
     simple-glob "^0.2"
     socket.io "~2.3.0"
     socket.io-client "~2.3.0"
@@ -623,6 +624,11 @@ bindings@^1.1.1:
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
+
+bintrees@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
+  integrity sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=
 
 bl@^2.2.1:
   version "2.2.1"
@@ -3139,6 +3145,13 @@ progress@^1.1.8:
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
   integrity sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=
 
+prom-client@10.2.3:
+  version "10.2.3"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-10.2.3.tgz#a51bf21c239c954a6c5be4b1361fdd380218bb41"
+  integrity sha512-Xboq5+TdUwuQtSSDRZRNnb5NprINlgQN999VqUjZxnLKydUNLeIPx6Eiahg6oJua3XBg2TGnh5Cth1s4I6+r7g==
+  dependencies:
+    tdigest "^0.1.1"
+
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
@@ -3859,6 +3872,13 @@ table@^3.7.8:
     lodash "^4.0.0"
     slice-ansi "0.0.4"
     string-width "^2.0.0"
+
+tdigest@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.1.tgz#2e3cb2c39ea449e55d1e6cd91117accca4588021"
+  integrity sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=
+  dependencies:
+    bintrees "1.0.1"
 
 text-table@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3739.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/bugfix/CLDSRV-5_RemoveExtraHeadersFrom304Responses`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/bugfix/CLDSRV-5_RemoveExtraHeadersFrom304Responses
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/bugfix/CLDSRV-5_RemoveExtraHeadersFrom304Responses
```

Please always comment pull request #3739 instead of this one.