### PR TITLE
bf: CLDSRV-28 fixed server crash

### DIFF
--- a/lib/api/apiUtils/bucket/getNotificationConfiguration.js
+++ b/lib/api/apiUtils/bucket/getNotificationConfiguration.js
@@ -16,9 +16,10 @@ function getNotificationConfiguration(parsedXml) {
     const targets = new Set(config.bucketNotificationDestinations.map(t => t.resource));
     const notifConfigTargets = notifConfig.queueConfig.map(t => t.queueArn.split(':')[5]);
     if (!notifConfigTargets.every(t => targets.has(t))) {
-        return { error: errors.MalformedXML.customizeDescription(
-            'queue arn target is not included in Cloudserver bucket notification config'),
-        };
+        // TODO: match the error message to AWS's response along with
+        // the request destination name in the response
+        const errDesc = 'Unable to validate the destination configuration';
+        return { error: errors.InvalidArgument.customizeDescription(errDesc) };
     }
     return notifConfig;
 }

--- a/lib/api/bucketPutNotification.js
+++ b/lib/api/bucketPutNotification.js
@@ -31,7 +31,8 @@ function bucketPutNotification(authInfo, request, log, callback) {
         next => parseXML(request.post, log, next),
         (parsedXml, next) => {
             const notificationConfig = getNotificationConfiguration(parsedXml);
-            process.nextTick(() => next(notificationConfig.error, notificationConfig));
+            const notifConfig = notificationConfig.error ? undefined : notificationConfig;
+            process.nextTick(() => next(notificationConfig.error, notifConfig));
         },
         (notifConfig, next) => metadataValidateBucket(metadataValParams, log,
             (err, bucket) => next(err, bucket, notifConfig)),

--- a/tests/functional/aws-node-sdk/test/bucket/putBucketNotification.js
+++ b/tests/functional/aws-node-sdk/test/bucket/putBucketNotification.js
@@ -105,6 +105,15 @@ describe('aws-sdk test put notification configuration', () => {
                     done();
                 });
             });
+
+        it('should not allow notification config request with unsupported destination',
+            done => {
+                const params = getNotificationParams(null, 'arn:scality:bucketnotif:::target100');
+                s3.putBucketNotificationConfiguration(params, err => {
+                    checkError(err, 'InvalidArgument', 400);
+                    done();
+                });
+            });
     });
 
     describe('cross origin requests', () => {
@@ -118,15 +127,14 @@ describe('aws-sdk test put notification configuration', () => {
             {
                 it: 'return valid error with invalid arn',
                 param: getNotificationParams(null, 'invalidArn'),
-                fail: true,
+                error: 'MalformedXML',
             }, {
-                it: 'return valid error with unknown destination',
+                it: 'return valid error with unknown/unsupported destination',
                 param: getNotificationParams(null, 'arn:scality:bucketnotif:::target100'),
-                fail: true,
+                error: 'InvalidArgument',
             }, {
                 it: 'save notification configuration with correct arn',
                 param: getNotificationParams(),
-                fail: false,
             },
         ];
 
@@ -135,8 +143,8 @@ describe('aws-sdk test put notification configuration', () => {
                 const req = s3.putBucketNotificationConfiguration(test.param);
                 req.httpRequest.headers.origin = 'http://localhost:3000';
                 req.send(err => {
-                    if (test.fail) {
-                        checkError(err, 'MalformedXML', 400);
+                    if (test.error) {
+                        checkError(err, test.error, 400);
                     } else {
                         assert.ifError(err);
                     }


### PR DESCRIPTION
Cloudserver crashes when a cross origin request is made to put bucket notification configuration with invalid ARN or a configuration with unknown destination.