### PR TITLE
CLDSRV-89 - update kubernetes readiness/liveness probe route

### DIFF
--- a/Healthchecks.md
+++ b/Healthchecks.md
@@ -1,6 +1,7 @@
 # S3 Healthcheck
 
-Scality S3 exposes a healthcheck route `/live` which returns a
+Scality S3 exposes a healthcheck route `/live` on the port used
+for the metrics (defaults to port 8002) which returns a
 response with HTTP code
 
 - 200 OK

--- a/Healthchecks.md
+++ b/Healthchecks.md
@@ -1,6 +1,6 @@
 # S3 Healthcheck
 
-Scality S3 exposes a healthcheck route `/healthcheck` which returns a
+Scality S3 exposes a healthcheck route `/live` which returns a
 response with HTTP code
 
 - 200 OK

--- a/Healthchecks.md
+++ b/Healthchecks.md
@@ -1,6 +1,6 @@
 # S3 Healthcheck
 
-Scality S3 exposes a healthcheck route `/_/healthcheck` which returns a
+Scality S3 exposes a healthcheck route `/healthcheck` which returns a
 response with HTTP code
 
 - 200 OK

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -2,7 +2,7 @@
 version: 0.2
 
 branches:
-  feature/*, documentation/*, improvement/*, bugfix/*, w/*, q/*, hotfix/*, dependabot/*:
+  feature/*, documentation/*, improvement/*, bugfix/*, w/*, q/*, hotfix/*, dependabot/*, user/*:
     stage: pre-merge
 
 models:

--- a/lib/management/push.js
+++ b/lib/management/push.js
@@ -277,7 +277,7 @@ function addOverlayMessageListener(callback) {
 
 function startPushConnectionHealthCheckServer(cb) {
     const server = http.createServer((req, res) => {
-        if (req.url !== '/healthcheck') {
+        if (req.url !== '/_/healthcheck') {
             res.writeHead(404);
             res.write('Not Found');
         } else if (connected) {

--- a/lib/management/push.js
+++ b/lib/management/push.js
@@ -277,7 +277,7 @@ function addOverlayMessageListener(callback) {
 
 function startPushConnectionHealthCheckServer(cb) {
     const server = http.createServer((req, res) => {
-        if (req.url !== '/_/healthcheck') {
+        if (req.url !== '/healthcheck') {
             res.writeHead(404);
             res.write('Not Found');
         } else if (connected) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -76,7 +76,7 @@ class S3Server {
         process.on('SIGHUP', this.cleanUp.bind(this));
         process.on('SIGQUIT', this.cleanUp.bind(this));
         process.on('SIGTERM', this.cleanUp.bind(this));
-        process.on('SIGPIPE', () => {});
+        process.on('SIGPIPE', () => { });
         // This will pick up exceptions up the stack
         process.on('uncaughtException', err => {
             // If just send the error object results in empty
@@ -182,16 +182,21 @@ class S3Server {
             reqUids = undefined;
         }
         const log = (reqUids !== undefined ?
-                    logger.newRequestLoggerFromSerializedUids(reqUids) :
-                    logger.newRequestLogger());
+            logger.newRequestLoggerFromSerializedUids(reqUids) :
+            logger.newRequestLogger());
         log.end().addDefaultFields(clientInfo);
 
-        log.info('received admin request', clientInfo);
+        log.debug('received admin request', clientInfo);
 
-        if (req.url.startsWith('/healthcheck')) {
-            healthcheckHandler(clientInfo.clientIP, req, res, log, statsClient);
-        } else {
-            monitoringClient.monitoringHandler(clientInfo.clientIP, req, res, log);
+        switch (req.url) {
+            case '/live':
+            case '/ready':
+                healthcheckHandler(clientInfo.clientIP, req, res, log, statsClient);
+                break;
+
+            default:
+                monitoringClient.monitoringHandler(clientInfo.clientIP, req, res, log);
+                break;
         }
     }
 
@@ -241,8 +246,10 @@ class S3Server {
                 port,
             };
             const { address } = addr;
-            logger.info('server started', { address, port,
-                pid: process.pid, serverIP: address, serverPort: port });
+            logger.info('server started', {
+                address, port,
+                pid: process.pid, serverIP: address, serverPort: port
+            });
         });
 
         if (ipAddress !== undefined) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -8,7 +8,7 @@ const monitoringClient = require('./utilities/monitoringHandler');
 
 const logger = require('./utilities/logger');
 const { internalHandlers } = require('./utilities/internalHandlers');
-const { clientCheck } = require('./utilities/healthcheckHandler');
+const { clientCheck, healthcheckHandler } = require('./utilities/healthcheckHandler');
 const _config = require('./Config').config;
 const { blacklistedPrefixes } = require('../constants');
 const api = require('./api/api');
@@ -187,7 +187,12 @@ class S3Server {
         log.end().addDefaultFields(clientInfo);
 
         log.info('received admin request', clientInfo);
-        monitoringClient.monitoringHandler(clientInfo.clientIP, req, res, log);
+
+        if (req.url.startsWith('/healthcheck')) {
+            healthcheckHandler(clientInfo.clientIP, req, res, log, statsClient);
+        } else {
+            monitoringClient.monitoringHandler(clientInfo.clientIP, req, res, log);
+        }
     }
 
     /**

--- a/lib/utilities/healthcheckHandler.js
+++ b/lib/utilities/healthcheckHandler.js
@@ -123,7 +123,7 @@ function healthcheckHandler(clientIP, req, res, log, statsClient) {
         });
     }
 
-    const deep = (req.url === '/_/healthcheck/deep');
+    const deep = (req.url === '/healthcheck/deep');
 
     // Attach the apiMethod method to the request, so it can used by monitoring in the server
     // eslint-disable-next-line no-param-reassign

--- a/lib/utilities/healthcheckHandler.js
+++ b/lib/utilities/healthcheckHandler.js
@@ -123,7 +123,7 @@ function healthcheckHandler(clientIP, req, res, log, statsClient) {
         });
     }
 
-    const deep = (req.url === '/healthcheck/deep');
+    const deep = (req.url === '/ready');
 
     // Attach the apiMethod method to the request, so it can used by monitoring in the server
     // eslint-disable-next-line no-param-reassign

--- a/lib/utilities/internalHandlers.js
+++ b/lib/utilities/internalHandlers.js
@@ -1,4 +1,3 @@
-const { healthcheckHandler } = require('./healthcheckHandler');
 const routeBackbeat = require('../routes/routeBackbeat');
 const routeMetadata = require('../routes/routeMetadata');
 const routeWorkflowEngineOperator =
@@ -6,7 +5,6 @@ const routeWorkflowEngineOperator =
 const { reportHandler } = require('./reportHandler');
 
 const internalHandlers = {
-    healthcheck: healthcheckHandler,
     backbeat: routeBackbeat,
     report: reportHandler,
     metadata: routeMetadata,

--- a/lib/utilities/monitoringHandler.js
+++ b/lib/utilities/monitoringHandler.js
@@ -189,10 +189,7 @@ function monitoringHandler(clientIP, req, res, log) {
     if (req.method !== 'GET') {
         return monitoringEndHandler(errors.MethodNotAllowed, []);
     }
-    const monitoring = (req.url === '/metrics');
-    const healthcheck = (req.url === '/healthcheck');
-    const healthcheckdeep = (req.url === '/healthcheck/deep');
-    if (!monitoring && !healthcheck && !healthcheckdeep) {
+    if (req.url !== '/metrics') {
         return monitoringEndHandler(errors.MethodNotAllowed, []);
     }
     return routeHandler(req, res, monitoringEndHandler);

--- a/lib/utilities/monitoringHandler.js
+++ b/lib/utilities/monitoringHandler.js
@@ -190,7 +190,9 @@ function monitoringHandler(clientIP, req, res, log) {
         return monitoringEndHandler(errors.MethodNotAllowed, []);
     }
     const monitoring = (req.url === '/metrics');
-    if (!monitoring) {
+    const healthcheck = (req.url === '/healthcheck');
+    const healthcheckdeep = (req.url === '/healthcheck/deep');
+    if (!monitoring && !healthcheck && !healthcheckdeep) {
         return monitoringEndHandler(errors.MethodNotAllowed, []);
     }
     return routeHandler(req, res, monitoringEndHandler);

--- a/tests/functional/healthchecks/test/checkRoutes.js
+++ b/tests/functional/healthchecks/test/checkRoutes.js
@@ -21,8 +21,8 @@ const transportStr = conf.transport;
 const transport = transportStr === 'http' ? http : https;
 const options = {
     host: conf.ipAddress,
-    path: '/_/healthcheck',
-    port: 8000,
+    path: '/healthcheck',
+    port: 8002,
 };
 
 function checkResult(expectedStatus, res) {
@@ -54,6 +54,7 @@ function makeDummyS3Request(cb) {
     const getOptions = deepCopy(options);
     getOptions.path = '/foo/bar';
     getOptions.method = 'GET';
+    getOptions.port = 8000;
     getOptions.agent = makeAgent();
     const req = transport.request(getOptions);
     req.end(() => cb());
@@ -97,7 +98,7 @@ describe('Healthcheck routes', () => {
     it('should return 200 on deep GET request', done => {
         const deepOptions = deepCopy(options);
         deepOptions.method = 'GET';
-        deepOptions.path = '/_/healthcheck/deep';
+        deepOptions.path = '/healthcheck/deep';
         deepOptions.agent = makeAgent();
         const req = transport.request(deepOptions, makeChecker(200, done));
         req.end();

--- a/tests/functional/healthchecks/test/checkRoutes.js
+++ b/tests/functional/healthchecks/test/checkRoutes.js
@@ -21,7 +21,7 @@ const transportStr = conf.transport;
 const transport = transportStr === 'http' ? http : https;
 const options = {
     host: conf.ipAddress,
-    path: '/healthcheck',
+    path: '/live',
     port: 8002,
 };
 
@@ -98,7 +98,7 @@ describe('Healthcheck routes', () => {
     it('should return 200 on deep GET request', done => {
         const deepOptions = deepCopy(options);
         deepOptions.method = 'GET';
-        deepOptions.path = '/healthcheck/deep';
+        deepOptions.path = '/ready';
         deepOptions.agent = makeAgent();
         const req = transport.request(deepOptions, makeChecker(200, done));
         req.end();

--- a/tests/functional/report/monitoring.js
+++ b/tests/functional/report/monitoring.js
@@ -28,9 +28,7 @@ describe('Monitoring - getting metrics', () => {
     }
 
     function parseMetric(metrics, name, labels) {
-        const labelsString = Object.entries(labels !== undefined ? labels : {
-            method: 'GET', code: '200', action: 'healthcheck',
-        }).map(e => `${e[0]}="${e[1]}"`).join(',');
+        const labelsString = Object.entries(labels).map(e => `${e[0]}="${e[1]}"`).join(',');
         const metric = metrics.match(new RegExp(`^${name}{${labelsString}} (.*)$`, 'm'));
         return metric ? metric[1] : null;
     }
@@ -63,9 +61,6 @@ describe('Monitoring - getting metrics', () => {
         ['/foo/bar',        { method: 'GET', code: '404', action: 'objectGet' }],
 
         // Internal handlers
-        ['/_/healthcheck',  { method: 'GET', code: '200', action: 'healthcheck' }],
-        ['/_/healthcheck/deep',
-                            { method: 'GET', code: '200', action: 'deepHealthcheck' }],
         ['/_/report',       { method: 'GET', code: '200', action: 'report' }],
         ['/_/backbeat',     { method: 'GET', code: '405', action: 'routeBackbeat' }],
         ['/_/metadata',     { method: 'GET', code: '403', action: 'routeMetadata' }],


### PR DESCRIPTION
Update the readiness and liveness route for kubernetes.
The operator will configure the pod to check for readiness
and liveness on the same port as for the metrics.

In this commit allow the new routes on the metric code path.
