### PR TITLE
bugfix: CLDSRV-56 Do not encode tokens again

### DIFF
--- a/lib/api/bucketGet.js
+++ b/lib/api/bucketGet.js
@@ -12,6 +12,12 @@ const versionIdUtils = versioning.VersionID;
 const { generateToken, decryptToken }
     = require('../api/apiUtils/object/continueToken');
 
+// do not url encode the continuation tokens
+const skipUrlEncoding = new Set([
+    'ContinuationToken',
+    'NextContinuationToken',
+]);
+
 /* Sample XML response for GET bucket objects V2:
 <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
     <Name>example-bucket</Name>
@@ -204,14 +210,14 @@ function processMasterVersions(bucketName, listParams, list) {
     const escapeXmlFn = listParams.encoding === 'url' ?
         querystring.escape : escapeForXml;
     xmlParams.forEach(p => {
-        if (p.value || p.tag === 'KeyCount') {
+        if (p.value && skipUrlEncoding.has(p.tag)) {
+            xml.push(`<${p.tag}>${p.value}</${p.tag}>`);
+        } else if (p.value || p.tag === 'KeyCount') {
             xml.push(`<${p.tag}>${escapeXmlFn(p.value)}</${p.tag}>`);
         } else if (p.tag !== 'NextMarker' &&
                 p.tag !== 'EncodingType' &&
                 p.tag !== 'Delimiter' &&
-                p.tag !== 'StartAfter' &&
-                p.tag !== 'ContinuationToken' &&
-                p.tag !== 'NextContinuationToken') {
+                p.tag !== 'StartAfter') {
             xml.push(`<${p.tag}/>`);
         }
     });

--- a/tests/unit/api/bucketGet.js
+++ b/tests/unit/api/bucketGet.js
@@ -12,7 +12,6 @@ const DummyRequest = require('../DummyRequest');
 
 const { errors } = require('arsenal');
 
-
 const authInfo = makeAuthInfo('accessKey1');
 const bucketName = 'bucketname';
 const delimiter = '/';
@@ -23,7 +22,7 @@ const prefix = 'sub';
 
 const objectName1 = `${prefix}${delimiter}objectName1`;
 const objectName2 = `${prefix}${delimiter}objectName2`;
-const objectName3 = 'notURIvalid$$';
+const objectName3 = 'invalidURI~~~b';
 const objectName4 = `${objectName1}&><"\'`;
 const testPutBucketRequest = new DummyRequest({
     bucketName,
@@ -106,6 +105,44 @@ const tests = [
             assert.strictEqual(result.ListBucketResult.Contents[0].Key[0],
                 objectName3);
             assert.strictEqual(result.ListBucketResult.Contents[1], undefined);
+        },
+    },
+    {
+        name: 'next token is not url encoded',
+        request: Object.assign(
+            {
+                query: { 'max-keys': '1' },
+                url: baseUrl,
+            },
+            baseGetRequest
+        ),
+        assertion: result => {
+            assert.strictEqual(result.ListBucketResult.Contents[0].Key[0],
+                objectName3);
+            assert.strictEqual(result.ListBucketResult.Contents[1], undefined);
+            assert.strictEqual(
+                result.ListBucketResult.NextContinuationToken[0],
+                'aW52YWxpZFVSSX5+fmI='
+            );
+        },
+    },
+    {
+        name: 'next token is not url encoded even with encoding url enabled',
+        request: Object.assign(
+            {
+                query: { 'encoding-type': 'url', 'max-keys': '1' },
+                url: baseUrl,
+            },
+            baseGetRequest
+        ),
+        assertion: result => {
+            assert.strictEqual(result.ListBucketResult.Contents[0].Key[0],
+                objectName3);
+            assert.strictEqual(result.ListBucketResult.Contents[1], undefined);
+            assert.strictEqual(
+                result.ListBucketResult.NextContinuationToken[0],
+                'aW52YWxpZFVSSX5+fmI='
+            );
         },
     },
     {


### PR DESCRIPTION
There is also the alternative approach of double decoding. We could also `while (token.contains('%')) token=decode(token)` to for sure get rid of extra encoding layers...