### PR TITLE
CLDSRV-16: fix object-lock comparison checks

### DIFF
--- a/lib/api/apiUtils/object/objectLockHelpers.js
+++ b/lib/api/apiUtils/object/objectLockHelpers.js
@@ -7,6 +7,11 @@ const moment = require('moment');
  */
 function calculateRetainUntilDate(retention) {
     const { days, years } = retention;
+
+    if (!days && !years) {
+        return undefined;
+    }
+
     const date = moment();
     // Calculate the number of days to retain the lock on the object
     const retainUntilDays = days || years * 365;
@@ -67,17 +72,25 @@ function validateHeaders(bucket, headers, log) {
  */
 function compareObjectLockInformation(headers, defaultRetention) {
     const objectLockInfoToSave = {};
+
+    if (defaultRetention && defaultRetention.rule) {
+        const defaultMode = defaultRetention.rule.mode;
+        const defaultTime = calculateRetainUntilDate(defaultRetention.rule);
+        if (defaultMode && defaultTime) {
+            objectLockInfoToSave.retentionInfo = {
+                mode: defaultMode,
+                date: defaultTime,
+            };
+        }
+    }
+
     if (headers) {
         const headerMode = headers['x-amz-object-lock-mode'];
         const headerDate = headers['x-amz-object-lock-retain-until-date'];
-        const objectRetention = headerMode && headerDate;
-        if (objectRetention || defaultRetention) {
-            const mode = headerMode || defaultRetention.rule.mode;
-            const date = headerDate
-                || calculateRetainUntilDate(defaultRetention.rule);
+        if (headerMode && headerDate) {
             objectLockInfoToSave.retentionInfo = {
-                mode,
-                date,
+                mode: headerMode,
+                date: headerDate,
             };
         }
         const headerLegalHold = headers['x-amz-object-lock-legal-hold'];
@@ -86,6 +99,7 @@ function compareObjectLockInformation(headers, defaultRetention) {
             objectLockInfoToSave.legalHold = legalHold;
         }
     }
+
     return objectLockInfoToSave;
 }
 


### PR DESCRIPTION
adds checks to avoid referencing properties of an `undefined` retention rule.