### PR TITLE
INTEGRATION [PR#4163 > development/7.10] bugfix: CLDSRV-96 S3C should send httpCode 400 back to client

### DIFF
--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -125,6 +125,9 @@ function _put(cipherBundle, value, valueSize,
                    if (err) {
                        log.error('put error from datastore',
                                  { error: err, implName });
+                       if (err.httpCode === 408) {
+                           return cb(errors.IncompleteBody);
+                       }
                        return cb(errors.ServiceUnavailable);
                    }
                    return cb(null, dataRetrievalInfo, hashedStream);
@@ -139,18 +142,21 @@ function _put(cipherBundle, value, valueSize,
     }
 
     return client.put(writeStream, valueSize, keyContext,
-                      log.getSerializedUids(), (err, key) => {
-                          if (err) {
-                              log.error('put error from datastore',
-                                        { error: err, implName });
-                              return cb(errors.InternalError);
-                          }
-                          const dataRetrievalInfo = {
-                              key,
-                              dataStoreName: implName,
-                          };
-                          return cb(null, dataRetrievalInfo, hashedStream);
-                      });
+        log.getSerializedUids(), (err, key) => {
+            if (err) {
+                log.error('put error from datastore',
+                        { error: err, implName });
+                if (err.httpCode === 408) {
+                    return cb(errors.IncompleteBody);
+                }
+                return cb(errors.InternalError);
+            }
+            const dataRetrievalInfo = {
+                key,
+                dataStoreName: implName,
+            };
+            return cb(null, dataRetrievalInfo, hashedStream);
+        });
 }
 
 const data = {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #4163.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/bugfix/CLDSRV-96-forward-408-errors-to-client-on-put`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/bugfix/CLDSRV-96-forward-408-errors-to-client-on-put
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/bugfix/CLDSRV-96-forward-408-errors-to-client-on-put
```

Please always comment pull request #4163 instead of this one.