### PR TITLE
ZENKO-3725 - update kubernetes readiness/liveness probe route

### DIFF
--- a/lib/utilities/monitoringHandler.js
+++ b/lib/utilities/monitoringHandler.js
@@ -190,7 +190,9 @@ function monitoringHandler(clientIP, req, res, log) {
         return monitoringEndHandler(errors.MethodNotAllowed, []);
     }
     const monitoring = (req.url === '/metrics');
-    if (!monitoring) {
+    const healthcheck = (req.url === '/healthcheck');
+    const healthcheckdeep = (req.url === '/healthcheck/deep');
+    if (!monitoring && !healthcheck && !healthcheckdeep) {
         return monitoringEndHandler(errors.MethodNotAllowed, []);
     }
     return routeHandler(req, res, monitoringEndHandler);


### PR DESCRIPTION
Update the readiness and liveness route for kubernetes.
The operator will configure the pod to check for readiness
and liveness on the same port as for the metrics.

In this commit allow the new routes on the metric code path.