### PR TITLE
INTEGRATION [PR#4314 > development/7.10] bugfix: CLDSRV-144 Do not allow non-printable characters in object names

### DIFF
--- a/lib/api/initiateMultipartUpload.js
+++ b/lib/api/initiateMultipartUpload.js
@@ -49,7 +49,7 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
 
     if (hasNonPrintables(objectKey)) {
         return callback(errors.InvalidInput.customizeDescription(
-            'object keys can not contain non-printable characters',
+            'object keys cannot contain non-printable characters',
         ));
     }
 

--- a/lib/api/initiateMultipartUpload.js
+++ b/lib/api/initiateMultipartUpload.js
@@ -4,6 +4,7 @@ const getMetaHeaders = s3middleware.userMetadata.getMetaHeaders;
 const convertToXml = s3middleware.convertToXml;
 const { pushMetric } = require('../utapi/utilities');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
+const { hasNonPrintables } = require('../utilities/stringChecks');
 const { cleanUpBucket } = require('./apiUtils/bucket/bucketCreation');
 const constants = require('../../constants');
 const services = require('../services');
@@ -45,6 +46,13 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'initiateMultipartUpload' });
     const bucketName = request.bucketName;
     const objectKey = request.objectKey;
+
+    if (hasNonPrintables(objectKey)) {
+        return callback(errors.InvalidInput.customizeDescription(
+            'object keys can not contain non-printable characters',
+        ));
+    }
+
     // Note that we are using the string set forth in constants.js
     // to split components in the storage
     // of each MPU.  AWS does not restrict characters in object keys so

--- a/lib/api/objectPut.js
+++ b/lib/api/objectPut.js
@@ -51,7 +51,7 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
 
     if (hasNonPrintables(objectKey)) {
         return callback(errors.InvalidInput.customizeDescription(
-            'object keys can not contain non-printable characters',
+            'object keys cannot contain non-printable characters',
         ));
     }
 

--- a/lib/api/objectPut.js
+++ b/lib/api/objectPut.js
@@ -8,6 +8,7 @@ const createAndStoreObject = require('./apiUtils/object/createAndStoreObject');
 const { checkQueryVersionId } = require('./apiUtils/object/versioning');
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
+const { hasNonPrintables } = require('../utilities/stringChecks');
 const kms = require('../kms/wrapper');
 
 const writeContinue = require('../utilities/writeContinue');
@@ -47,6 +48,13 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
     const requestType = 'objectPut';
     const valParams = { authInfo, bucketName, objectKey, requestType };
     const canonicalID = authInfo.getCanonicalID();
+
+    if (hasNonPrintables(objectKey)) {
+        return callback(errors.InvalidInput.customizeDescription(
+            'object keys can not contain non-printable characters',
+        ));
+    }
+
     log.trace('owner canonicalID to send to data', { canonicalID });
 
     return metadataValidateBucketAndObj(valParams, log,

--- a/lib/utilities/stringChecks.js
+++ b/lib/utilities/stringChecks.js
@@ -8,7 +8,7 @@
 function hasNonPrintables(value) {
     for (const char of value) {
         const codePoint = char.codePointAt(0);
-        if (codePoint < 32) {
+        if (codePoint < 32 || codePoint === 127) {
             return true;
         }
     }

--- a/lib/utilities/stringChecks.js
+++ b/lib/utilities/stringChecks.js
@@ -1,0 +1,20 @@
+/**
+ * hasNonPrintables returns whether or not the given value
+ * includes characters that are non-printable.
+ *
+ * @param {string} value - value to check for non-printables
+ * @returns {Boolean} whether or not the value has non-printables
+ */
+function hasNonPrintables(value) {
+    for (const char of value) {
+        const codePoint = char.codePointAt(0);
+        if (codePoint < 32) {
+            return true;
+        }
+    }
+    return false;
+}
+
+module.exports = {
+    hasNonPrintables,
+};


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #4314.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/bugfix/CLDSRV-144/do-not-allow-non-printable-chars`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/bugfix/CLDSRV-144/do-not-allow-non-printable-chars
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/bugfix/CLDSRV-144/do-not-allow-non-printable-chars
```

Please always comment pull request #4314 instead of this one.