### PR TITLE
Fix data-content overview panels

### DIFF
--- a/lib/utilities/monitoringHandler.js
+++ b/lib/utilities/monitoringHandler.js
@@ -2,7 +2,6 @@ const { errors } = require('arsenal');
 const client = require('prom-client');
 
 const collectDefaultMetrics = client.collectDefaultMetrics;
-let crrStatsPulled = false;
 const numberOfBuckets = new client.Gauge({
     name: 'cloud_server_number_of_buckets',
     help: 'Total number of buckets',
@@ -10,6 +9,10 @@ const numberOfBuckets = new client.Gauge({
 const numberOfObjects = new client.Gauge({
     name: 'cloud_server_number_of_objects',
     help: 'Total number of objects',
+});
+const lastReportTimestamp = new client.Gauge({
+    name: 'cloud_server_last_report_timestamp',
+    help: 'Timestamp of last object/bucket count report',
 });
 const numberOfIngestedObjects = new client.Gauge({
     name: 'cloud_server_number_of_ingested_objects',
@@ -122,7 +125,8 @@ function promMetrics(method, bucketName, code, action,
 }
 
 function crrCacheToProm(crrResults) {
-    if (!crrStatsPulled && crrResults) {
+    if (crrResults) {
+        lastReportTimestamp.setToCurrentTime();
         if (crrResults.getObjectCount) {
             numberOfBuckets.set(crrResults.getObjectCount.buckets || 0);
             numberOfObjects.set(crrResults.getObjectCount.objects || 0);
@@ -133,7 +137,6 @@ function crrCacheToProm(crrResults) {
             dataDiskTotal.set(crrResults.getDataDiskUsage.total || 0);
         }
     }
-    crrStatsPulled = true;
 }
 
 function writeResponse(res, error, results, cb) {

--- a/monitoring/dashboard.json
+++ b/monitoring/dashboard.json
@@ -286,7 +286,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "-sum(delta(cloud_server_data_disk_available{namespace=\"${namespace}\", job=\"${job}\"}[$__rate_interval]))",
+                    "expr": "-sum(deriv(cloud_server_data_disk_available{namespace=\"${namespace}\", job=\"${job}\"}[$__rate_interval]))",
                     "interval": "",
                     "legendFormat": "",
                     "refId": "A"

--- a/monitoring/dashboard.json
+++ b/monitoring/dashboard.json
@@ -362,12 +362,17 @@
                         "mode": "thresholds"
                     },
                     "mappings": [],
+                    "noValue": "-",
                     "thresholds": {
                         "mode": "absolute",
                         "steps": [
                             {
-                                "color": "blue",
+                                "color": "#808080",
                                 "value": null
+                            },
+                            {
+                                "color": "blue",
+                                "value": 0
                             }
                         ]
                     },
@@ -377,7 +382,7 @@
             },
             "gridPos": {
                 "h": 4,
-                "w": 9,
+                "w": 7,
                 "x": 15,
                 "y": 0
             },
@@ -412,7 +417,7 @@
         },
         {
             "datasource": "${DS_PROMETHEUS}",
-            "description": "Number of S3 objects available in the cluster.\nThis value is computed asynchronously, and update may be delayed up to 1h.",
+            "description": "Status of the reports-handler pod.",
             "fieldConfig": {
                 "defaults": {
                     "color": {
@@ -423,8 +428,74 @@
                         "mode": "absolute",
                         "steps": [
                             {
-                                "color": "blue",
+                                "color": "red",
                                 "value": null
+                            },
+                            {
+                                "color": "green",
+                                "value": 1
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 4,
+                "w": 2,
+                "x": 22,
+                "y": 0
+            },
+            "id": 58,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "8.0.6",
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "sum(up{namespace=\"${namespace}\", job=\"${reportJob}\"})",
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "title": "Reporter",
+            "type": "stat"
+        },
+        {
+            "datasource": "${DS_PROMETHEUS}",
+            "description": "Number of S3 objects available in the cluster.\nThis value is computed asynchronously, and update may be delayed up to 1h.",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "noValue": "-",
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "#808080",
+                                "value": null
+                            },
+                            {
+                                "color": "blue",
+                                "value": 0
                             }
                         ]
                     },
@@ -434,7 +505,7 @@
             },
             "gridPos": {
                 "h": 4,
-                "w": 9,
+                "w": 7,
                 "x": 15,
                 "y": 4
             },
@@ -465,6 +536,81 @@
                 }
             ],
             "title": "Objects",
+            "type": "stat"
+        },
+        {
+            "datasource": "${DS_PROMETHEUS}",
+            "description": "Time elapsed since the last report, when object/bucket count was updated.",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "noValue": "-",
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "#808080",
+                                "value": null
+                            },
+                            {
+                                "color": "green",
+                                "value": 0
+                            },
+                            {
+                                "color": "super-light-yellow",
+                                "value": 1800000
+                            },
+                            {
+                                "color": "orange",
+                                "value": 3600000
+                            },
+                            {
+                                "color": "red",
+                                "value": 3700000
+                            }
+                        ]
+                    },
+                    "unit": "ms"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 4,
+                "w": 2,
+                "x": 22,
+                "y": 4
+            },
+            "id": 59,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "8.0.6",
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "time() - cloud_server_last_report_timestamp{namespace=\"${namespace}\", job=\"${reportJob}\"}",
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "title": "Last Report",
             "type": "stat"
         },
         {
@@ -1665,5 +1811,5 @@
     "timezone": "",
     "title": "CloudServer",
     "uid": null,
-    "version": 13
+    "version": 14
 }

--- a/monitoring/dashboard.json
+++ b/monitoring/dashboard.json
@@ -232,7 +232,7 @@
         },
         {
             "datasource": "${DS_PROMETHEUS}",
-            "description": "",
+            "description": "Number of S3 buckets available in the cluster.\nThis value is computed asynchronously, and update may be delayed up to 1h.",
             "fieldConfig": {
                 "defaults": {
                     "color": {
@@ -289,7 +289,7 @@
         },
         {
             "datasource": "${DS_PROMETHEUS}",
-            "description": "",
+            "description": "Number of S3 objects available in the cluster.\nThis value is computed asynchronously, and update may be delayed up to 1h.",
             "fieldConfig": {
                 "defaults": {
                     "color": {
@@ -673,6 +673,7 @@
         },
         {
             "datasource": "${DS_PROMETHEUS}",
+            "description": "Rate of data ingested out-of-band (OOB) : cumulative amount of OOB data created (>0) or freed (<0) per second.",
             "fieldConfig": {
                 "defaults": {
                     "color": {
@@ -724,11 +725,12 @@
                     "refId": "A"
                 }
             ],
-            "title": "Data Injestion Rate",
+            "title": "OOB Ingest. Data Rate",
             "type": "stat"
         },
         {
             "datasource": "${DS_PROMETHEUS}",
+            "description": "Rate of object ingested out-of-band (OOB) : cumulative count of OOB object created (>0) or freed (<0) per second.",
             "fieldConfig": {
                 "defaults": {
                     "color": {
@@ -780,7 +782,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Object Injection Rate",
+            "title": "OOB Ingest. Rate",
             "type": "stat"
         },
         {
@@ -1709,5 +1711,5 @@
     "timezone": "",
     "title": "CloudServer",
     "uid": null,
-    "version": 8
+    "version": 9
 }

--- a/monitoring/dashboard.json
+++ b/monitoring/dashboard.json
@@ -36,6 +36,13 @@
             "label": "pod",
             "description": "Prefix of the Cloudserver pod names, used to filter only the Cloudserver instances.",
             "value": "artesca-data-connector-cloudserver"
+        },
+        {
+            "name": "reportJob",
+            "type": "constant",
+            "label": "report job",
+            "description": "Name of the Cloudserver Report job, used to filter only the Report Handler instances.",
+            "value": "artesca-data-ops-report-handler"
         }
     ],
     "editable": true,
@@ -278,7 +285,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "sum(cloud_server_number_of_buckets{namespace=\"${namespace}\",job=\"${job}\"})",
+                    "expr": "sum(cloud_server_number_of_buckets{namespace=\"${namespace}\",job=\"${reportJob}\"})",
                     "interval": "",
                     "legendFormat": "",
                     "refId": "A"
@@ -335,7 +342,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "sum(cloud_server_number_of_objects{namespace=\"${namespace}\",job=\"${job}\"})",
+                    "expr": "sum(cloud_server_number_of_objects{namespace=\"${namespace}\",job=\"${reportJob}\"})",
                     "interval": "",
                     "legendFormat": "",
                     "refId": "A"
@@ -1633,5 +1640,5 @@
     "timezone": "",
     "title": "CloudServer",
     "uid": null,
-    "version": 10
+    "version": 11
 }

--- a/monitoring/dashboard.json
+++ b/monitoring/dashboard.json
@@ -1469,47 +1469,14 @@
                         "mode": "palette-classic"
                     },
                     "custom": {
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "drawStyle": "line",
-                        "fillOpacity": 0,
-                        "gradientMode": "none",
                         "hideFrom": {
                             "legend": false,
                             "tooltip": false,
                             "viz": false
-                        },
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                            "type": "linear"
-                        },
-                        "showPoints": "auto",
-                        "spanNulls": false,
-                        "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                            "mode": "off"
                         }
                     },
                     "mappings": [],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "color": "green",
-                                "value": null
-                            },
-                            {
-                                "color": "red",
-                                "value": 80
-                            }
-                        ]
-                    }
+                    "unit": "short"
                 },
                 "overrides": []
             },
@@ -1521,11 +1488,17 @@
             },
             "id": 53,
             "options": {
+                "displayLabels": [
+                    "name"
+                ],
                 "legend": {
-                    "calcs": [],
-                    "displayMode": "list",
-                    "placement": "bottom"
+                    "displayMode": "table",
+                    "placement": "right",
+                    "values": [
+                        "value"
+                    ]
                 },
+                "pieType": "donut",
                 "tooltip": {
                     "mode": "single"
                 }
@@ -1533,11 +1506,12 @@
             "targets": [
                 {
                     "expr": "topk(10, sum by(bucketName) (count_over_time({namespace=\"${namespace}\", pod=~\"${pod}-.*\"} | json | bucketName!=\"\" and httpCode==404 [$__interval])))",
-                    "refId": "A"
+                    "refId": "A",
+                    "legendFormat": "{{bucketName}}"
                 }
             ],
             "title": "404 : Top10 by Bucket",
-            "type": "timeseries"
+            "type": "piechart"
         },
         {
             "datasource": "${DS_LOKI}",
@@ -1547,47 +1521,14 @@
                         "mode": "palette-classic"
                     },
                     "custom": {
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "drawStyle": "line",
-                        "fillOpacity": 0,
-                        "gradientMode": "none",
                         "hideFrom": {
                             "legend": false,
                             "tooltip": false,
                             "viz": false
-                        },
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                            "type": "linear"
-                        },
-                        "showPoints": "auto",
-                        "spanNulls": false,
-                        "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                            "mode": "off"
                         }
                     },
                     "mappings": [],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "color": "green",
-                                "value": null
-                            },
-                            {
-                                "color": "red",
-                                "value": 80
-                            }
-                        ]
-                    }
+                    "unit": "short"
                 },
                 "overrides": []
             },
@@ -1599,11 +1540,17 @@
             },
             "id": 54,
             "options": {
+                "displayLabels": [
+                    "name"
+                ],
                 "legend": {
-                    "calcs": [],
-                    "displayMode": "list",
-                    "placement": "bottom"
+                    "displayMode": "table",
+                    "placement": "right",
+                    "values": [
+                        "value"
+                    ]
                 },
+                "pieType": "donut",
                 "tooltip": {
                     "mode": "single"
                 }
@@ -1611,11 +1558,12 @@
             "targets": [
                 {
                     "expr": "topk(10, sum by(bucketName) (count_over_time({namespace=\"${namespace}\", pod=~\"${pod}-.*\"} | json | bucketName!=\"\" and httpCode==500 [$__interval])))",
-                    "refId": "A"
+                    "refId": "A",
+                    "legendFormat": "{{bucketName}}"
                 }
             ],
             "title": "500 : Top10 by Bucket",
-            "type": "timeseries"
+            "type": "piechart"
         },
         {
             "datasource": "${DS_LOKI}",
@@ -1625,47 +1573,14 @@
                         "mode": "palette-classic"
                     },
                     "custom": {
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "drawStyle": "line",
-                        "fillOpacity": 0,
-                        "gradientMode": "none",
                         "hideFrom": {
                             "legend": false,
                             "tooltip": false,
                             "viz": false
-                        },
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                            "type": "linear"
-                        },
-                        "showPoints": "auto",
-                        "spanNulls": false,
-                        "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                            "mode": "off"
                         }
                     },
                     "mappings": [],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "color": "green",
-                                "value": null
-                            },
-                            {
-                                "color": "red",
-                                "value": 80
-                            }
-                        ]
-                    }
+                    "unit": "short"
                 },
                 "overrides": []
             },
@@ -1677,11 +1592,17 @@
             },
             "id": 55,
             "options": {
+                "displayLabels": [
+                    "name"
+                ],
                 "legend": {
-                    "calcs": [],
-                    "displayMode": "list",
-                    "placement": "bottom"
+                    "displayMode": "table",
+                    "placement": "right",
+                    "values": [
+                        "value"
+                    ]
                 },
+                "pieType": "donut",
                 "tooltip": {
                     "mode": "single"
                 }
@@ -1689,11 +1610,12 @@
             "targets": [
                 {
                     "expr": "topk(10, sum by(bucketName) (count_over_time({namespace=\"${namespace}\", pod=~\"${pod}-.*\"} | json | bucketName!=\"\" and httpCode=~\"5..\" [$__interval])))",
-                    "refId": "A"
+                    "refId": "A",
+                    "legendFormat": "{{bucketName}}"
                 }
             ],
             "title": "5xx : Top10 by Bucket",
-            "type": "timeseries"
+            "type": "piechart"
         }
     ],
     "refresh": "30s",
@@ -1711,5 +1633,5 @@
     "timezone": "",
     "title": "CloudServer",
     "uid": null,
-    "version": 9
+    "version": 10
 }

--- a/monitoring/dashboard.json
+++ b/monitoring/dashboard.json
@@ -686,6 +686,7 @@
                     "color": {
                         "mode": "thresholds"
                     },
+                    "decimals": 1,
                     "mappings": [],
                     "thresholds": {
                         "mode": "absolute",
@@ -714,7 +715,7 @@
                 "orientation": "auto",
                 "reduceOptions": {
                     "calcs": [
-                        "last"
+                        "mean"
                     ],
                     "fields": "",
                     "values": false
@@ -743,6 +744,7 @@
                     "color": {
                         "mode": "thresholds"
                     },
+                    "decimals": 1,
                     "mappings": [],
                     "thresholds": {
                         "mode": "absolute",
@@ -771,7 +773,7 @@
                 "orientation": "auto",
                 "reduceOptions": {
                     "calcs": [
-                        "last"
+                        "mean"
                     ],
                     "fields": "",
                     "values": false
@@ -1640,5 +1642,5 @@
     "timezone": "",
     "title": "CloudServer",
     "uid": null,
-    "version": 11
+    "version": 12
 }

--- a/monitoring/dashboard.json
+++ b/monitoring/dashboard.json
@@ -239,6 +239,122 @@
         },
         {
             "datasource": "${DS_PROMETHEUS}",
+            "description": "Rate of data ingested : cumulative amount of data created (>0) or deleted (<0) per second.",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "decimals": 1,
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "dark-purple",
+                                "value": null
+                            }
+                        ]
+                    },
+                    "unit": "binBps"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 9,
+                "y": 0
+            },
+            "id": 56,
+            "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "mean"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "8.0.6",
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "-sum(delta(cloud_server_data_disk_available{namespace=\"${namespace}\", job=\"${job}\"}[$__rate_interval]))",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "title": "Ingestion Data Rate",
+            "type": "stat"
+        },
+        {
+            "datasource": "${DS_PROMETHEUS}",
+            "description": "Rate of object ingestion : cumulative count of object created (>0) or deleted (<0) per second.",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "decimals": 1,
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "dark-purple",
+                                "value": null
+                            }
+                        ]
+                    },
+                    "unit": "O/s"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 12,
+                "y": 0
+            },
+            "id": 57,
+            "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "mean"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "8.0.6",
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "sum(deriv(cloud_server_number_of_objects{namespace=\"${namespace}\", job=\"${job}\"}[$__rate_interval]))",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "title": "Ingestion Rate",
+            "type": "stat"
+        },
+        {
+            "datasource": "${DS_PROMETHEUS}",
             "description": "Number of S3 buckets available in the cluster.\nThis value is computed asynchronously, and update may be delayed up to 1h.",
             "fieldConfig": {
                 "defaults": {
@@ -250,7 +366,7 @@
                         "mode": "absolute",
                         "steps": [
                             {
-                                "color": "dark-purple",
+                                "color": "blue",
                                 "value": null
                             }
                         ]
@@ -261,13 +377,13 @@
             },
             "gridPos": {
                 "h": 4,
-                "w": 3,
-                "x": 9,
+                "w": 9,
+                "x": 15,
                 "y": 0
             },
             "id": 43,
             "options": {
-                "colorMode": "background",
+                "colorMode": "value",
                 "graphMode": "area",
                 "justifyMode": "auto",
                 "orientation": "auto",
@@ -307,7 +423,7 @@
                         "mode": "absolute",
                         "steps": [
                             {
-                                "color": "dark-purple",
+                                "color": "blue",
                                 "value": null
                             }
                         ]
@@ -318,13 +434,13 @@
             },
             "gridPos": {
                 "h": 4,
-                "w": 3,
-                "x": 12,
-                "y": 0
+                "w": 9,
+                "x": 15,
+                "y": 4
             },
             "id": 44,
             "options": {
-                "colorMode": "background",
+                "colorMode": "value",
                 "graphMode": "area",
                 "justifyMode": "auto",
                 "orientation": "auto",
@@ -350,99 +466,6 @@
             ],
             "title": "Objects",
             "type": "stat"
-        },
-        {
-            "datasource": "${DS_PROMETHEUS}",
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "palette-classic"
-                    },
-                    "custom": {
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "drawStyle": "line",
-                        "fillOpacity": 30,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                            "legend": false,
-                            "tooltip": false,
-                            "viz": false
-                        },
-                        "lineInterpolation": "smooth",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                            "type": "linear"
-                        },
-                        "showPoints": "auto",
-                        "spanNulls": false,
-                        "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                            "mode": "off"
-                        }
-                    },
-                    "mappings": [],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "color": "green",
-                                "value": null
-                            }
-                        ]
-                    }
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 8,
-                "w": 9,
-                "x": 15,
-                "y": 0
-            },
-            "id": 49,
-            "options": {
-                "legend": {
-                    "calcs": [],
-                    "displayMode": "list",
-                    "placement": "bottom"
-                },
-                "tooltip": {
-                    "mode": "single"
-                }
-            },
-            "targets": [
-                {
-                    "exemplar": true,
-                    "expr": "sum(delta(cloud_server_data_disk_total{namespace=\"${namespace}\",job=\"${job}\"}[$__rate_interval]))",
-                    "interval": "",
-                    "legendFormat": "Total",
-                    "refId": "A"
-                },
-                {
-                    "exemplar": true,
-                    "expr": "sum(delta(cloud_server_data_disk_free{namespace=\"${namespace}\",job=\"${job}\"}[$__rate_interval]))",
-                    "hide": false,
-                    "interval": "",
-                    "legendFormat": "Free",
-                    "refId": "B"
-                },
-                {
-                    "exemplar": true,
-                    "expr": "sum(delta(cloud_server_data_disk_available{namespace=\"${namespace}\",job=\"${job}\"}[$__rate_interval]))",
-                    "hide": false,
-                    "interval": "",
-                    "legendFormat": "Available",
-                    "refId": "C"
-                }
-            ],
-            "title": "Data disk storage",
-            "type": "timeseries"
         },
         {
             "datasource": "${DS_PROMETHEUS}",
@@ -680,7 +703,7 @@
         },
         {
             "datasource": "${DS_PROMETHEUS}",
-            "description": "Rate of data ingested out-of-band (OOB) : cumulative amount of OOB data created (>0) or freed (<0) per second.",
+            "description": "Rate of data ingested out-of-band (OOB) : cumulative amount of OOB data created (>0) or deleted (<0) per second.",
             "fieldConfig": {
                 "defaults": {
                     "color": {
@@ -738,7 +761,7 @@
         },
         {
             "datasource": "${DS_PROMETHEUS}",
-            "description": "Rate of object ingested out-of-band (OOB) : cumulative count of OOB object created (>0) or freed (<0) per second.",
+            "description": "Rate of object ingested out-of-band (OOB) : cumulative count of OOB object created (>0) or deleted (<0) per second.",
             "fieldConfig": {
                 "defaults": {
                     "color": {
@@ -1642,5 +1665,5 @@
     "timezone": "",
     "title": "CloudServer",
     "uid": null,
-    "version": 12
+    "version": 13
 }


### PR DESCRIPTION
- Remove _local data storage_ panel, which is not relevant
- Use object/bucket count from report-handler
- Show status of report-handler as well as time elapsed since last report
- Show ingestion rate in addition to OOB-ingestion rate
- Use piecharts for _TOP10 buckets with errors_ panels
- Add description to summary panels

<img width="1537" alt="Screenshot 2022-03-17 at 15 46 40" src="https://user-images.githubusercontent.com/3909027/158851149-912460fa-44b0-4f39-acad-7d1cad625347.png">
<img width="507" alt="Screenshot 2022-03-17 at 09 38 27" src="https://user-images.githubusercontent.com/3909027/158851235-b35a4b3a-a492-4014-bcb6-6523c27f6b0c.png">

Issue: CLDSRV-149
