### PR TITLE
Feature/cldsrv 112 add mdsearch api

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -7,7 +7,7 @@ const bucketDeleteEncryption = require('./bucketDeleteEncryption');
 const bucketDeleteWebsite = require('./bucketDeleteWebsite');
 const bucketDeleteLifecycle = require('./bucketDeleteLifecycle');
 const bucketDeletePolicy = require('./bucketDeletePolicy');
-const bucketGet = require('./bucketGet');
+const { bucketGet } = require('./bucketGet');
 const bucketGetACL = require('./bucketGetACL');
 const bucketGetCors = require('./bucketGetCors');
 const bucketGetVersioning = require('./bucketGetVersioning');
@@ -37,6 +37,7 @@ const completeMultipartUpload = require('./completeMultipartUpload');
 const initiateMultipartUpload = require('./initiateMultipartUpload');
 const listMultipartUploads = require('./listMultipartUploads');
 const listParts = require('./listParts');
+const metadataSearch = require('./metadataSearch');
 const { multiObjectDelete } = require('./multiObjectDelete');
 const multipartDelete = require('./multipartDelete');
 const objectCopy = require('./objectCopy');
@@ -296,6 +297,7 @@ const api = {
     initiateMultipartUpload,
     listMultipartUploads,
     listParts,
+    metadataSearch,
     multiObjectDelete,
     multipartDelete,
     objectDelete,

--- a/lib/api/bucketGet.js
+++ b/lib/api/bucketGet.js
@@ -6,8 +6,6 @@ const { metadataValidateBucket } = require('../metadata/metadataUtils');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const escapeForXml = s3middleware.escapeForXml;
 const { pushMetric } = require('../utapi/utilities');
-const validateSearchParams = require('../api/apiUtils/bucket/validateSearch');
-const parseWhere = require('../api/apiUtils/bucket/parseWhere');
 const versionIdUtils = versioning.VersionID;
 const monitoring = require('../utilities/monitoringHandler');
 const { generateToken, decryptToken }
@@ -316,14 +314,6 @@ function bucketGet(authInfo, request, log, callback) {
             'GET', bucketName, 400, 'listBucket');
         return callback(errors.InvalidArgument);
     }
-    let validatedAst;
-    if (params.search !== undefined) {
-        const astOrError = validateSearchParams(params.search);
-        if (astOrError.error) {
-            return callback(astOrError.error);
-        }
-        validatedAst = astOrError.ast;
-    }
     // AWS only returns 1000 keys even if max keys are greater.
     // Max keys stated in response xml can be greater than actual
     // keys returned.
@@ -377,21 +367,6 @@ function bucketGet(authInfo, request, log, callback) {
             return handleResult(listParams, requestMaxKeys, encoding, authInfo,
                 bucketName, emptyList, corsHeaders, log, callback);
         }
-        if (params.search !== undefined) {
-            log.info('performing search listing', { search: params.search });
-            try {
-                listParams.mongifiedSearch = parseWhere(validatedAst);
-            } catch (err) {
-                log.debug(err.message, {
-                    stack: err.stack,
-                });
-                monitoring.promMetrics(
-                    'GET', bucketName, 400, 'listBucket');
-                return callback(errors.InvalidArgument
-                .customizeDescription('Invalid sql where clause ' +
-                'sent as search query'));
-            }
-        }
         return services.getObjectListing(bucketName, listParams, log,
         (err, list) => {
             if (err) {
@@ -407,4 +382,8 @@ function bucketGet(authInfo, request, log, callback) {
     return undefined;
 }
 
-module.exports = bucketGet;
+module.exports = {
+    processVersions,
+    processMasterVersions,
+    bucketGet,
+};

--- a/lib/api/metadataSearch.js
+++ b/lib/api/metadataSearch.js
@@ -1,0 +1,149 @@
+const { errors, versioning } = require('arsenal');
+const constants = require('../../constants');
+const services = require('../services');
+const { metadataValidateBucket } = require('../metadata/metadataUtils');
+const collectCorsHeaders = require('../utilities/collectCorsHeaders');
+const { pushMetric } = require('../utapi/utilities');
+const validateSearchParams = require('../api/apiUtils/bucket/validateSearch');
+const parseWhere = require('../api/apiUtils/bucket/parseWhere');
+const versionIdUtils = versioning.VersionID;
+const monitoring = require('../utilities/monitoringHandler');
+const { decryptToken }
+    = require('../api/apiUtils/object/continueToken');
+const { config } = require('../Config');
+const { processVersions, processMasterVersions } = require('./bucketGet');
+
+
+function handleResult(listParams, requestMaxKeys, encoding, authInfo,
+                      bucketName, list, corsHeaders, log, callback) {
+    // eslint-disable-next-line no-param-reassign
+    listParams.maxKeys = requestMaxKeys;
+    // eslint-disable-next-line no-param-reassign
+    listParams.encoding = encoding;
+    let res;
+    if (listParams.listingType === 'DelimiterVersions') {
+        res = processVersions(bucketName, listParams, list,
+            config.versionIdEncodingType);
+    } else {
+        res = processMasterVersions(bucketName, listParams, list);
+    }
+    pushMetric('metadataSearch', log, { authInfo, bucket: bucketName });
+    monitoring.promMetrics('GET', bucketName, '200', 'metadataSearch');
+    return callback(null, res, corsHeaders);
+}
+
+/**
+ * metadataSearch - Return list of objects in bucket that meet the search query, supports v1 & v2
+ * @param  {AuthInfo} authInfo - Instance of AuthInfo class with
+ *                               requester's info
+ * @param  {object} request - http request object
+ * @param  {function} log - Werelogs request logger
+ * @param  {function} callback - callback to respond to http request
+ *  with either error code or xml response body
+ * @return {undefined}
+ */
+function metadataSearch(authInfo, request, log, callback) {
+    const params = request.query;
+    const bucketName = request.bucketName;
+    const v2 = params['list-type'];
+    if (v2 !== undefined && Number.parseInt(v2, 10) !== 2) {
+        return callback(errors.InvalidArgument.customizeDescription('Invalid ' +
+            'List Type specified in Request'));
+    }
+    log.debug('processing request', { method: 'metadataSearch' });
+    const encoding = params['encoding-type'];
+    if (encoding !== undefined && encoding !== 'url') {
+        monitoring.promMetrics(
+            'GET', bucketName, 400, 'metadataSearch');
+        return callback(errors.InvalidArgument.customizeDescription('Invalid ' +
+            'Encoding Method specified in Request'));
+    }
+    const requestMaxKeys = params['max-keys'] ?
+        Number.parseInt(params['max-keys'], 10) : 1000;
+    if (Number.isNaN(requestMaxKeys) || requestMaxKeys < 0) {
+        monitoring.promMetrics(
+            'GET', bucketName, 400, 'metadataSearch');
+        return callback(errors.InvalidArgument);
+    }
+    // AWS only returns 1000 keys even if max keys are greater.
+    // Max keys stated in response xml can be greater than actual
+    // keys returned.
+    const actualMaxKeys = Math.min(constants.listingHardLimit, requestMaxKeys);
+
+    const metadataValParams = {
+        authInfo,
+        bucketName,
+        requestType: 'metadataSearch',
+        request,
+    };
+    const listParams = {
+        listingType: 'DelimiterMaster',
+        maxKeys: actualMaxKeys,
+        delimiter: params.delimiter,
+        prefix: params.prefix,
+    };
+    try {
+        const validatedAst = validateSearchParams(params.search).ast;
+        listParams.mongifiedSearch = parseWhere(validatedAst);
+    } catch (err) {
+        log.debug(err.message, {
+            stack: err.stack,
+        });
+        monitoring.promMetrics(
+            'GET', bucketName, 400, 'metadataSearch');
+        return callback(errors.InvalidArgument
+            .customizeDescription('Invalid sql where clause ' +
+                'sent as search query'));
+    }
+    if (v2) {
+        listParams.v2 = true;
+        listParams.startAfter = params['start-after'];
+        listParams.continuationToken =
+            decryptToken(params['continuation-token']);
+        listParams.fetchOwner = params['fetch-owner'] === 'true';
+    } else {
+        listParams.marker = params.marker;
+    }
+
+    metadataValidateBucket(metadataValParams, log, (err, bucket) => {
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, bucket);
+        if (err) {
+            log.debug('error processing request', { error: err });
+            monitoring.promMetrics(
+                'GET', bucketName, err.code, 'metadataSearch');
+            return callback(err, null, corsHeaders);
+        }
+        if (params.versions !== undefined) {
+            listParams.listingType = 'DelimiterVersions';
+            delete listParams.marker;
+            listParams.keyMarker = params['key-marker'];
+            listParams.versionIdMarker = params['version-id-marker'] ?
+                versionIdUtils.decode(params['version-id-marker']) : undefined;
+        }
+        if (!requestMaxKeys) {
+            const emptyList = {
+                CommonPrefixes: [],
+                Contents: [],
+                Versions: [],
+                IsTruncated: false,
+            };
+            return handleResult(listParams, requestMaxKeys, encoding, authInfo,
+                bucketName, emptyList, corsHeaders, log, callback);
+        }
+        return services.getObjectListing(bucketName, listParams, log,
+            (err, list) => {
+                if (err) {
+                    log.debug('error processing request', { error: err });
+                    monitoring.promMetrics(
+                        'GET', bucketName, err.code, 'metadataSearch');
+                    return callback(err, null, corsHeaders);
+                }
+                return handleResult(listParams, requestMaxKeys, encoding, authInfo,
+                    bucketName, list, corsHeaders, log, callback);
+            });
+    });
+    return undefined;
+}
+
+module.exports = metadataSearch;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "github:scality/Arsenal#8.1.25",
+    "arsenal": "github:scality/Arsenal#8.1.26",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/tests/unit/api/bucketGet.js
+++ b/tests/unit/api/bucketGet.js
@@ -4,7 +4,7 @@ const querystring = require('querystring');
 const async = require('async');
 const { parseString } = require('xml2js');
 
-const bucketGet = require('../../../lib/api/bucketGet');
+const { bucketGet } = require('../../../lib/api/bucketGet');
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const objectPut = require('../../../lib/api/objectPut');
 const { cleanup, DummyRequestLogger, makeAuthInfo } = require('../helpers');

--- a/tests/unit/api/deletedFlagBucket.js
+++ b/tests/unit/api/deletedFlagBucket.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 const { errors } = require('arsenal');
 
 const BucketInfo = require('arsenal').models.BucketInfo;
-const bucketGet = require('../../../lib/api/bucketGet');
+const { bucketGet } = require('../../../lib/api/bucketGet');
 const bucketGetACL = require('../../../lib/api/bucketGetACL');
 const bucketGetCors = require('../../../lib/api/bucketGetCors');
 const bucketGetWebsite = require('../../../lib/api/bucketGetWebsite');

--- a/tests/unit/api/transientBucket.js
+++ b/tests/unit/api/transientBucket.js
@@ -3,7 +3,7 @@ const crypto = require('crypto');
 const { errors } = require('arsenal');
 
 const BucketInfo = require('arsenal').models.BucketInfo;
-const bucketGet = require('../../../lib/api/bucketGet');
+const { bucketGet } = require('../../../lib/api/bucketGet');
 const bucketGetACL = require('../../../lib/api/bucketGetACL');
 const bucketGetCors = require('../../../lib/api/bucketGetCors');
 const bucketGetWebsite = require('../../../lib/api/bucketGetWebsite');

--- a/yarn.lock
+++ b/yarn.lock
@@ -704,9 +704,9 @@ arraybuffer.slice@~0.0.7:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
   integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
 
-"arsenal@github:scality/Arsenal#8.1.25":
-  version "8.1.25"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/41d482cf7d8828a61adb813e2b0f0539ba1c7e09"
+"arsenal@github:scality/Arsenal#8.1.26":
+  version "8.1.26"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/68c5b42e6f8994c2d9ba10d91b70d9a01bbcd759"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
@@ -782,6 +782,44 @@ arsenal@scality/Arsenal#8.1.1:
     async "~2.6.1"
     aws-sdk "2.80.0"
     azure-storage "~2.1.0"
+    backo "^1.1.0"
+    base-x "3.0.8"
+    base62 "2.0.1"
+    bson "4.0.0"
+    debug "~4.1.0"
+    diskusage "^1.1.1"
+    fcntl "github:scality/node-fcntl"
+    hdclient scality/hdclient#489db2106570b9ea41bdacdf56131324d0db6a58
+    https-proxy-agent "^2.2.0"
+    ioredis "4.9.5"
+    ipaddr.js "1.9.1"
+    level "~5.0.1"
+    level-sublevel "~6.6.5"
+    mongodb "^3.0.1"
+    node-forge "^0.7.1"
+    prom-client "10.2.3"
+    simple-glob "^0.2.0"
+    socket.io "~2.3.0"
+    socket.io-client "~2.3.0"
+    sproxydclient "github:scality/sproxydclient#8.0.2"
+    utf8 "3.0.0"
+    uuid "^3.0.1"
+    werelogs scality/werelogs#8.1.0
+    xml2js "~0.4.23"
+  optionalDependencies:
+    ioctl "2.0.1"
+
+arsenal@scality/Arsenal#8.1.13:
+  version "8.1.11"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/e912617f025f33d74cf7ccb985d17c192dbc724e"
+  dependencies:
+    "@hapi/joi" "^15.1.0"
+    JSONStream "^1.0.0"
+    agentkeepalive "^4.1.3"
+    ajv "6.12.2"
+    async "~2.6.1"
+    aws-sdk "2.80.0"
+    azure-storage "2.10.3"
     backo "^1.1.0"
     base-x "3.0.8"
     base62 "2.0.1"


### PR DESCRIPTION
1. add new metadataSearch API (copy from bucketGet API)
2. remove search functionality from bucketGetAPI
3. didn't add unit test for this API cause in-memory db doesn't support metadata search
4. functional tests for md search already defined in https://github.com/scality/cloudserver/tree/development/8.3/tests/functional/aws-node-sdk/test/mdSearch, no need to change
5. unit tests for testing all search queries are defined in https://github.com/scality/cloudserver/blob/development/8.3/tests/unit/utils/validateSearch.js

please feel free to tell us if you feel like more tests are needed