### PR TITLE
bugfix: CLDSRV-177 fix crash with empty object replication

### DIFF
--- a/lib/api/apiUtils/object/locationKeysHaveChanged.js
+++ b/lib/api/apiUtils/object/locationKeysHaveChanged.js
@@ -8,12 +8,13 @@
 *
 * @param {array|string|null} prev - list of keys from the object being
 * overwritten
-* @param {array} curr - list of keys to be used in composing current object
+* @param {array|null} curr - list of keys to be used in composing
+* current object
 * @returns {boolean} true if no key in `curr` is present in `prev`,
 * false otherwise
 */
 function locationKeysHaveChanged(prev, curr) {
-    if (!prev || prev.length === 0) {
+    if (!prev || prev.length === 0 || !curr) {
         return true;
     }
     // backwards compatibility check if object is of model version 2

--- a/tests/functional/raw-node/test/routes/routeBackbeat.js
+++ b/tests/functional/raw-node/test/routes/routeBackbeat.js
@@ -26,6 +26,7 @@ const testData = 'testkey data';
 const testDataMd5 = crypto.createHash('md5')
           .update(testData, 'utf-8')
           .digest('hex');
+const emptyContentsMd5 = 'd41d8cd98f00b204e9800998ecf8427e';
 const testMd = {
     'md-model-version': 2,
     'owner-display-name': 'Bart',
@@ -342,8 +343,8 @@ describeSkipIfAWS('backbeat routes', () => {
             });
         });
 
-        it('should remove old object data locations if version is overwritten',
-        done => {
+        it('should remove old object data locations if version is overwritten ' +
+        'with same contents', done => {
             let oldLocation;
             const testKeyOldData = `${testKey}-old-data`;
             async.waterfall([next => {
@@ -436,6 +437,89 @@ describeSkipIfAWS('backbeat routes', () => {
                 done();
             });
         });
+
+        it('should remove old object data locations if version is overwritten ' +
+        'with empty contents', done => {
+            let oldLocation;
+            const testKeyOldData = `${testKey}-old-data`;
+            async.waterfall([next => {
+                // put object's data locations
+                makeBackbeatRequest({
+                    method: 'PUT', bucket: TEST_BUCKET,
+                    objectKey: testKey,
+                    resourceType: 'data',
+                    headers: {
+                        'content-length': testData.length,
+                        'content-md5': testDataMd5,
+                        'x-scal-canonical-id': testArn,
+                    },
+                    authCredentials: backbeatAuthCredentials,
+                    requestBody: testData }, next);
+            }, (response, next) => {
+                assert.strictEqual(response.statusCode, 200);
+                // put object metadata
+                const newMd = Object.assign({}, testMd);
+                newMd.location = JSON.parse(response.body);
+                oldLocation = newMd.location;
+                makeBackbeatRequest({
+                    method: 'PUT', bucket: TEST_BUCKET,
+                    objectKey: testKey,
+                    resourceType: 'metadata',
+                    authCredentials: backbeatAuthCredentials,
+                    requestBody: JSON.stringify(newMd),
+                }, next);
+            }, (response, next) => {
+                assert.strictEqual(response.statusCode, 200);
+                // put another object which metadata reference the
+                // same data locations, we will attempt to retrieve
+                // this object at the end of the test to confirm that
+                // its locations have been deleted
+                const oldDataMd = Object.assign({}, testMd);
+                oldDataMd.location = oldLocation;
+                makeBackbeatRequest({
+                    method: 'PUT', bucket: TEST_BUCKET,
+                    objectKey: testKeyOldData,
+                    resourceType: 'metadata',
+                    authCredentials: backbeatAuthCredentials,
+                    requestBody: JSON.stringify(oldDataMd),
+                }, next);
+            }, (response, next) => {
+                assert.strictEqual(response.statusCode, 200);
+                // overwrite the original object version with an empty location
+                const newMd = Object.assign({}, testMd);
+                newMd['content-length'] = 0;
+                newMd['content-md5'] = emptyContentsMd5;
+                newMd.location = null;
+                makeBackbeatRequest({
+                    method: 'PUT', bucket: TEST_BUCKET,
+                    objectKey: testKey,
+                    resourceType: 'metadata',
+                    authCredentials: backbeatAuthCredentials,
+                    requestBody: JSON.stringify(newMd),
+                }, next);
+            }, (response, next) => {
+                assert.strictEqual(response.statusCode, 200);
+                // give some time for the async deletes to complete
+                setTimeout(() => checkObjectData(s3, testKey, '', next),
+                           1000);
+            }, next => {
+                // check that the object copy referencing the old data
+                // locations is unreadable, confirming that the old
+                // data locations have been deleted
+                s3.getObject({
+                    Bucket: TEST_BUCKET,
+                    Key: testKeyOldData,
+                }, err => {
+                    assert(err, 'expected error to get object with old data ' +
+                           'locations, got success');
+                    next();
+                });
+            }], err => {
+                assert.ifError(err);
+                done();
+            });
+        });
+
         it('should not remove data locations on replayed metadata PUT',
         done => {
             let serializedNewMd;

--- a/tests/unit/api/apiUtils/locationKeysHaveChanged.js
+++ b/tests/unit/api/apiUtils/locationKeysHaveChanged.js
@@ -38,4 +38,16 @@ describe('Check if location keys have changed between object locations', () => {
         const curr = [{ key: 'ddd' }, { key: 'eee' }, { key: 'fff' }];
         assert.strictEqual(locationKeysHaveChanged(prev, curr), true);
     });
+
+    it('should return true if curr location is null', () => {
+        const prev = [{ key: 'ddd' }, { key: 'eee' }, { key: 'fff' }];
+        const curr = null;
+        assert.strictEqual(locationKeysHaveChanged(prev, curr), true);
+    });
+
+    it('should return true if both prev and curr locations are null', () => {
+        const prev = null;
+        const curr = null;
+        assert.strictEqual(locationKeysHaveChanged(prev, curr), true);
+    });
 });


### PR DESCRIPTION
Fix a case of crash when a replication occurs with an empty object
over a non-empty object.

It is not clear how this happens in practice but there can be some
corner cases with race conditions between object replication and
versioning getting suspended on the target bucket at the same time,
that could lead to this situation, as the check between replication
configuration and actual replication is not atomic.
