### PR TITLE
INTEGRATION [PR#3758 > development/8.2] CLDSRV-9 update werelogs to a properly tagged version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "utf8": "~2.1.1",
     "uuid": "^8.3.2",
     "vaultclient": "scality/vaultclient#4636126",
-    "werelogs": "scality/werelogs#0a4c576",
+    "werelogs": "scality/werelogs#8.1.0",
     "xml2js": "~0.4.16"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4133,6 +4133,12 @@ werelogs@scality/werelogs#4e0d97c:
   dependencies:
     safe-json-stringify "1.0.3"
 
+werelogs@scality/werelogs#8.1.0:
+  version "8.1.0"
+  resolved "https://codeload.github.com/scality/werelogs/tar.gz/e8f828725642c54c511cdbe580b18f43d3589313"
+  dependencies:
+    safe-json-stringify "1.0.3"
+
 which@^1.1.1, which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3758.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/feature/CLDSRV-9-upgrade-werelogs`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/feature/CLDSRV-9-upgrade-werelogs
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/feature/CLDSRV-9-upgrade-werelogs
```

Please always comment pull request #3758 instead of this one.