### PR TITLE
bugfix: CLDSRV-170 skip orphan cleanup in UploadPart[Copy]

### DIFF
--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -158,6 +158,22 @@ function completeMultipartUpload(authInfo, request, log, callback) {
             }
             return next(errors.MalformedXML, destBucket);
         },
+        function markOverviewForCompletion(destBucket, objMD, mpuBucket, jsonList,
+        storedMetadata, location, mpuOverviewKey, next) {
+            return services.metadataMarkMPObjectForCompletion({
+                bucketName: mpuBucket.getName(),
+                objectKey,
+                uploadId,
+                splitter,
+                storedMetadata,
+            }, log, err => {
+                if (err) {
+                    return next(err);
+                }
+                return next(null, destBucket, objMD, mpuBucket,
+                            jsonList, storedMetadata, location, mpuOverviewKey);
+            });
+        },
         function retrieveParts(destBucket, objMD, mpuBucket, jsonList,
         storedMetadata, location, mpuOverviewKey, next) {
             return services.getMPUparts(mpuBucket.getName(), uploadId, log,

--- a/lib/api/objectPutCopyPart.js
+++ b/lib/api/objectPutCopyPart.js
@@ -232,12 +232,12 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
                             res.controllingLocationConstraint;
                         return next(null, dataLocator, destBucketMD,
                             destObjLocationConstraint, copyObjectSize,
-                            sourceVerId, sourceLocationConstraintName);
+                            sourceVerId, sourceLocationConstraintName, splitter);
                     });
         },
         function goGetData(dataLocator, destBucketMD,
             destObjLocationConstraint, copyObjectSize, sourceVerId,
-            sourceLocationConstraintName, next) {
+            sourceLocationConstraintName, splitter, next) {
             data.uploadPartCopy(request, log, destBucketMD,
             sourceLocationConstraintName,
             destObjLocationConstraint, dataLocator, dataStoreContext,
@@ -246,18 +246,18 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
                     if (error.message === 'skip') {
                         return next(skipError, destBucketMD, eTag,
                             lastModified, sourceVerId,
-                            serverSideEncryption);
+                            serverSideEncryption, lastModified, splitter);
                     }
                     return next(error, destBucketMD);
                 }
                 return next(null, destBucketMD, locations, eTag,
                 copyObjectSize, sourceVerId, serverSideEncryption,
-                lastModified);
+                lastModified, splitter);
             });
         },
         function getExistingPartInfo(destBucketMD, locations, totalHash,
             copyObjectSize, sourceVerId, serverSideEncryption, lastModified,
-            next) {
+            splitter, next) {
             const partKey =
                 `${uploadId}${constants.splitter}${paddedPartNumber}`;
             metadata.getObjectMD(mpuBucketName, partKey, {}, log,
@@ -281,12 +281,12 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
                     }
                     return next(null, destBucketMD, locations, totalHash,
                         prevObjectSize, copyObjectSize, sourceVerId,
-                        serverSideEncryption, lastModified, oldLocations);
+                        serverSideEncryption, lastModified, oldLocations, splitter);
                 });
         },
         function storeNewPartMetadata(destBucketMD, locations, totalHash,
             prevObjectSize, copyObjectSize, sourceVerId, serverSideEncryption,
-            lastModified, oldLocations, next) {
+            lastModified, oldLocations, splitter, next) {
             const metaStoreParams = {
                 partNumber: paddedPartNumber,
                 contentMD5: totalHash,
@@ -302,20 +302,58 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
                         { error: err, method: 'storeNewPartMetadata' });
                         return next(err);
                     }
-                    return next(null, oldLocations, destBucketMD, totalHash,
+                    return next(null, locations, oldLocations, destBucketMD, totalHash,
                         lastModified, sourceVerId, serverSideEncryption,
-                        prevObjectSize, copyObjectSize);
+                        prevObjectSize, copyObjectSize, splitter);
                 });
         },
-        function cleanupExistingData(oldLocations, destBucketMD, totalHash,
+        function checkCanDeleteOldLocations(partLocations, oldLocations, destBucketMD,
+            totalHash, lastModified, sourceVerId, serverSideEncryption,
+            prevObjectSize, copyObjectSize, splitter, next) {
+            if (!oldLocations) {
+                return next(null, oldLocations, destBucketMD, totalHash,
+                    lastModified, sourceVerId, serverSideEncryption,
+                    prevObjectSize, copyObjectSize);
+            }
+            return services.isCompleteMPUInProgress({
+                bucketName: destBucketName,
+                objectKey: destObjectKey,
+                uploadId,
+                splitter,
+            }, log, (err, completeInProgress) => {
+                if (err) {
+                    return next(err, destBucketMD);
+                }
+                let oldLocationsToDelete = oldLocations;
+                // Prevent deletion of old data if a completeMPU
+                // is already in progress because then there is no
+                // guarantee that the old location will not be the
+                // committed one.
+                if (completeInProgress) {
+                    log.warn('not deleting old locations because CompleteMPU is in progress', {
+                        method: 'objectPutCopyPart::checkCanDeleteOldLocations',
+                        bucketName: destBucketName,
+                        objectKey: destObjectKey,
+                        uploadId,
+                        partLocations,
+                        oldLocations,
+                    });
+                    oldLocationsToDelete = null;
+                }
+                return next(null, oldLocationsToDelete, destBucketMD, totalHash,
+                    lastModified, sourceVerId, serverSideEncryption,
+                    prevObjectSize, copyObjectSize);
+            });
+        },
+        function cleanupExistingData(oldLocationsToDelete, destBucketMD, totalHash,
             lastModified, sourceVerId, serverSideEncryption,
             prevObjectSize, copyObjectSize, next) {
             // Clean up the old data now that new metadata (with new
             // data locations) has been stored
-            if (oldLocations) {
+            if (oldLocationsToDelete) {
                 const delLog = logger.newRequestLoggerFromSerializedUids(
                     log.getSerializedUids());
-                return data.batchDelete(oldLocations, request.method, null,
+                return data.batchDelete(oldLocationsToDelete, request.method, null,
                     delLog, err => {
                         if (err) {
                             // if error, log the error and move on as it is not

--- a/lib/api/objectPutPart.js
+++ b/lib/api/objectPutPart.js
@@ -13,6 +13,7 @@ const kms = require('../kms/wrapper');
 const metadata = require('../metadata/wrapper');
 const { pushMetric } = require('../utapi/utilities');
 const logger = require('../utilities/logger');
+const services = require('../services');
 const { config } = require('../Config');
 const multipleBackendGateway = require('../data/multipleBackendGateway');
 const locationConstraintCheck
@@ -272,19 +273,19 @@ function objectPutPart(authInfo, request, streamingV4Params, log,
                     }
                     return next(null, destinationBucket,
                         objectLocationConstraint, cipherBundle,
-                        partKey, prevObjectSize, oldLocations, partInfo);
+                        partKey, prevObjectSize, oldLocations, partInfo, splitter);
                 });
         },
         // Store in data backend.
         (destinationBucket, objectLocationConstraint, cipherBundle,
-        partKey, prevObjectSize, oldLocations, partInfo, next) => {
+        partKey, prevObjectSize, oldLocations, partInfo, splitter, next) => {
             // NOTE: set oldLocations to null so we do not batchDelete for now
             if (partInfo && partInfo.dataStoreType === 'azure') {
                 // skip to storing metadata
                 return next(null, destinationBucket, partInfo,
                   partInfo.dataStoreETag,
                   cipherBundle, partKey, prevObjectSize, null,
-                  objectLocationConstraint);
+                  objectLocationConstraint, splitter);
             }
             const objectContext = {
                 bucketName,
@@ -304,12 +305,13 @@ function objectPutPart(authInfo, request, streamingV4Params, log,
                     }
                     return next(null, destinationBucket, dataGetInfo, hexDigest,
                         cipherBundle, partKey, prevObjectSize, oldLocations,
-                        objectLocationConstraint);
+                        objectLocationConstraint, splitter);
                 });
         },
-        // Store data locations in metadata and delete any overwritten data.
+        // Store data locations in metadata and delete any overwritten
+        // data if completeMPU hasn't been initiated yet.
         (destinationBucket, dataGetInfo, hexDigest, cipherBundle, partKey,
-            prevObjectSize, oldLocations, objectLocationConstraint, next) => {
+         prevObjectSize, oldLocations, objectLocationConstraint, splitter, next) => {
             // Use an array to be consistent with objectPutCopyPart where there
             // could be multiple locations.
             const partLocations = [dataGetInfo];
@@ -339,19 +341,54 @@ function objectPutPart(authInfo, request, streamingV4Params, log,
                         });
                         return next(err, destinationBucket);
                     }
-                    return next(null, oldLocations, objectLocationConstraint,
-                        destinationBucket, hexDigest, prevObjectSize);
+                    return next(null, partLocations, oldLocations, objectLocationConstraint,
+                        destinationBucket, hexDigest, prevObjectSize, splitter);
                 });
+        },
+        (partLocations, oldLocations, objectLocationConstraint, destinationBucket,
+        hexDigest, prevObjectSize, splitter, next) => {
+            if (!oldLocations) {
+                return next(null, oldLocations, objectLocationConstraint,
+                    destinationBucket, hexDigest, prevObjectSize);
+            }
+            return services.isCompleteMPUInProgress({
+                bucketName,
+                objectKey,
+                uploadId,
+                splitter,
+            }, log, (err, completeInProgress) => {
+                if (err) {
+                    return next(err, destinationBucket);
+                }
+                let oldLocationsToDelete = oldLocations;
+                // Prevent deletion of old data if a completeMPU
+                // is already in progress because then there is no
+                // guarantee that the old location will not be the
+                // committed one.
+                if (completeInProgress) {
+                    log.warn('not deleting old locations because CompleteMPU is in progress', {
+                        method: 'objectPutPart::metadata.getObjectMD',
+                        bucketName,
+                        objectKey,
+                        uploadId,
+                        partLocations,
+                        oldLocations,
+                    });
+                    oldLocationsToDelete = null;
+                }
+                return next(null, oldLocationsToDelete, objectLocationConstraint,
+                    destinationBucket, hexDigest, prevObjectSize);
+            });
         },
         // Clean up any old data now that new metadata (with new
         // data locations) has been stored.
-        (oldLocations, objectLocationConstraint, destinationBucket, hexDigest,
+        (oldLocationsToDelete, objectLocationConstraint, destinationBucket, hexDigest,
             prevObjectSize, next) => {
-            if (oldLocations) {
+            if (oldLocationsToDelete) {
                 log.trace('overwriting mpu part, deleting data');
                 const delLog = logger.newRequestLoggerFromSerializedUids(
                     log.getSerializedUids());
-                return data.batchDelete(oldLocations, request.method,
+                return data.batchDelete(oldLocationsToDelete, request.method,
                     objectLocationConstraint, delLog, err => {
                         if (err) {
                             // if error, log the error and move on as it is not

--- a/lib/services.js
+++ b/lib/services.js
@@ -458,6 +458,80 @@ const services = {
         });
     },
 
+    /**
+     * Mark the MPU overview key with a flag when starting the
+     * CompleteMPU operation, to be checked by "put part" operations
+     *
+     * @param {object} params - params object
+     * @param {string} params.bucketName - name of MPU bucket
+     * @param {string} params.objectKey - object key
+     * @param {string} params.uploadId - upload ID
+     * @param {string} params.splitter - splitter for this overview key
+     * @param {object} params.storedMetadata - original metadata of the overview key
+     * @param {Logger} log - Logger object
+     * @param {function} cb - callback(err)
+     * @return {undefined}
+     */
+    metadataMarkMPObjectForCompletion(params, log, cb) {
+        assert.strictEqual(typeof params, 'object');
+        assert.strictEqual(typeof params.bucketName, 'string');
+        assert.strictEqual(typeof params.objectKey, 'string');
+        assert.strictEqual(typeof params.uploadId, 'string');
+        assert.strictEqual(typeof params.splitter, 'string');
+        assert.strictEqual(typeof params.storedMetadata, 'object');
+        const splitter = params.splitter;
+        const longMPUIdentifier =
+            `overview${splitter}${params.objectKey}${splitter}${params.uploadId}`;
+        const multipartObjectMD = Object.assign({}, params.storedMetadata);
+        multipartObjectMD.completeInProgress = true;
+        metadata.putObjectMD(params.bucketName, longMPUIdentifier, multipartObjectMD,
+        {}, log, err => {
+            if (err) {
+                log.error('error from metadata', { error: err });
+                return cb(err);
+            }
+            return cb();
+        });
+    },
+
+    /**
+     * Returns if a CompleteMPU operation is in progress for this
+     * object, by looking at the `completeInProgress` flag stored in
+     * the overview key
+     *
+     * @param {object} params - params object
+     * @param {string} params.bucketName - bucket name where object should be stored
+     * @param {string} params.objectKey - object key
+     * @param {string} params.uploadId - upload ID
+     * @param {string} params.splitter - splitter for this overview key
+     * @param {object} log - request logger instance
+     * @param {function} cb - callback(err, {bool} completeInProgress)
+     * @return {undefined}
+     */
+    isCompleteMPUInProgress(params, log, cb) {
+        assert.strictEqual(typeof params, 'object');
+        assert.strictEqual(typeof params.bucketName, 'string');
+        assert.strictEqual(typeof params.objectKey, 'string');
+        assert.strictEqual(typeof params.uploadId, 'string');
+        assert.strictEqual(typeof params.splitter, 'string');
+
+        const mpuBucketName = `${constants.mpuBucketPrefix}${params.bucketName}`;
+        const splitter = params.splitter;
+        const mpuOverviewKey =
+            `overview${splitter}${params.objectKey}${splitter}${params.uploadId}`;
+        return metadata.getObjectMD(mpuBucketName, mpuOverviewKey, {}, log,
+            (err, res) => {
+                if (err) {
+                    log.error('error getting the overview object from mpu bucket', {
+                        error: err,
+                        method: 'services.isCompleteMPUInProgress',
+                        params,
+                    });
+                    return cb(err);
+                }
+                return cb(null, Boolean(res.completeInProgress));
+            });
+    },
 
     /**
      * Checks whether bucket exists, multipart upload

--- a/tests/functional/aws-node-sdk/test/object/completeMPU.js
+++ b/tests/functional/aws-node-sdk/test/object/completeMPU.js
@@ -210,5 +210,39 @@ describe('Complete MPU', () => {
                 });
             });
         });
+
+        describe('with re-upload of part during CompleteMPU execution', () => {
+            let uploadId;
+            let eTag;
+
+            beforeEach(() => _initiateMpuAndPutOnePart()
+                .then(result => {
+                    uploadId = result.uploadId;
+                    eTag = result.eTag;
+                })
+            );
+
+            it('should complete the MPU successfully and leave a readable object', done => {
+                async.parallel([
+                    doneReUpload => s3.uploadPart({
+                        Bucket: bucket,
+                        Key: key,
+                        PartNumber: 1,
+                        UploadId: uploadId,
+                        Body: 'foo',
+                    }, err => {
+                        // in case the CompleteMPU finished earlier,
+                        // we may get a NoSuchKey error, so just
+                        // ignore it
+                        if (err && err.code === 'NoSuchKey') {
+                            return doneReUpload();
+                        }
+                        return doneReUpload(err);
+                    }),
+                    doneComplete => _completeMpuAndCheckVid(
+                        uploadId, eTag, undefined, doneComplete),
+                ], done);
+            });
+        });
     });
 });

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -1630,6 +1630,78 @@ describe('Multipart Upload API', () => {
         });
     });
 
+    it('should leave orphaned data when overwriting an object part during completeMPU',
+    done => {
+        const fullSizedPart = crypto.randomBytes(5 * 1024 * 1024);
+        const overWritePart = Buffer.from('Overwrite content', 'utf8');
+        let uploadId;
+
+        async.waterfall([
+            next => bucketPut(authInfo, bucketPutRequest, log, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
+            (json, next) => {
+                uploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                const requestObj = {
+                    bucketName,
+                    namespace,
+                    objectKey,
+                    headers: { host: `${bucketName}.s3.amazonaws.com` },
+                    url: `/${objectKey}?partNumber=1&uploadId=${uploadId}`,
+                    query: {
+                        partNumber: '1',
+                        uploadId,
+                    },
+                };
+                const partRequest = new DummyRequest(requestObj, fullSizedPart);
+                objectPutPart(authInfo, partRequest, undefined, log, (err, partCalculatedHash) => {
+                    assert.deepStrictEqual(err, null);
+                    next(null, requestObj, partCalculatedHash);
+                });
+            },
+            (requestObj, partCalculatedHash, next) => {
+                assert.deepStrictEqual(ds[1].value, fullSizedPart);
+                async.parallel([
+                    done => {
+                        const partRequest = new DummyRequest(requestObj, overWritePart);
+                        objectPutPart(authInfo, partRequest, undefined, log, err => {
+                            assert.deepStrictEqual(err, null);
+                            done();
+                        });
+                    },
+                    done => {
+                        const completeBody = '<CompleteMultipartUpload>' +
+                              '<Part>' +
+                              '<PartNumber>1</PartNumber>' +
+                              `<ETag>"${partCalculatedHash}"</ETag>` +
+                              '</Part>' +
+                              '</CompleteMultipartUpload>';
+
+                        const completeRequest = {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            parsedHost: 's3.amazonaws.com',
+                            url: `/${objectKey}?uploadId=${uploadId}`,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            query: { uploadId },
+                            post: completeBody,
+                        };
+                        completeMultipartUpload(authInfo, completeRequest, log, done);
+                    },
+                ], err => next(err));
+            },
+        ],
+        err => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(ds[0], undefined);
+            assert.deepStrictEqual(ds[1].value, fullSizedPart);
+            assert.deepStrictEqual(ds[2].value, overWritePart);
+            done();
+        });
+    });
+
     it('should throw an error on put of an object part with an invalid ' +
     'uploadId', done => {
         const testUploadId = 'invalidUploadID';
@@ -1829,12 +1901,22 @@ describe('complete mpu with versioning', () => {
             },
             (eTag, testUploadId, next) => {
                 const origPutObject = metadataBackend.putObject;
+                let callCount = 0;
                 metadataBackend.putObject =
-                    (bucketName, objName, objVal, params, log, cb) => {
-                        assert.strictEqual(params.replayId, testUploadId);
-                        metadataBackend.putObject = origPutObject;
-                        metadataBackend.putObject(
-                            bucketName, objName, objVal, params, log, cb);
+                    (putBucketName, objName, objVal, params, log, cb) => {
+                        if (callCount === 0) {
+                            // first putObject sets the completeInProgress flag in the overview key
+                            assert.strictEqual(putBucketName, `${constants.mpuBucketPrefix}${bucketName}`);
+                            assert.strictEqual(
+                                objName, `overview${splitter}${objectKey}${splitter}${testUploadId}`);
+                            assert.strictEqual(objVal.completeInProgress, true);
+                        } else {
+                            assert.strictEqual(params.replayId, testUploadId);
+                            metadataBackend.putObject = origPutObject;
+                        }
+                        origPutObject(
+                            putBucketName, objName, objVal, params, log, cb);
+                        callCount += 1;
                     };
                 const parts = [{ partNumber: 1, eTag }];
                 const completeRequest = _createCompleteMpuRequest(testUploadId,
@@ -1891,12 +1973,22 @@ describe('complete mpu with versioning', () => {
             },
             (eTag, testUploadId, next) => {
                 const origPutObject = metadataBackend.putObject;
+                let callCount = 0;
                 metadataBackend.putObject =
-                    (bucketName, objName, objVal, params, log, cb) => {
-                        assert.strictEqual(params.replayId, testUploadId);
-                        metadataBackend.putObject = origPutObject;
-                        metadataBackend.putObject(
-                            bucketName, objName, objVal, params, log, cb);
+                    (putBucketName, objName, objVal, params, log, cb) => {
+                        if (callCount === 0) {
+                            // first putObject sets the completeInProgress flag in the overview key
+                            assert.strictEqual(putBucketName, `${constants.mpuBucketPrefix}${bucketName}`);
+                            assert.strictEqual(
+                                objName, `overview${splitter}${objectKey}${splitter}${testUploadId}`);
+                            assert.strictEqual(objVal.completeInProgress, true);
+                        } else {
+                            assert.strictEqual(params.replayId, testUploadId);
+                            metadataBackend.putObject = origPutObject;
+                        }
+                        origPutObject(
+                            putBucketName, objName, objVal, params, log, cb);
+                        callCount += 1;
                     };
                 const parts = [{ partNumber: 1, eTag }];
                 const completeRequest = _createCompleteMpuRequest(testUploadId,


### PR DESCRIPTION
Do not delete orphan data in UploadPart/UploadPartCopy on overwrite
iff a CompleteMPU of the target MPU is already in progress.

This is to prevent a race condition where a CompleteMPU is running
while UploadPart is uploading a part for the same MPU.

It leaves an orphan in storage since only one of the upload data will
be present in the finished MPU, but the window is limited to the
CompleteMPU execution and should only occur when there are retries of
UploadPart due to prior stuck requests, or with broken clients
misusing the MPU API, so it should be acceptable.

Implementation details:

- set a flag in the MPU overview key when starting the CompleteMPU
  process, before listing the parts from metadata to construct the
  manifest

- in UploadPart/UploadPartCopy, after the part metadata is written and
  if the same part already existed, re-fetch the MPU overview key to
  check the flag: if set, skip the deletion of the old data of this
  part, since the CompleteMPU process in progress may choose either
  part data depending on the exact timing of the listing vs. the
  part overwrite.

(cherry picked from commit 84961115183cec724c7a9946dea4889f24c734a7)
