### PR TITLE
INTEGRATION [PR#3996 > development/8.2] bf(CLDSRV-37): Push metrics for backbeat routes

### DIFF
--- a/lib/routes/utilities/pushReplicationMetric.js
+++ b/lib/routes/utilities/pushReplicationMetric.js
@@ -1,31 +1,58 @@
+const assert = require('assert');
 const { ObjectMD } = require('arsenal').models;
 const { pushMetric } = require('../../utapi/utilities');
 
-function shouldPushMetric(prevObjectMD, newObjectMD) {
+function getMetricToPush(prevObjectMD, newObjectMD) {
     // We only want to update metrics for a destination bucket.
     if (newObjectMD.getReplicationStatus() !== 'REPLICA') {
-        return false;
+        return null;
     }
-    // The rule for a REPLICA is: push object metrics if it is a new
-    // object version i.e. there is no existing object of the same
-    // version. It is the case when updating ACLs and/or tags
-    // in-place, in which case we don't want to bump object metrics as
-    // the object is still there with the same data.
-    return !prevObjectMD;
+
+    // If the versionIds match then we have a MD only op
+    if (prevObjectMD.getVersionId() === newObjectMD.getVersionId()) {
+        // Replication of object tags and ACLs should only increment
+        // metrics if their value has changed.
+        try {
+            assert.deepStrictEqual(prevObjectMD.getAcl(), newObjectMD.getAcl());
+            assert.deepStrictEqual(
+                prevObjectMD.getTags(),
+                newObjectMD.getTags()
+            );
+        } catch (e) {
+            return 'replicateTags';
+        }
+        return null;
+    }
+
+    if (newObjectMD.getIsDeleteMarker()) {
+        return 'replicateDelete';
+    }
+
+    return 'replicateObject';
 }
 
 function pushReplicationMetric(prevValue, newValue, bucket, key, log) {
-    const prevObjectMD = prevValue ? new ObjectMD(prevValue) : null;
+    const prevObjectMD = new ObjectMD(prevValue);
     const newObjectMD = new ObjectMD(newValue);
-    if (!shouldPushMetric(prevObjectMD, newObjectMD)) {
+
+    const metricType = getMetricToPush(prevObjectMD, newObjectMD);
+
+    if (metricType === null) {
         return undefined;
     }
-    return pushMetric('putData', log, {
+
+    const metricObj = {
         bucket,
         keys: [key],
-        newByteLength: newObjectMD.getContentLength(),
-        oldByteLength: null,
-    });
+        canonicalID: newObjectMD.getOwnerId(),
+    };
+
+    if (metricType === 'replicateObject') {
+        metricObj.newByteLength = newObjectMD.getContentLength();
+        metricObj.oldByteLength = null;
+    }
+
+    return pushMetric(metricType, log, metricObj);
 }
 
-module.exports = { pushReplicationMetric, shouldPushMetric };
+module.exports = { pushReplicationMetric, getMetricToPush };

--- a/tests/unit/utils/pushReplicationMetric.js
+++ b/tests/unit/utils/pushReplicationMetric.js
@@ -1,48 +1,113 @@
 const assert = require('assert');
 const { ObjectMD } = require('arsenal').models;
 
-const { shouldPushMetric } =
+const { getMetricToPush } =
     require('../../../lib/routes/utilities/pushReplicationMetric');
 
-describe('shouldPushMetric', () => {
+describe('getMetricToPush', () => {
     it('should push metrics when putting a new replica version', () => {
-        const prevObjectMD = undefined;
+        const prevObjectMD = new ObjectMD()
+            .setVersionId('1');
         const objectMD = new ObjectMD()
+            .setVersionId('2')
             .setReplicationStatus('REPLICA');
-        const result = shouldPushMetric(prevObjectMD, objectMD);
-        assert.strictEqual(result, true);
-    });
-
-    it('should push metrics when putting a new replica version with public ACL',
-    () => {
-        const prevObjectMD = undefined;
-        const objectMD = new ObjectMD()
-              .setReplicationStatus('REPLICA');
-        const publicACL = objectMD.getAcl();
-        publicACL.Canned = 'public-read';
-        objectMD.setAcl(publicACL);
-        const result = shouldPushMetric(prevObjectMD, objectMD);
-        assert.strictEqual(result, true);
+        const result = getMetricToPush(prevObjectMD, objectMD);
+        assert.strictEqual(result, 'replicateObject');
     });
 
     it('should not push metrics for non-replica operations', () => {
-        const prevObjectMD = undefined;
+        const prevObjectMD = new ObjectMD();
         const objectMD = new ObjectMD()
             .setReplicationStatus('COMPLETED');
-        const result = shouldPushMetric(prevObjectMD, objectMD);
-        assert.strictEqual(result, false);
+        const result = getMetricToPush(prevObjectMD, objectMD);
+        assert.strictEqual(result, null);
     });
 
-    it('should not push metrics when updating replica in-place (ACL/Tagging)',
+    it('should push metrics for replica operations with tagging', () => {
+        const prevObjectMD = new ObjectMD()
+            .setVersionId('1');
+        const objectMD = new ObjectMD()
+            .setVersionId('1')
+            .setReplicationStatus('REPLICA')
+            .setTags({ 'object-tag-key': 'object-tag-value' });
+        const result = getMetricToPush(prevObjectMD, objectMD);
+        assert.strictEqual(result, 'replicateTags');
+    });
+
+    it('should push metrics for replica operations when deleting tagging',
+    () => {
+        const prevObjectMD = new ObjectMD()
+            .setTags({ 'object-tag-key': 'object-tag-value' });
+        const objectMD = new ObjectMD().setReplicationStatus('REPLICA');
+        const result = getMetricToPush(prevObjectMD, objectMD);
+        assert.strictEqual(result, 'replicateTags');
+    });
+
+    it('should not push metrics for replica operations with tagging ' +
+        'if tags are equal',
+        () => {
+            const prevObjectMD = new ObjectMD()
+                .setVersionId('1')
+                .setTags({ 'object-tag-key': 'object-tag-value' });
+            const objectMD = new ObjectMD()
+                .setVersionId('1')
+                .setReplicationStatus('REPLICA')
+                .setTags({ 'object-tag-key': 'object-tag-value' });
+            const result = getMetricToPush(prevObjectMD, objectMD);
+            assert.strictEqual(result, null);
+        }
+    );
+
+    it('should push metrics for replica operations with acl', () => {
+        const prevObjectMD = new ObjectMD()
+            .setVersionId('1');
+        const objectMD = new ObjectMD();
+        const publicACL = objectMD.getAcl();
+        publicACL.Canned = 'public-read';
+        objectMD
+            .setReplicationStatus('REPLICA')
+            .setAcl(publicACL)
+            .setVersionId('1');
+        const result = getMetricToPush(prevObjectMD, objectMD);
+        assert.strictEqual(result, 'replicateTags');
+    });
+
+
+    it('should push metrics for replica operations when resetting acl',
     () => {
         const prevObjectMD = new ObjectMD();
         const publicACL = prevObjectMD.getAcl();
         publicACL.Canned = 'public-read';
-        const objectMD = new ObjectMD()
+        prevObjectMD
             .setReplicationStatus('REPLICA')
-            .setTags({ 'object-tag-key': 'object-tag-value' })
-            .setAcl(publicACL);
-        const result = shouldPushMetric(prevObjectMD, objectMD);
-        assert.strictEqual(result, false);
+            .setAcl(publicACL)
+            .setVersionId('1');
+        const objectMD = new ObjectMD();
+        const privateACL = objectMD.getAcl();
+        privateACL.Canned = 'private';
+        objectMD
+            .setReplicationStatus('REPLICA')
+            .setAcl(privateACL)
+            .setVersionId('1');
+        const result = getMetricToPush(prevObjectMD, objectMD);
+        assert.strictEqual(result, 'replicateTags');
     });
+
+    it('should not push metrics for replica operations with acl ' +
+        'when they are equal',
+        () => {
+            const objectMD = new ObjectMD();
+            const publicACL = objectMD.getAcl();
+            publicACL.Canned = 'public-read';
+            objectMD
+                .setReplicationStatus('REPLICA')
+                .setAcl(publicACL)
+                .setVersionId('1');
+            const prevObjectMD = new ObjectMD()
+                .setAcl(publicACL)
+                .setVersionId('1');
+            const result = getMetricToPush(prevObjectMD, objectMD);
+            assert.strictEqual(result, null);
+        }
+    );
 });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #3996.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/bugfix/CLDSRV-37-pushReplicationMetrics`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/bugfix/CLDSRV-37-pushReplicationMetrics
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/bugfix/CLDSRV-37-pushReplicationMetrics
```

Please always comment pull request #3996 instead of this one.