### PR TITLE
CLDSRV-6 unexpected 403 errors

### DIFF
--- a/lib/api/apiUtils/authorization/permissionChecks.js
+++ b/lib/api/apiUtils/authorization/permissionChecks.js
@@ -278,85 +278,17 @@ function isBucketAuthorized(bucket, requestType, canonicalID, authInfo, log) {
     return (aclPermission || (bucketPolicyPermission === 'allow'));
 }
 
-function _isPermissionGranted(permissionList, canonicalID) {
-    if (permissionList.indexOf(publicId) > -1) {
-        return true;
-    }
-
-    if (permissionList.indexOf(allAuthedUsersId) > -1 &&
-        canonicalID !== publicId) {
-        return true;
-    }
-
-    if (permissionList.indexOf(canonicalID) > -1) {
-        return true;
-    }
-
-    return false;
-}
-
-function hasBucketReadAccess(bucket, requestType, canonicalID, authInfo, log) {
-    const bucketAcl = bucket.getAcl();
-    const bucketOwner = bucket.getOwner();
-    const bucketPolicy = bucket.getBucketPolicy();
-    let arn = null;
-    let requesterIsNotUser = true;
-
-    if (authInfo) {
-        requesterIsNotUser = !authInfo.isRequesterAnIAMUser();
-        arn = authInfo.getArn();
-    }
-
-    // bucket policies over acls if any is applicable
-    if (bucketPolicy) {
-        // bucketGet covers listObjects and listMultipartUploads, bucket read
-        // actions
-        const bucketListPermission = checkBucketPolicy(
-            bucketPolicy,
-            'bucketGet',
-            canonicalID,
-            arn,
-            bucketOwner,
-            log
-        );
-
-        if (bucketListPermission === 'explicitDeny') {
-            return false;
-        }
-
-        if (bucketListPermission === 'allow') {
-            return true;
-        }
-        // defaultDeny, fallback onto acls
-    }
-
-    if ((canonicalID === bucketOwner && requesterIsNotUser) ||
-        _isPermissionGranted(bucketAcl.FULL_CONTROL, canonicalID) ||
-        _isPermissionGranted(bucketAcl.READ, canonicalID)) {
-        return true;
-    }
-
-    if (bucketAcl.Canned === 'public-read' ||
-        bucketAcl.Canned === 'public-read-write' ||
-        (bucketAcl.Canned === 'authenticated-read' &&
-         canonicalID !== publicId)) {
-        return true;
-    }
-
-    return false;
-}
-
 function isObjAuthorized(bucket, objectMD, requestType, canonicalID, authInfo, log) {
     const bucketOwner = bucket.getOwner();
     if (!objectMD) {
+        // User is already authorized on the bucket for FULL_CONTROL or WRITE or
+        // bucket has canned ACL public-read-write
         if (requestType === 'objectPut' || requestType === 'objectDelete') {
             return true;
         }
-
-        // if read access is granted, return true to have the api handler
-        // respond accordingly to the missing object metadata
-        // if read access is not granted, return false for AccessDenied
-        return hasBucketReadAccess(bucket, requestType, canonicalID, authInfo, log);
+        // check bucket has read access
+        // 'bucketGet' covers listObjects and listMultipartUploads, bucket read actions
+        return isBucketAuthorized(bucket, 'bucketGet', canonicalID, authInfo, log);
     }
     let requesterIsNotUser = true;
     let arn = null;

--- a/tests/unit/api/objectACLauth.js
+++ b/tests/unit/api/objectACLauth.js
@@ -301,6 +301,20 @@ describe('without object metadata', () => {
 
     const tests = [
         {
+            it: 'should allow user if part of the bucket owner account',
+            canned: 'private', id: objectOwnerCanonicalId,
+            authInfo: userAuthInfo,
+            aclParam: null,
+            response: allowedAccess,
+        },
+        {
+            it: 'should not allow user if not part of the bucket owner account',
+            canned: 'private', id: accountToVet,
+            authInfo: altAcctAuthInfo,
+            aclParam: null,
+            response: deniedAccess,
+        },
+        {
             it: 'should allow bucket owner',
             canned: 'private', id: bucketOwnerCanonicalId,
             aclParam: null,


### PR DESCRIPTION
When a user, with bucket read access, requests a non-existing object (head object, get object tagging...) we are returning a **403** instead of a **404** error.

`hasBucketReadAccess` and `isBucketAuthorized` (with `bucketGet` as the "request type" argument) seems to have the same logic. 

`hasBucketReadAccess` was missing the `bucket.getOwner() === canonicalID` condition that will allow user (with the right user policy) to access its account bucket's objects without any extra bucket policy or bucket ACL needed.