### PR TITLE
Fix success rate gauge

### DIFF
--- a/monitoring/dashboard.json
+++ b/monitoring/dashboard.json
@@ -231,13 +231,14 @@
       "options": {
         "fieldOptions": {
           "calcs": [
-            "lastNotNull"
+            "mean"
           ],
           "defaults": {
             "decimals": null,
             "links": [],
             "max": 100,
             "min": 0,
+            "noValue": "-",
             "title": null,
             "unit": "percent"
           },
@@ -246,7 +247,7 @@
           "override": {},
           "thresholds": [
             {
-              "color": "red",
+              "color": "#808080",
               "index": 0,
               "line": true,
               "op": "gt",
@@ -254,8 +255,16 @@
               "yaxis": "left"
             },
             {
-              "color": "orange",
+              "color": "red",
               "index": 1,
+              "line": true,
+              "op": "gt",
+              "value": 0.0,
+              "yaxis": "left"
+            },
+            {
+              "color": "orange",
+              "index": 2,
               "line": true,
               "op": "gt",
               "value": 80.0,
@@ -263,7 +272,7 @@
             },
             {
               "color": "green",
-              "index": 2,
+              "index": 3,
               "line": true,
               "op": "gt",
               "value": 90.0,
@@ -278,10 +287,10 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(http_requests_total{namespace=\"${namespace}\", job=\"${job}\", code=~\"2..\"}[$__rate_interval])) * 100\n   /\nsum(rate(http_requests_total{namespace=\"${namespace}\", job=\"${job}\"}[$__rate_interval]))",
+          "expr": "sum(rate(http_requests_total{namespace=\"${namespace}\", job=\"${job}\", code=~\"2..\"}[$__rate_interval])) * 100\n   /\nsum(rate(http_requests_total{namespace=\"${namespace}\", job=\"${job}\"}[$__rate_interval]) > 0)",
           "format": "time_series",
           "hide": false,
-          "instant": true,
+          "instant": false,
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Success rate",
@@ -2286,5 +2295,5 @@
   "timezone": "",
   "title": "CloudServer",
   "uid": null,
-  "version": 18
+  "version": 19
 }

--- a/monitoring/dashboard.json
+++ b/monitoring/dashboard.json
@@ -151,7 +151,7 @@
           "custom": {},
           "decimals": 0,
           "mappings": [],
-          "noValue": "none",
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -186,7 +186,7 @@
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "last"
+            "sum"
           ],
           "fields": "",
           "values": false
@@ -657,7 +657,7 @@
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "sum"
           ],
           "fields": "",
           "values": false
@@ -729,7 +729,7 @@
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "sum"
           ],
           "fields": "",
           "values": false
@@ -801,7 +801,7 @@
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "sum"
           ],
           "fields": "",
           "values": false
@@ -2295,5 +2295,5 @@
   "timezone": "",
   "title": "CloudServer",
   "uid": null,
-  "version": 19
+  "version": 20
 }

--- a/monitoring/dashboard.py
+++ b/monitoring/dashboard.py
@@ -38,7 +38,8 @@ httpRequests = Stat(
     dataSource="${DS_PROMETHEUS}",
     decimals=0,
     format=UNITS.SHORT,
-    reduceCalc="last",
+    noValue="0",
+    reduceCalc="sum",
     targets=[Target(
         expr='sum(increase(http_requests_total{namespace="${namespace}", job="${job}"}[$__rate_interval]))',  # noqa: E501
     )],
@@ -203,7 +204,7 @@ def http_status_panel(title, code):
         decimals=0,
         format=UNITS.SHORT,
         noValue="0",
-        reduceCalc="lastNotNull",
+        reduceCalc="sum",
         targets=[Target(
             expr='sum(increase(http_requests_total{namespace="${namespace}",job="${job}",code=' + code + "}[$__rate_interval]))",  # noqa: E501
         )],

--- a/monitoring/dashboard.py
+++ b/monitoring/dashboard.py
@@ -1,7 +1,6 @@
 from grafanalib.core import (
     ConstantInput,
     DataSourceInput,
-    GaugePanel,
     Heatmap,
     HeatmapColor,
     RowPanel,
@@ -14,6 +13,7 @@ from scalgrafanalib import (
     layout,
     BarGauge,
     Dashboard,
+    GaugePanel,
     PieChart,
     Tooltip,
     Target,
@@ -50,23 +50,24 @@ httpRequests = Stat(
 successRate = GaugePanel(
     title="Success rate",
     dataSource="${DS_PROMETHEUS}",
-    calc="lastNotNull",
+    calc="mean",
     format=UNITS.PERCENT_FORMAT,
     min=0,
     max=100,
+    noValue="-",
     targets=[Target(
         expr="\n".join([
             'sum(rate(http_requests_total{namespace="${namespace}", job="${job}", code=~"2.."}[$__rate_interval])) * 100',  # noqa: E501
             "   /",
-            'sum(rate(http_requests_total{namespace="${namespace}", job="${job}"}[$__rate_interval]))',  # noqa: E501
+            'sum(rate(http_requests_total{namespace="${namespace}", job="${job}"}[$__rate_interval]) > 0)',  # noqa: E501
         ]),
-        instant=True,
         legendFormat="Success rate",
     )],
     thresholds=[
-        Threshold("red",    0, 0.0),
-        Threshold("orange", 1, 80.0),
-        Threshold("green",  2, 90.0),
+        Threshold("#808080", 0, 0.0),
+        Threshold("red",     1, 0.0),
+        Threshold("orange",  2, 80.0),
+        Threshold("green",   3, 90.0),
     ],
 )
 


### PR DESCRIPTION
- Filtering out period with no http requests (NaN)
- Display greyed-out "-" when no data
- Compute mean value over current range
- Also fix Stat-panel value of http request counter

Issue: CLDSRV-164