### PR TITLE
INTEGRATION [PR#4185 > development/8.2] bf: CLDSRV-106 put object retention fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "github:scality/Arsenal#7.10.5",
+    "arsenal": "github:scality/Arsenal#7.10.7",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/tests/functional/aws-node-sdk/test/object/putRetention.js
+++ b/tests/functional/aws-node-sdk/test/object/putRetention.js
@@ -12,7 +12,7 @@ const objectName = 'putobjectretentionobject';
 
 const retentionConfig = {
     Mode: 'GOVERNANCE',
-    RetainUntilDate: moment().add(1, 'Days').toISOString(),
+    RetainUntilDate: moment().add(1, 'd').add(123, 'ms').toISOString(),
 };
 
 describe('PUT object retention', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -629,9 +629,9 @@ arraybuffer.slice@~0.0.7:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
   integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
 
-"arsenal@github:scality/Arsenal#7.10.5":
-  version "7.10.4"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/8aa0f9d0305149b8a946e8a20b5837dc2be80bbc"
+"arsenal@github:scality/Arsenal#7.10.7":
+  version "7.10.6"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/38705d1962579c6cabab14056fcc0179e830ff0b"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
@@ -656,7 +656,7 @@ arraybuffer.slice@~0.0.7:
     werelogs scality/werelogs#8.1.0
     xml2js "~0.4.23"
   optionalDependencies:
-    ioctl "2.0.0"
+    ioctl "^2.0.2"
 
 arsenal@scality/Arsenal#7.10.1:
   version "7.10.1"
@@ -1037,7 +1037,7 @@ better-assert@~1.0.0:
   dependencies:
     callsite "1.0.0"
 
-bindings@^1.1.1:
+bindings@^1.1.1, bindings@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
@@ -3151,6 +3151,14 @@ ioctl@2.0.1:
   dependencies:
     bindings "^1.1.1"
     nan "^2.3.2"
+
+ioctl@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ioctl/-/ioctl-2.0.2.tgz#21543f661cb1b044761cbf721f5dde6be08ed060"
+  integrity sha512-GPEiU99bJb3Z50JDRujQ9t+q4JaRvc1UrD7F5/kHDVWlRA3L4TMwqbMw/XIu/BzqccFP8OfsK+JIXmlAvJDs1g==
+  dependencies:
+    bindings "^1.5.0"
+    nan "^2.14.0"
 
 ioredis@4.9.5:
   version "4.9.5"
@@ -6179,7 +6187,7 @@ sprintf-js@~1.0.2:
   resolved "https://codeload.github.com/scality/sproxydclient/tar.gz/30e7115668bc7e10b4ec3cfdbaa7a124cdc21cc5"
   dependencies:
     async "^3.1.0"
-    werelogs scality/werelogs#8.1.0
+    werelogs scality/werelogs#351a2a3
 
 sproxydclient@scality/sproxydclient#8.0.2:
   version "8.0.2"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #4185.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/bugfix/CLDSRV-106-put-object-retention-with-sub-seconds-fail`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/bugfix/CLDSRV-106-put-object-retention-with-sub-seconds-fail
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/bugfix/CLDSRV-106-put-object-retention-with-sub-seconds-fail
```

Please always comment pull request #4185 instead of this one.