### PR TITLE
Feature: CLDSRV-134 integrate new bucket format

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -177,7 +177,8 @@ stages:
             - linting-coverage
             - file-ft-tests
             - multiple-backend-test
-            - mongo-ft-tests
+            - mongo-v0-ft-tests
+            - mongo-v1-ft-tests
             - ceph-backend-tests
             - kmip-ft-tests
             - utapi-v2-tests
@@ -341,8 +342,8 @@ stages:
       - Upload: *upload-artifacts
       - Upload: *upload-junits
 
-  mongo-ft-tests:
-    worker: &s3-pod
+  mongo-v0-ft-tests:
+    worker:
       type: kube_pod
       path: eve/workers/pod.yaml
       images:
@@ -355,6 +356,7 @@ stages:
         env:
           <<: *mongo-vars
           <<: *global-env
+          DEFAULT_BUCKET_KEY_FORMAT: "v0"
     steps:
       - Git: *clone
       - ShellCommand: *credentials
@@ -368,6 +370,40 @@ stages:
           env:
             <<: *mongo-vars
             <<: *global-env
+            DEFAULT_BUCKET_KEY_FORMAT: "v0"
+      - ShellCommand: *setup-junit-upload
+      - Upload: *upload-artifacts
+      - Upload: *upload-junits
+
+  mongo-v1-ft-tests:
+    worker:
+      type: kube_pod
+      path: eve/workers/pod.yaml
+      images:
+        aggressor: eve/workers/build
+        s3: "."
+      vars:
+        aggressorMem: "2Gi"
+        s3Mem: "1664Mi"
+        redis: enabled
+        env:
+          <<: *mongo-vars
+          <<: *global-env
+          DEFAULT_BUCKET_KEY_FORMAT: "v1"
+    steps:
+      - Git: *clone
+      - ShellCommand: *credentials
+      - ShellCommand: *yarn-install
+      - ShellCommand:
+          command: |
+            set -ex
+            bash wait_for_local_port.bash 8000 40
+            yarn run ft_test
+          <<: *follow-s3-log
+          env:
+            <<: *mongo-vars
+            <<: *global-env
+            DEFAULT_BUCKET_KEY_FORMAT: "v1"
       - ShellCommand: *setup-junit-upload
       - Upload: *upload-artifacts
       - Upload: *upload-junits

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -390,6 +390,7 @@ stages:
           <<: *mongo-vars
           <<: *global-env
           DEFAULT_BUCKET_KEY_FORMAT: "v1"
+          METADATA_MAX_CACHED_BUCKETS: "1"
     steps:
       - Git: *clone
       - ShellCommand: *credentials
@@ -399,11 +400,13 @@ stages:
             set -ex
             bash wait_for_local_port.bash 8000 40
             yarn run ft_test
+            yarn run ft_mixed_bucket_format_version
           <<: *follow-s3-log
           env:
             <<: *mongo-vars
             <<: *global-env
             DEFAULT_BUCKET_KEY_FORMAT: "v1"
+            METADATA_MAX_CACHED_BUCKETS: "1"
       - ShellCommand: *setup-junit-upload
       - Upload: *upload-artifacts
       - Upload: *upload-junits

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "github:scality/Arsenal#8.1.32",
+    "arsenal": "github:scality/Arsenal#8.1.34",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "ft_awssdk_objects_misc": "cd tests/functional/aws-node-sdk && mocha --reporter mocha-multi-reporters --reporter-options configFile=$INIT_CWD/tests/reporter-config.json test/legacy test/object test/service test/support",
     "ft_awssdk_versioning": "cd tests/functional/aws-node-sdk && mocha --reporter mocha-multi-reporters --reporter-options configFile=$INIT_CWD/tests/reporter-config.json test/versioning/",
     "ft_awssdk_external_backends": "cd tests/functional/aws-node-sdk && mocha --reporter mocha-multi-reporters --reporter-options configFile=$INIT_CWD/tests/reporter-config.json test/multipleBackend",
+    "ft_mixed_bucket_format_version": "cd tests/functional/metadata && mocha --reporter mocha-multi-reporters --reporter-options configFile=$INIT_CWD/tests/reporter-config.json MixedVersionFormat.js",
     "ft_management": "cd tests/functional/report && yarn test",
     "ft_node": "cd tests/functional/raw-node && yarn test",
     "ft_node_routes": "cd tests/functional/raw-node && npm run test-routes",

--- a/tests/functional/metadata/MixedVersionFormat.js
+++ b/tests/functional/metadata/MixedVersionFormat.js
@@ -1,0 +1,196 @@
+const assert = require('assert');
+const async = require('async');
+const withV4 = require('../aws-node-sdk/test/support/withV4');
+const BucketUtility = require('../aws-node-sdk/lib/utility/bucket-util');
+const MongoClient = require('mongodb').MongoClient;
+const errors = require('arsenal');
+
+const replicaSetHosts = 'localhost:27017,localhost:27018,localhost:27019';
+const writeConcern = 'majority';
+const replicaSet = 'rs0';
+const readPreference = 'primary';
+const mongoUrl = `mongodb://${replicaSetHosts}/?w=${writeConcern}&` +
+    `replicaSet=${replicaSet}&readPreference=${readPreference}`;
+
+/**
+ * These tests are intended to see if the vFormat of buckets is respected
+ * when performing operations on the buckets. We perform operations on
+ * buckets with mixed vFormats that were created at the same time
+ *
+ * The mongo metadata uses a cache to store the vFormat of buckets,
+ * that value is supposed to be immutable, hence the value in cache never
+ * gets updated. Also the value of the default vFormat to use can not be
+ * modified while cloudserver is running.
+ *
+ * To overcome these issues, we set the METADATA_MAX_CACHED_BUCKETS
+ * environement variable to 1 which means that only one bucket vFormat is cached
+ * at once, and set the DEFAULT_BUCKET_KEY_FORMAT variable to v1.
+ *
+ * Now that we can only store one bucket vFormat in cache, buckets v0 and v1 are
+ * created in order, which leads to the first bucket's (v0) vFormat being removed
+ * from the cache. The vFormat of the v0 bucket is then updated manually.
+ * Next time the v0 bucket vFormat gets requested it will return the updated version
+ * i.e v0
+ */
+describe('Mongo backend mixed bucket format versions', () => {
+    withV4(sigCfg => {
+        let mongoClient;
+        let bucketUtil;
+        let s3;
+
+        function updateBucketVFormat(bucketName, vFormat) {
+            const db = mongoClient.db('metadata');
+            return db.collection('__metastore')
+                .updateOne({
+                    _id: bucketName,
+                }, {
+                    $set: { vFormat },
+                }, {});
+        }
+
+        function getObject(bucketName, key, cb) {
+            const db = mongoClient.db('metadata');
+            return db.collection(bucketName)
+            .findOne({
+                _id: key,
+            }, {}, (err, doc) => {
+                if (err) {
+                    return cb(err);
+                }
+                if (!doc) {
+                    return cb(errors.NoSuchKey);
+                }
+                return cb(null, doc.value);
+            });
+        }
+
+        before(done => {
+            MongoClient.connect(mongoUrl, {}, (err, client) => {
+                if (err) {
+                    return done(err);
+                }
+                mongoClient = client;
+                bucketUtil = new BucketUtility('default', sigCfg);
+                s3 = bucketUtil.s3;
+                return done();
+            });
+        });
+
+        beforeEach(() => {
+            process.stdout.write('Creating buckets');
+            return bucketUtil.createMany(['v0-bucket', 'v1-bucket'])
+            .then(async () => {
+                process.stdout.write('Updating bucket vFormat');
+                await updateBucketVFormat('v0-bucket', 'v0');
+                await updateBucketVFormat('v1-bucket', 'v1');
+            })
+            .catch(err => {
+                process.stdout.write('Error in afterEach');
+                throw err;
+            });
+        });
+
+        afterEach(() => {
+            process.stdout.write('Emptying buckets');
+            return bucketUtil.emptyMany(['v0-bucket', 'v1-bucket'])
+            .then(() => {
+                process.stdout.write('Deleting buckets');
+                return bucketUtil.deleteMany(['v0-bucket', 'v1-bucket']);
+            })
+            .catch(err => {
+                process.stdout.write('Error in afterEach');
+                throw err;
+            });
+        });
+
+        after(done => mongoClient.close(true, done));
+
+        ['v0', 'v1'].forEach(vFormat => {
+            it(`Should perform operations on non versioned bucket in ${vFormat} format`, done => {
+                const paramsObj1 = {
+                    Bucket: `${vFormat}-bucket`,
+                    Key: `${vFormat}-object-1`
+                };
+                const paramsObj2 = {
+                    Bucket: `${vFormat}-bucket`,
+                    Key: `${vFormat}-object-2`
+                };
+                const masterKey = vFormat === 'v0' ? `${vFormat}-object-1` : `\x7fM${vFormat}-object-1`;
+                async.series([
+                    next => s3.putObject(paramsObj1, next),
+                    next => s3.putObject(paramsObj2, next),
+                    // check if data stored in the correct format
+                    next => getObject(`${vFormat}-bucket`, masterKey, (err, doc) => {
+                        assert.ifError(err);
+                        assert.strictEqual(doc.key, `${vFormat}-object-1`);
+                        return next();
+                    }),
+                    // test if we can get object
+                    next => s3.getObject(paramsObj1, next),
+                    // test if we can list objects
+                    next => s3.listObjects({ Bucket: `${vFormat}-bucket` }, (err, data) => {
+                        assert.ifError(err);
+                        assert.strictEqual(data.Contents.length, 2);
+                        const keys = data.Contents.map(obj => obj.Key);
+                        assert(keys.includes(`${vFormat}-object-1`));
+                        assert(keys.includes(`${vFormat}-object-2`));
+                        return next();
+                    })
+                ], done);
+            });
+
+            it(`Should perform operations on versioned bucket in ${vFormat} format`, done => {
+                const paramsObj1 = {
+                    Bucket: `${vFormat}-bucket`,
+                    Key: `${vFormat}-object-1`
+                };
+                const paramsObj2 = {
+                    Bucket: `${vFormat}-bucket`,
+                    Key: `${vFormat}-object-2`
+                };
+                const versioningParams = {
+                    Bucket: `${vFormat}-bucket`,
+                    VersioningConfiguration: {
+                     Status: 'Enabled',
+                    }
+                };
+                const masterKey = vFormat === 'v0' ? `${vFormat}-object-1` : `\x7fM${vFormat}-object-1`;
+                async.series([
+                    next => s3.putBucketVersioning(versioningParams, next),
+                    next => s3.putObject(paramsObj1, next),
+                    next => s3.putObject(paramsObj1, next),
+                    next => s3.putObject(paramsObj2, next),
+                    // check if data stored in the correct version format
+                    next => getObject(`${vFormat}-bucket`, masterKey, (err, doc) => {
+                        assert.ifError(err);
+                        assert.strictEqual(doc.key, `${vFormat}-object-1`);
+                        return next();
+                    }),
+                    // test if we can get object
+                    next => s3.getObject(paramsObj1, next),
+                    // test if we can list objects
+                    next => s3.listObjects({ Bucket: `${vFormat}-bucket` }, (err, data) => {
+                        assert.ifError(err);
+                        assert.strictEqual(data.Contents.length, 2);
+                        const keys = data.Contents.map(obj => obj.Key);
+                        assert(keys.includes(`${vFormat}-object-1`));
+                        assert(keys.includes(`${vFormat}-object-2`));
+                        return next();
+                    }),
+                    // test if we can list object versions
+                    next => s3.listObjectVersions({ Bucket: `${vFormat}-bucket` }, (err, data) => {
+                        assert.ifError(err);
+                        assert.strictEqual(data.Versions.length, 3);
+                        const versionPerObject = {};
+                        data.Versions.forEach(version => {
+                            versionPerObject[version.Key] = (versionPerObject[version.Key] || 0) + 1;
+                        });
+                        assert.strictEqual(versionPerObject[`${vFormat}-object-1`], 2);
+                        assert.strictEqual(versionPerObject[`${vFormat}-object-2`], 1);
+                        return next();
+                    })
+                ], done);
+            });
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,9 +417,9 @@ arraybuffer.slice@~0.0.7:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
   integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
 
-"arsenal@github:scality/Arsenal#8.1.32":
-  version "8.1.32"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/5da4cd88ff1beeb08fb5bbbaa33062d5112faf03"
+"arsenal@github:scality/Arsenal#8.1.34":
+  version "8.1.34"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/5f8edd35e927bd8dec47ba54e0928b96928d063d"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"


### PR DESCRIPTION
- bump arsenal to integrate new bucket format for mongo metadata backend
- Added CI steps to run functional tests in both bucket version formats
- Added test for when having buckets with different vFormats at the same time