### PR TITLE
CLDSRV-34 - fix time computation for test comparison

### DIFF
--- a/tests/unit/api/objectHead.js
+++ b/tests/unit/api/objectHead.js
@@ -17,9 +17,10 @@ const postBody = Buffer.from('I am a body', 'utf8');
 const correctMD5 = 'be747eb4b75517bf6b3cf7c5fbb62f3a';
 const incorrectMD5 = 'fkjwelfjlslfksdfsdfsdfsdfsdfsdj';
 const objectName = 'objectName';
-const date = new Date();
-const laterDate = date.setMinutes(date.getMinutes() + 30);
-const earlierDate = date.setMinutes(date.getMinutes() - 30);
+const laterDate = new Date();
+laterDate.setMinutes(laterDate.getMinutes() + 30);
+const earlierDate = new Date();
+earlierDate.setMinutes(earlierDate.getMinutes() - 30);
 const testPutBucketRequest = {
     bucketName,
     namespace,


### PR DESCRIPTION
need a new date that is 30 minutes in the past.
Computation is based on a date already 30 minutes in the future,
take that date and rewind it by 60 minutes
- 30 to go back to the original data
- 30 to go back 30 minutes in the past

# Pull request template

## Description

### Motivation and context

This change is required as it brakes a unit test
