### PR TITLE
improvement: CLDSRV-79-support checkPolicy for session user

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -65,6 +65,7 @@ const writeContinue = require('../utilities/writeContinue');
 const validateQueryAndHeaders = require('../utilities/validateQueryAndHeaders');
 const parseCopySource = require('./apiUtils/object/parseCopySource');
 const { tagConditionKeyAuth } = require('./apiUtils/authorization/tagConditionKeys');
+const { isRequesterASessionUser } = require('./apiUtils/authorization/permissionChecks');
 
 const monitoringMap = policies.actionMaps.actionMonitoringMapS3;
 
@@ -173,6 +174,9 @@ const api = {
             const authNames = { accountName: userInfo.getAccountDisplayName() };
             if (userInfo.isRequesterAnIAMUser()) {
                 authNames.userName = userInfo.getIAMdisplayName();
+            }
+            if (isRequesterASessionUser(userInfo)) {
+                authNames.sessionName = userInfo.getShortid().split(':')[1];
             }
             log.addDefaultFields(authNames);
             if (tagAuthResults) {

--- a/lib/api/apiUtils/authorization/permissionChecks.js
+++ b/lib/api/apiUtils/authorization/permissionChecks.js
@@ -17,6 +17,15 @@ function isServiceAccount(canonicalID) {
     return getServiceAccountProperties(canonicalID) !== undefined;
 }
 
+function isRequesterASessionUser(authInfo) {
+    const regexpAssumedRoleArn = /^arn:aws:sts::[0-9]{12}:assumed-role\/.*$/;
+    return regexpAssumedRoleArn.test(authInfo.getArn());
+}
+
+function isRequesterNonAccountUser(authInfo) {
+    return authInfo.isRequesterAnIAMUser() || isRequesterASessionUser(authInfo);
+}
+
 function checkBucketAcls(bucket, requestType, canonicalID) {
     if (bucket.getOwner() === canonicalID) {
         return true;
@@ -284,7 +293,7 @@ function isBucketAuthorized(bucket, requestType, canonicalID, authInfo, log, req
     let requesterIsNotUser = true;
     let arn = null;
     if (authInfo) {
-        requesterIsNotUser = !authInfo.isRequesterAnIAMUser();
+        requesterIsNotUser = !isRequesterNonAccountUser(authInfo);
         arn = authInfo.getArn();
     }
     // if the bucket owner is an account, users should not have default access
@@ -320,7 +329,7 @@ function isObjAuthorized(bucket, objectMD, requestType, canonicalID, authInfo, l
     let requesterIsNotUser = true;
     let arn = null;
     if (authInfo) {
-        requesterIsNotUser = !authInfo.isRequesterAnIAMUser();
+        requesterIsNotUser = !isRequesterNonAccountUser(authInfo);
         arn = authInfo.getArn();
     }
     if (objectMD['owner-id'] === canonicalID && requesterIsNotUser) {
@@ -384,6 +393,8 @@ module.exports = {
     isObjAuthorized,
     getServiceAccountProperties,
     isServiceAccount,
+    isRequesterASessionUser,
+    isRequesterNonAccountUser,
     checkBucketAcls,
     checkObjectAcls,
     validatePolicyResource,

--- a/lib/api/bucketPut.js
+++ b/lib/api/bucketPut.js
@@ -10,6 +10,7 @@ const aclUtils = require('../utilities/aclUtils');
 const { pushMetric } = require('../utapi/utilities');
 const monitoring = require('../utilities/monitoringHandler');
 const { zenkoSeparator } = require('../../constants');
+const { isRequesterNonAccountUser } = require('./apiUtils/authorization/permissionChecks');
 const requestUtils = policies.requestUtils;
 
 let { restEndpoints, locationConstraints } = config;
@@ -148,7 +149,7 @@ function bucketPut(authInfo, request, log, callback) {
         next => _parseXML(request, log, next),
         // Check policies in Vault for a user.
         (locationConstraint, next) => {
-            if (authInfo.isRequesterAnIAMUser()) {
+            if (isRequesterNonAccountUser(authInfo)) {
                 const authParams = auth.server.extractParams(request, log, 's3',
                     request.query);
                 const ip = requestUtils.getClientIp(request, config);

--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -20,6 +20,7 @@ const { metadataGetObject } = require('../metadata/metadataUtils');
 const monitoring = require('../utilities/monitoringHandler');
 const { config } = require('../Config');
 const { isObjectLocked } = require('./apiUtils/object/objectLockHelpers');
+const { isRequesterNonAccountUser } = require('./apiUtils/authorization/permissionChecks');
 const requestUtils = policies.requestUtils;
 
 const versionIdUtils = versioning.VersionID;
@@ -357,7 +358,7 @@ function multiObjectDelete(authInfo, request, log, callback) {
             // if request from account, no need to check policies
             // all objects are inPlay so send array of object keys
             // as inPlay argument
-            if (!authInfo.isRequesterAnIAMUser()) {
+            if (!isRequesterNonAccountUser(authInfo)) {
                 return next(null, quietSetting, errorResults, objects);
             }
 

--- a/lib/api/objectPutCopyPart.js
+++ b/lib/api/objectPutCopyPart.js
@@ -17,6 +17,7 @@ const monitoring = require('../utilities/monitoringHandler');
 
 const versionIdUtils = versioning.VersionID;
 const { config } = require('../Config');
+const { isRequesterNonAccountUser } = require('./apiUtils/authorization/permissionChecks');
 
 const skipError = new Error('skip');
 
@@ -228,7 +229,7 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
                             return next(err);
                         }
                         const initiatorID = res.initiator.ID;
-                        const requesterID = authInfo.isRequesterAnIAMUser() ?
+                        const requesterID = isRequesterNonAccountUser(authInfo) ?
                             authInfo.getArn() : authInfo.getCanonicalID();
                         if (initiatorID !== requesterID) {
                             return next(errors.AccessDenied);

--- a/lib/api/objectPutPart.js
+++ b/lib/api/objectPutPart.js
@@ -20,6 +20,7 @@ const { BackendInfo } = models;
 
 const writeContinue = require('../utilities/writeContinue');
 const { getObjectSSEConfiguration } = require('./apiUtils/bucket/bucketEncryption');
+const { isRequesterNonAccountUser } = require('./apiUtils/authorization/permissionChecks');
 const skipError = new Error('skip');
 
 // We pad the partNumbers so that the parts will be sorted in numerical order.
@@ -179,7 +180,7 @@ function objectPutPart(authInfo, request, streamingV4Params, log,
                         return next(err, destinationBucket);
                     }
                     const initiatorID = res.initiator.ID;
-                    const requesterID = authInfo.isRequesterAnIAMUser() ?
+                    const requesterID = isRequesterNonAccountUser(authInfo) ?
                         authInfo.getArn() : authInfo.getCanonicalID();
                     if (initiatorID !== requesterID) {
                         return next(errors.AccessDenied, destinationBucket);

--- a/lib/api/objectPutRetention.js
+++ b/lib/api/objectPutRetention.js
@@ -12,6 +12,7 @@ const getReplicationInfo = require('./apiUtils/object/getReplicationInfo');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const metadata = require('../metadata/wrapper');
 const { config } = require('../Config');
+const { isRequesterNonAccountUser } = require('./apiUtils/authorization/permissionChecks');
 
 const { parseRetentionXml } = s3middleware.retention;
 const REPLICATION_ACTION = 'PUT_RETENTION';
@@ -83,8 +84,8 @@ function objectPutRetention(authInfo, request, log, callback) {
                 (err, retentionInfo) => next(err, bucket, retentionInfo, objectMD));
         },
         (bucket, retentionInfo, objectMD, next) => {
-            if (objectMD.retentionMode === 'GOVERNANCE' && authInfo.isRequesterAnIAMUser()) {
-                log.trace('object in GOVERNANCE mode and is user, checking for attached policies',
+            if (objectMD.retentionMode === 'GOVERNANCE' && isRequesterNonAccountUser(authInfo)) {
+                log.trace('object in GOVERNANCE mode and is not account, checking for attached policies',
                     { method: 'objectPutRetention' });
                 const authParams = auth.server.extractParams(request, log, 's3',
                     request.query);

--- a/lib/services.js
+++ b/lib/services.js
@@ -13,6 +13,7 @@ const logger = require('./utilities/logger');
 const { setObjectLockInformation }
     = require('./api/apiUtils/object/objectLockHelpers');
 const removeAWSChunked = require('./api/apiUtils/object/removeAWSChunked');
+const { isRequesterNonAccountUser } = require('./api/apiUtils/authorization/permissionChecks');
 const { parseTagFromQuery } = s3middleware.tagging;
 
 const usersBucket = constants.usersBucket;
@@ -531,7 +532,7 @@ const services = {
                         return cb(null, mpuBucket, mpuOverview, storedMetadata);
                     }
 
-                    const requesterID = authInfo.isRequesterAnIAMUser() ?
+                    const requesterID = isRequesterNonAccountUser(authInfo) ?
                         authInfo.getArn() : authInfo.getCanonicalID();
                     const isRequesterInitiator =
                         initiatorID === requesterID;

--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -6,6 +6,7 @@ const { UtapiClient, utapiVersion } = require('utapi');
 const logger = require('../utilities/logger');
 const _config = require('../Config').config;
 const { suppressedUtapiEventFields: suppressedEventFields } = require('../../constants');
+const { isRequesterNonAccountUser } = require('../api/apiUtils/authorization/permissionChecks');
 // setup utapi client
 let utapiConfig;
 
@@ -37,7 +38,7 @@ const bucketOwnerMetrics = [
 
 function evalAuthInfo(authInfo, canonicalID, action) {
     let accountId = authInfo.getCanonicalID();
-    let userId = authInfo.isRequesterAnIAMUser() ?
+    let userId = isRequesterNonAccountUser(authInfo) ?
         authInfo.getShortid() : undefined;
     // If action impacts 'numberOfObjectsStored' or 'storageUtilized' metric
     // only the bucket owner account's metrics should be updated


### PR DESCRIPTION
## Description

### Motivation and context

Currently in cloudserver, for some APIs, if it's an account user, we don't check any permission, we only check the permission of iam users. And also we assume only either it's an account user or it's iam user. This caused an issue after we introduced role session user in Vault, we should not use the logic that if it's not iam user then it must be an account user and we don't check anything for it. We need to support checking if it's a role session user for these APIs.

APIs affected are below: createBucket, multipleObjectDelete, objectPutCopyPart, objectPutPart, objectPutRetention

### Related issues

https://scality.atlassian.net/browse/CLDSRV-79

