### PR TITLE
CLDSRV-73 - convert nanoseconds to seconds

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -122,7 +122,7 @@ class S3Server {
             monitoringClient.httpRequestsTotal.labels(labels).inc();
             monitoringClient.httpRequestDurationSeconds
                 .labels(labels)
-                .observe(responseTimeInMs / 1000000);
+                .observe(responseTimeInMs / 1e9);
             monitoringClient.httpActiveRequests.dec();
         };
         res.on('close', monitorEndOfRequest);


### PR DESCRIPTION
during metric measurement we get the request time in nanoseconds.
Convert it to seconds, as per the standard from prometheus, by
dividing it by 1000000000.
