### PR TITLE
Expose cloudserver metrics on separate port and /metrics path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV NO_PROXY localhost,127.0.0.1
 ENV no_proxy localhost,127.0.0.1
 
 EXPOSE 8000
+EXPOSE 9090
 
 COPY ./package.json /usr/src/app/
 COPY ./yarn.lock /usr/src/app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV NO_PROXY localhost,127.0.0.1
 ENV no_proxy localhost,127.0.0.1
 
 EXPOSE 8000
-EXPOSE 9090
+EXPOSE 8002
 
 COPY ./package.json /usr/src/app/
 COPY ./yarn.lock /usr/src/app/

--- a/config.json
+++ b/config.json
@@ -1,6 +1,8 @@
 {
     "port": 8000,
     "listenOn": [],
+    "metricsPort": 9090,
+    "metricsListenOn": [],
     "replicationGroupId": "RG001",
     "restEndpoints": {
         "localhost": "us-east-1",

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
     "port": 8000,
     "listenOn": [],
-    "metricsPort": 9090,
+    "metricsPort": 8002,
     "metricsListenOn": [],
     "replicationGroupId": "RG001",
     "restEndpoints": {

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -477,6 +477,35 @@ class Config extends EventEmitter {
         return tlsFileContent;
     }
 
+    /**
+     * Parse list of endpoints.
+     * @param {string[] | undefined} listenOn - List of string of the form "ip:port"
+     * @param {string} fieldName - Name of field being parsed
+     * @returns {{ip: string, port: number}[]} - List of ip/port pairs
+     */
+    _parseEndpoints(listenOn, fieldName) {
+        let result = [];
+        if (listenOn !== undefined) {
+            assert(Array.isArray(listenOn)
+                && listenOn.every(e => typeof e === 'string'),
+                `bad config: ${fieldName} must be a list of strings`);
+            result = listenOn.map(item => {
+                const lastColon = item.lastIndexOf(':');
+                // if address is IPv6 format, it includes brackets
+                // that have to be removed from the final IP address
+                const ipAddress = item.indexOf(']') > 0 ?
+                    item.substr(1, lastColon - 2) :
+                    item.substr(0, lastColon);
+                // the port should not include the colon
+                const port = item.substr(lastColon + 1);
+                assert(Number.parseInt(port, 10),
+                    `bad config: ${fieldName} port must be a positive integer`);
+                return { ip: ipAddress, port };
+            });
+        }
+        return result;
+    }
+
     _getConfig() {
         let config;
         try {
@@ -505,25 +534,16 @@ class Config extends EventEmitter {
             this.port = config.port;
         }
 
-        this.listenOn = [];
-        if (config.listenOn !== undefined) {
-            assert(Array.isArray(config.listenOn)
-                && config.listenOn.every(e => typeof e === 'string'),
-                'bad config: listenOn must be a list of strings');
-            config.listenOn.forEach(item => {
-                const lastColon = item.lastIndexOf(':');
-                // if address is IPv6 format, it includes brackets
-                // that have to be removed from the final IP address
-                const ipAddress = item.indexOf(']') > 0 ?
-                    item.substr(1, lastColon - 2) :
-                    item.substr(0, lastColon);
-                // the port should not include the colon
-                const port = item.substr(lastColon + 1);
-                assert(Number.parseInt(port, 10),
-                    'bad config: listenOn port must be a positive integer');
-                this.listenOn.push({ ip: ipAddress, port });
-            });
+        this.listenOn = this._parseEndpoints(config.listenOn, 'listenOn');
+
+        this.metricsPort = 9090;
+        if (config.metricsPort !== undefined) {
+            assert(Number.isInteger(config.metricsPort) && config.metricsPort > 0,
+                'bad config: metricsPort must be a positive integer');
+            this.metricsPort = config.metricsPort;
         }
+
+        this.metricsListenOn = this._parseEndpoints(config.metricsListenOn, 'metricsListenOn');
 
         if (config.replicationGroupId) {
             assert(typeof config.replicationGroupId === 'string',

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -536,7 +536,7 @@ class Config extends EventEmitter {
 
         this.listenOn = this._parseEndpoints(config.listenOn, 'listenOn');
 
-        this.metricsPort = 9090;
+        this.metricsPort = 8002;
         if (config.metricsPort !== undefined) {
             assert(Number.isInteger(config.metricsPort) && config.metricsPort > 0,
                 'bad config: metricsPort must be a positive integer');

--- a/lib/server.js
+++ b/lib/server.js
@@ -162,21 +162,18 @@ class S3Server {
         monitoringClient.monitoringHandler(clientInfo.clientIP, req, res, log);
     }
 
-    /*
+    /**
      * This starts the http server.
+     * @param {http.RequestListener} listener - Callback to handle requests
+     * @param {number} port - Port to listen on
+     * @param {string | undefined} ipAddress - IpAddress to listen on
+     * @returns {http.Server} - The newly created http server
      */
-    startup(port, ipAddress) {
+    _startServer(listener, port, ipAddress) {
         // Todo: http.globalAgent.maxSockets, http.globalAgent.maxFreeSockets
+        let server;
         if (_config.https) {
-            this.server = https.createServer({
-                cert: _config.https.cert,
-                key: _config.https.key,
-                ca: _config.https.ca,
-                ciphers: arsenal.https.ciphers.ciphers,
-                dhparam: arsenal.https.dhparam.dhparam,
-                rejectUnauthorized: true,
-            });
-            this.metrics = https.createServer({
+            server = https.createServer({
                 cert: _config.https.cert,
                 key: _config.https.key,
                 ca: _config.https.ca,
@@ -188,28 +185,25 @@ class S3Server {
                 https: true,
             });
         } else {
-            this.server = http.createServer();
-            this.metrics = http.createServer();
+            server = http.createServer();
             logger.info('Http server configuration', {
                 https: false,
             });
         }
 
-        this.server.on('connection', socket => {
+        server.on('connection', socket => {
             socket.on('error', err => logger.info('request rejected',
                 { error: err }));
         });
 
         // https://nodejs.org/dist/latest-v6.x/
         // docs/api/http.html#http_event_checkexpectation
-        this.server.on('checkExpectation', this.routeRequest);
+        server.on('checkExpectation', listener);
+        server.on('request', listener);
+        server.on('checkContinue', listener);
 
-        this.server.on('request', this.routeRequest);
-
-        this.server.on('checkContinue', this.routeRequest);
-
-        this.server.on('listening', () => {
-            const addr = this.server.address() || {
+        server.on('listening', () => {
+            const addr = server.address() || {
                 address: ipAddress || '[::]',
                 port,
             };
@@ -218,47 +212,13 @@ class S3Server {
                 pid: process.pid, serverIP: address, serverPort: port });
         });
 
-        this.metrics.on('connection', socket => {
-            socket.on('error', err => logger.info('request rejected',
-                                                  { error: err }));
-        });
-
-        // Prometheus scraper response
-        const metricsPort = 9090;
-        this.metrics.on('listening', () => {
-            const addr = this.metrics.address() || {
-                address: ipAddress || '[::]',
-                port: metricsPort,
-            };
-            const { address } = addr;
-            logger.info('server started', {
-                address, port: metricsPort,
-                pid: process.pid, serverIP: address, serverPort: metricsPort
-            });
-        });
-        this.metrics.on('request', this.routeAdminRequest);
-        this.metrics.on('checkExpectation', this.routeAdminRequest);
-        this.metrics.on('checkContinue', this.routeAdminRequest);
-
         if (ipAddress !== undefined) {
-            this.server.listen(port, ipAddress);
-            this.metrics.listen(metricsPort, ipAddress);
+            server.listen(port, ipAddress);
         } else {
-            this.server.listen(port);
-            this.metrics.listen(metricsPort);
+            server.listen(port);
         }
 
-        // TODO this should wait for metadata healthcheck to be ok
-        // TODO only do this in cluster master
-        if (enableRemoteManagement) {
-            if (!isManagementAgentUsed()) {
-                setTimeout(() => {
-                    initManagement(logger.newRequestLogger());
-                }, 5000);
-            } else {
-                initManagementClient();
-            }
-        }
+        return server;
     }
 
     /*
@@ -302,16 +262,41 @@ class S3Server {
                 return;
             }
             log.debug('initial health check succeeded');
-            if (_config.listenOn.length > 0) {
-                _config.listenOn.forEach(item => {
-                    this.startup(item.port, item.ip);
-                });
+            if (this.started) {
                 return;
             }
-            if (!this.started) {
-                this.startup(_config.port);
-                this.started = true;
+
+            // Start API server(s)
+            if (_config.listenOn.length > 0) {
+                _config.listenOn.forEach(item => {
+                    this._startServer(this.routeRequest, item.port, item.ip);
+                });
+            } else {
+                this._startServer(this.routeRequest, _config.port);
             }
+
+            // Start metrics server(s)
+            if (_config.metricsListenOn.length > 0) {
+                _config.metricsListenOn.forEach(item => {
+                    this._startServer(this.routeAdminRequest, item.port, item.ip);
+                });
+            } else {
+                this._startServer(this.routeAdminRequest, _config.metricsPort);
+            }
+
+            // TODO this should wait for metadata healthcheck to be ok
+            // TODO only do this in cluster master
+            if (enableRemoteManagement) {
+                if (!isManagementAgentUsed()) {
+                    setTimeout(() => {
+                        initManagement(logger.newRequestLogger());
+                    }, 5000);
+                } else {
+                    initManagementClient();
+                }
+            }
+
+            this.started = true;
         });
     }
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -66,6 +66,7 @@ class S3Server {
     constructor(worker) {
         this.worker = worker;
         this.cluster = true;
+        this.servers = [];
         http.globalAgent = new HttpAgent({
             keepAlive: true,
             freeSocketTimeout: arsenal.constants.httpClientFreeSocketTimeout,
@@ -167,7 +168,7 @@ class S3Server {
      * @param {http.RequestListener} listener - Callback to handle requests
      * @param {number} port - Port to listen on
      * @param {string | undefined} ipAddress - IpAddress to listen on
-     * @returns {http.Server} - The newly created http server
+     * @returns {void}
      */
     _startServer(listener, port, ipAddress) {
         // Todo: http.globalAgent.maxSockets, http.globalAgent.maxFreeSockets
@@ -218,7 +219,7 @@ class S3Server {
             server.listen(port);
         }
 
-        return server;
+        this.servers.push(server);
     }
 
     /*
@@ -226,11 +227,9 @@ class S3Server {
      */
     cleanUp() {
         logger.info('server shutting down');
-        if (this.server) {
-            this.server.close(() => process.exit(0));
-        } else {
-            process.exit(0);
-        }
+        Promise.all(this.servers.map(server =>
+            new Promise(resolve => server.close(resolve))
+        )).then(() => process.exit(0));
     }
 
     caughtExceptionShutdown() {

--- a/lib/server.js
+++ b/lib/server.js
@@ -140,11 +140,20 @@ class S3Server {
                 dhparam: arsenal.https.dhparam.dhparam,
                 rejectUnauthorized: true,
             });
+            this.metrics = https.createServer({
+                cert: _config.https.cert,
+                key: _config.https.key,
+                ca: _config.https.ca,
+                ciphers: arsenal.https.ciphers.ciphers,
+                dhparam: arsenal.https.dhparam.dhparam,
+                rejectUnauthorized: true,
+            });
             logger.info('Https server configuration', {
                 https: true,
             });
         } else {
             this.server = http.createServer();
+            this.metrics = http.createServer();
             logger.info('Http server configuration', {
                 https: false,
             });
@@ -172,10 +181,34 @@ class S3Server {
             logger.info('server started', { address, port,
                 pid: process.pid, serverIP: address, serverPort: port });
         });
+
+        this.metrics.on('connection', socket => {
+            socket.on('error', err => logger.info('request rejected',
+                                                  { error: err }));
+        });
+
+        // Prometheus scraper response
+        this.metrics.on('listening', () => {
+            const addr = this.metrics.address() || {
+                address: ipAddress || '[::]',
+                port: 9090,
+            };
+            const { address } = addr;
+            logger.info('server started', {
+                address, port,
+                pid: process.pid, serverIP: address, serverPort: port
+            });
+        });
+        this.server.on('checkExpectation', monitoringClient.monitoringHandler);
+        this.metrics.on('request', monitoringClient.monitoringHandler);
+        this.server.on('checkContinue', monitoringClient.monitoringHandler);
+
         if (ipAddress !== undefined) {
             this.server.listen(port, ipAddress);
+            this.metrics.listen(9090, ipAddress);
         } else {
             this.server.listen(port);
+            this.metrics.listen(9090);
         }
 
         // TODO this should wait for metadata healthcheck to be ok

--- a/lib/server.js
+++ b/lib/server.js
@@ -126,6 +126,42 @@ class S3Server {
         routes(req, res, params, logger);
     }
 
+    /**
+     * Route requests on 'admin' port
+     * @param {http.IncomingMessage} req - http request object
+     * @param {http.ServerResponse} res - http response object
+     * @returns {void}
+     */
+    routeAdminRequest(req, res) {
+        // use proxied hostname if needed
+        if (req.headers['x-target-host']) {
+            // eslint-disable-next-line no-param-reassign
+            req.headers.host = req.headers['x-target-host'];
+        }
+
+        const clientInfo = {
+            clientIP: req.socket.remoteAddress,
+            clientPort: req.socket.remotePort,
+            httpMethod: req.method,
+            httpURL: req.url,
+            endpoint: req.endpoint,
+        };
+
+        let reqUids = req.headers['x-scal-request-uids'];
+        if (reqUids !== undefined && !/*isValidReqUids*/(reqUids.length < 128)) {
+            // simply ignore invalid id (any user can provide an
+            // invalid request ID through a crafted header)
+            reqUids = undefined;
+        }
+        const log = (reqUids !== undefined ?
+                    logger.newRequestLoggerFromSerializedUids(reqUids) :
+                    logger.newRequestLogger());
+        log.end().addDefaultFields(clientInfo);
+
+        log.info('received admin request', clientInfo);
+        monitoringClient.monitoringHandler(clientInfo.clientIP, req, res, log);
+    }
+
     /*
      * This starts the http server.
      */
@@ -188,27 +224,28 @@ class S3Server {
         });
 
         // Prometheus scraper response
+        const metricsPort = 9090;
         this.metrics.on('listening', () => {
             const addr = this.metrics.address() || {
                 address: ipAddress || '[::]',
-                port: 9090,
+                port: metricsPort,
             };
             const { address } = addr;
             logger.info('server started', {
-                address, port,
-                pid: process.pid, serverIP: address, serverPort: port
+                address, port: metricsPort,
+                pid: process.pid, serverIP: address, serverPort: metricsPort
             });
         });
-        this.server.on('checkExpectation', monitoringClient.monitoringHandler);
-        this.metrics.on('request', monitoringClient.monitoringHandler);
-        this.server.on('checkContinue', monitoringClient.monitoringHandler);
+        this.metrics.on('request', this.routeAdminRequest);
+        this.metrics.on('checkExpectation', this.routeAdminRequest);
+        this.metrics.on('checkContinue', this.routeAdminRequest);
 
         if (ipAddress !== undefined) {
             this.server.listen(port, ipAddress);
-            this.metrics.listen(9090, ipAddress);
+            this.metrics.listen(metricsPort, ipAddress);
         } else {
             this.server.listen(port);
-            this.metrics.listen(9090);
+            this.metrics.listen(metricsPort);
         }
 
         // TODO this should wait for metadata healthcheck to be ok

--- a/lib/utilities/internalHandlers.js
+++ b/lib/utilities/internalHandlers.js
@@ -4,13 +4,11 @@ const routeMetadata = require('../routes/routeMetadata');
 const routeWorkflowEngineOperator =
       require('../routes/routeWorkflowEngineOperator');
 const { reportHandler } = require('./reportHandler');
-const { monitoringHandler } = require('./monitoringHandler');
 
 const internalHandlers = {
     healthcheck: healthcheckHandler,
     backbeat: routeBackbeat,
     report: reportHandler,
-    monitoring: monitoringHandler,
     metadata: routeMetadata,
     'workflow-engine-operator': routeWorkflowEngineOperator,
 };

--- a/lib/utilities/monitoringHandler.js
+++ b/lib/utilities/monitoringHandler.js
@@ -161,11 +161,11 @@ function routeHandler(req, res, log, cb) {
  * Checks if client IP address is allowed to make http request to
  * S3 server. Defines function 'montiroingEndHandler', which is
  * called if IP not allowed or passed as callback.
- * @param {object} clientIP - IP address of client
- * @param {object} req - http request object
- * @param {object} res - http response object
- * @param {object} log - werelogs logger instance
- * @return {undefined}
+ * @param {string | undefined} clientIP - IP address of client
+ * @param {http.IncomingMessage} req - http request object
+ * @param {http.ServerResponse} res - http response object
+ * @param {RequestLogger} log - werelogs logger instance
+ * @return {void}
  */
 function monitoringHandler(clientIP, req, res, log) {
     function monitoringEndHandler(err, results) {
@@ -179,7 +179,7 @@ function monitoringHandler(clientIP, req, res, log) {
     if (req.method !== 'GET') {
         return monitoringEndHandler(res, errors.MethodNotAllowed);
     }
-    const monitoring = (req.url === '/metrics');
+    const monitoring = (req.url === '/_/metrics');
     if (!monitoring) {
         return monitoringEndHandler(res, errors.MethodNotAllowed);
     }

--- a/lib/utilities/monitoringHandler.js
+++ b/lib/utilities/monitoringHandler.js
@@ -57,47 +57,59 @@ function promMetrics(requestType, bucketName, code, typeOfRequest,
     let bytes;
 
     httpRequestsTotal.labels(requestType, 'cloud_server', code).inc();
-    if ((typeOfRequest === 'putObject' ||
-    typeOfRequest === 'copyObject' ||
-    typeOfRequest === 'putObjectPart') &&
-    code === '200') {
-        bytes = newByteLength - (isVersionedObj ? 0 : oldByteLength);
-        httpRequestSizeBytes
-            .labels(requestType, 'cloud_server', code)
-            .observe(newByteLength);
-        dataDiskAvailable.dec(bytes);
-        dataDiskFree.dec(bytes);
-        if (ingestSize) {
-            numberOfIngestedObjects.inc();
-            dataIngested.inc(ingestSize);
+
+    switch (typeOfRequest) {
+    case 'putobject':
+    case 'copyObject':
+    case 'putObjectPart':
+        if (code === '200') {
+            bytes = newByteLength - (isVersionedObj ? 0 : oldByteLength);
+            httpRequestSizeBytes
+                .labels(requestType, 'cloud_server', code)
+                .observe(newByteLength);
+            dataDiskAvailable.dec(bytes);
+            dataDiskFree.dec(bytes);
+            if (ingestSize) {
+                numberOfIngestedObjects.inc();
+                dataIngested.inc(ingestSize);
+            }
+            numberOfObjects.inc();
         }
-        numberOfObjects.inc();
-    }
-    if (typeOfRequest === 'createBucket' && code === '200') {
-        numberOfBuckets.inc();
-    }
-    if (typeOfRequest === 'getObject' && code === '200') {
-        httpResponseSizeBytes
-            .labels(requestType, 'cloud_server', code)
-            .observe(newByteLength);
-    }
-    if ((typeOfRequest === 'deleteBucket' ||
-    typeOfRequest === 'deleteBucketWebsite')
-    && (code === '200' || code === '204')) {
-        numberOfBuckets.dec();
-    }
-    if ((typeOfRequest === 'deleteObject' ||
-    typeOfRequest === 'abortMultipartUpload' ||
-    typeOfRequest === 'multiObjectDelete')
-    && code === '200') {
-        dataDiskAvailable.inc(newByteLength);
-        dataDiskFree.inc(newByteLength);
-        const objs = numOfObjectsRemoved || 1;
-        numberOfObjects.dec(objs);
-        if (ingestSize) {
-            numberOfIngestedObjects.dec(objs);
-            dataIngested.dec(ingestSize);
+        break;
+    case 'createBucket':
+        if (code === '200') {
+            numberOfBuckets.inc();
         }
+        break;
+    case 'getObject':
+        if (code === '200') {
+            httpResponseSizeBytes
+                .labels(requestType, 'cloud_server', code)
+                .observe(newByteLength);
+        }
+        break;
+    case 'deleteBucket':
+    case 'deleteBucketWebsite':
+        if (code === '200' || code === '204') {
+            numberOfBuckets.dec();
+        }
+        break;
+    case 'deleteObject':
+    case 'abortMultipartUpload':
+    case 'multiObjectDelete':
+        if (code === '200') {
+            dataDiskAvailable.inc(newByteLength);
+            dataDiskFree.inc(newByteLength);
+            const objs = numOfObjectsRemoved || 1;
+            numberOfObjects.dec(objs);
+            if (ingestSize) {
+                numberOfIngestedObjects.dec(objs);
+                dataIngested.dec(ingestSize);
+            }
+        }
+        break;
+    default:
+        break;
     }
 }
 
@@ -167,7 +179,7 @@ function monitoringHandler(clientIP, req, res, log) {
     if (req.method !== 'GET') {
         return monitoringEndHandler(res, errors.MethodNotAllowed);
     }
-    const monitoring = (req.url === '/_/monitoring/metrics');
+    const monitoring = (req.url === '/metrics');
     if (!monitoring) {
         return monitoringEndHandler(res, errors.MethodNotAllowed);
     }

--- a/lib/utilities/monitoringHandler.js
+++ b/lib/utilities/monitoringHandler.js
@@ -179,7 +179,7 @@ function monitoringHandler(clientIP, req, res, log) {
     if (req.method !== 'GET') {
         return monitoringEndHandler(res, errors.MethodNotAllowed);
     }
-    const monitoring = (req.url === '/_/metrics');
+    const monitoring = (req.url === '/metrics');
     if (!monitoring) {
         return monitoringEndHandler(res, errors.MethodNotAllowed);
     }


### PR DESCRIPTION
This reduces the attack surface, and ensure we do not leak (metrics) information via the `_/monitoring/metrics` path.

Issue: CLDSRV-51