### PR TITLE
Fix cloudserver alerts to better match the requirements

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -111,7 +111,7 @@ class S3Server {
         });
 
         const monitorEndOfRequest = () => {
-            const responseTimeInMs = Number(process.hrtime.bigint() - requestStartTime);
+            const responseTimeInNs = Number(process.hrtime.bigint() - requestStartTime);
             const labels = {
                 method: req.method,
                 code: res.statusCode,
@@ -122,7 +122,7 @@ class S3Server {
             monitoringClient.httpRequestsTotal.labels(labels).inc();
             monitoringClient.httpRequestDurationSeconds
                 .labels(labels)
-                .observe(responseTimeInMs / 1e9);
+                .observe(responseTimeInNs / 1e9);
             monitoringClient.httpActiveRequests.dec();
         };
         res.on('close', monitorEndOfRequest);

--- a/monitoring/alerts.yaml
+++ b/monitoring/alerts.yaml
@@ -87,8 +87,8 @@ groups:
   # 500ms
   - alert: DeleteLatencyWarning
     expr: |
-      rate(http_request_duration_seconds_sum{namespace="${namespace}",service="${service}",action="deleteObject|deleteBucket|multiObjectDelete"}[1m])
-          / rate(http_request_duration_seconds_count{namespace="${namespace}",service="${service}",action="deleteObject|deleteBucket|multiObjectDelete"}[1m])
+      rate(http_request_duration_seconds_sum{namespace="${namespace}",service="${service}",action="deleteObject"}[1m])
+          / rate(http_request_duration_seconds_count{namespace="${namespace}",service="${service}",action="deleteObject"}[1m])
         >= 500
     for: 5m
     labels:
@@ -100,8 +100,8 @@ groups:
   # than 1s
   - alert: DeleteLatencyCritical
     expr: |
-      rate(http_request_duration_seconds_sum{namespace="${namespace}",service="${service}",action="deleteObject|deleteBucket|multiObjectDelete"}[1m])
-          / rate(http_request_duration_seconds_count{namespace="${namespace}",service="${service}",action="deleteObject|deleteBucket|multiObjectDelete"}[1m])
+      rate(http_request_duration_seconds_sum{namespace="${namespace}",service="${service}",action="deleteObject"}[1m])
+          / rate(http_request_duration_seconds_count{namespace="${namespace}",service="${service}",action="deleteObject"}[1m])
         >= 1.000
     for: 5m
     labels:

--- a/monitoring/alerts.yaml
+++ b/monitoring/alerts.yaml
@@ -61,8 +61,8 @@ groups:
   # version listing operation latency is more than 300ms
   - alert: ListingLatencyWarning
     expr: |
-      rate(http_request_duration_seconds_sum{namespace="${namespace}",service="${service}",action="getService|listBucket"}[1m])
-          / rate(http_request_duration_seconds_count{namespace="${namespace}",service="${service}",action="getService|listBucket"}[1m])
+      rate(http_request_duration_seconds_sum{namespace="${namespace}",service="${service}",action="listBucket"}[1m])
+          / rate(http_request_duration_seconds_count{namespace="${namespace}",service="${service}",action="listBucket"}[1m])
         >= 0.300
     for: 5m
     labels:
@@ -74,8 +74,8 @@ groups:
   # version listing operation latency is more than 500ms
   - alert: ListingLatencyCritical
     expr: |
-      rate(http_request_duration_seconds_sum{namespace="${namespace}",service="${service}",action="getService|listBucket"}[1m])
-          / rate(http_request_duration_seconds_count{namespace="${namespace}",service="${service}",action="getService|listBucket"}[1m])
+      rate(http_request_duration_seconds_sum{namespace="${namespace}",service="${service}",action="listBucket"}[1m])
+          / rate(http_request_duration_seconds_count{namespace="${namespace}",service="${service}",action="listBucket"}[1m])
         >= 0.500
     for: 5m
     labels:

--- a/monitoring/alerts.yaml
+++ b/monitoring/alerts.yaml
@@ -42,6 +42,7 @@ groups:
     labels:
       severity: warning
     annotations:
+      description: "System errors represent more than 3% of all the response codes"
       summary: "High ratio of system erors"
 
   # As a platform admin I want to be alerted (critical) when the system errors are more than 5% of
@@ -55,6 +56,7 @@ groups:
     labels:
       severity: critical
     annotations:
+      description: "System errors represent more than 5% of all the response codes"
       summary: "Very high ratio of system erors"
 
   # As a platform admin I want to be alerted (warning) when a listing operation latency or a
@@ -68,6 +70,7 @@ groups:
     labels:
       severity: warning
     annotations:
+      description: "Latency of listing or version listing operations is more than 300ms"
       summary: "High listing latency"
 
   # As a platform admin I want to be alerted (critical) when a listing operation latency or a
@@ -81,6 +84,7 @@ groups:
     labels:
       severity: critical
     annotations:
+      description: "Latency of listing or version listing operations is more than 500ms"
       summary: "Very high listing latency"
 
   # As a platform admin I want to be alerted (warning) when a delete operation latency is more than
@@ -94,6 +98,7 @@ groups:
     labels:
       severity: warning
     annotations:
+      description: "Latency of delete object operations is more than 500ms"
       summary: "High delete latency"
 
   # As a platform admin I want to be alerted (critical) when a delete operation latency is more
@@ -107,5 +112,5 @@ groups:
     labels:
       severity: critical
     annotations:
+      description: "Latency of delete object operations is more than 1s"
       summary: "Very high delete latency"
-

--- a/monitoring/alerts.yaml
+++ b/monitoring/alerts.yaml
@@ -35,77 +35,77 @@ groups:
   # all the response codes
   - alert: SystemErrorsWarning
     expr: |
-      sum by(pod) (rate(http_requests_total{namespace="${namespace}", service="${service}", code=~"5.."}[1m]))
-          / sum by(pod) (rate(http_requests_total{namespace="${namespace}", service="${service}"}[1m]))
+      sum(rate(http_requests_total{namespace="${namespace}", service="${service}", code=~"5.."}[1m]))
+          / sum(rate(http_requests_total{namespace="${namespace}", service="${service}"}[1m]))
         >= 0.03
     for: 5m
     labels:
       severity: warning
     annotations:
-      summary: "High ratio of system erors on {{ $labels.pod }}"
+      summary: "High ratio of system erors"
 
   # As a platform admin I want to be alerted (critical) when the system errors are more than 5% of
   # all the response codes
   - alert: SystemErrorsCritical
     expr: |
-      sum by(pod) (rate(http_requests_total{namespace="${namespace}", service="${service}", code=~"5.."}[1m]))
-          / sum by(pod) (rate(http_requests_total{namespace="${namespace}", service="${service}"}[1m]))
+      sum(rate(http_requests_total{namespace="${namespace}", service="${service}", code=~"5.."}[1m]))
+          / sum(rate(http_requests_total{namespace="${namespace}", service="${service}"}[1m]))
         >= 0.05
     for: 5m
     labels:
       severity: critical
     annotations:
-      summary: "Very high ratio of system erors on {{ $labels.pod }}"
+      summary: "Very high ratio of system erors"
 
   # As a platform admin I want to be alerted (warning) when a listing operation latency or a
   # version listing operation latency is more than 300ms
   - alert: ListingLatencyWarning
     expr: |
-      rate(http_request_duration_seconds_sum{namespace="${namespace}",service="${service}",action="listBucket"}[1m])
-          / rate(http_request_duration_seconds_count{namespace="${namespace}",service="${service}",action="listBucket"}[1m])
+      sum(rate(http_request_duration_seconds_sum{namespace="${namespace}",service="${service}",action="listBucket"}[1m]))
+          / sum(rate(http_request_duration_seconds_count{namespace="${namespace}",service="${service}",action="listBucket"}[1m]))
         >= 0.300
     for: 5m
     labels:
       severity: warning
     annotations:
-      summary: "High listing latency on {{ $labels.pod }}"
+      summary: "High listing latency"
 
   # As a platform admin I want to be alerted (critical) when a listing operation latency or a
   # version listing operation latency is more than 500ms
   - alert: ListingLatencyCritical
     expr: |
-      rate(http_request_duration_seconds_sum{namespace="${namespace}",service="${service}",action="listBucket"}[1m])
-          / rate(http_request_duration_seconds_count{namespace="${namespace}",service="${service}",action="listBucket"}[1m])
+      sum(rate(http_request_duration_seconds_sum{namespace="${namespace}",service="${service}",action="listBucket"}[1m]))
+          / sum(rate(http_request_duration_seconds_count{namespace="${namespace}",service="${service}",action="listBucket"}[1m]))
         >= 0.500
     for: 5m
     labels:
       severity: critical
     annotations:
-      summary: "Very high listing latency on {{ $labels.pod }}"
+      summary: "Very high listing latency"
 
   # As a platform admin I want to be alerted (warning) when a delete operation latency is more than
   # 500ms
   - alert: DeleteLatencyWarning
     expr: |
-      rate(http_request_duration_seconds_sum{namespace="${namespace}",service="${service}",action="deleteObject"}[1m])
-          / rate(http_request_duration_seconds_count{namespace="${namespace}",service="${service}",action="deleteObject"}[1m])
+      sum(rate(http_request_duration_seconds_sum{namespace="${namespace}",service="${service}",action="deleteObject"}[1m]))
+          / sum(rate(http_request_duration_seconds_count{namespace="${namespace}",service="${service}",action="deleteObject"}[1m]))
         >= 500
     for: 5m
     labels:
       severity: warning
     annotations:
-      summary: "High delete latency on {{ $labels.pod }}"
+      summary: "High delete latency"
 
   # As a platform admin I want to be alerted (critical) when a delete operation latency is more
   # than 1s
   - alert: DeleteLatencyCritical
     expr: |
-      rate(http_request_duration_seconds_sum{namespace="${namespace}",service="${service}",action="deleteObject"}[1m])
-          / rate(http_request_duration_seconds_count{namespace="${namespace}",service="${service}",action="deleteObject"}[1m])
+      sum(rate(http_request_duration_seconds_sum{namespace="${namespace}",service="${service}",action="deleteObject"}[1m]))
+          / sum(rate(http_request_duration_seconds_count{namespace="${namespace}",service="${service}",action="deleteObject"}[1m]))
         >= 1.000
     for: 5m
     labels:
       severity: critical
     annotations:
-      summary: "Very high delete latency on {{ $labels.pod }}"
+      summary: "Very high delete latency"
 


### PR DESCRIPTION
* Separate alerts for "List object" only (not listing buckets)
* Alert for single object delete latency only (no multi-object delete or bucket delete)
* Overall latency delay (not by pod) → sum()
* Add description

Issue: CLDSRV-83