### PR TITLE
INTEGRATION [PR#3765 > development/8.2] S3C-4726 Log bytes deleted by AbortMultipartUpload calls

### DIFF
--- a/lib/api/multipartDelete.js
+++ b/lib/api/multipartDelete.js
@@ -52,6 +52,10 @@ function multipartDelete(authInfo, request, log, callback) {
                     byteLength: partSizeSum,
                     location,
                 });
+
+                log.addDefaultFields({
+                    bytesDeleted: partSizeSum,
+                });
             }
             return callback(null, corsHeaders);
         }, request);


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3765.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/feature/S3C-4726/log`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/feature/S3C-4726/log
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/feature/S3C-4726/log
```

Please always comment pull request #3765 instead of this one.