### PR TITLE
Improvement/cldsrv 13 hotfix get acl with predefined groups

### DIFF
--- a/lib/api/bucketGetACL.js
+++ b/lib/api/bucketGetACL.js
@@ -1,5 +1,4 @@
 const aclUtils = require('../utilities/aclUtils');
-const constants = require('../../constants');
 const { metadataValidateBucket } = require('../metadata/metadataUtils');
 const vault = require('../auth/vault');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
@@ -53,11 +52,6 @@ function bucketGetACL(authInfo, request, log, callback) {
             displayName: undefined,
         },
     };
-    const grantsByURI = [
-        constants.publicId,
-        constants.allAuthedUsersId,
-        constants.logId,
-    ];
 
     metadataValidateBucket(metadataValParams, log, (err, bucket) => {
         const corsHeaders = collectCorsHeaders(request.headers.origin,
@@ -68,13 +62,6 @@ function bucketGetACL(authInfo, request, log, callback) {
             return callback(err, null, corsHeaders);
         }
         const bucketACL = bucket.getAcl();
-        const allSpecificGrants = [].concat(
-            bucketACL.FULL_CONTROL,
-            bucketACL.WRITE,
-            bucketACL.WRITE_ACP,
-            bucketACL.READ,
-            bucketACL.READ_ACP
-        );
         grantInfo.ownerInfo.ID = bucket.getOwner();
         grantInfo.ownerInfo.displayName = bucket.getOwnerDisplayName();
         const ownerGrant = {
@@ -100,21 +87,9 @@ function bucketGetACL(authInfo, request, log, callback) {
         * privileges, want to display both and not lose the duplicate
         * when receive one dictionary entry back from Vault)
         */
-        const canonicalIDs = allSpecificGrants
-            .filter(item => grantsByURI.indexOf(item) < 0);
+        const canonicalIDs = aclUtils.getCanonicalIDs(bucketACL);
         // Build array with grants by URI
-        const uriGrantInfo = grantsByURI.map(uri => {
-            const permission = aclUtils.getPermissionType(uri, bucketACL,
-                'bucket');
-            if (permission) {
-                return {
-                    URI: uri,
-                    permission,
-                };
-            }
-            return undefined;
-        }).filter(item => item !== undefined);
-
+        const uriGrantInfo = aclUtils.getUriGrantInfo(bucketACL);
         if (canonicalIDs.length === 0) {
             /**
             * If no acl's set by account canonicalID, just add URI
@@ -138,25 +113,8 @@ function bucketGetACL(authInfo, request, log, callback) {
                     { method: 'vault.getEmailAddresses', error: err });
                 return callback(err, null, corsHeaders);
             }
-            const individualGrants = canonicalIDs.map(canonicalID => {
-                /**
-                 * Emails dict only contains entries that were found
-                 * in Vault
-                 */
-                if (emails[canonicalID]) {
-                    const permission = aclUtils.getPermissionType(
-                        canonicalID, bucketACL, 'bucket');
-                    if (permission) {
-                        const displayName = emails[canonicalID];
-                        return {
-                            ID: canonicalID,
-                            displayName,
-                            permission,
-                        };
-                    }
-                }
-                return undefined;
-            }).filter(item => item !== undefined);
+            const individualGrants =
+                aclUtils.getIndividualGrants(bucketACL, canonicalIDs, emails);
             // Add to grantInfo any individual grants and grants by uri
             grantInfo.grants = grantInfo.grants
                 .concat(individualGrants).concat(uriGrantInfo);

--- a/lib/api/objectGetACL.js
+++ b/lib/api/objectGetACL.js
@@ -3,7 +3,6 @@ const { errors } = require('arsenal');
 
 const aclUtils = require('../utilities/aclUtils');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
-const constants = require('../../constants');
 const { pushMetric } = require('../utapi/utilities');
 const { decodeVersionId, getVersionIdResHeader }
     = require('./apiUtils/object/versioning');
@@ -68,10 +67,6 @@ function objectGetACL(authInfo, request, log, callback) {
             displayName: undefined,
         },
     };
-    const grantsByURI = [constants.publicId,
-        constants.allAuthedUsersId,
-        constants.logId,
-    ];
 
     return async.waterfall([
         function validateBucketAndObj(next) {
@@ -79,24 +74,24 @@ function objectGetACL(authInfo, request, log, callback) {
                 (err, bucket, objectMD) => {
                     if (err) {
                         log.trace('request authorization failed',
-                        { method: 'objectGetACL', error: err });
+                            { method: 'objectGetACL', error: err });
                         return next(err);
                     }
                     if (!objectMD) {
                         const err = versionId ? errors.NoSuchVersion :
                             errors.NoSuchKey;
                         log.trace('error processing request',
-                        { method: 'objectGetACL', error: err });
+                            { method: 'objectGetACL', error: err });
                         return next(err, bucket);
                     }
                     if (objectMD.isDeleteMarker) {
                         if (versionId) {
                             log.trace('requested version is delete marker',
-                            { method: 'objectGetACL' });
+                                { method: 'objectGetACL' });
                             return next(errors.MethodNotAllowed);
                         }
                         log.trace('most recent version is delete marker',
-                        { method: 'objectGetACL' });
+                            { method: 'objectGetACL' });
                         return next(errors.NoSuchKey);
                     }
                     return next(null, bucket, objectMD);
@@ -106,12 +101,6 @@ function objectGetACL(authInfo, request, log, callback) {
             const verCfg = bucket.getVersioningConfiguration();
             const resVersionId = getVersionIdResHeader(verCfg, objectMD);
             const objectACL = objectMD.acl;
-            const allSpecificGrants = [].concat(
-                objectACL.FULL_CONTROL,
-                objectACL.WRITE_ACP,
-                objectACL.READ,
-                objectACL.READ_ACP
-            ).filter(item => item !== undefined);
             grantInfo.ownerInfo.ID = objectMD['owner-id'];
             grantInfo.ownerInfo.displayName = objectMD['owner-display-name'];
             // Object owner always has full control
@@ -129,10 +118,10 @@ function objectGetACL(authInfo, request, log, callback) {
                 let cannedGrants;
                 if (bucket.getOwner() !== objectMD['owner-id']) {
                     cannedGrants = aclUtils.handleCannedGrant(
-                    objectACL.Canned, ownerGrant, bucket);
+                        objectACL.Canned, ownerGrant, bucket);
                 } else {
                     cannedGrants = aclUtils.handleCannedGrant(
-                    objectACL.Canned, ownerGrant);
+                        objectACL.Canned, ownerGrant);
                 }
                 grantInfo.grants = grantInfo.grants.concat(cannedGrants);
                 const xml = aclUtils.convertToXml(grantInfo);
@@ -144,20 +133,9 @@ function objectGetACL(authInfo, request, log, callback) {
             * privileges, want to display both and not lose the duplicate
             * when receive one dictionary entry back from Vault)
             */
-            const canonicalIDs = allSpecificGrants.filter(item =>
-                grantsByURI.indexOf(item) < 0);
+            const canonicalIDs = aclUtils.getCanonicalIDs(objectACL);
             // Build array with grants by URI
-            const uriGrantInfo = grantsByURI.map(uri => {
-                const permission = aclUtils.getPermissionType(uri, objectACL,
-                    'object');
-                if (permission) {
-                    return {
-                        URI: uri,
-                        permission,
-                    };
-                }
-                return undefined;
-            }).filter(item => item !== undefined);
+            const uriGrantInfo = aclUtils.getUriGrantInfo(objectACL);
 
             if (canonicalIDs.length === 0) {
                 /**
@@ -179,25 +157,8 @@ function objectGetACL(authInfo, request, log, callback) {
                         { method: 'objectGetACL', error: err });
                     return next(err, bucket);
                 }
-                const individualGrants = canonicalIDs.map(canonicalID => {
-                /**
-                * Emails dict only contains entries that were found
-                * in Vault
-                */
-                    if (emails[canonicalID]) {
-                        const permission = aclUtils.getPermissionType(
-                            canonicalID, objectACL, 'object');
-                        if (permission) {
-                            const displayName = emails[canonicalID];
-                            return {
-                                ID: canonicalID,
-                                displayName,
-                                permission,
-                            };
-                        }
-                    }
-                    return undefined;
-                }).filter(item => item !== undefined);
+                const individualGrants = aclUtils.getIndividualGrants(objectACL,
+                    canonicalIDs, emails);
                 // Add to grantInfo any individual grants and grants by uri
                 grantInfo.grants = grantInfo.grants
                     .concat(individualGrants).concat(uriGrantInfo);

--- a/lib/utilities/aclUtils.js
+++ b/lib/utilities/aclUtils.js
@@ -354,6 +354,8 @@ aclUtils.getCanonicalIDs = function getCanonicalIDs(acl) {
         acl.READ_ACP
     );
     const uniqueGrantees = Array.from(new Set(aclGrantees));
+    // grantees can be a mix of canonicalIDs and predefined groups in the form
+    // of uri, so filter out only canonicalIDs
     return uniqueGrantees.filter(item => item && !grantsByURI.includes(item));
 };
 
@@ -365,17 +367,17 @@ aclUtils.getCanonicalIDs = function getCanonicalIDs(acl) {
 aclUtils.getUriGrantInfo = function getUriGrantInfo(acl) {
     const grants = getGrants(acl);
     const uriGrantInfo = [];
-    Object.entries(grants).forEach(([permission, grantees]) => {
-        if (Array.isArray(grantees)) {
-            grantees.forEach(grantee => {
-                if (grantsByURI.includes(grantee)) {
-                    uriGrantInfo.push({
-                        URI: grantee,
-                        permission,
-                    });
-                }
+    const validGrants = Object.entries(grants)
+        .filter(([permission, grantees]) => permission
+            && Array.isArray(grantees));
+    validGrants.forEach(([permission, grantees]) => {
+        grantees.filter(grantee => grantsByURI.includes(grantee))
+            .forEach(grantee => {
+                uriGrantInfo.push({
+                    URI: grantee,
+                    permission,
+                });
             });
-        }
     });
     return uriGrantInfo;
 };
@@ -393,19 +395,19 @@ aclUtils.getIndividualGrants = function getIndividualGrants(acl, canonicalIDs,
     emails) {
     const grants = getGrants(acl);
     const individualGrantInfo = [];
-    Object.entries(grants).forEach(([permission, grantees]) => {
-        if (Array.isArray(grantees)) {
-            grantees.forEach(grantee => {
-                const displayName = emails[grantee];
-                if (canonicalIDs.includes(grantee) && displayName) {
-                    individualGrantInfo.push({
-                        ID: grantee,
-                        displayName,
-                        permission,
-                    });
-                }
+    const validGrants = Object.entries(grants)
+        .filter(([permission, grantees]) => permission
+            && Array.isArray(grantees));
+    validGrants.forEach(([permission, grantees]) => {
+        grantees.filter(grantee => canonicalIDs.includes(grantee)
+            && emails[grantee])
+            .forEach(grantee => {
+                individualGrantInfo.push({
+                    ID: grantee,
+                    displayName: emails[grantee],
+                    permission,
+                });
             });
-        }
     });
     return individualGrantInfo;
 };

--- a/lib/utilities/aclUtils.js
+++ b/lib/utilities/aclUtils.js
@@ -11,6 +11,11 @@ const possibleGrantHeaders = ['x-amz-grant-read', 'x-amz-grant-write',
 const regexpEmailAddress = /^\S+@\S+.\S+$/;
 
 const aclUtils = {};
+const grantsByURI = [
+    constants.publicId,
+    constants.allAuthedUsersId,
+    constants.logId,
+];
 
 /**
  * handleCannedGrant - Populate grantInfo for a bucketGetACL or objectGetACL
@@ -109,10 +114,10 @@ aclUtils.parseAclXml = function parseAclXml(toBeParsed, log, next) {
             return next(errors.MalformedXML);
         }
         if (!result.AccessControlPolicy
-                || !result.AccessControlPolicy.AccessControlList
-                || result.AccessControlPolicy.AccessControlList.length !== 1
-                || (result.AccessControlPolicy.AccessControlList[0] !== '' &&
-                  Object.keys(result.AccessControlPolicy.AccessControlList[0])
+            || !result.AccessControlPolicy.AccessControlList
+            || result.AccessControlPolicy.AccessControlList.length !== 1
+            || (result.AccessControlPolicy.AccessControlList[0] !== '' &&
+                Object.keys(result.AccessControlPolicy.AccessControlList[0])
                     .some(listKey => listKey !== 'Grant'))) {
             log.debug('invalid acl', { acl: result });
             return next(errors.MalformedACLError);
@@ -135,7 +140,7 @@ aclUtils.parseAclXml = function parseAclXml(toBeParsed, log, next) {
 };
 
 aclUtils.getPermissionType = function getPermissionType(identifier, resourceACL,
-        resourceType) {
+    resourceType) {
     const fullControlIndex = resourceACL.FULL_CONTROL.indexOf(identifier);
     let writeIndex;
     if (resourceType === 'bucket') {
@@ -230,13 +235,13 @@ aclUtils.convertToXml = grantInfo => {
     const xml = [];
 
     xml.push('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
-             '<AccessControlPolicy>',
-             '<Owner>',
-             `<ID>${ownerInfo.ID}</ID>`,
-             `<DisplayName>${escapeForXml(ownerInfo.displayName)}` +
-                '</DisplayName>',
-             '</Owner>',
-             '<AccessControlList>'
+        '<AccessControlPolicy>',
+        '<Owner>',
+        `<ID>${ownerInfo.ID}</ID>`,
+        `<DisplayName>${escapeForXml(ownerInfo.displayName)}` +
+        '</DisplayName>',
+        '</Owner>',
+        '<AccessControlList>'
     );
 
     grants.forEach(grant => {
@@ -246,30 +251,30 @@ aclUtils.convertToXml = grantInfo => {
         // grant has an ID or URI
         if (grant.ID) {
             xml.push('<Grantee xmlns:xsi="http://www.w3.org/2001/' +
-                        'XMLSchema-instance" xsi:type="CanonicalUser">',
-                     `<ID>${grant.ID}</ID>`
+                'XMLSchema-instance" xsi:type="CanonicalUser">',
+                `<ID>${grant.ID}</ID>`
             );
         } else if (grant.URI) {
             xml.push('<Grantee xmlns:xsi="http://www.w3.org/2001/' +
-                        'XMLSchema-instance" xsi:type="Group">',
-                     `<URI>${escapeForXml(grant.URI)}</URI>`
+                'XMLSchema-instance" xsi:type="Group">',
+                `<URI>${escapeForXml(grant.URI)}</URI>`
             );
         }
 
         if (grant.displayName) {
             xml.push(`<DisplayName>${escapeForXml(grant.displayName)}` +
-                     '</DisplayName>'
+                '</DisplayName>'
             );
         }
 
         xml.push('</Grantee>',
-                 `<Permission>${grant.permission}</Permission>`,
-                 '</Grant>'
+            `<Permission>${grant.permission}</Permission>`,
+            '</Grant>'
         );
     });
 
     xml.push('</AccessControlList>',
-             '</AccessControlPolicy>'
+        '</AccessControlPolicy>'
     );
 
     return xml.join('');
@@ -318,6 +323,91 @@ aclUtils.checkGrantHeaderValidity = function checkGrantHeaderValidity(headers) {
         }
     }
     return true;
+};
+
+/**
+ * getGrants - Get all acl grants as an object
+ * @param {object} acl - acl from metadata
+ * @returns {object} grants
+ */
+function getGrants(acl) {
+    return {
+        FULL_CONTROL: acl.FULL_CONTROL,
+        WRITE: acl.WRITE,
+        WRITE_ACP: acl.WRITE_ACP,
+        READ: acl.READ,
+        READ_ACP: acl.READ_ACP,
+    };
+}
+
+/**
+ * getCanonicalIDs - Get all the unique canonical IDs from object or bucket acl
+ * @param {object} acl - acl from metadata
+ * @returns {array} canonicalIDs - array of unique canonicalIDs from acl
+ */
+aclUtils.getCanonicalIDs = function getCanonicalIDs(acl) {
+    const aclGrantees = [].concat(
+        acl.FULL_CONTROL,
+        acl.WRITE,
+        acl.WRITE_ACP,
+        acl.READ,
+        acl.READ_ACP
+    );
+    const uniqueGrantees = Array.from(new Set(aclGrantees));
+    return uniqueGrantees.filter(item => item && !grantsByURI.includes(item));
+};
+
+/**
+ * getUriGrantInfo - Get all the grants from object or bucket acl by uri
+ * @param {object} acl - acl from metadata
+ * @returns {array} uriGrantInfo - array of grants by uri
+ */
+aclUtils.getUriGrantInfo = function getUriGrantInfo(acl) {
+    const grants = getGrants(acl);
+    const uriGrantInfo = [];
+    Object.entries(grants).forEach(([permission, grantees]) => {
+        if (Array.isArray(grantees)) {
+            grantees.forEach(grantee => {
+                if (grantsByURI.includes(grantee)) {
+                    uriGrantInfo.push({
+                        URI: grantee,
+                        permission,
+                    });
+                }
+            });
+        }
+    });
+    return uriGrantInfo;
+};
+
+/**
+ * getIndividualGrants - Get all the grants from object or bucket acl mapped to
+ * canonicalID/email
+ * @param {object} acl - acl from metadata
+ * @param {array} canonicalIDs - list of canonicalIDs from acl
+ * @param {array} emails - canonicalID/email dictionary
+ * @returns {array} individualGrantInfo - array of grants mapped to
+ * canonicalID/email
+ */
+aclUtils.getIndividualGrants = function getIndividualGrants(acl, canonicalIDs,
+    emails) {
+    const grants = getGrants(acl);
+    const individualGrantInfo = [];
+    Object.entries(grants).forEach(([permission, grantees]) => {
+        if (Array.isArray(grantees)) {
+            grantees.forEach(grantee => {
+                const displayName = emails[grantee];
+                if (canonicalIDs.includes(grantee) && displayName) {
+                    individualGrantInfo.push({
+                        ID: grantee,
+                        displayName,
+                        permission,
+                    });
+                }
+            });
+        }
+    });
+    return individualGrantInfo;
 };
 
 module.exports = aclUtils;

--- a/tests/unit/api/bucketGetACL.js
+++ b/tests/unit/api/bucketGetACL.js
@@ -53,8 +53,7 @@ describe('bucketGetACL API', () => {
             (corsHeaders, next) => bucketGetACL(authInfo,
                 testGetACLRequest, log, next),
             (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, result) => {
+        ], (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
                 AccessControlList[0].Grant[0].Grantee[0]
                 .ID[0], canonicalID);
@@ -86,8 +85,7 @@ describe('bucketGetACL API', () => {
             (corsHeaders, next) => bucketGetACL(authInfo, testGetACLRequest,
                 log, next),
             (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, result) => {
+        ], (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
                 AccessControlList[0].Grant[0].Grantee[0]
                 .ID[0], canonicalID);
@@ -130,8 +128,7 @@ describe('bucketGetACL API', () => {
             (corsHeaders, next) => bucketGetACL(authInfo, testGetACLRequest,
                 log, next),
             (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, result) => {
+        ], (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
                 AccessControlList[0].Grant[0].Grantee[0]
                 .ID[0], canonicalID);
@@ -168,8 +165,7 @@ describe('bucketGetACL API', () => {
             (corsHeaders, next) => bucketGetACL(authInfo, testGetACLRequest,
                 log, next),
             (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, result) => {
+        ], (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
                 AccessControlList[0].Grant[0].Grantee[0]
                 .ID[0], canonicalID);
@@ -207,8 +203,7 @@ describe('bucketGetACL API', () => {
             (corsHeaders, next) => bucketGetACL(authInfo, testGetACLRequest,
                 log, next),
             (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, result) => {
+        ], (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
                 AccessControlList[0].Grant[0].Grantee[0]
                 .ID[0], canonicalID);
@@ -266,8 +261,7 @@ describe('bucketGetACL API', () => {
             (corsHeaders, next) => bucketGetACL(authInfo, testGetACLRequest,
                 log, next),
             (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, result) => {
+        ], (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
                 AccessControlList[0].Grant[0].Grantee[0]
                 .ID[0], canonicalIDforSample1);
@@ -318,6 +312,99 @@ describe('bucketGetACL API', () => {
                 .Permission[0], 'READ');
             assert.strictEqual(result.AccessControlPolicy.
                 AccessControlList[0].Grant[6], undefined);
+            done();
+        });
+    });
+
+    const grantsByURI = [
+        constants.publicId,
+        constants.allAuthedUsersId,
+        constants.logId,
+    ];
+
+    grantsByURI.forEach(uri => {
+        it('should get all ACLs when predefined group - ' +
+        `${uri} is used for multiple grants`, done => {
+            const testPutACLRequest = {
+                bucketName,
+                namespace,
+                headers: {
+                    'host': `${bucketName}.s3.amazonaws.com`,
+                    'x-amz-grant-full-control': `uri = ${uri}`,
+                    'x-amz-grant-read': `uri = ${uri}`,
+                    'x-amz-grant-write': `uri = ${uri}`,
+                    'x-amz-grant-read-acp': `uri = ${uri}`,
+                    'x-amz-grant-write-acp': `uri = ${uri}`,
+                },
+                url: '/?acl',
+                query: { acl: '' },
+            };
+
+            async.waterfall([
+                next => bucketPut(authInfo, testBucketPutRequest,
+                    log, next), (corsHeaders, next) =>
+                    bucketPutACL(authInfo, testPutACLRequest, log, next),
+                (corsHeaders, next) => bucketGetACL(authInfo,
+                    testGetACLRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+            ], (err, result) => {
+                assert.ifError(err);
+                const grants =
+                    result.AccessControlPolicy.AccessControlList[0].Grant;
+                grants.forEach(grant => {
+                    assert.strictEqual(grant.Permission.length, 1);
+                    assert.strictEqual(grant.Grantee.length, 1);
+                    assert.strictEqual(grant.Grantee[0].URI.length, 1);
+                    assert.strictEqual(grant.Grantee[0].URI[0], `${uri}`);
+                });
+                done();
+            });
+        });
+    });
+
+    it('should get all ACLs when predefined groups are used for ' +
+    'more than one grant', done => {
+        const { allAuthedUsersId, publicId } = constants;
+        const testPutACLRequest = {
+            bucketName,
+            namespace,
+            headers: {
+                'host': `${bucketName}.s3.amazonaws.com`,
+                'x-amz-grant-write': `uri = ${allAuthedUsersId} `,
+                'x-amz-grant-write-acp': `uri = ${allAuthedUsersId} `,
+                'x-amz-grant-read': `uri = ${publicId} `,
+                'x-amz-grant-read-acp': `uri = ${publicId} `,
+            },
+            url: '/?acl',
+            query: { acl: '' },
+        };
+
+        async.waterfall([
+            next => bucketPut(authInfo, testBucketPutRequest, log, next),
+            (corsHeaders, next) =>
+                bucketPutACL(authInfo, testPutACLRequest, log, next),
+            (corsHeaders, next) => bucketGetACL(authInfo, testGetACLRequest,
+                log, next),
+            (result, corsHeaders, next) => parseString(result, next),
+        ], (err, result) => {
+            assert.ifError(err);
+            const grants =
+                result.AccessControlPolicy.AccessControlList[0].Grant;
+            grants.forEach(grant => {
+                const permissions = grant.Permission;
+                assert.strictEqual(permissions.length, 1);
+                const permission = permissions[0];
+                assert.strictEqual(grant.Grantee.length, 1);
+                const grantees = grant.Grantee[0].URI;
+                assert.strictEqual(grantees.length, 1);
+                const grantee = grantees[0];
+                if (['WRITE', 'WRITE_ACP'].includes(permission)) {
+                    assert.strictEqual(grantee, constants.allAuthedUsersId);
+                }
+                if (['READ', 'READ_ACP'].includes(permission)) {
+                    assert.strictEqual(grantee, constants.publicId);
+                }
+            });
             done();
         });
     });

--- a/tests/unit/api/objectGetACL.js
+++ b/tests/unit/api/objectGetACL.js
@@ -64,8 +64,7 @@ describe('objectGetACL API', () => {
                 objectGetACL(authInfo, testGetACLRequest, log, next);
             },
             (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, result) => {
+        ], (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
                 AccessControlList[0].Grant[0].Grantee[0]
                 .ID[0], canonicalID);
@@ -77,7 +76,7 @@ describe('objectGetACL API', () => {
     });
 
     it('should return an error if try to get an ACL ' +
-        'for a nonexistent object', done => {
+    'for a nonexistent object', done => {
         bucketPut(authInfo, testBucketPutRequest, log, () => {
             objectGetACL(authInfo, testGetACLRequest, log, err => {
                 assert.deepStrictEqual(err, errors.NoSuchKey);
@@ -103,8 +102,7 @@ describe('objectGetACL API', () => {
                 objectGetACL(authInfo, testGetACLRequest, log, next);
             },
             (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, result) => {
+        ], (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
                 AccessControlList[0].Grant[0].Grantee[0]
                 .ID[0], canonicalID);
@@ -139,8 +137,7 @@ describe('objectGetACL API', () => {
                 objectGetACL(authInfo, testGetACLRequest, log, next);
             },
             (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, result) => {
+        ], (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
                 AccessControlList[0].Grant[0].Grantee[0]
                 .ID[0], canonicalID);
@@ -182,8 +179,7 @@ describe('objectGetACL API', () => {
                 objectGetACL(authInfo, testGetACLRequest, log, next);
             },
             (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, result) => {
+        ], (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
                 AccessControlList[0].Grant[0].Grantee[0]
                 .ID[0], canonicalID);
@@ -223,8 +219,7 @@ describe('objectGetACL API', () => {
                 objectGetACL(authInfo, testGetACLRequest, log, next);
             },
             (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, result) => {
+        ], (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
                 AccessControlList[0].Grant[0].Grantee[0]
                 .ID[0], canonicalID);
@@ -263,8 +258,7 @@ describe('objectGetACL API', () => {
                 objectGetACL(authInfo, testGetACLRequest, log, next);
             },
             (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, result) => {
+        ], (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
                 AccessControlList[0].Grant[0].Grantee[0]
                 .ID[0], canonicalID);
@@ -313,12 +307,11 @@ describe('objectGetACL API', () => {
                 objectGetACL(authInfo, testGetACLRequest, log, next);
             },
             (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, result) => {
+        ], (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
                 AccessControlList[0].Grant[0].Grantee[0]
                 .ID[0], '79a59df900b949e55d96a1e698fbacedfd6e09d98' +
-                'eacf8f8d5218e7cd47ef2be');
+            'eacf8f8d5218e7cd47ef2be');
             assert.strictEqual(result.AccessControlPolicy.
                 AccessControlList[0].Grant[0].Grantee[0]
                 .DisplayName[0], 'sampleaccount1@sampling.com');
@@ -328,7 +321,7 @@ describe('objectGetACL API', () => {
             assert.strictEqual(result.AccessControlPolicy.
                 AccessControlList[0].Grant[1].Grantee[0]
                 .ID[0], '79a59df900b949e55d96a1e698fbacedfd6e09d98' +
-                'eacf8f8d5218e7cd47ef2bf');
+            'eacf8f8d5218e7cd47ef2bf');
             assert.strictEqual(result.AccessControlPolicy.
                 AccessControlList[0].Grant[1].Grantee[0]
                 .DisplayName[0], 'sampleaccount2@sampling.com');
@@ -338,7 +331,7 @@ describe('objectGetACL API', () => {
             assert.strictEqual(result.AccessControlPolicy.
                 AccessControlList[0].Grant[2].Grantee[0]
                 .ID[0], '79a59df900b949e55d96a1e698fbacedfd6e09d98' +
-                'eacf8f8d5218e7cd47ef2bf');
+            'eacf8f8d5218e7cd47ef2bf');
             assert.strictEqual(result.AccessControlPolicy.
                 AccessControlList[0].Grant[2].Grantee[0]
                 .DisplayName[0], 'sampleaccount2@sampling.com');
@@ -348,7 +341,7 @@ describe('objectGetACL API', () => {
             assert.strictEqual(result.AccessControlPolicy.
                 AccessControlList[0].Grant[3].Grantee[0]
                 .ID[0], '79a59df900b949e55d96a1e698fbacedfd6e09d98' +
-                'eacf8f8d5218e7cd47ef2be');
+            'eacf8f8d5218e7cd47ef2be');
             assert.strictEqual(result.AccessControlPolicy.
                 AccessControlList[0].Grant[3].Grantee[0]
                 .DisplayName[0], 'sampleaccount1@sampling.com');
@@ -365,6 +358,52 @@ describe('objectGetACL API', () => {
                 AccessControlList[0].Grant[5],
                 undefined);
             done();
+        });
+    });
+
+    const grantsByURI = [
+        constants.publicId,
+        constants.allAuthedUsersId,
+    ];
+
+    grantsByURI.forEach(uri => {
+        it('should get all ACLs when predefined group - ' +
+        `${uri} is used for multiple grants`, done => {
+            const testPutObjectRequest = new DummyRequest({
+                bucketName,
+                namespace,
+                objectKey: objectName,
+                headers: {
+                    'x-amz-grant-full-control': `uri=${uri}`,
+                    'x-amz-grant-read': `uri=${uri}`,
+                    'x-amz-grant-write': `uri=${uri}`,
+                    'x-amz-grant-read-acp': `uri=${uri}`,
+                    'x-amz-grant-write-acp': `uri=${uri}`,
+                },
+                url: `/${bucketName}/${objectName}`,
+            }, postBody);
+            async.waterfall([
+                next => bucketPut(authInfo, testBucketPutRequest,
+                    log, next),
+                (corsHeaders, next) => objectPut(authInfo,
+                    testPutObjectRequest, undefined, log, next),
+                (resHeaders, next) => {
+                    assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
+                    objectGetACL(authInfo, testGetACLRequest, log, next);
+                },
+                (result, corsHeaders, next) => parseString(result, next),
+            ], (err, result) => {
+                assert.ifError(err);
+                const grants =
+                    result.AccessControlPolicy.AccessControlList[0].Grant;
+                grants.forEach(grant => {
+                    assert.strictEqual(grant.Permission.length, 1);
+                    assert.strictEqual(grant.Grantee.length, 1);
+                    assert.strictEqual(grant.Grantee[0].URI.length, 1);
+                    assert.strictEqual(grant.Grantee[0].URI[0], `${uri}`);
+                });
+                done();
+            });
         });
     });
 });

--- a/tests/unit/api/objectGetACL.js
+++ b/tests/unit/api/objectGetACL.js
@@ -376,7 +376,6 @@ describe('objectGetACL API', () => {
                 headers: {
                     'x-amz-grant-full-control': `uri=${uri}`,
                     'x-amz-grant-read': `uri=${uri}`,
-                    'x-amz-grant-write': `uri=${uri}`,
                     'x-amz-grant-read-acp': `uri=${uri}`,
                     'x-amz-grant-write-acp': `uri=${uri}`,
                 },


### PR DESCRIPTION
Corrected listing ACLs for an object or a bucket when predefined groups are used.
