### PR TITLE
INTEGRATION [PR#4086 > development/7.10] bf(CLDSRV-66): Don't pass `oldByteLength` for completeMPU if versioned bucket

### DIFF
--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -444,10 +444,14 @@ function completeMultipartUpload(authInfo, request, log, callback) {
             resHeaders['x-amz-version-id'] =
                 versionIdUtils.encode(generatedVersionId);
         }
+
+        const vcfg = destinationBucket.getVersioningConfiguration();
+        const isVersionedObj = vcfg && vcfg.Status === 'Enabled';
+
         xmlParams.eTag = `"${aggregateETag}"`;
         const xml = convertToXml('completeMultipartUpload', xmlParams);
         pushMetric('completeMultipartUpload', log, {
-            oldByteLength: !generatedVersionId ? oldByteLength : null,
+            oldByteLength: isVersionedObj ? null : oldByteLength,
             authInfo,
             canonicalID: destinationBucket.getOwner(),
             bucket: bucketName,

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -447,7 +447,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
         xmlParams.eTag = `"${aggregateETag}"`;
         const xml = convertToXml('completeMultipartUpload', xmlParams);
         pushMetric('completeMultipartUpload', log, {
-            oldByteLength,
+            oldByteLength: !generatedVersionId ? oldByteLength : null,
             authInfo,
             canonicalID: destinationBucket.getOwner(),
             bucket: bucketName,


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #4086.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/bugfix/CLDSRV-66/fix_utapiv1_mpu_versioned_bucket`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/bugfix/CLDSRV-66/fix_utapiv1_mpu_versioned_bucket
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/bugfix/CLDSRV-66/fix_utapiv1_mpu_versioned_bucket
```

Please always comment pull request #4086 instead of this one.