### PR TITLE
CLDSRV-35 - Update aggressor image to bionic

### DIFF
--- a/eve/workers/build/Dockerfile
+++ b/eve/workers/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:xenial-curl
+FROM buildpack-deps:bionic-curl
 
 #
 # Install packages needed by the buildchain
@@ -9,6 +9,7 @@ RUN curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb http://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
     && apt-get update \
     && cat /tmp/*packages.list | xargs apt-get install -y \
+    && update-ca-certificates \
     && git clone https://github.com/tj/n.git \
     && make -C ./n \
     && n 10.22.0 \

--- a/eve/workers/build/s3_packages.list
+++ b/eve/workers/build/s3_packages.list
@@ -1,6 +1,8 @@
 build-essential
+ca-certificates
 curl
 default-jdk
+gnupg2
 libdigest-hmac-perl
 lsof
 maven

--- a/tests/functional/jaws/pom.xml
+++ b/tests/functional/jaws/pom.xml
@@ -71,5 +71,10 @@
       <artifactId>aws-java-sdk</artifactId>
       <version>1.11.37</version>
     </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.1</version>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
# Pull request template

## Description

### Motivation and context

Xenial is now out of date and has reached end-of-support.

### Related issues

SSL certificates are not updated anymore, so we can't download
anything from HTTPS, we can't retrieve gpg keys.
