### PR TITLE
CLDSRV-80 - use git tag to tag dashboard during release

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -561,6 +561,6 @@ stages:
       - ShellCommand:
           name: push dashboards to the production namespace
           command: |
-            oras push ${REGISTRY}/${PROJECT}-dev/${PROJECT}-dashboards:$revision ${LAYERS}
+            oras push ${REGISTRY}/${PROJECT}/${PROJECT}-dashboards:%(prop:tag)s ${LAYERS}
           env: *oras
           workdir: build/monitoring/


### PR DESCRIPTION
Use the git tag a image tag when releasing cloudserver dashboards.