### PR TITLE
INTEGRATION [PR#4044 > development/8.3] CLDSRV-53 pass replayId when completing/deleting an MPU

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -94,8 +94,8 @@ const services = {
         const { objectKey, authInfo, size, contentMD5, metaHeaders,
             contentType, cacheControl, contentDisposition, contentEncoding,
             expires, multipart, headers, overrideMetadata, log,
-            lastModifiedDate, versioning, versionId, tagging, taggingCopy,
-            replicationInfo, dataStoreName } = params;
+            lastModifiedDate, versioning, versionId, uploadId,
+            tagging, taggingCopy, replicationInfo, dataStoreName } = params;
         log.trace('storing object in metadata');
         assert.strictEqual(typeof bucketName, 'string');
         const md = new ObjectMD();
@@ -139,6 +139,10 @@ const services = {
         }
         if (versionId || versionId === '') {
             options.versionId = versionId;
+        }
+        if (uploadId) {
+            md.setUploadId(uploadId);
+            options.replayId = uploadId;
         }
         // information to store about the version and the null version id
         // in the object metadata
@@ -245,8 +249,12 @@ const services = {
         assert.strictEqual(typeof objectMD, 'object');
 
         function deleteMDandData() {
-            return metadata.deleteObjectMD(bucketName, objectKey, options, log,
-                (err, res) => {
+            const deleteOptions = Object.assign({}, options);
+            if (objectMD.uploadId) {
+                deleteOptions.replayId = objectMD.uploadId;
+            }
+            return metadata.deleteObjectMD(
+                bucketName, objectKey, deleteOptions, log, (err, res) => {
                     if (err) {
                         return cb(err, res);
                     }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "github:scality/Arsenal#7.4.11",
+    "arsenal": "github:scality/Arsenal#7.4.12",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/tests/unit/api/objectDelete.js
+++ b/tests/unit/api/objectDelete.js
@@ -1,5 +1,8 @@
 const assert = require('assert');
+const async = require('async');
+const crypto = require('crypto');
 const { errors } = require('arsenal');
+const xml2js = require('xml2js');
 
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const bucketPutACL = require('../../../lib/api/bucketPutACL');
@@ -8,6 +11,12 @@ const { cleanup, DummyRequestLogger, makeAuthInfo } = require('../helpers');
 const objectPut = require('../../../lib/api/objectPut');
 const objectDelete = require('../../../lib/api/objectDelete');
 const objectGet = require('../../../lib/api/objectGet');
+const initiateMultipartUpload
+    = require('../../../lib/api/initiateMultipartUpload');
+const objectPutPart = require('../../../lib/api/objectPutPart');
+const completeMultipartUpload
+    = require('../../../lib/api/completeMultipartUpload');
+const metadataBackend = require('../../../lib/metadata/in_memory/backend');
 const DummyRequest = require('../DummyRequest');
 
 const log = new DummyRequestLogger();
@@ -69,6 +78,14 @@ describe('objectDelete API', () => {
         url: `/${bucketName}/${objectKey}`,
     });
 
+    const initiateMPURequest = {
+        bucketName,
+        namespace,
+        objectKey,
+        headers: { host: `${bucketName}.s3.amazonaws.com` },
+        url: `/${objectKey}?uploads`,
+    };
+
     it('should delete an object', done => {
         bucketPut(authInfo, testBucketPutRequest, log, () => {
             objectPut(authInfo, testPutObjectRequest,
@@ -110,6 +127,68 @@ describe('objectDelete API', () => {
                     });
                 });
         });
+    });
+
+    it('should delete a multipart upload', done => {
+        const partBody = Buffer.from('I am a part\n', 'utf8');
+        let testUploadId;
+        let calculatedHash;
+        async.waterfall([
+            next => bucketPut(authInfo, testBucketPutRequest, log, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateMPURequest, log, next),
+            (result, corsHeaders, next) => xml2js.parseString(result, next),
+            (json, next) => {
+                testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                const md5Hash = crypto.createHash('md5').update(partBody);
+                calculatedHash = md5Hash.digest('hex');
+                const partRequest = new DummyRequest({
+                    bucketName,
+                    namespace,
+                    objectKey,
+                    headers: { host: `${bucketName}.s3.amazonaws.com` },
+                    url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                    query: {
+                        partNumber: '1',
+                        uploadId: testUploadId,
+                    },
+                    calculatedHash,
+                }, partBody);
+                objectPutPart(authInfo, partRequest, undefined, log, next);
+            },
+            (hexDigest, corsHeaders, next) => {
+                const completeBody = '<CompleteMultipartUpload>' +
+                      '<Part>' +
+                      '<PartNumber>1</PartNumber>' +
+                      `<ETag>"${calculatedHash}"</ETag>` +
+                      '</Part>' +
+                      '</CompleteMultipartUpload>';
+                const completeRequest = {
+                    bucketName,
+                    namespace,
+                    objectKey,
+                    parsedHost: 's3.amazonaws.com',
+                    url: `/${objectKey}?uploadId=${testUploadId}`,
+                    headers: { host: `${bucketName}.s3.amazonaws.com` },
+                    query: { uploadId: testUploadId },
+                    post: completeBody,
+                };
+                completeMultipartUpload(authInfo, completeRequest, log, next);
+            },
+            (result, resHeaders, next) => {
+                const origDeleteObject = metadataBackend.deleteObject;
+                metadataBackend.deleteObject =
+                    (bucketName, objName, params, log, cb) => {
+                        assert.strictEqual(params.replayId, testUploadId);
+                        cb();
+                    };
+                objectDelete(authInfo, testDeleteRequest, log, err => {
+                    assert.ifError(err);
+                    metadataBackend.deleteObject = origDeleteObject;
+                    next();
+                });
+            },
+        ], done);
     });
 
     it('should prevent anonymous user deleteObject API access', done => {

--- a/tests/unit/api/objectDelete.js
+++ b/tests/unit/api/objectDelete.js
@@ -1,7 +1,8 @@
 const assert = require('assert');
 const async = require('async');
 const crypto = require('crypto');
-const { errors } = require('arsenal');
+const { errors, storage } = require('arsenal');
+const metadataBackend = storage.metadata.inMemory.metastore;
 const xml2js = require('xml2js');
 
 const { bucketPut } = require('../../../lib/api/bucketPut');
@@ -16,7 +17,6 @@ const initiateMultipartUpload
 const objectPutPart = require('../../../lib/api/objectPutPart');
 const completeMultipartUpload
     = require('../../../lib/api/completeMultipartUpload');
-const metadataBackend = require('../../../lib/metadata/in_memory/backend');
 const DummyRequest = require('../DummyRequest');
 
 const log = new DummyRequestLogger();

--- a/yarn.lock
+++ b/yarn.lock
@@ -282,9 +282,9 @@ arraybuffer.slice@~0.0.7:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
   integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
 
-"arsenal@github:scality/Arsenal#7.4.11":
-  version "7.4.11"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/f941132c8a0e0e435ea1bac6ed0c22be93cda21d"
+"arsenal@github:scality/Arsenal#7.4.12":
+  version "7.4.12"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/04581abbf68d041b8a1d4a35239809ac707673f0"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
@@ -379,7 +379,7 @@ arsenal@scality/Arsenal#918a1d7:
     JSONStream "^1.0.0"
     ajv "6.12.2"
     async "~2.1.5"
-    debug "~2.3.3"
+    debug "~2.6.9"
     diskusage "^1.1.1"
     ioredis "4.9.5"
     ipaddr.js "1.9.1"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #4044.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.3/improvement/CLDSRV-53-passReplayIdOnMPUCompleteAndDelete`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.3/improvement/CLDSRV-53-passReplayIdOnMPUCompleteAndDelete
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.3/improvement/CLDSRV-53-passReplayIdOnMPUCompleteAndDelete
```

Please always comment pull request #4044 instead of this one.