### PR TITLE
ft: CLDSRV-142 integrate armory

### DIFF
--- a/lib/metadata/bucketfile/backend.js
+++ b/lib/metadata/bucketfile/backend.js
@@ -1,5 +1,6 @@
 const cluster = require('cluster');
 const arsenal = require('arsenal');
+const armory = require('armory');
 
 const logger = require('../../utilities/logger');
 const BucketInfo = arsenal.models.BucketInfo;
@@ -7,7 +8,7 @@ const constants = require('../../../constants');
 const { config } = require('../../Config');
 
 const errors = arsenal.errors;
-const MetadataFileClient = arsenal.storage.metadata.MetadataFileClient;
+const MetadataFileClient = armory.storage.metadata.MetadataFileClient;
 const versionSep = arsenal.versioning.VersioningConstants.VersionId.Separator;
 
 const METASTORE = '__metastore';

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
+    "armory": "github:scality/armory#1.0.2",
     "arsenal": "github:scality/arsenal#7.4.16",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,7 +74,7 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-JSONStream@^1.0.0:
+JSONStream@^1.0.0, JSONStream@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
   integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
@@ -261,6 +261,15 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+"armory@github:scality/armory#1.0.2":
+  version "1.0.2"
+  resolved "https://codeload.github.com/scality/armory/tar.gz/eabe0ad72ba4c31adac542dc7868aaeb06923c9a"
+  dependencies:
+    JSONStream "^1.3.5"
+    arsenal scality/arsenal#7.4.17
+    ioctl "^2.0.2"
+    werelogs scality/werelogs#8.1.0
+
 arraybuffer.slice@~0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
@@ -295,8 +304,34 @@ arraybuffer.slice@~0.0.7:
 
 arsenal@scality/Arsenal#7.4.16:
   version "7.4.16"
-  uid "90d6556229e63bf4484f4017a011602ad94947b4"
   resolved "https://codeload.github.com/scality/Arsenal/tar.gz/90d6556229e63bf4484f4017a011602ad94947b4"
+  dependencies:
+    "@hapi/joi" "^15.1.0"
+    JSONStream "^1.0.0"
+    agentkeepalive "^4.1.3"
+    ajv "6.12.2"
+    async "~2.1.5"
+    debug "~2.6.9"
+    diskusage "^1.1.1"
+    ioredis "4.9.5"
+    ipaddr.js "1.9.1"
+    level "~5.0.1"
+    level-sublevel "~6.6.5"
+    node-forge "^0.7.1"
+    prom-client "10.2.3"
+    simple-glob "^0.2"
+    socket.io "~2.3.0"
+    socket.io-client "~2.3.0"
+    utf8 "2.1.2"
+    uuid "^3.0.1"
+    werelogs scality/werelogs#8.1.0
+    xml2js "~0.4.23"
+  optionalDependencies:
+    ioctl "^2.0.2"
+
+arsenal@scality/arsenal#7.4.17:
+  version "7.4.17"
+  resolved "https://codeload.github.com/scality/arsenal/tar.gz/5f8c92a0a20e8d3114f128edb8504008219d0e7c"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"


### PR DESCRIPTION
# Pull request template

## Description

Integrate Armory for data and metadata backends.

### Motivation and context

We could move data and metadata specific dependencies to Armory from Arsenal and Cloudserver, e.g. bucketclient, sproxydclient, aws-sdk, etc and make Arsenal much lighter.

### Related issues

Please use the following link syntaxes #600 to reference issues in the
current repository

## Checklist

### Add tests to cover the changes

New tests added or existing tests modified to cover all changes

### Code conforms with the [style guide](https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#coding-style-guidelines)

### Sign your work

In order to contribute to the project, you must sign your work
https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#sign-your-work

Thank you again for contributing! We will try to test and integrate the change
as soon as we can.
