### PR TITLE
[BACKPORT 7.4] bugfix: S3C-2775 update logic for counting object replicas

### DIFF
--- a/lib/routes/utilities/pushReplicationMetric.js
+++ b/lib/routes/utilities/pushReplicationMetric.js
@@ -1,5 +1,3 @@
-const assert = require('assert');
-
 const { ObjectMD } = require('arsenal').models;
 const { pushMetric } = require('../../utapi/utilities');
 
@@ -8,18 +6,16 @@ function shouldPushMetric(prevObjectMD, newObjectMD) {
     if (newObjectMD.getReplicationStatus() !== 'REPLICA') {
         return false;
     }
-    try {
-        // Replication of object tags and ACLs should not increment metrics.
-        assert.deepStrictEqual(prevObjectMD.getAcl(), newObjectMD.getAcl());
-        assert.deepStrictEqual(prevObjectMD.getTags(), newObjectMD.getTags());
-    } catch (e) {
-        return false;
-    }
-    return true;
+    // The rule for a REPLICA is: push object metrics if it is a new
+    // object version i.e. there is no existing object of the same
+    // version. It is the case when updating ACLs and/or tags
+    // in-place, in which case we don't want to bump object metrics as
+    // the object is still there with the same data.
+    return !prevObjectMD;
 }
 
 function pushReplicationMetric(prevValue, newValue, bucket, key, log) {
-    const prevObjectMD = new ObjectMD(prevValue);
+    const prevObjectMD = prevValue ? new ObjectMD(prevValue) : null;
     const newObjectMD = new ObjectMD(newValue);
     if (!shouldPushMetric(prevObjectMD, newObjectMD)) {
         return undefined;

--- a/tests/functional/raw-node/test/routes/routeBackbeat.js
+++ b/tests/functional/raw-node/test/routes/routeBackbeat.js
@@ -82,6 +82,7 @@ function checkObjectData(s3, objectKey, dataValue, done) {
  * @param {object} params.authCredentials.accessKey - access key
  * @param {object} params.authCredentials.secretKey - secret key
  * @param {string} [params.requestBody] - request body contents
+ * @param {object} [params.queryObj] - query params
  * @param {function} callback - with error and response parameters
  * @return {undefined} - and call callback
  */
@@ -186,6 +187,10 @@ describeSkipIfAWS('backbeat routes', () => {
                             method: 'PUT', bucket: TEST_BUCKET,
                             objectKey: testCase.encodedKey,
                             resourceType: 'metadata',
+                            queryObj: {
+                                versionId: versionIdUtils.encode(
+                                    testMd.versionId),
+                            },
                             authCredentials: backbeatAuthCredentials,
                             requestBody: JSON.stringify(newMd),
                         }, next);
@@ -223,6 +228,9 @@ describeSkipIfAWS('backbeat routes', () => {
                     method: 'PUT', bucket: TEST_BUCKET,
                     objectKey: 'test-updatemd-key',
                     resourceType: 'metadata',
+                    queryObj: {
+                        versionId: versionIdUtils.encode(testMd.versionId),
+                    },
                     authCredentials: backbeatAuthCredentials,
                     requestBody: JSON.stringify(newMd),
                 }, next);
@@ -233,6 +241,9 @@ describeSkipIfAWS('backbeat routes', () => {
                     method: 'PUT', bucket: TEST_BUCKET,
                     objectKey: 'test-updatemd-key',
                     resourceType: 'metadata',
+                    queryObj: {
+                        versionId: versionIdUtils.encode(testMd.versionId),
+                    },
                     headers: { 'x-scal-replication-content': 'METADATA' },
                     authCredentials: backbeatAuthCredentials,
                     requestBody: JSON.stringify(newMd),
@@ -267,6 +278,9 @@ describeSkipIfAWS('backbeat routes', () => {
         done => makeBackbeatRequest({
             method: 'PUT', bucket: NONVERSIONED_BUCKET,
             objectKey: testKey, resourceType: 'metadata',
+            queryObj: {
+                versionId: versionIdUtils.encode(testMd.versionId),
+            },
             authCredentials: backbeatAuthCredentials,
             requestBody: JSON.stringify(testMd),
         },
@@ -315,6 +329,9 @@ describeSkipIfAWS('backbeat routes', () => {
                     method: 'PUT', bucket: TEST_BUCKET,
                     objectKey: 'does-not-exist',
                     resourceType: 'metadata',
+                    queryObj: {
+                        versionId: versionIdUtils.encode(testMd.versionId),
+                    },
                     headers: { 'x-scal-replication-content': 'METADATA' },
                     authCredentials: backbeatAuthCredentials,
                     requestBody: JSON.stringify(newMd),


### PR DESCRIPTION
Before, we were relying on the presence of ACL change to know if the
operation is metadata-only. This was not correct, as a new object can
be put with specific ACL too.

Instead, consider that if there is already an object present with the
same version, we are necessarily updating this object hence the object
counter should not be updated.

NOTE: this change will come along with another change in backbeat: the
PUT /_/backbeat/metadata route will be provided the version ID of the
object to PUT, so that the validation of the existing object (through
the metadataValidateBucketAndObj helper) checks the specific version
instead of checking the master key (which for backbeat replication
purpose is also incorrect). Without this backbeat change, the
replicated object count metric becomes wrong when an object is
rewritten.

(cherry picked from commit 69e6d678a010dc8db1cf171a83d08430991369d3)

# Pull request template

## Description

### Motivation and context

Why is this change required? What problem does it solve?

### Related issues

Please use the following link syntaxes #600 to reference issues in the
current repository

## Checklist

### Add tests to cover the changes

New tests added or existing tests modified to cover all changes

### Code conforms with the [style guide](https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#coding-style-guidelines)

### Sign your work

In order to contribute to the project, you must sign your work
https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#sign-your-work

Thank you again for contributing! We will try to test and integrate the change
as soon as we can.
