### PR TITLE
improvement: CLDSRV-155-search_bucket support list versions

### DIFF
--- a/tests/functional/aws-node-sdk/test/mdSearch/basicSearch.js
+++ b/tests/functional/aws-node-sdk/test/mdSearch/basicSearch.js
@@ -42,47 +42,47 @@ runIfMongo('Basic search', () => {
     it('should list object with searched for system metadata', done => {
         const encodedSearch = encodeURIComponent(`key="${objectKey}"`);
         return runAndCheckSearch(s3Client, bucketName,
-            encodedSearch, objectKey, done);
+            encodedSearch, false, objectKey, done);
     });
 
     it('should list object with regex searched for system metadata', done => {
         const encodedSearch = encodeURIComponent('key LIKE "find.*"');
         return runAndCheckSearch(s3Client, bucketName,
-            encodedSearch, objectKey, done);
+            encodedSearch, false, objectKey, done);
     });
 
     it('should list object with regex searched for system metadata with flags',
     done => {
         const encodedSearch = encodeURIComponent('key LIKE "/FIND.*/i"');
         return runAndCheckSearch(s3Client, bucketName,
-            encodedSearch, objectKey, done);
+            encodedSearch, false, objectKey, done);
     });
 
     it('should return empty when no object match regex', done => {
         const encodedSearch = encodeURIComponent('key LIKE "/NOTFOUND.*/i"');
         return runAndCheckSearch(s3Client, bucketName,
-            encodedSearch, null, done);
+            encodedSearch, false, null, done);
     });
 
     it('should list object with searched for user metadata', done => {
         const encodedSearch =
             encodeURIComponent(`x-amz-meta-food="${userMetadata.food}"`);
-        return runAndCheckSearch(s3Client, bucketName, encodedSearch,
-            objectKey, done);
+        return runAndCheckSearch(s3Client, bucketName,
+            encodedSearch, false, objectKey, done);
     });
 
     it('should list object with searched for tag metadata', done => {
         const encodedSearch =
             encodeURIComponent('tags.item-type="main"');
-        return runAndCheckSearch(s3Client, bucketName, encodedSearch,
-            objectKey, done);
+        return runAndCheckSearch(s3Client, bucketName,
+            encodedSearch, false, objectKey, done);
     });
 
     it('should return empty listing when no object has user md', done => {
         const encodedSearch =
         encodeURIComponent('x-amz-meta-food="nosuchfood"');
         return runAndCheckSearch(s3Client, bucketName,
-            encodedSearch, null, done);
+            encodedSearch, false, null, done);
     });
 
     describe('search when overwrite object', () => {
@@ -96,8 +96,8 @@ runIfMongo('Basic search', () => {
                 const encodedSearch =
                 encodeURIComponent('x-amz-meta-food' +
                 `="${updatedUserMetadata.food}"`);
-                return runAndCheckSearch(s3Client, bucketName, encodedSearch,
-                objectKey, done);
+                return runAndCheckSearch(s3Client, bucketName,
+                    encodedSearch, false, objectKey, done);
             });
     });
 });
@@ -115,7 +115,7 @@ runIfMongo('Search when no objects in bucket', () => {
     it('should return empty listing when no objects in bucket', done => {
         const encodedSearch = encodeURIComponent(`key="${objectKey}"`);
         return runAndCheckSearch(s3Client, bucketName,
-            encodedSearch, null, done);
+            encodedSearch, false, null, done);
     });
 });
 
@@ -136,6 +136,6 @@ runIfMongo('Invalid regular expression searches', () => {
             message: 'Invalid sql where clause sent as search query',
         };
         return runAndCheckSearch(s3Client, bucketName,
-            encodedSearch, testError, done);
+            encodedSearch, false, testError, done);
     });
 });

--- a/tests/functional/aws-node-sdk/test/mdSearch/utils/helpers.js
+++ b/tests/functional/aws-node-sdk/test/mdSearch/utils/helpers.js
@@ -19,23 +19,51 @@ const testUtils = {};
 testUtils.runIfMongo = process.env.S3METADATA === 'mongodb' ?
     describe : describe.skip;
 
-testUtils.runAndCheckSearch = (s3Client, bucketName, encodedSearch,
+testUtils.runAndCheckSearch = (s3Client, bucketName, encodedSearch, listVersions,
     testResult, done) => {
-    const searchRequest = s3Client.listObjects({ Bucket: bucketName });
-    searchRequest.on('build', () => {
-        searchRequest.httpRequest.path =
-        `${searchRequest.httpRequest.path}?search=${encodedSearch}`;
-    });
-    searchRequest.on('success', res => {
-        if (testResult) {
-            assert(res.data.Contents[0], 'should be Contents listed');
-            assert.strictEqual(res.data.Contents[0].Key, testResult);
-            assert.strictEqual(res.data.Contents.length, 1);
-        } else {
-            assert.strictEqual(res.data.Contents.length, 0);
-        }
-        return done();
-    });
+    let searchRequest;
+    if (listVersions) {
+        searchRequest = s3Client.listObjectVersions({ Bucket: bucketName });
+        searchRequest.on('build', () => {
+            searchRequest.httpRequest.path =
+                `/${bucketName}?search=${encodedSearch}&&versions`;
+        });
+        searchRequest.on('success', res => {
+            if (testResult) {
+                assert.notStrictEqual(res.data.Versions[0].VersionId, undefined);
+                if (Array.isArray(testResult)) {
+                    assert.strictEqual(res.data.Versions.length, testResult.length);
+                    async.forEachOf(testResult, (expected, i, next) => {
+                        assert.strictEqual(res.data.Versions[i].Key, expected);
+                        next();
+                    });
+                } else {
+                    assert(res.data.Versions[0], 'should be Contents listed');
+                    assert.strictEqual(res.data.Versions[0].Key, testResult);
+                    assert.strictEqual(res.data.Versions.length, 1);
+                }
+            } else {
+                assert.strictEqual(res.data.Versions.length, 0);
+            }
+            return done();
+        });
+    } else {
+        searchRequest = s3Client.listObjects({ Bucket: bucketName });
+        searchRequest.on('build', () => {
+            searchRequest.httpRequest.path =
+                `/${bucketName}?search=${encodedSearch}`;
+        });
+        searchRequest.on('success', res => {
+            if (testResult) {
+                assert(res.data.Contents[0], 'should be Contents listed');
+                assert.strictEqual(res.data.Contents[0].Key, testResult);
+                assert.strictEqual(res.data.Contents.length, 1);
+            } else {
+                assert.strictEqual(res.data.Contents.length, 0);
+            }
+            return done();
+        });
+    }
     searchRequest.on('error', err => {
         if (testResult) {
             assert.strictEqual(err.code, testResult.code);

--- a/tests/functional/aws-node-sdk/test/mdSearch/versionEnabledSearch.js
+++ b/tests/functional/aws-node-sdk/test/mdSearch/versionEnabledSearch.js
@@ -3,7 +3,7 @@ const { runAndCheckSearch, removeAllVersions, runIfMongo } =
     require('./utils/helpers');
 
 const userMetadata = { food: 'pizza' };
-const updatedMetadata = { food: 'salad' };
+const updatedMetadata = { food: 'pineapple' };
 const masterKey = 'master';
 
 runIfMongo('Search in version enabled bucket', () => {
@@ -38,11 +38,11 @@ runIfMongo('Search in version enabled bucket', () => {
             });
     });
 
-    it('should list just master object with searched for metadata', done => {
+    it('should list just master object with searched for metadata by default', done => {
         const encodedSearch =
         encodeURIComponent(`x-amz-meta-food="${userMetadata.food}"`);
         return runAndCheckSearch(s3Client, bucketName,
-            encodedSearch, masterKey, done);
+            encodedSearch, false, masterKey, done);
     });
 
     describe('New version overwrite', () => {
@@ -51,11 +51,18 @@ runIfMongo('Search in version enabled bucket', () => {
                 Key: masterKey, Metadata: updatedMetadata }, done);
         });
 
-        it('should list just master object with updated metadata', done => {
+        it('should list just master object with updated metadata by default', done => {
             const encodedSearch =
             encodeURIComponent(`x-amz-meta-food="${updatedMetadata.food}"`);
             return runAndCheckSearch(s3Client, bucketName,
-                encodedSearch, masterKey, done);
+                encodedSearch, false, masterKey, done);
+        });
+
+        it('should list all object versions that met search query while specifying versions param', done => {
+            const encodedSearch =
+                encodeURIComponent('x-amz-meta-food LIKE "pi.*"');
+            return runAndCheckSearch(s3Client, bucketName,
+                encodedSearch, true, [masterKey, masterKey], done);
         });
     });
 });


### PR DESCRIPTION
metadataSearch API support listing object versions originally, but we didn't make it controllable through the search tool `search_bucket` and didn't have tests for listing searched result with versions, so this PR is to add these.