### PR TITLE
INTEGRATION [PR#3847 > development/8.2] build(deps): bump aws-sdk from 2.905.0 to 2.982.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@hapi/joi": "^17.1.0",
     "arsenal": "github:scality/Arsenal#836c65e",
     "async": "~2.5.0",
-    "aws-sdk": "2.905.0",
+    "aws-sdk": "2.982.0",
     "azure-storage": "^2.1.0",
     "bucketclient": "scality/bucketclient#8.1.0",
     "commander": "^2.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -490,10 +490,10 @@ aws-sdk@2.80.0:
     xml2js "0.4.17"
     xmlbuilder "4.2.1"
 
-aws-sdk@2.905.0:
-  version "2.905.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.905.0.tgz#35f9a7af77ecc0f62598b9498aee7c90b7ace5c5"
-  integrity sha512-5A12gp+DCkJBdu3U2UvAHUACgd69NEqDBB+XUlGxaiO7a7T7y+9Azr3GKGFVICZ/vbr2Or7bUm4//wu3LVPnsg==
+aws-sdk@2.982.0:
+  version "2.982.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.982.0.tgz#0c7d874ab11ed5b054a411bc01678937c6def013"
+  integrity sha512-5w+m8Ia35NqB4TOZHEKts5zSV+FTdc7hTYbN4N4lZ4YU3cLTMt496ojh5UI3Deo8IIlqgTf3UVuq6Y6cPpVxkg==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3847.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/dependabot/npm_and_yarn/development/7.4/aws-sdk-2.982.0`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/dependabot/npm_and_yarn/development/7.4/aws-sdk-2.982.0
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/dependabot/npm_and_yarn/development/7.4/aws-sdk-2.982.0
```

Please always comment pull request #3847 instead of this one.