### PR TITLE
improvement: CLDSRV-61 refactor and test versioning helpers

### DIFF
--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -128,6 +128,22 @@ function _deleteNullVersionMD(bucketName, objKey, options, mst, log, cb) {
         });
 }
 
+/**
+ * Process state from the master version of an object and the bucket
+ * versioning configuration, return a set of options objects
+ *
+ * @param {object} mst - state of master version, as returned by
+ * getMasterState()
+ * @param {string} vstat - bucket versioning status: 'Enabled' or 'Suspended'
+ *
+ * @return {object} result object with the following attributes:
+ * - {object} options: versioning-related options to pass to the
+     services.metadataStoreObject() call
+ * - {object} [storeOptions]: options for metadata to create a new
+     null version key, if needed
+ * - {object} [delOptions]: options for metadata to delete the null
+     version key, if needed
+ */
 function processVersioningState(mst, vstat) {
     const options = {};
     const storeOptions = {};
@@ -176,6 +192,19 @@ function processVersioningState(mst, vstat) {
     return { options };
 }
 
+/**
+ * Build the state of the master version from its object metadata
+ *
+ * @param {object} objMD - object metadata parsed from JSON
+ *
+ * @return {object} state of master version, with the following attributes:
+ * - {boolean} exists - true if the object exists (i.e. if `objMD` is truish)
+ * - {string} versionId - version ID of the master key
+ * - {boolean} isNull - whether the master version is a null version
+ * - {string} nullVersionId - if not a null version, reference to the
+ *   null version ID
+ * - {array} objLocation - array of data locations
+ */
 function getMasterState(objMD) {
     if (!objMD) {
         return {};

--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -128,7 +128,7 @@ function _deleteNullVersionMD(bucketName, objKey, options, mst, log, cb) {
         });
 }
 
-function processVersioningState(mst, vstat, cb) {
+function processVersioningState(mst, vstat) {
     const options = {};
     const storeOptions = {};
     const delOptions = {};
@@ -142,9 +142,9 @@ function processVersioningState(mst, vstat, cb) {
             // if null version exists, clean it up prior to put
             if (mst.isNull) {
                 delOptions.versionId = mst.versionId;
-                return cb(null, options, null, delOptions);
+                return { options, delOptions };
             }
-            return cb(null, options);
+            return { options };
         }
         // versioning is enabled, create a new version
         options.versioning = true;
@@ -154,9 +154,9 @@ function processVersioningState(mst, vstat, cb) {
             storeOptions.versionId = versionId;
             storeOptions.isNull = true;
             options.nullVersionId = versionId;
-            return cb(null, options, storeOptions);
+            return { options, storeOptions };
         }
-        return cb(null, options);
+        return { options };
     }
     // master is versioned and is not a null version
     const nullVersionId = mst.nullVersionId;
@@ -165,15 +165,15 @@ function processVersioningState(mst, vstat, cb) {
         options.versionId = '';
         options.isNull = true;
         if (nullVersionId === undefined) {
-            return cb(null, options);
+            return { options };
         }
         delOptions.versionId = nullVersionId;
-        return cb(null, options, null, delOptions);
+        return { options, delOptions };
     }
     // versioning is enabled, put the new version
     options.versioning = true;
     options.nullVersionId = nullVersionId;
-    return cb(null, options);
+    return { options };
 }
 
 function getMasterState(objMD) {
@@ -212,35 +212,29 @@ function getMasterState(objMD) {
  */
 function versioningPreprocessing(bucketName, bucketMD, objectKey, objMD,
     log, callback) {
-    const options = {};
     const mst = getMasterState(objMD);
     const vCfg = bucketMD.getVersioningConfiguration();
     // bucket is not versioning configured
     if (!vCfg) {
-        options.dataToDelete = mst.objLocation;
+        const options = { dataToDelete: mst.objLocation };
         return process.nextTick(callback, null, options);
     }
     // bucket is versioning configured
-    return async.waterfall([
-        function processState(next) {
-            processVersioningState(mst, vCfg.Status,
-                (err, options, storeOptions, delOptions) => {
-                    process.nextTick(next, err, options, storeOptions,
-                        delOptions);
-                });
-        },
-        function storeVersion(options, storeOptions, delOptions, next) {
+    const { options, storeOptions, delOptions } =
+          processVersioningState(mst, vCfg.Status);
+    return async.series([
+        function storeVersion(next) {
             if (!storeOptions) {
-                return process.nextTick(next, null, options, delOptions);
+                return process.nextTick(next);
             }
             const versionMD = Object.assign({}, objMD, storeOptions);
             const params = { versionId: storeOptions.versionId };
             return _storeNullVersionMD(bucketName, objectKey, versionMD,
-                params, log, err => next(err, options, delOptions));
+                params, log, next);
         },
-        function deleteNullVersion(options, delOptions, next) {
+        function deleteNullVersion(next) {
             if (!delOptions) {
-                return process.nextTick(next, null, options);
+                return process.nextTick(next);
             }
             return _deleteNullVersionMD(bucketName, objectKey, delOptions, mst,
                 log, (err, nullDataToDelete) => {
@@ -258,10 +252,10 @@ function versioningPreprocessing(bucketName, bucketMD, objectKey, objMD,
                         return next(errors.InternalError);
                     }
                     Object.assign(options, { dataToDelete: nullDataToDelete });
-                    return next(null, options);
+                    return next();
                 });
         },
-    ], (err, options) => callback(err, options));
+    ], err => callback(err, options));
 }
 
 /** preprocessingVersioningDelete - return versioning information for S3 to
@@ -323,6 +317,8 @@ module.exports = {
     decodeVersionId,
     getVersionIdResHeader,
     checkQueryVersionId,
+    processVersioningState,
+    getMasterState,
     versioningPreprocessing,
     preprocessingVersioningDelete,
 };

--- a/tests/unit/api/apiUtils/versioning.js
+++ b/tests/unit/api/apiUtils/versioning.js
@@ -1,0 +1,135 @@
+const assert = require('assert');
+
+const { config } = require('../../../../lib/Config');
+const { versioning } = require('arsenal');
+const INF_VID = versioning.VersionID.getInfVid(config.replicationGroupId);
+
+const { processVersioningState, getMasterState } =
+      require('../../../../lib/api/apiUtils/object/versioning');
+
+describe('versioning helpers', () => {
+    describe('getMasterState+processVersioningState', () => {
+        [
+            {
+                // no prior version exists
+                objMD: null,
+                versioningEnabledExpectedRes: {
+                    options: {
+                        versioning: true,
+                    },
+                },
+                versioningSuspendedExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
+                    },
+                },
+            },
+            {
+                // prior non-null object version exists
+                objMD: {
+                    versionId: 'v1',
+                },
+                versioningEnabledExpectedRes: {
+                    options: {
+                        versioning: true,
+                    },
+                },
+                versioningSuspendedExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
+                    },
+                },
+            },
+            {
+                // prior null object version exists
+                objMD: {
+                    versionId: 'vnull',
+                    isNull: true,
+                },
+                versioningEnabledExpectedRes: {
+                    options: {
+                        versioning: true,
+                        nullVersionId: 'vnull',
+                    },
+                    // instruct to first copy the null version onto a
+                    // newly created version key preserving the version ID
+                    storeOptions: {
+                        isNull: true,
+                        versionId: 'vnull',
+                    },
+                },
+                versioningSuspendedExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
+                    },
+                    delOptions: {
+                        versionId: 'vnull',
+                    },
+                },
+            },
+            {
+                // prior object exists, put before versioning was first enabled
+                objMD: {},
+                versioningEnabledExpectedRes: {
+                    options: {
+                        versioning: true,
+                        nullVersionId: INF_VID,
+                    },
+                    // instruct to first copy the null version onto a
+                    // newly created version key as the oldest version
+                    storeOptions: {
+                        isNull: true,
+                        versionId: INF_VID,
+                    },
+                },
+                versioningSuspendedExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
+                    },
+                },
+            },
+            {
+                // prior non-null object version exists with ref to null version
+                objMD: {
+                    versionId: 'v1',
+                    nullVersionId: 'vnull',
+                },
+                versioningEnabledExpectedRes: {
+                    options: {
+                        versioning: true,
+                        nullVersionId: 'vnull',
+                    },
+                },
+                versioningSuspendedExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
+                    },
+                    delOptions: {
+                        versionId: 'vnull',
+                    },
+                },
+            },
+        ].forEach(testCase =>
+            ['Enabled', 'Suspended'].forEach(versioningStatus => it(
+            `with objMD ${JSON.stringify(testCase.objMD)} and versioning ` +
+            `Status=${versioningStatus}`, () => {
+                const mst = getMasterState(testCase.objMD);
+                // stringify and parse to get rid of the "undefined"
+                // properties, artifacts of how the function builds the
+                // result
+                const res = JSON.parse(
+                    JSON.stringify(
+                        processVersioningState(mst, versioningStatus)
+                    )
+                );
+                const expectedRes =
+                      testCase[`versioning${versioningStatus}ExpectedRes`];
+                assert.deepStrictEqual(res, expectedRes);
+            })));
+    });
+});


### PR DESCRIPTION
- add unit tests for processVersioningState helper

- remove the callback argument, instead, return the list of parameters
  as an object, it simplifies and enhances testability

- add unit tests for preprocessingVersioningDelete helper
