### PR TITLE
INTEGRATION [PR#4038 > development/8.3] bugfix: CLDSRV-56 Do not encode tokens again

### DIFF
--- a/lib/api/bucketGet.js
+++ b/lib/api/bucketGet.js
@@ -204,14 +204,16 @@ function processMasterVersions(bucketName, listParams, list) {
     const escapeXmlFn = listParams.encoding === 'url' ?
         querystring.escape : escapeForXml;
     xmlParams.forEach(p => {
-        if (p.value || p.tag === 'KeyCount') {
+        if (p.value &&
+            (p.tag === 'ContinuationToken' || p.tag === 'NextContinuationToken')) {
+            // do not url encode the continuation tokens
+            xml.push(`<${p.tag}>${p.value}</${p.tag}>`);
+        } else if (p.value || p.tag === 'KeyCount') {
             xml.push(`<${p.tag}>${escapeXmlFn(p.value)}</${p.tag}>`);
         } else if (p.tag !== 'NextMarker' &&
                 p.tag !== 'EncodingType' &&
                 p.tag !== 'Delimiter' &&
-                p.tag !== 'StartAfter' &&
-                p.tag !== 'ContinuationToken' &&
-                p.tag !== 'NextContinuationToken') {
+                p.tag !== 'StartAfter') {
             xml.push(`<${p.tag}/>`);
         }
     });
@@ -323,8 +325,7 @@ function bucketGet(authInfo, request, log, callback) {
     if (v2) {
         listParams.v2 = true;
         listParams.startAfter = params['start-after'];
-        listParams.continuationToken =
-            decryptToken(params['continuation-token']);
+        listParams.continuationToken = decryptToken(params['continuation-token']);
         listParams.fetchOwner = params['fetch-owner'] === 'true';
     } else {
         listParams.marker = params.marker;

--- a/tests/unit/api/bucketGet.js
+++ b/tests/unit/api/bucketGet.js
@@ -12,7 +12,6 @@ const DummyRequest = require('../DummyRequest');
 
 const { errors } = require('arsenal');
 
-
 const authInfo = makeAuthInfo('accessKey1');
 const bucketName = 'bucketname';
 const delimiter = '/';
@@ -23,7 +22,7 @@ const prefix = 'sub';
 
 const objectName1 = `${prefix}${delimiter}objectName1`;
 const objectName2 = `${prefix}${delimiter}objectName2`;
-const objectName3 = 'notURIvalid$$';
+const objectName3 = 'invalidURI~~~b';
 const objectName4 = `${objectName1}&><"\'`;
 const testPutBucketRequest = new DummyRequest({
     bucketName,
@@ -106,6 +105,25 @@ const tests = [
             assert.strictEqual(result.ListBucketResult.Contents[0].Key[0],
                 objectName3);
             assert.strictEqual(result.ListBucketResult.Contents[1], undefined);
+        },
+    },
+    {
+        name: 'next token is not url encoded',
+        request: Object.assign(
+            {
+                query: { 'encoding-type': 'url', 'max-keys': '1' },
+                url: baseUrl,
+            },
+            baseGetRequest
+        ),
+        assertion: result => {
+            assert.strictEqual(result.ListBucketResult.Contents[0].Key[0],
+                objectName3);
+            assert.strictEqual(result.ListBucketResult.Contents[1], undefined);
+            assert.strictEqual(
+                result.ListBucketResult.NextContinuationToken[0],
+                'aW52YWxpZFVSSX5+fmI='
+            );
         },
     },
     {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #4038.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.3/bugfix/CLDSRV-56_DoNotEncodeTokensAgain`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.3/bugfix/CLDSRV-56_DoNotEncodeTokensAgain
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.3/bugfix/CLDSRV-56_DoNotEncodeTokensAgain
```

Please always comment pull request #4038 instead of this one.