### PR TITLE
improvement: CLDSRV-60 cleanup replay IDs of null versions

### DIFF
--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -245,6 +245,7 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
             metadataStoreParams.versioning = options.versioning;
             metadataStoreParams.isNull = options.isNull;
             metadataStoreParams.nullVersionId = options.nullVersionId;
+            metadataStoreParams.nullUploadId = options.nullUploadId;
             return _storeInMDandDeleteData(bucketName, infoArr,
                 cipherBundle, metadataStoreParams,
                 options.dataToDelete, requestLogger, requestMethod, next);

--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -158,6 +158,9 @@ function processVersioningState(mst, vstat) {
             // if null version exists, clean it up prior to put
             if (mst.isNull) {
                 delOptions.versionId = mst.versionId;
+                if (mst.uploadId) {
+                    delOptions.replayId = mst.uploadId;
+                }
                 return { options, delOptions };
             }
             return { options };
@@ -170,6 +173,11 @@ function processVersioningState(mst, vstat) {
             storeOptions.versionId = versionId;
             storeOptions.isNull = true;
             options.nullVersionId = versionId;
+            // non-versioned (non-null) MPU objects don't have a
+            // replay ID, so don't reference their uploadId
+            if (mst.isNull && mst.uploadId) {
+                options.nullUploadId = mst.uploadId;
+            }
             return { options, storeOptions };
         }
         return { options };
@@ -184,11 +192,17 @@ function processVersioningState(mst, vstat) {
             return { options };
         }
         delOptions.versionId = nullVersionId;
+        if (mst.nullUploadId) {
+            delOptions.replayId = mst.nullUploadId;
+        }
         return { options, delOptions };
     }
     // versioning is enabled, put the new version
     options.versioning = true;
     options.nullVersionId = nullVersionId;
+    if (mst.nullUploadId) {
+        options.nullUploadId = mst.nullUploadId;
+    }
     return { options };
 }
 
@@ -212,8 +226,10 @@ function getMasterState(objMD) {
     const mst = {
         exists: true,
         versionId: objMD.versionId,
+        uploadId: objMD.uploadId,
         isNull: objMD.isNull,
         nullVersionId: objMD.nullVersionId,
+        nullUploadId: objMD.nullUploadId,
     };
     if (objMD.location) {
         mst.objLocation = Array.isArray(objMD.location) ?
@@ -313,6 +329,9 @@ function preprocessingVersioningDelete(bucketName, bucketMD, objectMD,
         // deleting a specific version
         options.deleteData = true;
         options.versionId = reqVersionId;
+        if (objectMD.uploadId) {
+            options.replayId = objectMD.uploadId;
+        }
         return callback(null, options);
     }
     if (reqVersionId) {
@@ -320,18 +339,26 @@ function preprocessingVersioningDelete(bucketName, bucketMD, objectMD,
         if (objectMD.versionId === undefined) {
             // object is not versioned, deleting it
             options.deleteData = true;
+            // non-versioned (non-null) MPU objects don't have a
+            // replay ID, so don't reference their uploadId
             return callback(null, options);
         }
         if (objectMD.isNull) {
             // master is the null version
             options.deleteData = true;
             options.versionId = objectMD.versionId;
+            if (objectMD.uploadId) {
+                options.replayId = objectMD.uploadId;
+            }
             return callback(null, options);
         }
         if (objectMD.nullVersionId) {
             // null version exists, deleting it
             options.deleteData = true;
             options.versionId = objectMD.nullVersionId;
+            if (objectMD.nullUploadId) {
+                options.replayId = objectMD.nullUploadId;
+            }
             return callback(null, options);
         }
         // null version does not exist, no deletion

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -327,6 +327,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     metaStoreParams.versioning = options.versioning;
                     metaStoreParams.isNull = options.isNull;
                     metaStoreParams.nullVersionId = options.nullVersionId;
+                    metaStoreParams.nullUploadId = options.nullUploadId;
                     return next(null, destBucket, dataLocations,
                         metaStoreParams, mpuBucket, keysToDelete, aggregateETag,
                         objMD, extraPartLocations, pseudoCipherBundle,

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -408,6 +408,8 @@ function objectCopy(authInfo, request, sourceBucket,
                     storeMetadataParams.isNull = options.isNull;
                     // eslint-disable-next-line
                     storeMetadataParams.nullVersionId = options.nullVersionId;
+                    // eslint-disable-next-line
+                    storeMetadataParams.nullUploadId = options.nullUploadId;
                     const dataToDelete = options.dataToDelete;
                     return next(null, storeMetadataParams, destDataGetInfoArr,
                         destObjMD, serverSideEncryption, destBucketMD,

--- a/lib/services.js
+++ b/lib/services.js
@@ -146,9 +146,10 @@ const services = {
         }
         // information to store about the version and the null version id
         // in the object metadata
-        const { isNull, nullVersionId, isDeleteMarker } = params;
+        const { isNull, nullVersionId, nullUploadId, isDeleteMarker } = params;
         md.setIsNull(isNull)
             .setNullVersionId(nullVersionId)
+            .setNullUploadId(nullUploadId)
             .setIsDeleteMarker(isDeleteMarker);
         if (versionId && versionId !== 'null') {
             md.setVersionId(versionId);
@@ -249,12 +250,8 @@ const services = {
         assert.strictEqual(typeof objectMD, 'object');
 
         function deleteMDandData() {
-            const deleteOptions = Object.assign({}, options);
-            if (objectMD.uploadId) {
-                deleteOptions.replayId = objectMD.uploadId;
-            }
-            return metadata.deleteObjectMD(
-                bucketName, objectKey, deleteOptions, log, (err, res) => {
+            return metadata.deleteObjectMD(bucketName, objectKey, options, log,
+                (err, res) => {
                     if (err) {
                         return cb(err, res);
                     }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "github:scality/Arsenal#7.4.12",
+    "arsenal": "github:scality/Arsenal#7.4.13",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/tests/unit/api/apiUtils/versioning.js
+++ b/tests/unit/api/apiUtils/versioning.js
@@ -44,6 +44,24 @@ describe('versioning helpers', () => {
                 },
             },
             {
+                // prior MPU object non-null version exists
+                objMD: {
+                    versionId: 'v1',
+                    uploadId: 'fooUploadId',
+                },
+                versioningEnabledExpectedRes: {
+                    options: {
+                        versioning: true,
+                    },
+                },
+                versioningSuspendedExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
+                    },
+                },
+            },
+            {
                 // prior null object version exists
                 objMD: {
                     versionId: 'vnull',
@@ -72,8 +90,64 @@ describe('versioning helpers', () => {
                 },
             },
             {
+                // prior MPU object null version exists
+                objMD: {
+                    versionId: 'vnull',
+                    isNull: true,
+                    uploadId: 'fooUploadId',
+                },
+                versioningEnabledExpectedRes: {
+                    options: {
+                        versioning: true,
+                        nullVersionId: 'vnull',
+                        nullUploadId: 'fooUploadId',
+                    },
+                    // instruct to first copy the null version onto a
+                    // newly created version key preserving the version ID
+                    storeOptions: {
+                        isNull: true,
+                        versionId: 'vnull',
+                    },
+                },
+                versioningSuspendedExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
+                    },
+                    delOptions: {
+                        versionId: 'vnull',
+                        replayId: 'fooUploadId',
+                    },
+                },
+            },
+            {
                 // prior object exists, put before versioning was first enabled
                 objMD: {},
+                versioningEnabledExpectedRes: {
+                    options: {
+                        versioning: true,
+                        nullVersionId: INF_VID,
+                    },
+                    // instruct to first copy the null version onto a
+                    // newly created version key as the oldest version
+                    storeOptions: {
+                        isNull: true,
+                        versionId: INF_VID,
+                    },
+                },
+                versioningSuspendedExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
+                    },
+                },
+            },
+            {
+                // prior MPU object exists, put before versioning was
+                // first enabled
+                objMD: {
+                    uploadId: 'fooUploadId',
+                },
                 versioningEnabledExpectedRes: {
                     options: {
                         versioning: true,
@@ -112,6 +186,56 @@ describe('versioning helpers', () => {
                     },
                     delOptions: {
                         versionId: 'vnull',
+                    },
+                },
+            },
+            {
+                // prior MPU object non-null version exists with ref
+                // to null version
+                objMD: {
+                    versionId: 'v1',
+                    uploadId: 'fooUploadId',
+                    nullVersionId: 'vnull',
+                },
+                versioningEnabledExpectedRes: {
+                    options: {
+                        versioning: true,
+                        nullVersionId: 'vnull',
+                    },
+                },
+                versioningSuspendedExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
+                    },
+                    delOptions: {
+                        versionId: 'vnull',
+                    },
+                },
+            },
+            {
+                // prior object non-null version exists with ref to
+                // MPU null version
+                objMD: {
+                    versionId: 'v1',
+                    nullVersionId: 'vnull',
+                    nullUploadId: 'nullFooUploadId',
+                },
+                versioningEnabledExpectedRes: {
+                    options: {
+                        versioning: true,
+                        nullVersionId: 'vnull',
+                        nullUploadId: 'nullFooUploadId',
+                    },
+                },
+                versioningSuspendedExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
+                    },
+                    delOptions: {
+                        versionId: 'vnull',
+                        replayId: 'nullFooUploadId',
                     },
                 },
             },
@@ -155,6 +279,19 @@ describe('versioning helpers', () => {
                 },
             },
             {
+                // delete MPU object non-null version
+                objMD: {
+                    versionId: 'v1',
+                    uploadId: 'fooUploadId',
+                },
+                reqVersionId: 'v1',
+                expectedRes: {
+                    deleteData: true,
+                    versionId: 'v1',
+                    replayId: 'fooUploadId',
+                },
+            },
+            {
                 // delete null object version
                 objMD: {
                     versionId: 'vnull',
@@ -167,8 +304,32 @@ describe('versioning helpers', () => {
                 },
             },
             {
+                // delete MPU object null version
+                objMD: {
+                    versionId: 'vnull',
+                    isNull: true,
+                    uploadId: 'fooUploadId',
+                },
+                reqVersionId: 'null',
+                expectedRes: {
+                    deleteData: true,
+                    versionId: 'vnull',
+                    replayId: 'fooUploadId',
+                },
+            },
+            {
                 // delete object put before versioning was first enabled
                 objMD: {},
+                reqVersionId: 'null',
+                expectedRes: {
+                    deleteData: true,
+                },
+            },
+            {
+                // delete MPU object put before versioning was first enabled
+                objMD: {
+                    uploadId: 'fooUploadId',
+                },
                 reqVersionId: 'null',
                 expectedRes: {
                     deleteData: true,
@@ -187,6 +348,33 @@ describe('versioning helpers', () => {
                 },
             },
             {
+                // delete MPU object non-null version with ref to null version
+                objMD: {
+                    versionId: 'v1',
+                    uploadId: 'fooUploadId',
+                    nullVersionId: 'vnull',
+                },
+                reqVersionId: 'v1',
+                expectedRes: {
+                    deleteData: true,
+                    versionId: 'v1',
+                    replayId: 'fooUploadId',
+                },
+            },
+            {
+                // delete non-null object version with ref to MPU null version
+                objMD: {
+                    versionId: 'v1',
+                    nullVersionId: 'vnull',
+                    nullUploadId: 'nullFooUploadId',
+                },
+                reqVersionId: 'v1',
+                expectedRes: {
+                    deleteData: true,
+                    versionId: 'v1',
+                },
+            },
+            {
                 // delete null object version from ref to null version
                 objMD: {
                     versionId: 'v1',
@@ -196,6 +384,20 @@ describe('versioning helpers', () => {
                 expectedRes: {
                     deleteData: true,
                     versionId: 'vnull',
+                },
+            },
+            {
+                // delete MPU object null version from ref to null version
+                objMD: {
+                    versionId: 'v1',
+                    nullVersionId: 'vnull',
+                    nullUploadId: 'nullFooUploadId',
+                },
+                reqVersionId: 'null',
+                expectedRes: {
+                    deleteData: true,
+                    versionId: 'vnull',
+                    replayId: 'nullFooUploadId',
                 },
             },
             {

--- a/tests/unit/api/apiUtils/versioning.js
+++ b/tests/unit/api/apiUtils/versioning.js
@@ -12,7 +12,7 @@ describe('versioning helpers', () => {
     describe('getMasterState+processVersioningState', () => {
         [
             {
-                // no prior version exists
+                description: 'no prior version exists',
                 objMD: null,
                 versioningEnabledExpectedRes: {
                     options: {
@@ -27,7 +27,7 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                // prior non-null object version exists
+                description: 'prior non-null object version exists',
                 objMD: {
                     versionId: 'v1',
                 },
@@ -44,7 +44,7 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                // prior MPU object non-null version exists
+                description: 'prior MPU object non-null version exists',
                 objMD: {
                     versionId: 'v1',
                     uploadId: 'fooUploadId',
@@ -62,7 +62,7 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                // prior null object version exists
+                description: 'prior null object version exists',
                 objMD: {
                     versionId: 'vnull',
                     isNull: true,
@@ -90,7 +90,7 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                // prior MPU object null version exists
+                description: 'prior MPU object null version exists',
                 objMD: {
                     versionId: 'vnull',
                     isNull: true,
@@ -121,7 +121,8 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                // prior object exists, put before versioning was first enabled
+                description:
+                'prior object exists, put before versioning was first enabled',
                 objMD: {},
                 versioningEnabledExpectedRes: {
                     options: {
@@ -143,8 +144,8 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                // prior MPU object exists, put before versioning was
-                // first enabled
+                description: 'prior MPU object exists, put before versioning ' +
+                    'was first enabled',
                 objMD: {
                     uploadId: 'fooUploadId',
                 },
@@ -168,7 +169,8 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                // prior non-null object version exists with ref to null version
+                description:
+                'prior non-null object version exists with ref to null version',
                 objMD: {
                     versionId: 'v1',
                     nullVersionId: 'vnull',
@@ -190,8 +192,8 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                // prior MPU object non-null version exists with ref
-                // to null version
+                description: 'prior MPU object non-null version exists with ' +
+                    'ref to null version',
                 objMD: {
                     versionId: 'v1',
                     uploadId: 'fooUploadId',
@@ -214,8 +216,8 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                // prior object non-null version exists with ref to
-                // MPU null version
+                description: 'prior object non-null version exists with ' +
+                    'ref to MPU null version',
                 objMD: {
                     versionId: 'v1',
                     nullVersionId: 'vnull',
@@ -241,8 +243,8 @@ describe('versioning helpers', () => {
             },
         ].forEach(testCase =>
             ['Enabled', 'Suspended'].forEach(versioningStatus => it(
-            `with objMD ${JSON.stringify(testCase.objMD)} and versioning ` +
-            `Status=${versioningStatus}`, () => {
+            `${testCase.description}, versioning Status=${versioningStatus}`,
+            () => {
                 const mst = getMasterState(testCase.objMD);
                 // stringify and parse to get rid of the "undefined"
                 // properties, artifacts of how the function builds the
@@ -261,14 +263,14 @@ describe('versioning helpers', () => {
     describe('preprocessingVersioningDelete', () => {
         [
             {
+                description: 'no reqVersionId: no delete action',
                 objMD: {
                     versionId: 'v1',
                 },
-                // no reqVersionId: no delete action
                 expectedRes: {},
             },
             {
-                // delete non-null object version
+                description: 'delete non-null object version',
                 objMD: {
                     versionId: 'v1',
                 },
@@ -279,7 +281,7 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                // delete MPU object non-null version
+                description: 'delete MPU object non-null version',
                 objMD: {
                     versionId: 'v1',
                     uploadId: 'fooUploadId',
@@ -292,7 +294,7 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                // delete null object version
+                description: 'delete null object version',
                 objMD: {
                     versionId: 'vnull',
                     isNull: true,
@@ -304,7 +306,7 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                // delete MPU object null version
+                description: 'delete MPU object null version',
                 objMD: {
                     versionId: 'vnull',
                     isNull: true,
@@ -318,7 +320,8 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                // delete object put before versioning was first enabled
+                description:
+                'delete object put before versioning was first enabled',
                 objMD: {},
                 reqVersionId: 'null',
                 expectedRes: {
@@ -326,7 +329,8 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                // delete MPU object put before versioning was first enabled
+                description:
+                'delete MPU object put before versioning was first enabled',
                 objMD: {
                     uploadId: 'fooUploadId',
                 },
@@ -336,7 +340,8 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                // delete non-null object version with ref to null version
+                description:
+                'delete non-null object version with ref to null version',
                 objMD: {
                     versionId: 'v1',
                     nullVersionId: 'vnull',
@@ -348,7 +353,8 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                // delete MPU object non-null version with ref to null version
+                description:
+                'delete MPU object non-null version with ref to null version',
                 objMD: {
                     versionId: 'v1',
                     uploadId: 'fooUploadId',
@@ -362,7 +368,8 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                // delete non-null object version with ref to MPU null version
+                description:
+                'delete non-null object version with ref to MPU null version',
                 objMD: {
                     versionId: 'v1',
                     nullVersionId: 'vnull',
@@ -375,7 +382,8 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                // delete null object version from ref to null version
+                description:
+                'delete null object version from ref to null version',
                 objMD: {
                     versionId: 'v1',
                     nullVersionId: 'vnull',
@@ -387,7 +395,8 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                // delete MPU object null version from ref to null version
+                description:
+                'delete MPU object null version from ref to null version',
                 objMD: {
                     versionId: 'v1',
                     nullVersionId: 'vnull',
@@ -401,16 +410,14 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                // delete null version that does not exist
+                description: 'delete null version that does not exist',
                 objMD: {
                     versionId: 'v1',
                 },
                 reqVersionId: 'null',
                 expectedError: errors.NoSuchKey,
             },
-        ].forEach(testCase => it(
-        `with objMD ${JSON.stringify(testCase.objMD)} and ` +
-        `reqVersionId="${testCase.reqVersionId}"`, done => {
+        ].forEach(testCase => it(testCase.description, done => {
             const mockBucketMD = {
                 getVersioningConfiguration: () => ({ Status: 'Enabled' }),
             };

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -497,14 +497,6 @@ describe('Multipart Upload API', () => {
                 };
                 const awsVerifiedETag =
                     '"953e9e776f285afc0bfcf1ab4668299d-1"';
-                const origPutObject = metadataBackend.putObject;
-                metadataBackend.putObject =
-                    (bucketName, objName, objVal, params, log, cb) => {
-                        assert.strictEqual(params.replayId, testUploadId);
-                        metadataBackend.putObject = origPutObject;
-                        metadataBackend.putObject(
-                            bucketName, objName, objVal, params, log, cb);
-                    };
                 completeMultipartUpload(authInfo,
                     completeRequest, log, (err, result) => {
                         parseString(result, (err, json) => {
@@ -1762,13 +1754,15 @@ describe('complete mpu with versioning', () => {
     const enableVersioningRequest =
         versioningTestUtils.createBucketPutVersioningReq(bucketName, 'Enabled');
     const suspendVersioningRequest = versioningTestUtils
-        .createBucketPutVersioningReq(bucketName, 'Suspended');
-    const testPutObjectRequests = objData.slice(0, 2).map(data =>
-        versioningTestUtils.createPutObjectRequest(bucketName, objectKey,
-            data));
+          .createBucketPutVersioningReq(bucketName, 'Suspended');
+    let testPutObjectRequests;
 
     beforeEach(done => {
         cleanup();
+        testPutObjectRequests = objData
+              .slice(0, 2)
+              .map(data => versioningTestUtils.createPutObjectRequest(
+                  bucketName, objectKey, data));
         bucketPut(authInfo, bucketPutRequest, log, done);
     });
 
@@ -1778,7 +1772,58 @@ describe('complete mpu with versioning', () => {
     });
 
     it('should delete null version when creating new null version, ' +
-    'even when null version is not the latest version', done => {
+    'when null version is the latest version', done => {
+        async.waterfall([
+            next => bucketPutVersioning(authInfo,
+                suspendVersioningRequest, log, err => next(err)),
+            next => initiateMultipartUpload(
+                authInfo, initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
+            (json, next) => {
+                const partBody = objData[2];
+                const testUploadId =
+                    json.InitiateMultipartUploadResult.UploadId[0];
+                const partRequest = _createPutPartRequest(testUploadId, 1,
+                    partBody);
+                objectPutPart(authInfo, partRequest, undefined, log,
+                    (err, eTag) => next(err, eTag, testUploadId));
+            },
+            (eTag, testUploadId, next) => {
+                const origPutObject = metadataBackend.putObject;
+                metadataBackend.putObject =
+                    (bucketName, objName, objVal, params, log, cb) => {
+                        assert.strictEqual(params.replayId, testUploadId);
+                        metadataBackend.putObject = origPutObject;
+                        metadataBackend.putObject(
+                            bucketName, objName, objVal, params, log, cb);
+                    };
+                const parts = [{ partNumber: 1, eTag }];
+                const completeRequest = _createCompleteMpuRequest(testUploadId,
+                    parts);
+                completeMultipartUpload(authInfo, completeRequest, log,
+                                        err => next(err, testUploadId));
+            },
+            (testUploadId, next) => {
+                const origDeleteObject = metadataBackend.deleteObject;
+                metadataBackend.deleteObject =
+                    (bucketName, objName, params, log, cb) => {
+                        assert.strictEqual(params.replayId, testUploadId);
+                        metadataBackend.deleteObject = origDeleteObject;
+                        metadataBackend.deleteObject(
+                            bucketName, objName, params, log, cb);
+                    };
+                // overwrite null version with a non-MPU object
+                objectPut(authInfo, testPutObjectRequests[1],
+                          undefined, log, err => next(err));
+            },
+        ], err => {
+            assert.ifError(err, `Unexpected err: ${err}`);
+            done();
+        });
+    });
+
+    it('should delete null version when creating new null version, ' +
+    'when null version is not the latest version', done => {
         async.waterfall([
             // putting null version: put obj before versioning configured
             next => objectPut(authInfo, testPutObjectRequests[0],
@@ -1806,18 +1851,39 @@ describe('complete mpu with versioning', () => {
                     (err, eTag) => next(err, eTag, testUploadId));
             },
             (eTag, testUploadId, next) => {
+                const origPutObject = metadataBackend.putObject;
+                metadataBackend.putObject =
+                    (bucketName, objName, objVal, params, log, cb) => {
+                        assert.strictEqual(params.replayId, testUploadId);
+                        metadataBackend.putObject = origPutObject;
+                        metadataBackend.putObject(
+                            bucketName, objName, objVal, params, log, cb);
+                    };
                 const parts = [{ partNumber: 1, eTag }];
                 const completeRequest = _createCompleteMpuRequest(testUploadId,
                     parts);
-                completeMultipartUpload(authInfo, completeRequest, log, next);
+                completeMultipartUpload(authInfo, completeRequest, log,
+                                        err => next(err, testUploadId));
+            },
+            (testUploadId, next) => {
+                versioningTestUtils.assertDataStoreValues(
+                    ds, [undefined, objData[1], objData[2]]);
+
+                const origDeleteObject = metadataBackend.deleteObject;
+                metadataBackend.deleteObject =
+                    (bucketName, objName, params, log, cb) => {
+                        assert.strictEqual(params.replayId, testUploadId);
+                        metadataBackend.deleteObject = origDeleteObject;
+                        metadataBackend.deleteObject(
+                            bucketName, objName, params, log, cb);
+                    };
+                // overwrite null version with a non-MPU object
+                objectPut(authInfo, testPutObjectRequests[1],
+                          undefined, log, err => next(err));
             },
         ], err => {
             assert.ifError(err, `Unexpected err: ${err}`);
-            process.nextTick(() => {
-                versioningTestUtils.assertDataStoreValues(ds, [undefined,
-                    objData[1], objData[2]]);
-                done(err);
-            });
+            done();
         });
     });
 

--- a/tests/unit/api/objectDelete.js
+++ b/tests/unit/api/objectDelete.js
@@ -16,7 +16,6 @@ const initiateMultipartUpload
 const objectPutPart = require('../../../lib/api/objectPutPart');
 const completeMultipartUpload
     = require('../../../lib/api/completeMultipartUpload');
-const metadataBackend = require('../../../lib/metadata/in_memory/backend');
 const DummyRequest = require('../DummyRequest');
 
 const log = new DummyRequestLogger();
@@ -175,19 +174,8 @@ describe('objectDelete API', () => {
                 };
                 completeMultipartUpload(authInfo, completeRequest, log, next);
             },
-            (result, resHeaders, next) => {
-                const origDeleteObject = metadataBackend.deleteObject;
-                metadataBackend.deleteObject =
-                    (bucketName, objName, params, log, cb) => {
-                        assert.strictEqual(params.replayId, testUploadId);
-                        cb();
-                    };
-                objectDelete(authInfo, testDeleteRequest, log, err => {
-                    assert.ifError(err);
-                    metadataBackend.deleteObject = origDeleteObject;
-                    next();
-                });
-            },
+            (result, resHeaders, next) =>
+                objectDelete(authInfo, testDeleteRequest, log, next),
         ], done);
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -282,9 +282,9 @@ arraybuffer.slice@~0.0.7:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
   integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
 
-"arsenal@github:scality/Arsenal#7.4.12":
-  version "7.4.12"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/04581abbf68d041b8a1d4a35239809ac707673f0"
+"arsenal@github:scality/Arsenal#7.4.13":
+  version "7.4.13"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/5ce057a498b35d995041785ee92b0307ea0ceba5"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
@@ -4214,9 +4214,10 @@ vaultclient@scality/vaultclient#cc9ba34:
   version "7.4.0"
   resolved "https://codeload.github.com/scality/vaultclient/tar.gz/cc9ba34b9abf3aac8324e912671547f5fc31baf4"
   dependencies:
-    arsenal scality/Arsenal#9f2e74e
+    agentkeepalive "^4.1.3"
+    arsenal scality/Arsenal#918a1d7
     commander "2.20.0"
-    werelogs scality/werelogs#4e0d97c
+    werelogs scality/werelogs#8.1.0
     xml2js "0.4.19"
 
 verror@1.10.0:


### PR DESCRIPTION
* cleanup replay IDs of null versions

Replace the previous way of passing replayId option to metadata DELETE by the result of the preprocessingVersioningDelete function, since it handles more cases like when a bucket with versioning suspended has to delete the previous null version, in which case, the null version's replay IDs have to be cleaned up.

* process upload IDs in versioning helpers

In versioning helpers, make sure we pass on the nullUploadId/replayId to the metadataStoreObject() or deleteObject() function, so that they can update ObjectMD and pass the appropriate replay options to metadata
