### PR TITLE
bugfix: CLDSRV-85-revert some parts to fix `InitialRequesterId-not-equal-to-requesterId`

### DIFF
--- a/lib/api/objectPutCopyPart.js
+++ b/lib/api/objectPutCopyPart.js
@@ -17,7 +17,6 @@ const monitoring = require('../utilities/monitoringHandler');
 
 const versionIdUtils = versioning.VersionID;
 const { config } = require('../Config');
-const { isRequesterNonAccountUser } = require('./apiUtils/authorization/permissionChecks');
 
 const skipError = new Error('skip');
 
@@ -229,7 +228,7 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
                             return next(err);
                         }
                         const initiatorID = res.initiator.ID;
-                        const requesterID = isRequesterNonAccountUser(authInfo) ?
+                        const requesterID = authInfo.isRequesterAnIAMUser() ?
                             authInfo.getArn() : authInfo.getCanonicalID();
                         if (initiatorID !== requesterID) {
                             return next(errors.AccessDenied);

--- a/lib/api/objectPutPart.js
+++ b/lib/api/objectPutPart.js
@@ -20,7 +20,6 @@ const { BackendInfo } = models;
 
 const writeContinue = require('../utilities/writeContinue');
 const { getObjectSSEConfiguration } = require('./apiUtils/bucket/bucketEncryption');
-const { isRequesterNonAccountUser } = require('./apiUtils/authorization/permissionChecks');
 const skipError = new Error('skip');
 
 // We pad the partNumbers so that the parts will be sorted in numerical order.
@@ -180,7 +179,7 @@ function objectPutPart(authInfo, request, streamingV4Params, log,
                         return next(err, destinationBucket);
                     }
                     const initiatorID = res.initiator.ID;
-                    const requesterID = isRequesterNonAccountUser(authInfo) ?
+                    const requesterID = authInfo.isRequesterAnIAMUser() ?
                         authInfo.getArn() : authInfo.getCanonicalID();
                     if (initiatorID !== requesterID) {
                         return next(errors.AccessDenied, destinationBucket);

--- a/lib/services.js
+++ b/lib/services.js
@@ -13,7 +13,6 @@ const logger = require('./utilities/logger');
 const { setObjectLockInformation }
     = require('./api/apiUtils/object/objectLockHelpers');
 const removeAWSChunked = require('./api/apiUtils/object/removeAWSChunked');
-const { isRequesterNonAccountUser } = require('./api/apiUtils/authorization/permissionChecks');
 const { parseTagFromQuery } = s3middleware.tagging;
 
 const usersBucket = constants.usersBucket;
@@ -537,7 +536,7 @@ const services = {
                         return cb(null, mpuBucket, mpuOverview, storedMetadata);
                     }
 
-                    const requesterID = isRequesterNonAccountUser(authInfo) ?
+                    const requesterID = authInfo.isRequesterAnIAMUser() ?
                         authInfo.getArn() : authInfo.getCanonicalID();
                     const isRequesterInitiator =
                         initiatorID === requesterID;

--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -6,7 +6,6 @@ const { UtapiClient, utapiVersion } = require('utapi');
 const logger = require('../utilities/logger');
 const _config = require('../Config').config;
 const { suppressedUtapiEventFields: suppressedEventFields } = require('../../constants');
-const { isRequesterNonAccountUser } = require('../api/apiUtils/authorization/permissionChecks');
 // setup utapi client
 let utapiConfig;
 
@@ -38,7 +37,7 @@ const bucketOwnerMetrics = [
 
 function evalAuthInfo(authInfo, canonicalID, action) {
     let accountId = authInfo.getCanonicalID();
-    let userId = isRequesterNonAccountUser(authInfo) ?
+    let userId = authInfo.isRequesterAnIAMUser() ?
         authInfo.getShortid() : undefined;
     // If action impacts 'numberOfObjectsStored' or 'storageUtilized' metric
     // only the bucket owner account's metrics should be updated


### PR DESCRIPTION
bug introduced by this PR https://github.com/scality/cloudserver/pull/4131

requesterId won't be equal to initialrequesterId after I made some changes in the previous pr, so here we need to revert them, only keep the changes for the checkPolicies part.