### PR TITLE
Relax client health check

### DIFF
--- a/lib/utilities/healthcheckHandler.js
+++ b/lib/utilities/healthcheckHandler.js
@@ -66,7 +66,8 @@ function clientCheck(flightCheckOnStartUp, log, cb) {
         // manual check makes S3 return 500 error if any backend failed
         // other than aws_s3 or azure
         const obj = results.reduce((obj, item) => Object.assign(obj, item), {});
-        fail = Object.keys(obj).some(k =>
+        // fail only if *all* backend fail, so that we can still serve the ones which are working
+        fail = Object.keys(obj).every(k =>
             // if there is an error from an external backend,
             // only return a 500 if it is on startup
             // (flightCheckOnStartUp set to true)


### PR DESCRIPTION
Fail the check (both on startup and /ready route) only if all backends are failing: so that the working backends can still be used.

Issue: CLDSRV-110