### PR TITLE
bugfix: CLDSRV-31 disable KMS healthchecks

### DIFF
--- a/lib/utilities/healthcheckHandler.js
+++ b/lib/utilities/healthcheckHandler.js
@@ -3,7 +3,6 @@ const _config = require('../Config').config;
 const data = require('../data/wrapper');
 const vault = require('../auth/vault');
 const metadata = require('../metadata/wrapper');
-const kms = require('../kms/wrapper');
 const async = require('async');
 
 // current function utility is minimal, but will be expanded
@@ -41,11 +40,15 @@ function writeResponse(res, error, log, results, cb) {
  * @return {undefined}
  */
 function clientCheck(flightCheckOnStartUp, log, cb) {
+    // FIXME S3C-4833 KMS healthchecks have been disabled:
+    // - they should be reworked to avoid blocking all requests,
+    //   including unencrypted requests
+    // - they should not prevent Cloudserver from starting up
     const clients = [
         data,
         metadata,
         vault,
-        kms,
+        // kms,
     ];
     const clientTasks = [];
     clients.forEach(client => {


### PR DESCRIPTION
Disable KMS healthchecks introduced with S3C-4562, because when the
KMS is unavailable, Cloudserver would not start, or if already
started, would reject all requests (including unencrypted ones).

The KMS healthchecks will be reworked later, this is a quick fix for now.

