### PR TITLE
INTEGRATION [PR#4286 > development/8.4] CLDSRV-193: allow extension of ret period without header

### DIFF
--- a/lib/api/apiUtils/object/objectLockHelpers.js
+++ b/lib/api/apiUtils/object/objectLockHelpers.js
@@ -166,8 +166,12 @@ function validateObjectLockUpdate(objectMD, retentionInfo, bypassGovernance) {
 
     const existingDate = new Date(existingDateISO);
     const isExpired = existingDate < Date.now();
+    const isExtended = new Date(retentionInfo.date) > existingDate;
 
     if (existingMode === 'GOVERNANCE' && !isExpired && !bypassGovernance) {
+        if (retentionInfo.mode === 'GOVERNANCE' && isExtended) {
+            return null;
+        }
         return errors.AccessDenied;
     }
 
@@ -176,7 +180,7 @@ function validateObjectLockUpdate(objectMD, retentionInfo, bypassGovernance) {
             return errors.AccessDenied;
         }
 
-        if (new Date(retentionInfo.date) < existingDate) {
+        if (!isExtended) {
             return errors.AccessDenied;
         }
     }

--- a/tests/unit/api/apiUtils/objectLockHelpers.js
+++ b/tests/unit/api/apiUtils/objectLockHelpers.js
@@ -255,6 +255,21 @@ describe('objectLockHelpers: validateObjectLockUpdate', () => {
         assert.strictEqual(error, null);
     });
 
+    it('should allow extending retention period if in GOVERNANCE if bypassGovernanceRetention is false', () => {
+        const objMD = {
+            retentionMode: 'GOVERNANCE',
+            retentionDate: moment().add(1, 'days').toISOString(),
+        };
+
+        const retentionInfo = {
+            mode: 'GOVERNANCE',
+            date: moment().add(2, 'days').toISOString(),
+        };
+
+        const error = validateObjectLockUpdate(objMD, retentionInfo, false);
+        assert.strictEqual(error, null);
+    });
+
     it('should disallow shortening retention period if in COMPLIANCE', () => {
         const objMD = {
             retentionMode: 'COMPLIANCE',


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #4286.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.4/bugfix/CLDSRV-139-allow-extending-re-period-in-governance-without-bypass-header`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.4/bugfix/CLDSRV-139-allow-extending-re-period-in-governance-without-bypass-header
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.4/bugfix/CLDSRV-139-allow-extending-re-period-in-governance-without-bypass-header
```

Please always comment pull request #4286 instead of this one.