### PR TITLE
INTEGRATION [PR#4163 > development/8.3] bugfix: CLDSRV-96 S3C should send httpCode 400 back to client

### DIFF
--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -125,6 +125,9 @@ function _put(cipherBundle, value, valueSize,
                    if (err) {
                        log.error('put error from datastore',
                                  { error: err, implName });
+                       if (err.httpCode === 408) {
+                           return cb(errors.IncompleteBody);
+                       }
                        return cb(errors.ServiceUnavailable);
                    }
                    return cb(null, dataRetrievalInfo, hashedStream);
@@ -139,18 +142,21 @@ function _put(cipherBundle, value, valueSize,
     }
 
     return client.put(writeStream, valueSize, keyContext,
-                      log.getSerializedUids(), (err, key) => {
-                          if (err) {
-                              log.error('put error from datastore',
-                                        { error: err, implName });
-                              return cb(errors.InternalError);
-                          }
-                          const dataRetrievalInfo = {
-                              key,
-                              dataStoreName: implName,
-                          };
-                          return cb(null, dataRetrievalInfo, hashedStream);
-                      });
+        log.getSerializedUids(), (err, key) => {
+            if (err) {
+                log.error('put error from datastore',
+                        { error: err, implName });
+                if (err.httpCode === 408) {
+                    return cb(errors.IncompleteBody);
+                }
+                return cb(errors.InternalError);
+            }
+            const dataRetrievalInfo = {
+                key,
+                dataStoreName: implName,
+            };
+            return cb(null, dataRetrievalInfo, hashedStream);
+        });
 }
 
 const data = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -675,9 +675,9 @@ arraybuffer.slice@~0.0.7:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
   integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
 
-"arsenal@github:scality/Arsenal#8.1.18":
-  version "8.1.18"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/3ab7ef4e8ddeac355d0c33bc15df511c90ef59d7"
+"arsenal@github:scality/Arsenal#8.1.19":
+  version "8.1.19"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/6a529e066f1c7d7c3d81f7de19431d8515a2874e"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #4163.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.3/bugfix/CLDSRV-96-forward-408-errors-to-client-on-put`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.3/bugfix/CLDSRV-96-forward-408-errors-to-client-on-put
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.3/bugfix/CLDSRV-96-forward-408-errors-to-client-on-put
```

Please always comment pull request #4163 instead of this one.