### PR TITLE
CLDSRV-173 DeleteMarkers created by Lifecycle should not be replicated

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -174,6 +174,10 @@ const constants = {
         'bucket',
     ],
     allowedUtapiEventFilterStates: ['allow', 'deny'],
+    // The AWS assumed Role resource type
+    assumedRoleArnResourceType: 'assumed-role',
+    // Session name of the backbeat lifecycle assumed role session.
+    backbeatLifecycleSessionName: 'backbeat-lifecycle',
 };
 
 module.exports = constants;

--- a/lib/api/apiUtils/authorization/permissionChecks.js
+++ b/lib/api/apiUtils/authorization/permissionChecks.js
@@ -1,7 +1,8 @@
 const { evaluators, actionMaps, RequestContext } = require('arsenal').policies;
 const constants = require('../../../../constants');
 
-const { allAuthedUsersId, bucketOwnerActions, logId, publicId } = constants;
+const { allAuthedUsersId, bucketOwnerActions, logId, publicId,
+    assumedRoleArnResourceType, backbeatLifecycleSessionName } = constants;
 
 // whitelist buckets to allow public read on objects
 const publicReadBuckets = process.env.ALLOW_PUBLIC_READ_BUCKETS ?
@@ -364,10 +365,34 @@ function validatePolicyResource(bucketName, policy) {
     });
 }
 
+/** isLifecycleSession - check if it is the Lifecycle assumed role session arn.
+ * @param {string} arn - Amazon resource name - example:
+ * arn:aws:sts::257038443293:assumed-role/rolename/backbeat-lifecycle
+ * @return {boolean} true if Lifecycle assumed role session arn, false if not.
+ */
+function isLifecycleSession(arn) {
+    if (!arn) {
+        return false;
+    }
+
+    const arnSplits = arn.split(':');
+    const service = arnSplits[2];
+
+    const resourceNames = arnSplits[arnSplits.length - 1].split('/');
+
+    const resourceType = resourceNames[0];
+    const sessionName = resourceNames[resourceNames.length - 1];
+
+    return (service === 'sts' &&
+        resourceType === assumedRoleArnResourceType &&
+        sessionName === backbeatLifecycleSessionName);
+}
+
 module.exports = {
     isBucketAuthorized,
     isObjAuthorized,
     checkBucketAcls,
     checkObjectAcls,
     validatePolicyResource,
+    isLifecycleSession,
 };

--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -136,9 +136,10 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
         size,
         headers,
         isDeleteMarker,
-        replicationInfo: getReplicationInfo(objectKey, bucketMD, false, size),
+        replicationInfo: getReplicationInfo(objectKey, bucketMD, false, size, null, null, authInfo, isDeleteMarker),
         log,
     };
+
     if (!isDeleteMarker) {
         metadataStoreParams.contentType = request.headers['content-type'];
         metadataStoreParams.cacheControl = request.headers['cache-control'];

--- a/lib/api/apiUtils/object/getReplicationInfo.js
+++ b/lib/api/apiUtils/object/getReplicationInfo.js
@@ -1,4 +1,5 @@
 const s3config = require('../../../Config').config;
+const { isLifecycleSession } = require('../authorization/permissionChecks.js');
 
 function _getBackend(objectMD, site) {
     const backends = objectMD ? objectMD.replicationInfo.backends : [];
@@ -63,14 +64,22 @@ function _getReplicationInfo(rule, replicationConfig, content, operationType,
  * @param {boolean} objSize - The size, in bytes, of the object being PUT
  * @param {string} operationType - The type of operation to replicate
  * @param {object} objectMD - The object metadata
+ * @param {AuthInfo} [authInfo] - authentication info of object owner
+ * @param {boolean} [isDeleteMarker] - whether creating a delete marker
  * @return {undefined}
  */
 function getReplicationInfo(objKey, bucketMD, isMD, objSize, operationType,
-    objectMD) {
+    objectMD, authInfo, isDeleteMarker) {
     const content = isMD || objSize === 0 ? ['METADATA'] : ['DATA', 'METADATA'];
     const config = bucketMD.getReplicationConfiguration();
     // If bucket does not have a replication configuration, do not replicate.
     if (config) {
+        // If delete an object due to a lifecycle action,
+        // the delete marker is not replicated to the destination buckets.
+        if (isDeleteMarker && authInfo && isLifecycleSession(authInfo.getArn())) {
+            return undefined;
+        }
+
         const rule = config.rules.find(rule =>
             (objKey.startsWith(rule.prefix) && rule.enabled));
         if (rule) {

--- a/tests/unit/api/apiUtils/getReplicationInfo.js
+++ b/tests/unit/api/apiUtils/getReplicationInfo.js
@@ -3,14 +3,15 @@ const assert = require('assert');
 const BucketInfo = require('arsenal').models.BucketInfo;
 const getReplicationInfo =
       require('../../../../lib/api/apiUtils/object/getReplicationInfo');
+const { makeAuthInfo } = require('../../helpers');
 
-function _getObjectReplicationInfo(replicationConfig) {
+function _getObjectReplicationInfo(replicationConfig, authInfo, isDeleteMarker) {
     const bucketInfo = new BucketInfo(
         'testbucket', 'someCanonicalId', 'accountDisplayName',
         new Date().toJSON(),
         null, null, null, null, null, null, null, null, null,
         replicationConfig);
-    return getReplicationInfo('fookey', bucketInfo, true, 123, null, null);
+    return getReplicationInfo('fookey', bucketInfo, true, 123, null, null, authInfo, isDeleteMarker);
 }
 
 describe('getReplicationInfo helper', () => {
@@ -40,6 +41,65 @@ describe('getReplicationInfo helper', () => {
         });
     });
 
+    it('should get replication info when action comming from a non-lifecycle session', () => {
+        const replicationConfig = {
+            role: 'arn:aws:iam::root:role/s3-replication-role',
+            rules: [{
+                prefix: '',
+                enabled: true,
+                storageClass: 'awsbackend',
+            }],
+            destination: 'tosomewhere',
+        };
+
+        const authInfo = makeAuthInfo('accessKey1', null, 'another-session');
+        const replicationInfo = _getObjectReplicationInfo(replicationConfig, authInfo, true);
+
+        assert.deepStrictEqual(replicationInfo, {
+            status: 'PENDING',
+            backends: [{
+                site: 'awsbackend',
+                status: 'PENDING',
+                dataStoreVersionId: '',
+            }],
+            content: ['METADATA'],
+            destination: 'tosomewhere',
+            storageClass: 'awsbackend',
+            role: 'arn:aws:iam::root:role/s3-replication-role',
+            storageType: 'aws_s3',
+        });
+    });
+
+    it('should get replication info when action comming from a lifecycle session ' +
+    'but action is not delete marker', () => {
+        const replicationConfig = {
+            role: 'arn:aws:iam::root:role/s3-replication-role',
+            rules: [{
+                prefix: '',
+                enabled: true,
+                storageClass: 'awsbackend',
+            }],
+            destination: 'tosomewhere',
+        };
+
+        const authInfo = makeAuthInfo('accessKey1', null, 'backbeat-lifecycle');
+        const replicationInfo = _getObjectReplicationInfo(replicationConfig, authInfo, false);
+
+        assert.deepStrictEqual(replicationInfo, {
+            status: 'PENDING',
+            backends: [{
+                site: 'awsbackend',
+                status: 'PENDING',
+                dataStoreVersionId: '',
+            }],
+            content: ['METADATA'],
+            destination: 'tosomewhere',
+            storageClass: 'awsbackend',
+            role: 'arn:aws:iam::root:role/s3-replication-role',
+            storageType: 'aws_s3',
+        });
+    });
+
     it('should not get replication info when rules are disabled', () => {
         const replicationConfig = {
             role: 'arn:aws:iam::root:role/s3-replication-role',
@@ -51,6 +111,23 @@ describe('getReplicationInfo helper', () => {
             destination: 'tosomewhere',
         };
         const replicationInfo = _getObjectReplicationInfo(replicationConfig);
+        assert.deepStrictEqual(replicationInfo, undefined);
+    });
+
+    it('should not get replication info when action comming from lifecycle session', () => {
+        const replicationConfig = {
+            role: 'arn:aws:iam::root:role/s3-replication-role',
+            rules: [{
+                prefix: '',
+                enabled: true,
+                storageClass: 'awsbackend',
+            }],
+            destination: 'tosomewhere',
+        };
+
+        const authInfo = makeAuthInfo('accessKey1', null, 'backbeat-lifecycle');
+        const replicationInfo = _getObjectReplicationInfo(replicationConfig, authInfo, true);
+
         assert.deepStrictEqual(replicationInfo, undefined);
     });
 });

--- a/tests/unit/api/apiUtils/permissionChecks.js
+++ b/tests/unit/api/apiUtils/permissionChecks.js
@@ -1,0 +1,41 @@
+const assert = require('assert');
+
+const { isLifecycleSession } =
+      require('../../../../lib/api/apiUtils/authorization/permissionChecks.js');
+
+const tests = [
+    {
+        arn: 'arn:aws:sts::257038443293:assumed-role/rolename/backbeat-lifecycle',
+        description: 'a role assumed by lifecycle service',
+        expectedResult: true,
+    },
+    {
+        arn: undefined,
+        description: 'undefined',
+        expectedResult: false,
+    },
+    {
+        arn: '',
+        description: 'empty',
+        expectedResult: false,
+    },
+    {
+        arn: 'arn:aws:iam::257038443293:user/bart',
+        description: 'a user',
+        expectedResult: false,
+    },
+    {
+        arn: 'arn:aws:sts::257038443293:assumed-role/rolename/other-service',
+        description: 'a role assumed by another service',
+        expectedResult: false,
+    },
+];
+
+describe('authInfoHelper', () => {
+    tests.forEach(t => {
+        it(`should return ${t.expectedResult} if arn is ${t.description}`, () => {
+            const result = isLifecycleSession(t.arn);
+            assert.equal(result, t.expectedResult);
+        });
+    });
+});

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -64,7 +64,7 @@ function timeDiff(startTime) {
     return milliseconds;
 }
 
-function makeAuthInfo(accessKey, userName) {
+function makeAuthInfo(accessKey, userName, sessionName) {
     const canIdMap = {
         accessKey1: '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7'
             + 'cd47ef2be',
@@ -90,6 +90,11 @@ function makeAuthInfo(accessKey, userName) {
     if (userName) {
         params.IAMdisplayName = `${accessKey}-${userName}-userDisplayName`;
         params.arn = `arn:aws:iam::${shortid}:user/${userName}`;
+    }
+
+    if (sessionName) {
+        params.IAMdisplayName = `[assumedRole] rolename:${sessionName}`;
+        params.arn = `arn:aws:sts::${shortid}:assumed-role/rolename/${sessionName}`;
     }
 
     return new AuthInfo(params);


### PR DESCRIPTION
https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-what-is-isnot-replicated.html
Changes needed to be compliant with Amazon:
"if AWS S3 deletes an object due to a lifecycle action, the delete marker is not replicated to the destination buckets."