### PR TITLE
improvement: CLDSRV-8 server-side encryption deep healthcheck

### DIFF
--- a/lib/kms/wrapper.js
+++ b/lib/kms/wrapper.js
@@ -299,6 +299,29 @@ class KMS {
             return cb(err, decipherBundle);
         });
     }
+
+    static checkHealth(log, cb) {
+        if (!client.healthcheck) {
+            return cb(null, {
+                [implName]: { code: 200, message: 'OK' },
+            });
+        }
+        return client.healthcheck(log, err => {
+            const respBody = {};
+            if (err) {
+                respBody[implName] = {
+                    error: err.description,
+                    code: err.code,
+                };
+            } else {
+                respBody[implName] = {
+                    code: 200,
+                    message: 'OK',
+                };
+            }
+            return cb(null, respBody);
+        });
+    }
 }
 
 module.exports = KMS;

--- a/lib/utilities/healthcheckHandler.js
+++ b/lib/utilities/healthcheckHandler.js
@@ -3,6 +3,7 @@ const _config = require('../Config').config;
 const data = require('../data/wrapper');
 const vault = require('../auth/vault');
 const metadata = require('../metadata/wrapper');
+const kms = require('../kms/wrapper');
 const async = require('async');
 
 // current function utility is minimal, but will be expanded
@@ -44,6 +45,7 @@ function clientCheck(flightCheckOnStartUp, log, cb) {
         data,
         metadata,
         vault,
+        kms,
     ];
     const clientTasks = [];
     clients.forEach(client => {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "github:scality/Arsenal#735c6f2",
+    "arsenal": "github:scality/Arsenal#9aa8710",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -650,9 +650,9 @@ arraybuffer.slice@~0.0.7:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
   integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
 
-"arsenal@github:scality/Arsenal#735c6f2":
+"arsenal@github:scality/Arsenal#9aa8710":
   version "7.7.2"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/735c6f2fb51e2edc3c11f48ccea8b5cdae81f437"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/9aa8710a57b037685ad2851543808df3a41476b2"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"


### PR DESCRIPTION
Implement a deep healthcheck for server-side encryption in the
Cloudserver deep healthcheck route.

For now, only the KMIP backend has an implementation for the deep
healthcheck, hence all other backends (NAE KMS, file etc.) will just
return success without checking anything.
