### PR TITLE
improvement: CLDSRV-153 bump arsenal in dev/8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "github:scality/Arsenal#8.1.34",
+    "arsenal": "github:scality/Arsenal#8.1.36",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",


### PR DESCRIPTION
fixed this issue(https://scality.atlassian.net/browse/ARTESCA-2237) in cloudserver dev/8.3 branch that will be merged to zenko 2.2.x and then artesca 1.3.1