### PR TITLE
Improvement/cldsrv 191 bump arsenal post breaking changes dev8x

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,5 +43,8 @@
         "new-parens": "off",
         "no-multi-spaces": "off",
         "quote-props": "off"
+    },
+    "parserOptions": {
+        "ecmaVersion": 2020
     }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN cd /tmp \
     && rm -rf /tmp/Python-$PY_VERSION.tgz
 
 RUN yarn cache clean \
-    && yarn install --production --ignore-optional --ignore-engines --network-concurrency 1  \
+    && yarn install --production --ignore-optional --ignore-engines --network-concurrency 1 \
     && apt-get autoremove --purge -y python git build-essential \
     && rm -rf /var/lib/apt/lists/* \
     && yarn cache clean \

--- a/lib/api/apiUtils/authorization/tagConditionKeys.js
+++ b/lib/api/apiUtils/authorization/tagConditionKeys.js
@@ -49,7 +49,7 @@ function updateRequestContexts(request, requestContexts, apiMethod, log, cb) {
                 return metadata.getObjectMD(bucketName, objectKey, { versionId: reqVersionId }, log,
                 (err, objMD) => {
                     if (err) {
-                        if (err.NoSuchKey) {
+                        if (err.is.NoSuchKey) {
                             return next();
                         }
                         log.trace('error getting request object tags');

--- a/lib/api/apiUtils/bucket/bucketCreation.js
+++ b/lib/api/apiUtils/bucket/bucketCreation.js
@@ -24,7 +24,7 @@ function addToUsersBucket(canonicalID, bucketName, bucketMD, log, cb) {
 
     // Get new format usersBucket to see if it exists
     return metadata.getBucket(usersBucket, log, (err, usersBucketAttrs) => {
-        if (err && !err.NoSuchBucket && !err.BucketAlreadyExists) {
+        if (err && !err.is.NoSuchBucket && !err.is.BucketAlreadyExists) {
             return cb(err);
         }
         const splitter = usersBucketAttrs ?
@@ -41,7 +41,7 @@ function addToUsersBucket(canonicalID, bucketName, bucketMD, log, cb) {
             usersBucket : oldUsersBucket;
         return metadata.putObjectMD(usersBucketBeingCalled, key,
             omVal, {}, log, err => {
-                if (err && err.NoSuchBucket) {
+                if (err?.is.NoSuchBucket) {
                     // There must be no usersBucket so createBucket
                     // one using the new format
                     log.trace('users bucket does not exist, ' +
@@ -62,8 +62,7 @@ function addToUsersBucket(canonicalID, bucketName, bucketMD, log, cb) {
                             // error with respect
                             // to the usersBucket.
                             if (err &&
-                                err !==
-                                    errors.BucketAlreadyExists) {
+                                !err.is.BucketAlreadyExists) {
                                 log.error('error from metadata', {
                                     error: err,
                                 });
@@ -224,7 +223,7 @@ function createBucket(authInfo, bucketName, headers,
         },
         getAnyExistingBucketInfo: function getAnyExistingBucketInfo(callback) {
             metadata.getBucket(bucketName, log, (err, data) => {
-                if (err && err.NoSuchBucket) {
+                if (err?.is.NoSuchBucket) {
                     return callback(null, 'NoBucketYet');
                 }
                 if (err) {

--- a/lib/api/apiUtils/bucket/bucketDeletion.js
+++ b/lib/api/apiUtils/bucket/bucketDeletion.js
@@ -16,7 +16,7 @@ function _deleteMPUbucket(destinationBucketName, log, cb) {
         `${mpuBucketPrefix}${destinationBucketName}`;
     return metadata.deleteBucket(mpuBucketName, log, err => {
         // If the mpu bucket does not exist, just move on
-        if (err && err.NoSuchBucket) {
+        if (err?.is.NoSuchBucket) {
             return cb();
         }
         return cb(err);
@@ -90,7 +90,7 @@ function deleteBucket(authInfo, bucketMD, bucketName, canonicalID, log, cb) {
                 log, (err, objectsListRes) => {
                     // If no shadow bucket ever created, no ongoing MPU's, so
                     // continue with deletion
-                    if (err && err.NoSuchBucket) {
+                    if (err?.is.NoSuchBucket) {
                         return next();
                     }
                     if (err) {

--- a/lib/api/apiUtils/bucket/deleteUserBucketEntry.js
+++ b/lib/api/apiUtils/bucket/deleteUserBucketEntry.js
@@ -11,16 +11,16 @@ function deleteUserBucketEntry(bucketName, canonicalID, log, cb) {
     metadata.deleteObjectMD(usersBucket, keyForUserBucket, {}, log, error => {
         // If the object representing the bucket is not in the
         // users bucket just continue
-        if (error && error.NoSuchKey) {
+        if (error?.is.NoSuchKey) {
             return cb(null);
         // BACKWARDS COMPATIBILITY: Remove this once no longer
         // have old user bucket format
-        } else if (error && error.NoSuchBucket) {
+        } else if (error?.is.NoSuchBucket) {
             const keyForUserBucket2 = createKeyForUserBucket(canonicalID,
                 oldSplitter, bucketName);
             return metadata.deleteObjectMD(oldUsersBucket, keyForUserBucket2,
                 {}, log, error => {
-                    if (error && !error.NoSuchKey) {
+                    if (error && !error.is.NoSuchKey) {
                         log.error('from metadata while deleting user bucket',
                             { error });
                         return cb(error);

--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -262,7 +262,7 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
                     if (err) {
                         // TODO: check AWS error when user requested a specific
                         // version before any versions have been put
-                        const logLvl = err === errors.BadRequest ?
+                        const logLvl = err.is.BadRequest ?
                             'debug' : 'error';
                         log[logLvl]('error getting versioning info', {
                             error: err,

--- a/lib/api/apiUtils/object/setUpCopyLocator.js
+++ b/lib/api/apiUtils/object/setUpCopyLocator.js
@@ -2,7 +2,7 @@ const { errors } = require('arsenal');
 const {
     parseRangeSpec,
     parseRange,
-} = require('arsenal/lib/network/http/utils');
+} = require('arsenal').network.http.utils;
 
 const constants = require('../../../../constants');
 const setPartRanges = require('./setPartRanges');

--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -292,7 +292,7 @@ function versioningPreprocessing(bucketName, bucketMD, objectKey, objMD,
                         // it's possible there was a concurrent request to
                         // delete the null version, so proceed with putting a
                         // new version
-                        if (err === errors.NoSuchKey) {
+                        if (err.is.NoSuchKey) {
                             return next(null, options);
                         }
                         return next(errors.InternalError);

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -339,7 +339,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     if (err) {
                         // TODO: check AWS error when user requested a specific
                         // version before any versions have been put
-                        const logLvl = err === errors.BadRequest ?
+                        const logLvl = err.is.BadRequest ?
                             'debug' : 'error';
                         log[logLvl]('error getting versioning info', {
                             error: err,

--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -214,12 +214,12 @@ function getObjMetadataAndDelete(authInfo, canonicalID, request,
             (versionId, callback) => metadataGetObject(bucketName, entry.key,
                 versionId, log, (err, objMD) => {
                     // if general error from metadata return error
-                    if (err && !err.NoSuchKey) {
+                    if (err && !err.is.NoSuchKey) {
                         monitoring.promMetrics('DELETE', bucketName, err.code,
                             'multiObjectDelete');
                         return callback(err);
                     }
-                    if (err && err.NoSuchKey) {
+                    if (err?.is.NoSuchKey) {
                         const verCfg = bucket.getVersioningConfiguration();
                         // To adhere to AWS behavior, create a delete marker
                         // if trying to delete an object that does not exist
@@ -396,7 +396,8 @@ function multiObjectDelete(authInfo, request, log, callback) {
             return vault.checkPolicies(requestContextParams, authInfo.getArn(),
                 log, (err, authorizationResults) => {
                     // there were no policies so received a blanket AccessDenied
-                    if (err && err.AccessDenied) {
+                    log.info('please see here: ', { err, authorizationResults });
+                    if (err?.is.AccessDenied) {
                         objects.forEach(entry => {
                             errorResults.push({
                                 entry,

--- a/lib/api/multipartDelete.js
+++ b/lib/api/multipartDelete.js
@@ -1,5 +1,3 @@
-const { errors } = require('arsenal');
-
 const abortMultipartUpload = require('./apiUtils/object/abortMultipartUpload');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const isLegacyAWSBehavior = require('../utilities/legacyAWSBehavior');
@@ -30,10 +28,10 @@ function multipartDelete(authInfo, request, log, callback) {
                 request.method, destinationBucket);
             const location = destinationBucket ?
                 destinationBucket.getLocationConstraint() : null;
-            if (err && err !== errors.NoSuchUpload) {
+            if (err && !err.is.NoSuchUpload) {
                 return callback(err, corsHeaders);
             }
-            if (err === errors.NoSuchUpload && isLegacyAWSBehavior(location)) {
+            if (err?.is.NoSuchUpload && isLegacyAWSBehavior(location)) {
                 log.trace('did not find valid mpu with uploadId', {
                     method: 'multipartDelete',
                     uploadId,

--- a/lib/api/objectGet.js
+++ b/lib/api/objectGet.js
@@ -1,5 +1,5 @@
 const { errors, s3middleware } = require('arsenal');
-const { parseRange } = require('arsenal/lib/network/http/utils');
+const { parseRange } = require('arsenal').network.http.utils;
 
 const { data } = require('../data/wrapper');
 
@@ -283,7 +283,7 @@ function objectGet(authInfo, request, returnTagCount, log, callback) {
         }
         return data.head(dataLocator, log, err => {
             if (err) {
-                if (!err.LocationNotFound) {
+                if (!err.is.LocationNotFound) {
                     log.error('error from external backend checking for ' +
                               'object existence', { error: err });
                 }

--- a/lib/api/objectHead.js
+++ b/lib/api/objectHead.js
@@ -1,6 +1,6 @@
 const { errors, s3middleware } = require('arsenal');
 const validateHeaders = s3middleware.validateConditionalHeaders;
-const { parseRange } = require('arsenal/lib/network/http/utils');
+const { parseRange } = require('arsenal').network.http.utils;
 
 const { decodeVersionId } = require('./apiUtils/object/versioning');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');

--- a/lib/api/objectPutCopyPart.js
+++ b/lib/api/objectPutCopyPart.js
@@ -187,7 +187,7 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
             sourceLocationConstraintName, next) {
             return metadata.getBucket(mpuBucketName, log,
                 (err, mpuBucket) => {
-                    if (err && err.NoSuchBucket) {
+                    if (err?.is.NoSuchBucket) {
                         return next(errors.NoSuchUpload);
                     }
                     if (err) {
@@ -216,7 +216,7 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
             return metadata.getObjectMD(mpuBucketName, mpuOverviewKey,
                     null, log, (err, res) => {
                         if (err) {
-                            if (err.NoSuchKey) {
+                            if (err.is.NoSuchKey) {
                                 return next(errors.NoSuchUpload);
                             }
                             log.error('error getting overview object from ' +
@@ -269,7 +269,7 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
             metadata.getObjectMD(mpuBucketName, partKey, {}, log,
                 (err, result) => {
                     // If there is nothing being overwritten just move on
-                    if (err && !err.NoSuchKey) {
+                    if (err && !err.is.NoSuchKey) {
                         log.debug('error getting current part (if any)',
                         { error: err });
                         return next(err);

--- a/lib/api/objectPutPart.js
+++ b/lib/api/objectPutPart.js
@@ -101,7 +101,7 @@ function objectPutPart(authInfo, request, streamingV4Params, log,
         // Get the destination bucket.
         next => metadata.getBucket(bucketName, log,
             (err, destinationBucket) => {
-                if (err && err.NoSuchBucket) {
+                if (err?.is.NoSuchBucket) {
                     return next(errors.NoSuchBucket, destinationBucket);
                 }
                 if (err) {
@@ -149,7 +149,7 @@ function objectPutPart(authInfo, request, streamingV4Params, log,
         (destinationBucket, cipherBundle, next) =>
             metadata.getBucket(mpuBucketName, log,
             (err, mpuBucket) => {
-                if (err && err.NoSuchBucket) {
+                if (err?.is.NoSuchBucket) {
                     return next(errors.NoSuchUpload, destinationBucket);
                 }
                 if (err) {
@@ -232,7 +232,7 @@ function objectPutPart(authInfo, request, streamingV4Params, log,
             return metadata.getObjectMD(mpuBucketName, partKey, {}, log,
                 (err, res) => {
                     // If there is no object with the same key, continue.
-                    if (err && !err.NoSuchKey) {
+                    if (err && !err.is.NoSuchKey) {
                         log.error('error getting current part (if any)', {
                             error: err,
                             method: 'objectPutPart::metadata.getObjectMD',

--- a/lib/api/websiteGet.js
+++ b/lib/api/websiteGet.js
@@ -166,7 +166,7 @@ function websiteGet(request, log, callback) {
                       'bucketGet', constants.publicId, null, log, request);
                     // if index object does not exist and bucket is private AWS
                     // returns 403 - AccessDenied error.
-                    if (err === errors.NoSuchKey && !bucketAuthorized) {
+                    if (err.is.NoSuchKey && !bucketAuthorized) {
                         returnErr = errors.AccessDenied;
                     }
                     return _errorActions(returnErr,

--- a/lib/api/websiteHead.js
+++ b/lib/api/websiteHead.js
@@ -114,7 +114,7 @@ function websiteHead(request, log, callback) {
                       'bucketGet', constants.publicId, null, log, request);
                     // if index object does not exist and bucket is private AWS
                     // returns 403 - AccessDenied error.
-                    if (err === errors.NoSuchKey && !bucketAuthorized) {
+                    if (err.is.NoSuchKey && !bucketAuthorized) {
                         returnErr = errors.AccessDenied;
                     }
                     return _errorActions(returnErr, routingRules,

--- a/lib/management/configuration.js
+++ b/lib/management/configuration.js
@@ -190,7 +190,7 @@ function loadCachedOverlay(log, callback) {
     return metadata.getObjectMD(managementDatabaseName,
         latestOverlayVersionKey, {}, log, (err, version) => {
             if (err) {
-                if (err.NoSuchKey) {
+                if (err.is.NoSuchKey) {
                     return process.nextTick(callback, null, {});
                 }
                 return callback(err);
@@ -198,7 +198,7 @@ function loadCachedOverlay(log, callback) {
             return metadata.getObjectMD(managementDatabaseName,
                 `configuration/overlay/${version}`, {}, log, (err, conf) => {
                     if (err) {
-                        if (err.NoSuchKey) {
+                        if (err.is.NoSuchKey) {
                             return process.nextTick(callback, null, {});
                         }
                         return callback(err);

--- a/lib/management/credentials.js
+++ b/lib/management/credentials.js
@@ -99,7 +99,7 @@ function initManagementCredentials(
     managementEndpoint, instanceId, log, callback) {
     getStoredCredentials(log, (error, value) => {
         if (error) {
-            if (error.NoSuchKey) {
+            if (error.is.NoSuchKey) {
                 return issueCredentials(managementEndpoint, instanceId, log,
                 (error, value) => {
                     if (error) {

--- a/lib/management/index.js
+++ b/lib/management/index.js
@@ -34,7 +34,7 @@ function initManagementDatabase(log, callback) {
 
     metadata.createBucket(managementDatabaseName, md, log, error => {
         if (error) {
-            if (error.BucketAlreadyExists) {
+            if (error.is.BucketAlreadyExists) {
                 log.info('created management database');
                 return callback();
             }

--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -1037,7 +1037,7 @@ function batchDelete(request, response, log, callback) {
                 _loc.deleteVersion = true;
             }
             dataWrapper.data.delete(_loc, log, err => {
-                if (err && err.ObjNotFound) {
+                if (err?.is.ObjNotFound) {
                     log.info('batch delete: data location do not exist', {
                         method: 'batchDelete',
                         location: loc,

--- a/lib/services.js
+++ b/lib/services.js
@@ -40,7 +40,7 @@ const services = {
                 // buckets to list. By returning an empty array, the
                 // getService API will just respond with the user info
                 // without listing any buckets.
-                if (err && err.NoSuchBucket) {
+                if (err?.is.NoSuchBucket) {
                     log.trace('no buckets found');
                     // If we checked the old user bucket, that means we
                     // already checked the new user bucket. If neither the
@@ -551,7 +551,7 @@ const services = {
         // If the MPU was initiated, the mpu bucket should exist.
         const mpuBucketName = `${constants.mpuBucketPrefix}${bucketName}`;
         metadata.getBucket(mpuBucketName, log, (err, mpuBucket) => {
-            if (err && err.NoSuchBucket) {
+            if (err?.is.NoSuchBucket) {
                 log.debug('bucket not found in metadata', { error: err,
                     method: 'services.metadataValidateMultipart' });
                 return cb(errors.NoSuchUpload);
@@ -573,7 +573,7 @@ const services = {
             metadata.getObjectMD(mpuBucket.getName(), mpuOverviewKey,
                 {}, log, (err, storedMetadata) => {
                     if (err) {
-                        if (err.NoSuchKey) {
+                        if (err.is.NoSuchKey) {
                             return cb(errors.NoSuchUpload);
                         }
                         log.error('error from metadata', { error: err });
@@ -749,7 +749,7 @@ const services = {
         assert.strictEqual(typeof bucketName, 'string');
         const MPUBucketName = `${constants.mpuBucketPrefix}${bucketName}`;
         metadata.getBucket(MPUBucketName, log, (err, bucket) => {
-            if (err && err.NoSuchBucket) {
+            if (err?.is.NoSuchBucket) {
                 log.trace('no buckets found');
                 const creationDate = new Date().toJSON();
                 const mpuBucket = new BucketInfo(MPUBucketName,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "github:scality/Arsenal#8.1.38",
+    "arsenal": "git+https://github.com/scality/Arsenal.git#8.1.47",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",
@@ -46,14 +46,14 @@
     "utf-8-validate": "^5.0.8",
     "utf8": "~2.1.1",
     "uuid": "^8.3.2",
-    "vaultclient": "scality/vaultclient#8.3.3",
+    "vaultclient": "scality/vaultclient#8.3.5",
     "werelogs": "scality/werelogs#8.1.0",
     "ws": "^5.1.0",
     "xml2js": "~0.4.16"
   },
   "devDependencies": {
     "bluebird": "^3.3.1",
-    "eslint": "^5.3.0",
+    "eslint": "^8.14.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-config-scality": "scality/Guidelines#8.2.0",
     "eslint-plugin-import": "^2.14.0",

--- a/tests/functional/aws-node-sdk/test/bucket/deleteBucketReplication.js
+++ b/tests/functional/aws-node-sdk/test/bucket/deleteBucketReplication.js
@@ -81,7 +81,7 @@ describe('aws-node-sdk test deleteBucketReplication', () => {
             }),
             next => deleteReplicationAndCheckResponse(bucket, next),
             next => s3.getBucketReplication({ Bucket: bucket }, err => {
-                assert(errors.ReplicationConfigurationNotFoundError[err.code]);
+                assert(errors.ReplicationConfigurationNotFoundError.is[err.code]);
                 return next();
             }),
         ], done));

--- a/tests/functional/aws-node-sdk/test/bucket/getBucketReplication.js
+++ b/tests/functional/aws-node-sdk/test/bucket/getBucketReplication.js
@@ -45,7 +45,7 @@ describe('aws-node-sdk test getBucketReplication', () => {
     it("should return 'ReplicationConfigurationNotFoundError' if bucket does " +
     'not have a replication configuration', done =>
         s3.getBucketReplication({ Bucket: bucket }, err => {
-            assert(errors.ReplicationConfigurationNotFoundError[err.code]);
+            assert(errors.ReplicationConfigurationNotFoundError.is[err.code]);
             return done();
         }));
 

--- a/tests/functional/aws-node-sdk/test/object/getObjectLegalHold.js
+++ b/tests/functional/aws-node-sdk/test/object/getObjectLegalHold.js
@@ -12,6 +12,10 @@ const bucket = 'mock-bucket-lock';
 const unlockedBucket = 'mock-bucket-no-lock';
 const key = 'mock-object-legalhold';
 const keyNoHold = 'mock-object-no-legalhold';
+const nonExistingId = process.env.AWS_ON_AIR ?
+    'MhhyTHhmZ4cxSi4Y9SMe5P7UJAz7HLJ9' :
+    '3939393939393939393936493939393939393939756e6437';
+
 
 const isCEPH = process.env.CI_CEPH !== undefined;
 const describeSkipIfCeph = isCEPH ? describe.skip : describe;
@@ -89,7 +93,7 @@ describeSkipIfCeph('GET object legal hold', () => {
             s3.getObjectLegalHold({
                 Bucket: bucket,
                 Key: key,
-                VersionId: '000000000000',
+                VersionId: nonExistingId,
             }, err => {
                 checkError(err, 'NoSuchVersion', 404);
                 done();

--- a/tests/functional/aws-node-sdk/test/object/getPartSize.js
+++ b/tests/functional/aws-node-sdk/test/object/getPartSize.js
@@ -117,7 +117,7 @@ describe('Part size tests with object head', () => {
                 partNumbers.forEach(part => {
                     it(`should return the size of part ${part + 1} ` +
                         `when --part-number is set to ${part + 1}`, done => {
-                        const partNumber = Number.parseInt(part, 0) + 1;
+                        const partNumber = Number.parseInt(part, 10) + 1;
                         const partSize = bodySize + partNumber;
 
                         s3.headObject({ Bucket: bucket, Key: object, PartNumber: partNumber }, (err, data) => {

--- a/tests/functional/aws-node-sdk/test/object/getRetention.js
+++ b/tests/functional/aws-node-sdk/test/object/getRetention.js
@@ -13,6 +13,9 @@ const bucketName = 'lockenabledbucket';
 const unlockedBucket = 'locknotenabledbucket';
 const objectName = 'putobjectretentionobject';
 const noRetentionObject = 'objectwithnoretention';
+const nonExistingId = process.env.AWS_ON_AIR ?
+    'MhhyTHhmZ4cxSi4Y9SMe5P7UJAz7HLJ9' :
+    '3939393939393939393936493939393939393939756e6437';
 
 const retainDate = moment().add(1, 'days').toISOString();
 
@@ -109,7 +112,7 @@ describeSkipIfCeph('GET object retention', () => {
             s3.getObjectRetention({
                 Bucket: bucketName,
                 Key: objectName,
-                VersionId: '000000000000',
+                VersionId: nonExistingId,
             }, err => {
                 checkError(err, 'NoSuchVersion', 404);
                 done();

--- a/tests/functional/aws-node-sdk/test/object/putObjectLegalHold.js
+++ b/tests/functional/aws-node-sdk/test/object/putObjectLegalHold.js
@@ -8,6 +8,9 @@ const changeObjectLock = require('../../../../utilities/objectLock-util');
 const bucket = 'mock-bucket-lock';
 const unlockedBucket = 'mock-bucket-no-lock';
 const key = 'mock-object';
+const nonExistingId = process.env.AWS_ON_AIR ?
+    'MhhyTHhmZ4cxSi4Y9SMe5P7UJAz7HLJ9' :
+    '3939393939393939393936493939393939393939756e6437';
 
 const mockLegalHold = {
     empty: {},
@@ -101,7 +104,7 @@ describeSkipIfCeph('PUT object legal hold', () => {
             s3.putObjectLegalHold({
                 Bucket: bucket,
                 Key: key,
-                VersionId: '000000000000',
+                VersionId: nonExistingId,
                 LegalHold: mockLegalHold.on,
             }, err => {
                 checkError(err, 'NoSuchVersion', 404);

--- a/tests/functional/aws-node-sdk/test/object/putRetention.js
+++ b/tests/functional/aws-node-sdk/test/object/putRetention.js
@@ -9,6 +9,9 @@ const changeObjectLock = require('../../../../utilities/objectLock-util');
 const bucketName = 'lockenabledputbucket';
 const unlockedBucket = 'locknotenabledputbucket';
 const objectName = 'putobjectretentionobject';
+const nonExistingId = process.env.AWS_ON_AIR ?
+    'MhhyTHhmZ4cxSi4Y9SMe5P7UJAz7HLJ9' :
+    '3939393939393939393936493939393939393939756e6437';
 
 const retentionConfig = {
     Mode: 'GOVERNANCE',
@@ -82,7 +85,7 @@ describeSkipIfCeph('PUT object retention', () => {
             s3.putObjectRetention({
                 Bucket: bucketName,
                 Key: objectName,
-                VersionId: '000000000000',
+                VersionId: nonExistingId,
                 Retention: retentionConfig,
             }, err => {
                 checkError(err, 'NoSuchVersion', 404);

--- a/tests/functional/metadata/MongoClientInterface.js
+++ b/tests/functional/metadata/MongoClientInterface.js
@@ -221,7 +221,7 @@ runIfMongo('MongoClientInterface', () => {
                 // new version entry should not have been created
                 (id, next) => getObject({ versionId: id }, err => {
                     assert(err);
-                    assert(err.NoSuchKey);
+                    assert(err.is.NoSuchKey);
                     return next();
                 }),
             ], done);

--- a/tests/multipleBackend/backendHealthcheckResponse.js
+++ b/tests/multipleBackend/backendHealthcheckResponse.js
@@ -1,6 +1,5 @@
 'use strict'; // eslint-disable-line strict
 const assert = require('assert');
-const { errors } = require('arsenal');
 const DummyRequestLogger = require('../unit/helpers').DummyRequestLogger;
 const clientCheck
     = require('../../lib/utilities/healthcheckHandler').clientCheck;
@@ -71,7 +70,7 @@ describe.skip('Healthcheck response', () => {
                 const azureLocationNonExistContainerError =
                     results[azureLocationNonExistContainer].error;
                 if (err) {
-                    assert.strictEqual(err, errors.InternalError,
+                    assert(err.is.InternalError,
                         `got unexpected err in clientCheck: ${err}`);
                     assert(azureLocationNonExistContainerError.startsWith(
                         'The specified container is being deleted.'));

--- a/tests/multipleBackend/multipartUpload.js
+++ b/tests/multipleBackend/multipartUpload.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const async = require('async');
 const AWS = require('aws-sdk');
 const { parseString } = require('xml2js');
-const { errors, models } = require('arsenal');
+const { models } = require('arsenal');
 
 const BucketInfo = models.BucketInfo;
 const { getRealAwsConfig } =
@@ -475,8 +475,8 @@ describe.skip('Multipart Upload API with AWS Backend', function mpuTestSuite() {
                     if (isCEPH) {
                         wantedDesc = 'Error returned from AWS: null';
                     }
-                    assert.deepStrictEqual(err, errors.ServiceUnavailable
-                      .customizeDescription(wantedDesc));
+                    assert.strictEqual(err.is.ServiceUnavailable, true);
+                    assert.deepStrictEqual(err.description, wantedDesc);
                     done();
                 });
             });
@@ -527,7 +527,7 @@ describe.skip('Multipart Upload API with AWS Backend', function mpuTestSuite() {
         const fakeKey = `key-${Date.now()}`;
         const delParams = getDeleteParams(fakeKey, fakeUploadId);
         multipartDelete(authInfo, delParams, log, err => {
-            assert.equal(err, errors.NoSuchUpload,
+            assert.strictEqual(err.is.NoSuchUpload, true,
                 `Error aborting MPU: ${err}`);
             done();
         });
@@ -653,7 +653,7 @@ describe.skip('Multipart Upload API with AWS Backend', function mpuTestSuite() {
             const compParams = getCompleteParams(objectKey, uploadId);
             compParams.post = errorBody;
             completeMultipartUpload(authInfo, compParams, log, err => {
-                assert.deepStrictEqual(err, errors.InvalidPart);
+                assert.strictEqual(err.is.InvalidPart, true);
                 done();
             });
         });
@@ -675,7 +675,7 @@ describe.skip('Multipart Upload API with AWS Backend', function mpuTestSuite() {
             const compParams = getCompleteParams(objectKey, uploadId);
             compParams.post = errorBody;
             completeMultipartUpload(authInfo, compParams, log, err => {
-                assert.deepStrictEqual(err, errors.InvalidPartOrder);
+                assert.strictEqual(err.is.InvalidPartOrder, true);
                 done();
             });
         });
@@ -704,7 +704,7 @@ describe.skip('Multipart Upload API with AWS Backend', function mpuTestSuite() {
                 const compParams = getCompleteParams(objectKey, uploadId);
                 compParams.post = errorBody;
                 completeMultipartUpload(authInfo, compParams, log, err => {
-                    assert.deepStrictEqual(err, errors.EntityTooSmall);
+                    assert.strictEqual(err.is.EntityTooSmall, true);
                     done();
                 });
             });
@@ -842,7 +842,7 @@ describe.skip('Multipart Upload API with AWS Backend', function mpuTestSuite() {
                     (uploadId, next) => {
                         const listParams = getListParams(objectKey, uploadId);
                         listParts(authInfo, listParams, log, err => {
-                            assert(err.NoSuchUpload);
+                            assert.strictEqual(err.is.NoSuchUpload, true);
                             next();
                         });
                     },

--- a/tests/multipleBackend/objectPut.js
+++ b/tests/multipleBackend/objectPut.js
@@ -60,7 +60,7 @@ function put(bucketLoc, objLoc, requestHost, cb, errorDescription) {
             resHeaders) => {
             if (errorDescription) {
                 assert.strictEqual(err.code, 400);
-                assert(err.InvalidArgument);
+                assert(err.is.InvalidArgument);
                 assert(err.description.indexOf(errorDescription) > -1);
             } else {
                 assert.strictEqual(err, null, `Error putting object: ${err}`);

--- a/tests/multipleBackend/objectPutCopyPart.js
+++ b/tests/multipleBackend/objectPutCopyPart.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const async = require('async');
 const { parseString } = require('xml2js');
 const AWS = require('aws-sdk');
-const { storage } = require('arsenal');
+const { storage, errors } = require('arsenal');
 
 const { cleanup, DummyRequestLogger, makeAuthInfo }
     = require('../unit/helpers');
@@ -154,8 +154,7 @@ errorPutCopyPart) {
         return objectPutCopyPart(authInfo, copyPartReq,
             bucketName, sourceObjName, undefined, log, (err, copyResult) => {
                 if (errorPutCopyPart) {
-                    assert.strictEqual(err.code, errorPutCopyPart.statusCode);
-                    assert(err[errorPutCopyPart.code]);
+                    assert.strictEqual(err.is[errorPutCopyPart.type], true);
                     return cb();
                 }
                 assert.strictEqual(err, null);
@@ -300,9 +299,8 @@ function testSuite() {
     itSkipCeph('should return error 403 AccessDenied copying part to a ' +
     'different AWS location without object READ access',
     done => {
-        const errorPutCopyPart = { code: 'AccessDenied', statusCode: 403 };
         copyPutPart(null, awsLocation, awsLocation2, 'localhost', done,
-        errorPutCopyPart);
+            errors.AccessDenied);
     });
 
 

--- a/tests/multipleBackend/objectPutPart.js
+++ b/tests/multipleBackend/objectPutPart.js
@@ -102,7 +102,7 @@ errorDescription) {
     (err, json) => {
         if (errorDescription) {
             assert.strictEqual(err.code, 400);
-            assert(err.InvalidArgument);
+            assert(err.is.InvalidArgument);
             assert(err.description.indexOf(errorDescription) > -1);
             return cb();
         }

--- a/tests/unit/api/apiUtils/objectLockHelpers.js
+++ b/tests/unit/api/apiUtils/objectLockHelpers.js
@@ -37,7 +37,7 @@ describe('objectLockHelpers: validateHeaders', () => {
             = validateHeaders(objLockDisabledBucketInfo, headers, log);
         const expectedError = errors.InvalidRequest.customizeDescription(
             'Bucket is missing ObjectLockConfiguration');
-        assert.strictEqual(objectLockValidationError.InvalidRequest, true);
+        assert.strictEqual(objectLockValidationError.is.InvalidRequest, true);
         assert.strictEqual(objectLockValidationError.description,
             expectedError.description);
     });
@@ -90,7 +90,7 @@ describe('objectLockHelpers: validateHeaders', () => {
         const expectedError = errors.InvalidArgument.customizeDescription(
             'x-amz-object-lock-retain-until-date and x-amz-object-lock-mode ' +
             'must both be supplied');
-        assert.strictEqual(objectLockValidationError.InvalidArgument, true);
+        assert.strictEqual(objectLockValidationError.is.InvalidArgument, true);
         assert.strictEqual(objectLockValidationError.description,
             expectedError.description);
     });
@@ -104,7 +104,7 @@ describe('objectLockHelpers: validateHeaders', () => {
         const expectedError = errors.InvalidArgument.customizeDescription(
             'x-amz-object-lock-retain-until-date and x-amz-object-lock-mode ' +
             'must both be supplied');
-        assert.strictEqual(objectLockValidationError.InvalidArgument, true);
+        assert.strictEqual(objectLockValidationError.is.InvalidArgument, true);
         assert.strictEqual(objectLockValidationError.description,
             expectedError.description);
     });
@@ -118,7 +118,7 @@ describe('objectLockHelpers: validateHeaders', () => {
             'The retain until date must be in the future!');
         const objectLockValidationError
             = validateHeaders(bucketInfo, headers, log);
-        assert.strictEqual(objectLockValidationError.InvalidArgument, true);
+        assert.strictEqual(objectLockValidationError.is.InvalidArgument, true);
         assert.strictEqual(objectLockValidationError.description,
             expectedError.description);
     });
@@ -131,7 +131,7 @@ describe('objectLockHelpers: validateHeaders', () => {
             = validateHeaders(bucketInfo, headers, log);
         const expectedError = errors.InvalidArgument.customizeDescription(
             'Legal hold status must be one of "ON", "OFF"');
-        assert.strictEqual(objectLockValidationError.InvalidArgument, true);
+        assert.strictEqual(objectLockValidationError.is.InvalidArgument, true);
         assert.strictEqual(objectLockValidationError.description,
             expectedError.description);
     });
@@ -145,7 +145,7 @@ describe('objectLockHelpers: validateHeaders', () => {
             = validateHeaders(bucketInfo, headers, log);
         const expectedError = errors.InvalidArgument.customizeDescription(
             'Unknown wormMode directive');
-        assert.strictEqual(objectLockValidationError.InvalidArgument, true);
+        assert.strictEqual(objectLockValidationError.is.InvalidArgument, true);
         assert.strictEqual(objectLockValidationError.description,
             expectedError.description);
     });
@@ -207,7 +207,7 @@ describe('objectLockHelpers: validateObjectLockUpdate', () => {
         };
 
         const error = validateObjectLockUpdate(objMD, retentionInfo, false);
-        assert.deepStrictEqual(error, errors.AccessDenied);
+        assert.strictEqual(error.is.AccessDenied, true);
     });
 
     it('should disallow COMPLIANCE => GOVERNANCE if retention is not expired', () => {
@@ -222,7 +222,7 @@ describe('objectLockHelpers: validateObjectLockUpdate', () => {
         };
 
         const error = validateObjectLockUpdate(objMD, retentionInfo);
-        assert.deepStrictEqual(error, errors.AccessDenied);
+        assert.strictEqual(error.is.AccessDenied, true);
     });
 
     it('should allow COMPLIANCE => GOVERNANCE if retention is expired', () => {
@@ -282,7 +282,7 @@ describe('objectLockHelpers: validateObjectLockUpdate', () => {
         };
 
         const error = validateObjectLockUpdate(objMD, retentionInfo);
-        assert.deepStrictEqual(error, errors.AccessDenied);
+        assert.strictEqual(error.is.AccessDenied, true);
     });
 
     it('should allow shortening retention period if in GOVERNANCE', () => {

--- a/tests/unit/api/apiUtils/versioning.js
+++ b/tests/unit/api/apiUtils/versioning.js
@@ -425,7 +425,7 @@ describe('versioning helpers', () => {
                 'foobucket', mockBucketMD, testCase.objMD,
                 testCase.reqVersionId, null, (err, options) => {
                     if (testCase.expectedError) {
-                        assert.strictEqual(err, testCase.expectedError);
+                        assert.strictEqual(err.is[testCase.expectedError.type], true);
                     } else {
                         assert.ifError(err);
                         assert.deepStrictEqual(options, testCase.expectedRes);

--- a/tests/unit/api/bucketDelete.js
+++ b/tests/unit/api/bucketDelete.js
@@ -2,7 +2,6 @@ const crypto = require('crypto');
 const assert = require('assert');
 const async = require('async');
 const { parseString } = require('xml2js');
-const { errors } = require('arsenal');
 
 const bucketDelete = require('../../../lib/api/bucketDelete');
 const { bucketPut } = require('../../../lib/api/bucketPut');
@@ -112,7 +111,7 @@ describe('bucketDelete API', () => {
             objectPut(authInfo, testPutObjectRequest, undefined, log, err => {
                 assert.strictEqual(err, null);
                 bucketDelete(authInfo, testRequest, log, err => {
-                    assert.deepStrictEqual(err, errors.BucketNotEmpty);
+                    assert.strictEqual(err.is.BucketNotEmpty, true);
                     metadata.getBucket(bucketName, log, (err, md) => {
                         assert.strictEqual(md.getName(), bucketName);
                         metadata.listObject(usersBucket,
@@ -146,7 +145,7 @@ describe('bucketDelete API', () => {
         bucketPut(authInfo, testRequest, log, () => {
             bucketDelete(authInfo, testRequest, log, () => {
                 metadata.getBucket(bucketName, log, (err, md) => {
-                    assert.deepStrictEqual(err, errors.NoSuchBucket);
+                    assert.strictEqual(err.is.NoSuchBucket, true);
                     assert.strictEqual(md, undefined);
                     metadata.listObject(usersBucket, { prefix: canonicalID },
                         log, (err, listResponse) => {
@@ -169,7 +168,7 @@ describe('bucketDelete API', () => {
     it('should prevent anonymous user delete bucket API access', done => {
         const publicAuthInfo = makeAuthInfo(constants.publicId);
         bucketDelete(publicAuthInfo, testRequest, log, err => {
-            assert.deepStrictEqual(err, errors.AccessDenied);
+            assert.strictEqual(err.is.AccessDenied, true);
             done();
         });
     });

--- a/tests/unit/api/bucketGet.js
+++ b/tests/unit/api/bucketGet.js
@@ -10,8 +10,6 @@ const objectPut = require('../../../lib/api/objectPut');
 const { cleanup, DummyRequestLogger, makeAuthInfo } = require('../helpers');
 const DummyRequest = require('../DummyRequest');
 
-const { errors } = require('arsenal');
-
 const authInfo = makeAuthInfo('accessKey1');
 const bucketName = 'bucketname';
 const delimiter = '/';
@@ -199,7 +197,7 @@ describe('bucketGet API', () => {
         const testGetRequest = Object.assign({ query: { 'max-keys': '-1' } },
             baseGetRequest);
         bucketGet(authInfo, testGetRequest, log, err => {
-            assert.deepStrictEqual(err, errors.InvalidArgument);
+            assert.strictEqual(err.is.InvalidArgument, true);
             done();
         });
     });

--- a/tests/unit/api/bucketGetLifecycle.js
+++ b/tests/unit/api/bucketGetLifecycle.js
@@ -28,7 +28,7 @@ describe('getBucketLifecycle API', () => {
     'bucket has no lifecycle', done => {
         const lifecycleRequest = getLifecycleRequest(bucketName);
         bucketGetLifecycle(authInfo, lifecycleRequest, log, err => {
-            assert.strictEqual(err.NoSuchLifecycleConfiguration, true);
+            assert.strictEqual(err.is.NoSuchLifecycleConfiguration, true);
             done();
         });
     });

--- a/tests/unit/api/bucketGetObjectLock.js
+++ b/tests/unit/api/bucketGetObjectLock.js
@@ -74,7 +74,7 @@ describe('bucketGetObjectLock API', () => {
         'object lock is not enabled on the bucket', done => {
         const objectLockRequest = getObjectLockConfigRequest(bucketName);
         bucketGetObjectLock(authInfo, objectLockRequest, log, err => {
-            assert.strictEqual(err.ObjectLockConfigurationNotFoundError, true);
+            assert.strictEqual(err.is.ObjectLockConfigurationNotFoundError, true);
             done();
         });
     });

--- a/tests/unit/api/bucketGetPolicy.js
+++ b/tests/unit/api/bucketGetPolicy.js
@@ -44,7 +44,7 @@ describe('getBucketPolicy API', () => {
     it('should return NoSuchBucketPolicy error if ' +
     'bucket has no policy', done => {
         bucketGetPolicy(authInfo, testBasicRequest, log, err => {
-            assert.strictEqual(err.NoSuchBucketPolicy, true);
+            assert.strictEqual(err.is.NoSuchBucketPolicy, true);
             done();
         });
     });

--- a/tests/unit/api/bucketHead.js
+++ b/tests/unit/api/bucketHead.js
@@ -1,5 +1,4 @@
 const assert = require('assert');
-const { errors } = require('arsenal');
 
 const bucketHead = require('../../../lib/api/bucketHead');
 const { bucketPut } = require('../../../lib/api/bucketPut');
@@ -22,7 +21,7 @@ describe('bucketHead API', () => {
 
     it('should return an error if the bucket does not exist', done => {
         bucketHead(authInfo, testRequest, log, err => {
-            assert.deepStrictEqual(err, errors.NoSuchBucket);
+            assert.strictEqual(err.is.NoSuchBucket, true);
             done();
         });
     });
@@ -31,7 +30,7 @@ describe('bucketHead API', () => {
         const otherAuthInfo = makeAuthInfo('accessKey2');
         bucketPut(otherAuthInfo, testRequest, log, () => {
             bucketHead(authInfo, testRequest, log, err => {
-                assert.deepStrictEqual(err, errors.AccessDenied);
+                assert.strictEqual(err.is.AccessDenied, true);
                 done();
             });
         });

--- a/tests/unit/api/bucketPut.js
+++ b/tests/unit/api/bucketPut.js
@@ -1,5 +1,4 @@
 const assert = require('assert');
-const { errors } = require('arsenal');
 
 const { checkLocationConstraint } = require('../../../lib/api/bucketPut');
 const { bucketPut } = require('../../../lib/api/bucketPut');
@@ -83,8 +82,8 @@ describe('checkLocationConstraint function', () => {
             if (testCheck.isError) {
                 assert.notEqual(checkLocation.error, null,
                   'Expected failure but got success');
-                assert.strictEqual(checkLocation.error.
-                  InvalidLocationConstraint, true);
+                assert.strictEqual(
+                    checkLocation.error.is.InvalidLocationConstraint, true);
             } else {
                 assert.ifError(checkLocation.error);
                 assert.strictEqual(checkLocation.locationConstraint,
@@ -105,7 +104,7 @@ describe('bucketPut API', () => {
         bucketPut(authInfo, testRequest, log, () => {
             bucketPut(otherAuthInfo, testRequest,
                 log, err => {
-                    assert.deepStrictEqual(err, errors.BucketAlreadyExists);
+                    assert.strictEqual(err.is.BucketAlreadyExists, true);
                     done();
                 });
         });
@@ -188,9 +187,9 @@ describe('bucketPut API', () => {
             post: '',
         };
         bucketPut(authInfo, testRequest, log, err => {
-            assert.deepStrictEqual(err, errors.InvalidArgument);
+            assert.strictEqual(err.is.InvalidArgument, true);
             metadata.getBucket(bucketName, log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchBucket);
+                assert.strictEqual(err.is.NoSuchBucket, true);
                 done();
             });
         });
@@ -209,9 +208,9 @@ describe('bucketPut API', () => {
             post: '',
         };
         bucketPut(authInfo, testRequest, log, err => {
-            assert.deepStrictEqual(err, errors.InvalidArgument);
+            assert.strictEqual(err.is.InvalidArgument, true);
             metadata.getBucket(bucketName, log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchBucket);
+                assert.strictEqual(err.is.NoSuchBucket, true);
                 done();
             });
         });
@@ -231,9 +230,9 @@ describe('bucketPut API', () => {
             post: '',
         };
         bucketPut(authInfo, testRequest, log, err => {
-            assert.deepStrictEqual(err, errors.UnresolvableGrantByEmailAddress);
+            assert.strictEqual(err.is.UnresolvableGrantByEmailAddress, true);
             metadata.getBucket(bucketName, log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchBucket);
+                assert.strictEqual(err.is.NoSuchBucket, true);
                 done();
             });
         });
@@ -309,7 +308,7 @@ describe('bucketPut API', () => {
     it('should prevent anonymous user from accessing putBucket API', done => {
         const publicAuthInfo = makeAuthInfo(constants.publicId);
         bucketPut(publicAuthInfo, testRequest, log, err => {
-            assert.deepStrictEqual(err, errors.AccessDenied);
+            assert.strictEqual(err.is.AccessDenied, true);
         });
         done();
     });
@@ -367,11 +366,10 @@ describe('bucketPut API', () => {
 
         it('should return error if location constraint config is not updated',
             done => bucketPut(authInfo, req, log, err => {
-                const expectedError = errors.InvalidLocationConstraint;
-                expectedError.description = 'value of the location you are ' +
+                assert.strictEqual(err.is.InvalidLocationConstraint, true);
+                assert.strictEqual(err.description, 'value of the location you are ' +
                     `attempting to set - ${newLCKey} - is not listed in the ` +
-                    'locationConstraint config';
-                assert.deepStrictEqual(err, expectedError);
+                    'locationConstraint config');
                 done();
             }));
 

--- a/tests/unit/api/bucketPutACL.js
+++ b/tests/unit/api/bucketPutACL.js
@@ -1,5 +1,4 @@
 const assert = require('assert');
-const { errors } = require('arsenal');
 
 const aclUtils = require('../../../lib/utilities/aclUtils');
 const { bucketPut } = require('../../../lib/api/bucketPut');
@@ -75,7 +74,7 @@ describe('putBucketACL API', () => {
         };
 
         bucketPutACL(authInfo, testACLRequest, log, err => {
-            assert.deepStrictEqual(err, errors.InvalidArgument);
+            assert.strictEqual(err.is.InvalidArgument, true);
             done();
         });
     });
@@ -273,7 +272,7 @@ describe('putBucketACL API', () => {
                 query: { acl: '' },
             };
             return bucketPutACL(authInfo, testACLRequest, log, err => {
-                assert.deepStrictEqual(err, errors.InvalidArgument);
+                assert.strictEqual(err.is.InvalidArgument, true);
                 done();
             });
         });
@@ -295,7 +294,7 @@ describe('putBucketACL API', () => {
         };
 
         bucketPutACL(authInfo, testACLRequest, log, err => {
-            assert.deepStrictEqual(err, errors.UnresolvableGrantByEmailAddress);
+            assert.strictEqual(err.is.UnresolvableGrantByEmailAddress, true);
             done();
         });
     });
@@ -421,7 +420,7 @@ describe('putBucketACL API', () => {
         };
 
         bucketPutACL(authInfo, testACLRequest, log, err => {
-            assert.deepStrictEqual(err, errors.MalformedACLError);
+            assert.strictEqual(err.is.MalformedACLError, true);
             done();
         });
     });
@@ -464,7 +463,7 @@ describe('putBucketACL API', () => {
         };
 
         bucketPutACL(authInfo, testACLRequest, log, err => {
-            assert.deepStrictEqual(err, errors.MalformedACLError);
+            assert.strictEqual(err.is.MalformedACLError, true);
             done();
         });
     });
@@ -496,7 +495,7 @@ describe('putBucketACL API', () => {
         };
 
         return bucketPutACL(authInfo, testACLRequest, log, err => {
-            assert.deepStrictEqual(err, errors.InvalidArgument);
+            assert.strictEqual(err.is.InvalidArgument, true);
             done();
         });
     });
@@ -527,7 +526,7 @@ describe('putBucketACL API', () => {
             query: { acl: '' },
         };
         bucketPutACL(authInfo, testACLRequest, log, err => {
-            assert.deepStrictEqual(err, errors.UnresolvableGrantByEmailAddress);
+            assert.strictEqual(err.is.UnresolvableGrantByEmailAddress, true);
             done();
         });
     });
@@ -563,7 +562,7 @@ describe('putBucketACL API', () => {
         };
 
         bucketPutACL(authInfo, testACLRequest, log, err => {
-            assert.deepStrictEqual(err, errors.MalformedACLError);
+            assert.strictEqual(err.is.MalformedACLError, true);
             done();
         });
     });
@@ -608,7 +607,7 @@ describe('putBucketACL API', () => {
         };
 
         bucketPutACL(authInfo, testACLRequest, log, err => {
-            assert.deepStrictEqual(err, errors.MalformedACLError);
+            assert.strictEqual(err.is.MalformedACLError, true);
             done();
         });
     });
@@ -643,7 +642,7 @@ describe('putBucketACL API', () => {
         };
 
         bucketPutACL(authInfo, testACLRequest, log, err => {
-            assert.deepStrictEqual(err, errors.MalformedXML);
+            assert.strictEqual(err.is.MalformedXML, true);
             done();
         });
     });
@@ -677,7 +676,7 @@ describe('putBucketACL API', () => {
         };
 
         bucketPutACL(authInfo, testACLRequest, log, err => {
-            assert.deepStrictEqual(err, errors.InvalidArgument);
+            assert.strictEqual(err.is.InvalidArgument, true);
             done();
         });
     });
@@ -698,7 +697,7 @@ describe('putBucketACL API', () => {
         };
 
         bucketPutACL(authInfo, testACLRequest, log, err => {
-            assert.deepStrictEqual(err, errors.InvalidArgument);
+            assert.strictEqual(err.is.InvalidArgument, true);
             done();
         });
     });

--- a/tests/unit/api/bucketPutCors.js
+++ b/tests/unit/api/bucketPutCors.js
@@ -129,7 +129,7 @@ describe('PUT bucket cors :: helper validation functions ', () => {
             `<ID>${testValue}</ID>`);
             parseCorsXml(xml, log, err => {
                 assert(err, 'Expected error but found none');
-                assert.deepStrictEqual(err, errors.MalformedXML);
+                assert.strictEqual(err.is.MalformedXML, true);
                 return done();
             });
         });
@@ -175,7 +175,7 @@ describe('PUT bucket cors :: helper validation functions ', () => {
                 `<MaxAgeSeconds>${testValue}</MaxAgeSeconds>`);
             parseCorsXml(xml, log, err => {
                 assert(err, 'Expected error but found none');
-                assert.deepStrictEqual(err, errors.MalformedXML);
+                assert.strictEqual(err.is.MalformedXML, true);
                 return done();
             });
         });

--- a/tests/unit/api/bucketPutEncryption.js
+++ b/tests/unit/api/bucketPutEncryption.js
@@ -25,7 +25,7 @@ describe('bucketPutEncryption API', () => {
     describe('test invalid sse configs', () => {
         it('should reject an empty config', done => {
             bucketPutEncryption(authInfo, templateRequest(bucketName, { post: '' }), log, err => {
-                assert.strictEqual(err.MalformedXML, true);
+                assert.strictEqual(err.is.MalformedXML, true);
                 done();
             });
         });
@@ -36,7 +36,7 @@ describe('bucketPutEncryption API', () => {
                 <ServerSideEncryptionConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
                 </ServerSideEncryptionConfiguration>`,
             }), log, err => {
-                assert.strictEqual(err.MalformedXML, true);
+                assert.strictEqual(err.is.MalformedXML, true);
                 done();
             });
         });
@@ -48,7 +48,7 @@ describe('bucketPutEncryption API', () => {
                 <Rule></Rule>
                 </ServerSideEncryptionConfiguration>`,
             }), log, err => {
-                assert.strictEqual(err.MalformedXML, true);
+                assert.strictEqual(err.is.MalformedXML, true);
                 done();
             });
         });
@@ -56,7 +56,7 @@ describe('bucketPutEncryption API', () => {
         it('should reject a config with no SSEAlgorithm', done => {
             const post = templateSSEConfig({});
             bucketPutEncryption(authInfo, templateRequest(bucketName, { post }), log, err => {
-                assert.strictEqual(err.MalformedXML, true);
+                assert.strictEqual(err.is.MalformedXML, true);
                 done();
             });
         });
@@ -64,7 +64,7 @@ describe('bucketPutEncryption API', () => {
         it('should reject a config with an invalid SSEAlgorithm', done => {
             const post = templateSSEConfig({ algorithm: 'InvalidAlgo' });
             bucketPutEncryption(authInfo, templateRequest(bucketName, { post }), log, err => {
-                assert.strictEqual(err.MalformedXML, true);
+                assert.strictEqual(err.is.MalformedXML, true);
                 done();
             });
         });
@@ -72,7 +72,7 @@ describe('bucketPutEncryption API', () => {
         it('should reject a config with SSEAlgorithm == AES256 and a provided KMSMasterKeyID', done => {
             const post = templateSSEConfig({ algorithm: 'AES256', keyId: '12345' });
             bucketPutEncryption(authInfo, templateRequest(bucketName, { post }), log, err => {
-                assert.strictEqual(err.InvalidArgument, true);
+                assert.strictEqual(err.is.InvalidArgument, true);
                 done();
             });
         });

--- a/tests/unit/api/bucketPutObjectLock.js
+++ b/tests/unit/api/bucketPutObjectLock.js
@@ -48,7 +48,7 @@ describe('putBucketObjectLock API', () => {
 
         it('should return InvalidBucketState error', done => {
             bucketPutObjectLock(authInfo, putObjLockRequest, log, err => {
-                assert.strictEqual(err.InvalidBucketState, true);
+                assert.strictEqual(err.is.InvalidBucketState, true);
                 done();
             });
         });

--- a/tests/unit/api/bucketPutPolicy.js
+++ b/tests/unit/api/bucketPutPolicy.js
@@ -70,7 +70,7 @@ describe('putBucketPolicy API', () => {
         expectedBucketPolicy.Statement[0].Resource = 'arn:aws::s3:::badname';
         bucketPutPolicy(authInfo, getPolicyRequest(expectedBucketPolicy),
         log, err => {
-            assert.strictEqual(err.MalformedPolicy, true);
+            assert.strictEqual(err.is.MalformedPolicy, true);
             assert.strictEqual(err.description, 'Policy has invalid resource');
             return done();
         });
@@ -81,7 +81,7 @@ describe('putBucketPolicy API', () => {
             { StringEquals: { 's3:x-amz-acl': ['public-read'] } };
         bucketPutPolicy(authInfo, getPolicyRequest(expectedBucketPolicy), log,
         err => {
-            assert.strictEqual(err.NotImplemented, true);
+            assert.strictEqual(err.is.NotImplemented, true);
             done();
         });
     });
@@ -90,7 +90,7 @@ describe('putBucketPolicy API', () => {
         expectedBucketPolicy.Statement[0].Principal = { Service: ['test.com'] };
         bucketPutPolicy(authInfo, getPolicyRequest(expectedBucketPolicy), log,
         err => {
-            assert.strictEqual(err.NotImplemented, true);
+            assert.strictEqual(err.is.NotImplemented, true);
             done();
         });
     });
@@ -100,7 +100,7 @@ describe('putBucketPolicy API', () => {
             { Federated: 'www.test.com' };
         bucketPutPolicy(authInfo, getPolicyRequest(expectedBucketPolicy), log,
         err => {
-            assert.strictEqual(err.NotImplemented, true);
+            assert.strictEqual(err.is.NotImplemented, true);
             done();
         });
     });

--- a/tests/unit/api/bucketPutReplication.js
+++ b/tests/unit/api/bucketPutReplication.js
@@ -15,7 +15,7 @@ function checkError(xml, expectedErr, cb) {
         if (expectedErr === null) {
             assert.strictEqual(err, null, `expected no error but got '${err}'`);
         } else {
-            assert(err[expectedErr], 'incorrect error response: should be ' +
+            assert(err.is[expectedErr], 'incorrect error response: should be ' +
                 `'Error: ${expectedErr}' but got '${err}'`);
         }
         return cb();

--- a/tests/unit/api/bucketPutVersioning.js
+++ b/tests/unit/api/bucketPutVersioning.js
@@ -138,7 +138,7 @@ describe('bucketPutVersioning API', () => {
                 next => {
                     const request = _putVersioningRequest(xmlSuspendVersioning);
                     bucketPutVersioning(authInfo, request, log, err => {
-                        assert(err.InvalidBucketState);
+                        assert(err.is.InvalidBucketState);
                         next();
                     });
                 },

--- a/tests/unit/api/deletedFlagBucket.js
+++ b/tests/unit/api/deletedFlagBucket.js
@@ -1,6 +1,5 @@
 const crypto = require('crypto');
 const assert = require('assert');
-const { errors } = require('arsenal');
 
 const BucketInfo = require('arsenal').models.BucketInfo;
 const { bucketGet } = require('../../../lib/api/bucketGet');
@@ -96,7 +95,7 @@ function confirmDeleted(done) {
         process.nextTick(() => {
             process.nextTick(() => {
                 metadata.getBucket(bucketName, log, err => {
-                    assert.deepStrictEqual(err, errors.NoSuchBucket);
+                    assert.strictEqual(err.is.NoSuchBucket, true);
                     return checkBucketListing(authInfo, bucketName, 0, done);
                 });
             });
@@ -138,7 +137,7 @@ describe('deleted flag bucket handling', () => {
         'different account sends put bucket request for bucket with ' +
         'deleted flag', done => {
         bucketPut(otherAccountAuthInfo, baseTestRequest, log, err => {
-            assert.deepStrictEqual(err, errors.BucketAlreadyExists);
+            assert.strictEqual(err.is.BucketAlreadyExists, true);
             metadata.getBucket(bucketName, log, (err, data) => {
                 assert.strictEqual(data._transient, false);
                 assert.strictEqual(data._deleted, true);
@@ -193,7 +192,7 @@ describe('deleted flag bucket handling', () => {
                 'x-amz-acl': 'public-read' }, 'headers',
                 baseTestRequest, baseTestRequest.headers);
             bucketPutACL(otherAccountAuthInfo, putACLRequest, log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchBucket);
+                assert.strictEqual(err.is.NoSuchBucket, true);
                 metadata.getBucket(bucketName, log, (err, data) => {
                     assert.strictEqual(data._deleted, true);
                     assert.strictEqual(data._transient, false);
@@ -212,7 +211,7 @@ describe('deleted flag bucket handling', () => {
                 baseTestRequest, baseTestRequest.headers);
             const unauthorizedAccount = makeAuthInfo('keepMeOut');
             bucketPutACL(unauthorizedAccount, putACLRequest, log, err => {
-                assert.deepStrictEqual(err, errors.AccessDenied);
+                assert.strictEqual(err.is.AccessDenied, true);
                 metadata.getBucket(bucketName, log, (err, data) => {
                     assert.strictEqual(data._deleted, true);
                     assert.strictEqual(data._transient, false);
@@ -266,7 +265,7 @@ describe('deleted flag bucket handling', () => {
         const postBody = Buffer.from('I am a body', 'utf8');
         const putObjRequest = new DummyRequest(setUpRequest, postBody);
         objectPut(otherAccountAuthInfo, putObjRequest, undefined, log, err => {
-            assert.deepStrictEqual(err, errors.NoSuchBucket);
+            assert.strictEqual(err.is.NoSuchBucket, true);
             done();
         });
     });
@@ -314,7 +313,7 @@ describe('deleted flag bucket handling', () => {
         initiateRequest.objectKey = 'objectName';
         initiateMultipartUpload(otherAccountAuthInfo, initiateRequest, log,
             err => {
-                assert.deepStrictEqual(err, errors.NoSuchBucket);
+                assert.strictEqual(err.is.NoSuchBucket, true);
                 done();
             });
     });
@@ -331,7 +330,7 @@ describe('deleted flag bucket handling', () => {
         'authorized', done => {
         bucketDelete(otherAccountAuthInfo, baseTestRequest,
             log, err => {
-                assert.deepStrictEqual(err, errors.AccessDenied);
+                assert.strictEqual(err.is.AccessDenied, true);
                 done();
             });
     });
@@ -340,7 +339,7 @@ describe('deleted flag bucket handling', () => {
         'NoSuchBucket error and complete deletion', done => {
         bucketDeleteWebsite(authInfo, baseTestRequest,
             log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchBucket);
+                assert.strictEqual(err.is.NoSuchBucket, true);
                 confirmDeleted(done);
             });
     });
@@ -349,7 +348,7 @@ describe('deleted flag bucket handling', () => {
         'NoSuchBucket error and complete deletion', done => {
         bucketGet(authInfo, baseTestRequest,
             log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchBucket);
+                assert.strictEqual(err.is.NoSuchBucket, true);
                 confirmDeleted(done);
             });
     });
@@ -358,7 +357,7 @@ describe('deleted flag bucket handling', () => {
         'NoSuchBucket error and complete deletion', done => {
         bucketGetACL(authInfo, baseTestRequest,
             log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchBucket);
+                assert.strictEqual(err.is.NoSuchBucket, true);
                 confirmDeleted(done);
             });
     });
@@ -367,7 +366,7 @@ describe('deleted flag bucket handling', () => {
     'NoSuchBucket error and complete deletion', done => {
         bucketGetCors(authInfo, baseTestRequest,
         log, err => {
-            assert.deepStrictEqual(err, errors.NoSuchBucket);
+            assert.strictEqual(err.is.NoSuchBucket, true);
             confirmDeleted(done);
         });
     });
@@ -383,7 +382,7 @@ describe('deleted flag bucket handling', () => {
         bucketPutCorsRequest.headers['content-md5'] = crypto.createHash('md5')
             .update(bucketPutCorsRequest.post, 'utf8').digest('base64');
         bucketPutCors(authInfo, bucketPutCorsRequest, log, err => {
-            assert.deepStrictEqual(err, errors.NoSuchBucket);
+            assert.strictEqual(err.is.NoSuchBucket, true);
             confirmDeleted(done);
         });
     });
@@ -391,7 +390,7 @@ describe('deleted flag bucket handling', () => {
     it('bucketDeleteCors request on bucket with delete flag should return ' +
         'NoSuchBucket error and complete deletion', done => {
         bucketDeleteCors(authInfo, baseTestRequest, log, err => {
-            assert.deepStrictEqual(err, errors.NoSuchBucket);
+            assert.strictEqual(err.is.NoSuchBucket, true);
             confirmDeleted(done);
         });
     });
@@ -400,7 +399,7 @@ describe('deleted flag bucket handling', () => {
     'NoSuchBucket error and complete deletion', done => {
         bucketGetWebsite(authInfo, baseTestRequest,
         log, err => {
-            assert.deepStrictEqual(err, errors.NoSuchBucket);
+            assert.strictEqual(err.is.NoSuchBucket, true);
             confirmDeleted(done);
         });
     });
@@ -414,7 +413,7 @@ describe('deleted flag bucket handling', () => {
         '</WebsiteConfiguration>';
         bucketPutWebsite(authInfo, bucketPutWebsiteRequest,
         log, err => {
-            assert.deepStrictEqual(err, errors.NoSuchBucket);
+            assert.strictEqual(err.is.NoSuchBucket, true);
             confirmDeleted(done);
         });
     });
@@ -423,7 +422,7 @@ describe('deleted flag bucket handling', () => {
         'NoSuchBucket error and complete deletion', done => {
         bucketHead(authInfo, baseTestRequest,
             log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchBucket);
+                assert.strictEqual(err.is.NoSuchBucket, true);
                 confirmDeleted(done);
             });
     });
@@ -438,13 +437,13 @@ describe('deleted flag bucket handling', () => {
         if (extraArgNeeded) {
             return apiAction(authInfo, mpuRequest, undefined,
                 log, err => {
-                    assert.deepStrictEqual(err, errors.NoSuchUpload);
+                    assert.strictEqual(err.is.NoSuchUpload, true);
                     return done();
                 });
         }
         return apiAction(authInfo, mpuRequest,
             log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchUpload);
+                assert.strictEqual(err.is.NoSuchUpload, true);
                 return done();
             });
     }
@@ -495,7 +494,7 @@ describe('deleted flag bucket handling', () => {
         listRequest.query = {};
         listMultipartUploads(authInfo, listRequest,
             log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchBucket);
+                assert.strictEqual(err.is.NoSuchBucket, true);
                 done();
             });
     });
@@ -505,7 +504,7 @@ describe('deleted flag bucket handling', () => {
         done => {
             objectGet(authInfo, baseTestRequest, false,
             log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchBucket);
+                assert.strictEqual(err.is.NoSuchBucket, true);
                 confirmDeleted(done);
             });
         });
@@ -514,7 +513,7 @@ describe('deleted flag bucket handling', () => {
         'NoSuchBucket error and complete deletion', done => {
         objectGetACL(authInfo, baseTestRequest,
         log, err => {
-            assert.deepStrictEqual(err, errors.NoSuchBucket);
+            assert.strictEqual(err.is.NoSuchBucket, true);
             confirmDeleted(done);
         });
     });
@@ -523,7 +522,7 @@ describe('deleted flag bucket handling', () => {
         'NoSuchBucket error and complete deletion', done => {
         objectHead(authInfo, baseTestRequest,
         log, err => {
-            assert.deepStrictEqual(err, errors.NoSuchBucket);
+            assert.strictEqual(err.is.NoSuchBucket, true);
             confirmDeleted(done);
         });
     });
@@ -532,7 +531,7 @@ describe('deleted flag bucket handling', () => {
         'NoSuchBucket error and complete deletion', done => {
         objectPutACL(authInfo, baseTestRequest,
         log, err => {
-            assert.deepStrictEqual(err, errors.NoSuchBucket);
+            assert.strictEqual(err.is.NoSuchBucket, true);
             confirmDeleted(done);
         });
     });
@@ -541,7 +540,7 @@ describe('deleted flag bucket handling', () => {
         'NoSuchBucket error', done => {
         objectDelete(authInfo, baseTestRequest,
         log, err => {
-            assert.deepStrictEqual(err, errors.NoSuchBucket);
+            assert.strictEqual(err.is.NoSuchBucket, true);
             confirmDeleted(done);
         });
     });

--- a/tests/unit/api/multipartDelete.js
+++ b/tests/unit/api/multipartDelete.js
@@ -2,8 +2,6 @@ const assert = require('assert');
 const async = require('async');
 const { parseString } = require('xml2js');
 
-const { errors } = require('arsenal');
-
 const { cleanup, DummyRequestLogger } = require('../helpers');
 const { config } = require('../../../lib/Config');
 const DummyRequest = require('../DummyRequest');
@@ -123,7 +121,7 @@ describe('Multipart Delete API', () => {
     'exist and legacyAwsBehavior set to true',
     done => {
         _createAndAbortMpu(true, true, eastLocation, err => {
-            assert.strictEqual(err, errors.NoSuchUpload,
+            assert.strictEqual(err.is.NoSuchUpload, true,
                 `Expected NoSuchUpload, got ${err}`);
             done();
         });

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -169,7 +169,7 @@ describe('Multipart Upload API', () => {
         'no destination bucket', done => {
         initiateMultipartUpload(authInfo, initiateRequest,
             log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchBucket);
+                assert.strictEqual(err.is.NoSuchBucket, true);
                 done();
             });
     });
@@ -316,7 +316,7 @@ describe('Multipart Upload API', () => {
             }, postBody);
             objectPutPart(authInfo, partRequest, undefined, log,
                 (err, result) => {
-                    assert.deepStrictEqual(err, errors.TooManyParts);
+                    assert.strictEqual(err.is.TooManyParts, true);
                     assert.strictEqual(result, undefined);
                     done();
                 });
@@ -352,7 +352,7 @@ describe('Multipart Upload API', () => {
             }, postBody);
             objectPutPart(authInfo, partRequest, undefined, log,
                 (err, result) => {
-                    assert.deepStrictEqual(err, errors.InvalidArgument);
+                    assert.strictEqual(err.is.InvalidArgument, true);
                     assert.strictEqual(result, undefined);
                     done();
                 });
@@ -395,7 +395,7 @@ describe('Multipart Upload API', () => {
             }, postBody);
             objectPutPart(authInfo, partRequest, undefined,
                 log, (err, result) => {
-                    assert.deepStrictEqual(err, errors.EntityTooLarge);
+                    assert.strictEqual(err.is.EntityTooLarge, true);
                     assert.strictEqual(result, undefined);
                     done();
                 });
@@ -692,7 +692,7 @@ describe('Multipart Upload API', () => {
                 };
                 completeMultipartUpload(authInfo,
                     completeRequest, log, err => {
-                        assert.deepStrictEqual(err, errors.MalformedXML);
+                        assert.strictEqual(err.is.MalformedXML, true);
                         assert.strictEqual(metadata.keyMaps.get(mpuBucket).size,
                                            2);
                         done();
@@ -746,7 +746,7 @@ describe('Multipart Upload API', () => {
                     calculatedHash,
                 };
                 completeMultipartUpload(authInfo, completeRequest, log, err => {
-                    assert.deepStrictEqual(err, errors.MalformedXML);
+                    assert.strictEqual(err.is.MalformedXML, true);
                     done();
                 });
             });
@@ -819,8 +819,7 @@ describe('Multipart Upload API', () => {
                     };
                     completeMultipartUpload(authInfo,
                         completeRequest, log, err => {
-                            assert.deepStrictEqual(err,
-                                errors.InvalidPartOrder);
+                            assert.strictEqual(err.is.InvalidPartOrder, true);
                             assert.strictEqual(metadata.keyMaps
                                                        .get(mpuBucket).size, 3);
                             done();
@@ -877,8 +876,7 @@ describe('Multipart Upload API', () => {
                     calculatedHash,
                 };
                 completeMultipartUpload(authInfo, completeRequest, log, err => {
-                    assert.deepStrictEqual(err,
-                        errors.InvalidPart);
+                    assert.strictEqual(err.is.InvalidPart, true);
                     assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 2);
                     done();
                 });
@@ -951,7 +949,7 @@ describe('Multipart Upload API', () => {
                     assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 3);
                     completeMultipartUpload(authInfo,
                         completeRequest, log, err => {
-                            assert.deepStrictEqual(err, errors.InvalidPart);
+                            assert.strictEqual(err.is.InvalidPart, true);
                             done();
                         });
                 });
@@ -1033,8 +1031,7 @@ describe('Multipart Upload API', () => {
                     assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 3);
                     completeMultipartUpload(authInfo,
                         completeRequest, log, err => {
-                            assert.deepStrictEqual(err,
-                                                   errors.EntityTooSmall);
+                            assert.strictEqual(err.is.EntityTooSmall, true);
                             done();
                         });
                 });
@@ -1717,7 +1714,7 @@ describe('Multipart Upload API', () => {
 
         bucketPut(authInfo, bucketPutRequest, log, () =>
           objectPutPart(authInfo, partRequest, undefined, log, err => {
-              assert.strictEqual(err, errors.NoSuchUpload);
+              assert.strictEqual(err.is.NoSuchUpload, true);
               done();
           })
         );
@@ -1832,7 +1829,7 @@ describe('Multipart Upload API', () => {
                 completeMultipartUpload(authInfo, completeRequest, log, err => {
                     // expect a failure here because we could not
                     // remove the overview key
-                    assert.strictEqual(err, errors.InternalError);
+                    assert.strictEqual(err.is.InternalError, true);
                     next(null, eTag, testUploadId);
                 });
             },
@@ -2055,7 +2052,7 @@ describe('complete mpu with versioning', () => {
                 completeMultipartUpload(authInfo, completeRequest, log, err => {
                     // expect a failure here because we could not
                     // remove the overview key
-                    assert.strictEqual(err, errors.InternalError);
+                    assert.strictEqual(err.is.InternalError, true);
                     next(null, eTag, testUploadId);
                 });
             },

--- a/tests/unit/api/objectCopyPart.js
+++ b/tests/unit/api/objectCopyPart.js
@@ -110,7 +110,7 @@ describe('objectCopyPart', () => {
             _createObjectCopyPartRequest(destBucketName, uploadId, headers);
         objectPutCopyPart(
             authInfo, req, sourceBucketName, objectKey, undefined, log, err => {
-                assert(err.InvalidArgument);
+                assert.strictEqual(err.is.InvalidArgument, true);
                 assert.strictEqual(err.description,
                     'The x-amz-copy-source-range value must be of the form ' +
                     'bytes=first-last where first and last are the ' +

--- a/tests/unit/api/objectDelete.js
+++ b/tests/unit/api/objectDelete.js
@@ -97,8 +97,7 @@ describe('objectDelete API', () => {
                         assert.strictEqual(err, null);
                         objectGet(authInfo, testGetObjectRequest, false,
                             log, err => {
-                                assert.deepStrictEqual(err,
-                                    errors.NoSuchKey);
+                                assert.strictEqual(err.is.NoSuchKey, true);
                                 done();
                             });
                     });
@@ -187,7 +186,7 @@ describe('objectDelete API', () => {
         const publicAuthInfo = makeAuthInfo(constants.publicId);
         bucketPut(authInfo, testBucketPutRequest, log, () => {
             objectDelete(publicAuthInfo, testDeleteRequest, log, err => {
-                assert.deepStrictEqual(err, errors.AccessDenied);
+                assert.strictEqual(err.is.AccessDenied, true);
                 done();
             });
         });
@@ -236,7 +235,7 @@ describe('objectDelete API', () => {
                 url: `/${bucketName}/${objectKey}`,
             });
             objectDelete(authInfo, testDeleteRequest, log, err => {
-                assert.deepStrictEqual(err, errors.PreconditionFailed);
+                assert.strictEqual(err.is.PreconditionFailed, true);
                 done();
             });
         });
@@ -254,7 +253,7 @@ describe('objectDelete API', () => {
                 assert.strictEqual(err, null);
                 objectGet(authInfo, testGetObjectRequest, false, log,
                 err => {
-                    assert.deepStrictEqual(err, errors.NoSuchKey);
+                    assert.strictEqual(err.is.NoSuchKey, true);
                     done();
                 });
             });
@@ -270,7 +269,7 @@ describe('objectDelete API', () => {
                 url: `/${bucketName}/${objectKey}`,
             });
             objectDelete(authInfo, testDeleteRequest, log, err => {
-                assert.deepStrictEqual(err, errors.NotModified);
+                assert.strictEqual(err.is.NotModified, true);
                 done();
             });
         });
@@ -288,7 +287,7 @@ describe('objectDelete API', () => {
                 assert.strictEqual(err, null);
                 objectGet(authInfo, testGetObjectRequest, false, log,
                 err => {
-                    assert.deepStrictEqual(err, errors.NoSuchKey);
+                    assert.strictEqual(err.is.NoSuchKey, true);
                     done();
                 });
             });

--- a/tests/unit/api/objectGetACL.js
+++ b/tests/unit/api/objectGetACL.js
@@ -1,7 +1,6 @@
 const assert = require('assert');
 const async = require('async');
 const { parseString } = require('xml2js');
-const { errors } = require('arsenal');
 
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const constants = require('../../../constants');
@@ -79,7 +78,7 @@ describe('objectGetACL API', () => {
     'for a nonexistent object', done => {
         bucketPut(authInfo, testBucketPutRequest, log, () => {
             objectGetACL(authInfo, testGetACLRequest, log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchKey);
+                assert.strictEqual(err.is.NoSuchKey, true);
                 done();
             });
         });

--- a/tests/unit/api/objectGetLegalHold.js
+++ b/tests/unit/api/objectGetLegalHold.js
@@ -61,7 +61,7 @@ describe('getObjectLegalHold API', () => {
         it('should return InvalidRequest error', done => {
             objectGetLegalHold(authInfo, getObjectLegalHoldRequest, log,
                 err => {
-                    assert.strictEqual(err.InvalidRequest, true);
+                    assert.strictEqual(err.is.InvalidRequest, true);
                     done();
                 });
         });
@@ -84,8 +84,7 @@ describe('getObjectLegalHold API', () => {
             done => {
                 objectGetLegalHold(authInfo, getObjectLegalHoldRequest, log,
                     err => {
-                        const error = err.NoSuchObjectLockConfiguration;
-                        assert.strictEqual(error, true);
+                        assert.strictEqual(err.is.NoSuchObjectLockConfiguration, true);
                         done();
                     });
             });

--- a/tests/unit/api/objectGetRetention.js
+++ b/tests/unit/api/objectGetRetention.js
@@ -64,7 +64,7 @@ describe('getObjectRetention API', () => {
 
         it('should return InvalidRequest error', done => {
             objectGetRetention(authInfo, getObjRetRequest, log, err => {
-                assert.strictEqual(err.InvalidRequest, true);
+                assert.strictEqual(err.is.InvalidRequest, true);
                 done();
             });
         });
@@ -85,7 +85,7 @@ describe('getObjectRetention API', () => {
         it('should return NoSuchObjectLockConfiguration if no retention set',
         done => {
             objectGetRetention(authInfo, getObjRetRequest, log, err => {
-                assert.strictEqual(err.NoSuchObjectLockConfiguration, true);
+                assert.strictEqual(err.is.NoSuchObjectLockConfiguration, true);
                 done();
             });
         });

--- a/tests/unit/api/objectHead.js
+++ b/tests/unit/api/objectHead.js
@@ -1,5 +1,4 @@
 const assert = require('assert');
-const { errors } = require('arsenal');
 
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const { cleanup, DummyRequestLogger, makeAuthInfo } = require('../helpers');
@@ -61,7 +60,7 @@ describe('objectHead API', () => {
                 (err, resHeaders) => {
                     assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
                     objectHead(authInfo, testGetRequest, log, err => {
-                        assert.deepStrictEqual(err, errors.NotModified);
+                        assert.strictEqual(err.is.NotModified, true);
                         done();
                     });
                 });
@@ -84,8 +83,7 @@ describe('objectHead API', () => {
                 (err, resHeaders) => {
                     assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
                     objectHead(authInfo, testGetRequest, log, err => {
-                        assert.deepStrictEqual(err,
-                            errors.PreconditionFailed);
+                        assert.strictEqual(err.is.PreconditionFailed, true);
                         done();
                     });
                 });
@@ -108,8 +106,7 @@ describe('objectHead API', () => {
                 (err, resHeaders) => {
                     assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
                     objectHead(authInfo, testGetRequest, log, err => {
-                        assert.deepStrictEqual(err,
-                            errors.PreconditionFailed);
+                        assert.strictEqual(err.is.PreconditionFailed, true);
                         done();
                     });
                 });
@@ -132,7 +129,7 @@ describe('objectHead API', () => {
                 (err, resHeaders) => {
                     assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
                     objectHead(authInfo, testGetRequest, log, err => {
-                        assert.deepStrictEqual(err, errors.NotModified);
+                        assert.strictEqual(err.is.NotModified, true);
                         done();
                     });
                 });
@@ -172,16 +169,15 @@ describe('objectHead API', () => {
                 partNumber: '1',
             },
         };
-        const customizedInvalidRequestError = errors.InvalidRequest
-            .customizeDescription('Cannot specify both Range header and ' +
-                'partNumber query parameter.');
 
         bucketPut(authInfo, testPutBucketRequest, log, () => {
             objectPut(authInfo, testPutObjectRequest, undefined, log, err => {
                 assert.strictEqual(err, null, `Error objectPut: ${err}`);
                 objectHead(authInfo, testGetRequest, log, err => {
-                    assert.deepStrictEqual(err, customizedInvalidRequestError);
-                    assert.deepStrictEqual(err.InvalidRequest, true);
+                    assert.strictEqual(err.is.InvalidRequest, true);
+                    assert.strictEqual(err.description,
+                        'Cannot specify both Range header and ' +
+                        'partNumber query parameter.');
                     done();
                 });
             });
@@ -199,15 +195,13 @@ describe('objectHead API', () => {
                 partNumber: 'nan',
             },
         };
-        const customizedInvalidArgumentError = errors.InvalidArgument
-            .customizeDescription('Part number must be a number.');
 
         bucketPut(authInfo, testPutBucketRequest, log, () => {
             objectPut(authInfo, testPutObjectRequest, undefined, log, err => {
                 assert.strictEqual(err, null, `Error objectPut: ${err}`);
                 objectHead(authInfo, testGetRequest, log, err => {
-                    assert.deepStrictEqual(err, customizedInvalidArgumentError);
-                    assert.deepStrictEqual(err.InvalidArgument, true);
+                    assert.strictEqual(err.is.InvalidArgument, true);
+                    assert.strictEqual(err.description, 'Part number must be a number.');
                     done();
                 });
             });

--- a/tests/unit/api/objectPut.js
+++ b/tests/unit/api/objectPut.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const async = require('async');
 const moment = require('moment');
-const { errors, s3middleware, storage } = require('arsenal');
+const { s3middleware, storage } = require('arsenal');
 
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const bucketPutObjectLock = require('../../../lib/api/bucketPutObjectLock');
@@ -86,7 +86,7 @@ describe('parseTagFromQuery', () => {
         it(`should ${behavior} if tag set: "${test.tagging}"`, done => {
             const result = parseTagFromQuery(test.tagging);
             if (test.error) {
-                assert(result[test.error.status]);
+                assert.strictEqual(result.is[test.error.status], true);
                 assert.strictEqual(result.code, test.error.statusCode);
             } else {
                 assert.deepStrictEqual(result, test.result);
@@ -114,7 +114,7 @@ describe('objectPut API', () => {
 
     it('should return an error if the bucket does not exist', done => {
         objectPut(authInfo, testPutObjectRequest, undefined, log, err => {
-            assert.deepStrictEqual(err, errors.NoSuchBucket);
+            assert.strictEqual(err.is.NoSuchBucket, true);
             done();
         });
     });
@@ -125,7 +125,7 @@ describe('objectPut API', () => {
             log, () => {
                 objectPut(authInfo, testPutObjectRequest,
                     undefined, log, err => {
-                        assert.deepStrictEqual(err, errors.AccessDenied);
+                        assert.strictEqual(err.is.AccessDenied, true);
                         done();
                     });
             });
@@ -136,7 +136,7 @@ describe('objectPut API', () => {
         testPutObjectRequest.parsedContentLength = maximumAllowedUploadSize + 1;
         bucketPut(authInfo, testPutBucketRequest, log, () => {
             objectPut(authInfo, testPutObjectRequest, undefined, log, err => {
-                assert.deepStrictEqual(err, errors.EntityTooLarge);
+                assert.strictEqual(err.is.EntityTooLarge, true);
                 done();
             });
         });
@@ -464,9 +464,8 @@ describe('objectPut API', () => {
 
         bucketPut(authInfo, testPutBucketRequest, log, () => {
             objectPut(authInfo, testPutObjectRequest, undefined, log, err => {
-                assert.deepStrictEqual(err, errors.InvalidRequest
-                    .customizeDescription(
-                        'Bucket is missing ObjectLockConfiguration'));
+                assert.strictEqual(err.is.InvalidRequest, true);
+                assert.strictEqual(err.description, 'Bucket is missing ObjectLockConfiguration');
                 done();
             });
         });
@@ -605,7 +604,7 @@ describe('objectPut API with versioning', () => {
         bucketPut(authInfo, testPutBucketRequest, log, () => {
             objectPut(authInfo, testPutObjectRequest, undefined, log,
             err => {
-                assert.deepStrictEqual(err, errors.BadDigest);
+                assert.strictEqual(err.is.BadDigest, true);
                 // orphan objects don't get deleted
                 // until the next tick
                 // in memory

--- a/tests/unit/api/objectPutACL.js
+++ b/tests/unit/api/objectPutACL.js
@@ -1,5 +1,4 @@
 const assert = require('assert');
-const { errors } = require('arsenal');
 
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const constants = require('../../../constants');
@@ -63,8 +62,7 @@ describe('putObjectACL API', () => {
                 (err, resHeaders) => {
                     assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
                     objectPutACL(authInfo, testObjACLRequest, log, err => {
-                        assert
-                            .deepStrictEqual(err, errors.InvalidArgument);
+                        assert.strictEqual(err.is.InvalidArgument, true);
                         done();
                     });
                 });
@@ -208,8 +206,7 @@ describe('putObjectACL API', () => {
                 (err, resHeaders) => {
                     assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
                     objectPutACL(authInfo, testObjACLRequest, log, err => {
-                        assert.strictEqual(err,
-                            errors.UnresolvableGrantByEmailAddress);
+                        assert.strictEqual(err.is.UnresolvableGrantByEmailAddress, true);
                         done();
                     });
                 });
@@ -274,8 +271,7 @@ describe('putObjectACL API', () => {
             objectPut(authInfo, testPutObjectRequest, undefined, log,
                 () => {
                     objectPutACL(authInfo, testObjACLRequest, log, err => {
-                        assert.deepStrictEqual(err,
-                            errors.AccessDenied);
+                        assert.strictEqual(err.is.AccessDenied, true);
                         done();
                     });
                 });
@@ -342,8 +338,7 @@ describe('putObjectACL API', () => {
                 (err, resHeaders) => {
                     assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
                     objectPutACL(authInfo, testObjACLRequest, log, err => {
-                        assert.strictEqual(err,
-                            errors.UnresolvableGrantByEmailAddress);
+                        assert.strictEqual(err.is.UnresolvableGrantByEmailAddress, true);
                         done();
                     });
                 });
@@ -371,8 +366,7 @@ describe('putObjectACL API', () => {
                 (err, resHeaders) => {
                     assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
                     objectPutACL(authInfo, testObjACLRequest, log, err => {
-                        assert.deepStrictEqual(err,
-                            errors.MalformedACLError);
+                        assert.strictEqual(err.is.MalformedACLError, true);
                         done();
                     });
                 });
@@ -400,7 +394,7 @@ describe('putObjectACL API', () => {
                 (err, resHeaders) => {
                     assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
                     objectPutACL(authInfo, testObjACLRequest, log, err => {
-                        assert.deepStrictEqual(err, errors.MalformedXML);
+                        assert.strictEqual(err.is.MalformedXML, true);
                         done();
                     });
                 });
@@ -427,7 +421,7 @@ describe('putObjectACL API', () => {
                 (err, resHeaders) => {
                     assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
                     objectPutACL(authInfo, testObjACLRequest, log, err => {
-                        assert.deepStrictEqual(err, errors.InvalidArgument);
+                        assert.strictEqual(err.is.InvalidArgument, true);
                         done();
                     });
                 });
@@ -455,7 +449,7 @@ describe('putObjectACL API', () => {
                 (err, resHeaders) => {
                     assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
                     objectPutACL(authInfo, testObjACLRequest, log, err => {
-                        assert.deepStrictEqual(err, errors.InvalidArgument);
+                        assert.strictEqual(err.is.InvalidArgument, true);
                         done();
                     });
                 });

--- a/tests/unit/api/objectPutLegalHold.js
+++ b/tests/unit/api/objectPutLegalHold.js
@@ -55,7 +55,7 @@ describe('putObjectLegalHold API', () => {
 
         it('should return InvalidRequest error', done => {
             objectPutLegalHold(authInfo, putLegalHoldReq('ON'), log, err => {
-                assert.strictEqual(err.InvalidRequest, true);
+                assert.strictEqual(err.is.InvalidRequest, true);
                 done();
             });
         });

--- a/tests/unit/api/objectPutRetention.js
+++ b/tests/unit/api/objectPutRetention.js
@@ -1,7 +1,6 @@
 const assert = require('assert');
 const moment = require('moment');
 
-const { errors } = require('arsenal');
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const objectPut = require('../../../lib/api/objectPut');
 const objectPutRetention = require('../../../lib/api/objectPutRetention');
@@ -99,7 +98,7 @@ describe('putObjectRetention API', () => {
 
         it('should return InvalidRequest error', done => {
             objectPutRetention(authInfo, putObjRetRequestGovernance, log, err => {
-                assert.strictEqual(err.InvalidRequest, true);
+                assert.strictEqual(err.is.InvalidRequest, true);
                 done();
             });
         });
@@ -134,7 +133,7 @@ describe('putObjectRetention API', () => {
             objectPutRetention(authInfo, putObjRetRequestCompliance, log, err => {
                 assert.ifError(err);
                 return objectPutRetention(authInfo, putObjRetRequestGovernance, log, err => {
-                    assert.deepStrictEqual(err, errors.AccessDenied);
+                    assert.strictEqual(err.is.AccessDenied, true);
                     done();
                 });
             });
@@ -144,7 +143,7 @@ describe('putObjectRetention API', () => {
             objectPutRetention(authInfo, putObjRetRequestCompliance, log, err => {
                 assert.ifError(err);
                 return objectPutRetention(authInfo, putObjRetRequestComplianceShorter, log, err => {
-                    assert.deepStrictEqual(err, errors.AccessDenied);
+                    assert.strictEqual(err.is.AccessDenied, true);
                     done();
                 });
             });
@@ -155,7 +154,7 @@ describe('putObjectRetention API', () => {
             objectPutRetention(authInfo, putObjRetRequestGovernance, log, err => {
                 assert.ifError(err);
                 return objectPutRetention(authInfo, putObjRetRequestGovernance, log, err => {
-                    assert.deepStrictEqual(err, errors.AccessDenied);
+                    assert.strictEqual(err.is.AccessDenied, true);
                     done();
                 });
             });

--- a/tests/unit/api/objectPutTagging.js
+++ b/tests/unit/api/objectPutTagging.js
@@ -38,7 +38,7 @@ const testPutObjectRequest = new DummyRequest({
 function _checkError(err, code, errorName) {
     assert(err, 'Expected error but found none');
     assert.strictEqual(err.code, code);
-    assert(err[errorName]);
+    assert.strictEqual(err.is[errorName], true);
 }
 
 function _generateSampleXml(key, value) {

--- a/tests/unit/api/serviceGet.js
+++ b/tests/unit/api/serviceGet.js
@@ -1,7 +1,6 @@
 const assert = require('assert');
 const async = require('async');
 const { parseString } = require('xml2js');
-const { errors } = require('arsenal');
 
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const constants = require('../../../constants');
@@ -79,7 +78,7 @@ describe('serviceGet API', () => {
     it('should prevent anonymous user from accessing getService API', done => {
         const publicAuthInfo = makeAuthInfo(constants.publicId);
         serviceGet(publicAuthInfo, serviceGetRequest, log, err => {
-            assert.deepStrictEqual(err, errors.AccessDenied);
+            assert.strictEqual(err.is.AccessDenied, true);
             done();
         });
     });

--- a/tests/unit/api/transientBucket.js
+++ b/tests/unit/api/transientBucket.js
@@ -1,6 +1,5 @@
 const assert = require('assert');
 const crypto = require('crypto');
-const { errors } = require('arsenal');
 
 const BucketInfo = require('arsenal').models.BucketInfo;
 const { bucketGet } = require('../../../lib/api/bucketGet');
@@ -101,7 +100,7 @@ describe('transient bucket handling', () => {
     it('putBucket request should return error if ' +
         'transient bucket created by different account', done => {
         bucketPut(otherAccountAuthInfo, baseTestRequest, log, err => {
-            assert.deepStrictEqual(err, errors.BucketAlreadyExists);
+            assert.strictEqual(err.is.BucketAlreadyExists, true);
             serviceGet(otherAccountAuthInfo, serviceGetRequest,
                 log, (err, data) => {
                     parseString(data, (err, result) => {
@@ -237,7 +236,7 @@ describe('transient bucket handling', () => {
         bucketDelete(authInfo, baseTestRequest, log, err => {
             assert.ifError(err);
             metadata.getBucket(bucketName, log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchBucket);
+                assert.strictEqual(err.is.NoSuchBucket, true);
                 done();
             });
         });
@@ -247,7 +246,7 @@ describe('transient bucket handling', () => {
         'request is not from owner', done => {
         bucketDelete(otherAccountAuthInfo, baseTestRequest,
             log, err => {
-                assert.deepStrictEqual(err, errors.AccessDenied);
+                assert.strictEqual(err.is.AccessDenied, true);
                 done();
             });
     });
@@ -260,7 +259,7 @@ describe('transient bucket handling', () => {
         bucketGetRequest.query = {};
         bucketGet(authInfo, bucketGetRequest,
             log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchBucket);
+                assert.strictEqual(err.is.NoSuchBucket, true);
                 done();
             });
     });
@@ -273,7 +272,7 @@ describe('transient bucket handling', () => {
         bucketGetACLRequest.query = { acl: '' };
         bucketGetACL(authInfo, bucketGetACLRequest,
             log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchBucket);
+                assert.strictEqual(err.is.NoSuchBucket, true);
                 done();
             });
     });
@@ -281,7 +280,7 @@ describe('transient bucket handling', () => {
     it('bucketGetCors request on transient bucket should return ' +
         'NoSuchBucket error', done => {
         bucketGetCors(authInfo, baseTestRequest, log, err => {
-            assert.deepStrictEqual(err, errors.NoSuchBucket);
+            assert.strictEqual(err.is.NoSuchBucket, true);
             done();
         });
     });
@@ -297,7 +296,7 @@ describe('transient bucket handling', () => {
         bucketPutCorsRequest.headers['content-md5'] = crypto.createHash('md5')
             .update(bucketPutCorsRequest.post, 'utf8').digest('base64');
         bucketPutCors(authInfo, bucketPutCorsRequest, log, err => {
-            assert.deepStrictEqual(err, errors.NoSuchBucket);
+            assert.strictEqual(err.is.NoSuchBucket, true);
             done();
         });
     });
@@ -305,7 +304,7 @@ describe('transient bucket handling', () => {
     it('bucketDeleteCors request on transient bucket should return ' +
         'NoSuchBucket error', done => {
         bucketDeleteCors(authInfo, baseTestRequest, log, err => {
-            assert.deepStrictEqual(err, errors.NoSuchBucket);
+            assert.strictEqual(err.is.NoSuchBucket, true);
             done();
         });
     });
@@ -313,7 +312,7 @@ describe('transient bucket handling', () => {
     it('bucketGetWebsite request on transient bucket should return ' +
         'NoSuchBucket error', done => {
         bucketGetWebsite(authInfo, baseTestRequest, log, err => {
-            assert.deepStrictEqual(err, errors.NoSuchBucket);
+            assert.strictEqual(err.is.NoSuchBucket, true);
             done();
         });
     });
@@ -326,7 +325,7 @@ describe('transient bucket handling', () => {
         '<IndexDocument><Suffix>index.html</Suffix></IndexDocument>' +
         '</WebsiteConfiguration>';
         bucketPutWebsite(authInfo, bucketPutWebsiteRequest, log, err => {
-            assert.deepStrictEqual(err, errors.NoSuchBucket);
+            assert.strictEqual(err.is.NoSuchBucket, true);
             done();
         });
     });
@@ -334,7 +333,7 @@ describe('transient bucket handling', () => {
     it('bucketDeleteWebsite request on transient bucket should return ' +
         'NoSuchBucket error', done => {
         bucketDeleteWebsite(authInfo, baseTestRequest, log, err => {
-            assert.deepStrictEqual(err, errors.NoSuchBucket);
+            assert.strictEqual(err.is.NoSuchBucket, true);
             done();
         });
     });
@@ -343,7 +342,7 @@ describe('transient bucket handling', () => {
         'error', done => {
         bucketHead(authInfo, baseTestRequest,
             log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchBucket);
+                assert.strictEqual(err.is.NoSuchBucket, true);
                 done();
             });
     });
@@ -357,7 +356,7 @@ describe('transient bucket handling', () => {
         completeMpuRequest.query = { uploadId };
         completeMultipartUpload(authInfo, completeMpuRequest,
             log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchUpload);
+                assert.strictEqual(err.is.NoSuchUpload, true);
                 done();
             });
     });
@@ -371,7 +370,7 @@ describe('transient bucket handling', () => {
         listRequest.query = { uploadId };
         listParts(authInfo, listRequest,
             log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchUpload);
+                assert.strictEqual(err.is.NoSuchUpload, true);
                 done();
             });
     });
@@ -396,7 +395,7 @@ describe('transient bucket handling', () => {
             config.locationConstraints[locationConstraint].
                 legacyAwsBehavior = true;
             multipartDelete(authInfo, deleteRequest, log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchUpload);
+                assert.strictEqual(err.is.NoSuchUpload, true);
                 done();
             });
         });
@@ -423,7 +422,7 @@ describe('transient bucket handling', () => {
             partNumber: '1' };
         objectPutPart(authInfo, putPartRequest, undefined,
             log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchUpload);
+                assert.strictEqual(err.is.NoSuchUpload, true);
                 done();
             });
     });
@@ -435,7 +434,7 @@ describe('transient bucket handling', () => {
         listRequest.query = {};
         listMultipartUploads(authInfo, listRequest,
             log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchBucket);
+                assert.strictEqual(err.is.NoSuchBucket, true);
                 done();
             });
     });
@@ -445,7 +444,7 @@ describe('transient bucket handling', () => {
         done => {
             objectGet(authInfo, baseTestRequest, false,
             log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchBucket);
+                assert.strictEqual(err.is.NoSuchBucket, true);
                 done();
             });
         });
@@ -454,7 +453,7 @@ describe('transient bucket handling', () => {
         'NoSuchBucket error', done => {
         objectGetACL(authInfo, baseTestRequest,
         log, err => {
-            assert.deepStrictEqual(err, errors.NoSuchBucket);
+            assert.strictEqual(err.is.NoSuchBucket, true);
             done();
         });
     });
@@ -463,7 +462,7 @@ describe('transient bucket handling', () => {
         'NoSuchBucket error', done => {
         objectHead(authInfo, baseTestRequest,
         log, err => {
-            assert.deepStrictEqual(err, errors.NoSuchBucket);
+            assert.strictEqual(err.is.NoSuchBucket, true);
             done();
         });
     });
@@ -472,7 +471,7 @@ describe('transient bucket handling', () => {
         'NoSuchBucket error', done => {
         objectPutACL(authInfo, baseTestRequest,
         log, err => {
-            assert.deepStrictEqual(err, errors.NoSuchBucket);
+            assert.strictEqual(err.is.NoSuchBucket, true);
             done();
         });
     });
@@ -481,7 +480,7 @@ describe('transient bucket handling', () => {
         'NoSuchBucket error', done => {
         objectDelete(authInfo, baseTestRequest,
         log, err => {
-            assert.deepStrictEqual(err, errors.NoSuchBucket);
+            assert.strictEqual(err.is.NoSuchBucket, true);
             done();
         });
     });

--- a/tests/unit/bucket/bucketCreation.js
+++ b/tests/unit/bucket/bucketCreation.js
@@ -1,5 +1,3 @@
-const { errors } = require('arsenal');
-
 const assert = require('assert');
 
 const { cleanup, DummyRequestLogger } = require('../helpers');
@@ -45,7 +43,7 @@ describe('bucket creation', () => {
         it('should return 409 if try to recreate in non-us-east-1', done => {
             createBucket(authInfo, bucketName, headers,
             normalBehaviorLocationConstraint, log, err => {
-                assert.strictEqual(err, errors.BucketAlreadyOwnedByYou);
+                assert.strictEqual(err.is.BucketAlreadyOwnedByYou, true);
                 done();
             });
         });
@@ -64,7 +62,7 @@ describe('bucket creation', () => {
         it('should return 409 if try to recreate in us-east-1', done => {
             createBucket(authInfo, bucketName, headers,
             specialBehaviorLocationConstraint, log, err => {
-                assert.strictEqual(err, errors.BucketAlreadyOwnedByYou);
+                assert.strictEqual(err.is.BucketAlreadyOwnedByYou, true);
                 done();
             });
         });

--- a/tests/unit/bucket/bucket_mem_api.js
+++ b/tests/unit/bucket/bucket_mem_api.js
@@ -1,8 +1,6 @@
 const assert = require('assert');
 const async = require('async');
 
-const { errors } = require('arsenal');
-
 const BucketInfo = require('arsenal').models.BucketInfo;
 const { cleanup, DummyRequestLogger } = require('../helpers');
 const { isKeyInContents }
@@ -39,7 +37,7 @@ describe('bucket API for getting, putting and deleting ' +
     it('should return an error in response ' +
        'to getObjectMD when no such key', done => {
         metadata.getObjectMD(bucketName, 'notThere', {}, log, (err, value) => {
-            assert.deepStrictEqual(err, errors.NoSuchKey);
+            assert.strictEqual(err.is.NoSuchKey, true);
             assert.strictEqual(value, undefined);
             done();
         });
@@ -52,7 +50,7 @@ describe('bucket API for getting, putting and deleting ' +
             () => {
                 metadata.getObjectMD(bucketName, 'objectToDelete', {}, log,
                     (err, value) => {
-                        assert.deepStrictEqual(err, errors.NoSuchKey);
+                        assert.strictEqual(err.is.NoSuchKey, true);
                         assert.strictEqual(value, undefined);
                         done();
                     });

--- a/tests/unit/multipleBackend/getReplicationBackendDataLocator.js
+++ b/tests/unit/multipleBackend/getReplicationBackendDataLocator.js
@@ -30,7 +30,7 @@ describe('Replication Backend Compare', () => {
     it('should return error if no match in replication backends', () => {
         const repBackendResult =
             getReplicationBackendDataLocator(locCheckResult, repNoMatch);
-        assert(repBackendResult.error.InvalidLocationConstraint);
+        assert.strictEqual(repBackendResult.error.is.InvalidLocationConstraint, true);
     });
     it('should return a status and reason if backend status is PENDING', () => {
         const repBackendResult =

--- a/tests/unit/multipleBackend/locationConstraintCheck.js
+++ b/tests/unit/multipleBackend/locationConstraintCheck.js
@@ -40,7 +40,7 @@ describe('Location Constraint Check', () => {
             createTestRequest('fail-region'), null, testBucket, log);
         assert.strictEqual(backendInfoObj.err.code, 400,
             'Expected "Invalid Argument" code error');
-        assert(backendInfoObj.err.InvalidArgument, 'Expected "Invalid ' +
+        assert(backendInfoObj.err.is.InvalidArgument, 'Expected "Invalid ' +
         'Argument" error');
         done();
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,27 +2,6 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
-  integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
-  dependencies:
-    "@babel/highlight" "^7.16.7"
-
-"@babel/helper-validator-identifier@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
-  integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
-
-"@babel/highlight@^7.16.7":
-  version "7.17.9"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.17.9.tgz#61b2ee7f32ea0454612def4fccdae0de232b73e3"
-  integrity sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.16.7"
-    chalk "^2.0.0"
-    js-tokens "^4.0.0"
-
 "@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
@@ -36,6 +15,21 @@
     colorspace "1.1.x"
     enabled "2.0.x"
     kuler "^2.0.0"
+
+"@eslint/eslintrc@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.2.2.tgz#4989b9e8c0216747ee7cca314ae73791bb281aae"
+  integrity sha512-lTVWHs7O2hjBFZunXTZYnYqtB9GakA1lnxIf+gKq2nY5gxkkNi/lQvveW6t8gFdOHTg6nG50Xs95PrLqVpcaLg==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.3.2"
+    espree "^9.3.1"
+    globals "^13.9.0"
+    ignore "^5.2.0"
+    import-fresh "^3.2.1"
+    js-yaml "^4.1.0"
+    minimatch "^3.0.4"
+    strip-json-comments "^3.1.1"
 
 "@gar/promisify@^1.0.1":
   version "1.1.3"
@@ -114,6 +108,20 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
+"@humanwhocodes/config-array@^0.9.2":
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.5.tgz#2cbaf9a89460da24b5ca6531b8bbfc23e1df50c7"
+  integrity sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==
+  dependencies:
+    "@humanwhocodes/object-schema" "^1.2.1"
+    debug "^4.1.1"
+    minimatch "^3.0.4"
+
+"@humanwhocodes/object-schema@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
+  integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
+
 "@npmcli/fs@^1.0.0":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-1.1.1.tgz#72f719fe935e687c56a4faecf3c03d06ba593257"
@@ -136,6 +144,23 @@
   integrity sha512-7ooeoNwbqAeaq+dxgQwM9PvEsFsC0VEfnKxTt634Q7287wf3J2ErtbFtW+BmivuOL1AyDR5rBfHz4MhvX2I04Q==
   dependencies:
     dayjs "^1.10.5"
+
+"@sideway/address@^4.1.3":
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.4.tgz#03dccebc6ea47fdc226f7d3d1ad512955d4783f0"
+  integrity sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
+  integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
+
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.3":
   version "1.8.3"
@@ -170,10 +195,20 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@types/async@^3.2.12":
+  version "3.2.13"
+  resolved "https://registry.yarnpkg.com/@types/async/-/async-3.2.13.tgz#ec023074c70180d17cbc9117ddc3cec2f3894ea4"
+  integrity sha512-7Q3awrhnvm89OzfsmqeqRQh8mh+8Pxfgq1UvSAn2nWQ5y/F3+NrbIF0RbkWq8+5dY99ozgap2b3DNBNwjLVOxw==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
+"@types/utf8@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/utf8/-/utf8-3.0.1.tgz#bf081663d4fff05ee63b41f377a35f8b189f7e5b"
+  integrity sha512-1EkWuw7rT3BMz2HpmcEOr/HL61mWNA6Ulr/KdbXR9AI0A55wD4Qfv8hizd8Q1DnknSIzzDvQmvvY/guvX7jjZA==
 
 JSONStream@^1.0.0:
   version "1.3.5"
@@ -257,15 +292,15 @@ accesscontrol@^2.2.1:
   dependencies:
     notation "^1.3.6"
 
-acorn-jsx@^5.0.0:
+acorn-jsx@^5.3.1:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^6.0.7:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
-  integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
+acorn@^8.7.0:
+  version "8.7.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
+  integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
 
 after@0.8.2:
   version "0.8.2"
@@ -313,7 +348,17 @@ ajv@6.12.2:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^6.10.2, ajv@^6.12.3, ajv@^6.9.1:
+ajv@6.12.3:
+  version "6.12.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.3.tgz#18c5af38a111ddeb4f2697bd78d68abc1cabd706"
+  integrity sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -322,11 +367,6 @@ ajv@^6.10.2, ajv@^6.12.3, ajv@^6.9.1:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
-
-ansi-escapes@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
-  integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -338,11 +378,6 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
   integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
 
-ansi-regex@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
-  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
-
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -353,12 +388,19 @@ ansi-styles@^2.2.1:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
   integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
 
-ansi-styles@^3.2.0, ansi-styles@^3.2.1:
+ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
 
 append-field@^1.0.0:
   version "1.0.0"
@@ -392,6 +434,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
@@ -423,11 +470,12 @@ arraybuffer.slice@~0.0.7:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
   integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
 
-"arsenal@github:scality/Arsenal#8.1.38":
-  version "8.1.38"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/d18f4d10bdfec6c3d211036490c9de5f5e97219c"
+"arsenal@git+https://github.com/scality/Arsenal#8.1.45":
+  version "8.1.45"
+  resolved "git+https://github.com/scality/Arsenal#fb286c6403fcd4dec775e1cba2c1961a80f86503"
   dependencies:
-    "@hapi/joi" "^15.1.0"
+    "@types/async" "^3.2.12"
+    "@types/utf8" "^3.0.1"
     JSONStream "^1.0.0"
     agentkeepalive "^4.1.3"
     ajv "6.12.2"
@@ -440,20 +488,60 @@ arraybuffer.slice@~0.0.7:
     bson "4.0.0"
     debug "~4.1.0"
     diskusage "^1.1.1"
-    eslint-plugin-import "^2.25.4"
     fcntl "github:scality/node-fcntl#0.2.0"
     hdclient scality/hdclient#1.1.0
     https-proxy-agent "^2.2.0"
     ioredis "^4.28.5"
     ipaddr.js "1.9.1"
+    joi "^17.6.0"
     level "~5.0.1"
     level-sublevel "~6.6.5"
     mongodb "^3.0.1"
     node-forge "^0.7.1"
     prom-client "10.2.3"
     simple-glob "^0.2.0"
-    socket.io "~2.3.0"
-    socket.io-client "~2.3.0"
+    socket.io "2.4.1"
+    socket.io-client "2.4.0"
+    sproxydclient "github:scality/sproxydclient#8.0.3"
+    utf8 "3.0.0"
+    uuid "^3.0.1"
+    werelogs scality/werelogs#8.1.0
+    xml2js "~0.4.23"
+  optionalDependencies:
+    ioctl "^2.0.2"
+
+"arsenal@git+https://github.com/scality/Arsenal.git#8.1.47":
+  version "8.1.47"
+  resolved "git+https://github.com/scality/Arsenal.git#e37712e94f747de6c2118d0280da7370e8aedd69"
+  dependencies:
+    "@types/async" "^3.2.12"
+    "@types/utf8" "^3.0.1"
+    JSONStream "^1.0.0"
+    agentkeepalive "^4.1.3"
+    ajv "6.12.3"
+    async "~2.6.4"
+    aws-sdk "2.80.0"
+    azure-storage "2.10.3"
+    backo "^1.1.0"
+    base-x "3.0.8"
+    base62 "2.0.1"
+    bson "4.0.0"
+    debug "~4.1.0"
+    diskusage "^1.1.1"
+    fcntl "github:scality/node-fcntl#0.2.0"
+    hdclient scality/hdclient#1.1.0
+    https-proxy-agent "^2.2.0"
+    ioredis "^4.28.5"
+    ipaddr.js "1.9.1"
+    joi "^17.6.0"
+    level "~5.0.1"
+    level-sublevel "~6.6.5"
+    mongodb "^3.0.1"
+    node-forge "^1.3.0"
+    prom-client "10.2.3"
+    simple-glob "^0.2.0"
+    socket.io "2.4.1"
+    socket.io-client "2.4.0"
     sproxydclient "github:scality/sproxydclient#8.0.3"
     utf8 "3.0.0"
     uuid "^3.0.1"
@@ -465,44 +553,6 @@ arraybuffer.slice@~0.0.7:
 arsenal@scality/Arsenal#8.1.27:
   version "8.1.27"
   resolved "https://codeload.github.com/scality/Arsenal/tar.gz/3c9ab1bb99c2b3134882e7d8ad12573a073188f4"
-  dependencies:
-    "@hapi/joi" "^15.1.0"
-    JSONStream "^1.0.0"
-    agentkeepalive "^4.1.3"
-    ajv "6.12.2"
-    async "~2.6.1"
-    aws-sdk "2.80.0"
-    azure-storage "2.10.3"
-    backo "^1.1.0"
-    base-x "3.0.8"
-    base62 "2.0.1"
-    bson "4.0.0"
-    debug "~4.1.0"
-    diskusage "^1.1.1"
-    fcntl "github:scality/node-fcntl#0.2.0"
-    hdclient scality/hdclient#1.1.0
-    https-proxy-agent "^2.2.0"
-    ioredis "4.9.5"
-    ipaddr.js "1.9.1"
-    level "~5.0.1"
-    level-sublevel "~6.6.5"
-    mongodb "^3.0.1"
-    node-forge "^0.7.1"
-    prom-client "10.2.3"
-    simple-glob "^0.2.0"
-    socket.io "~2.3.0"
-    socket.io-client "~2.3.0"
-    sproxydclient "github:scality/sproxydclient#8.0.3"
-    utf8 "3.0.0"
-    uuid "^3.0.1"
-    werelogs scality/werelogs#8.1.0
-    xml2js "~0.4.23"
-  optionalDependencies:
-    ioctl "^2.0.2"
-
-arsenal@scality/Arsenal#8.1.29:
-  version "8.1.29"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/0dbdff3a001981f7cbb44ff49e0a7d033a245cdd"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
@@ -550,11 +600,6 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
-astral-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
-  integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
-
 async-limiter@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
@@ -565,7 +610,7 @@ async@1.x:
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
-async@^2.1.4, async@^2.3.0, async@~2.6.1:
+async@^2.1.4, async@^2.3.0, async@~2.6.1, async@~2.6.4:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
   integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
@@ -1076,7 +1121,7 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -1085,10 +1130,13 @@ chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chardet@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
-  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+chalk@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
 
 charenc@0.0.2, charenc@~0.0.1:
   version "0.0.2"
@@ -1104,18 +1152,6 @@ clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
-
-cli-cursor@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
-  integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
-  dependencies:
-    restore-cursor "^2.0.0"
-
-cli-width@^2.0.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
-  integrity sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==
 
 clone@^2.1.2:
   version "2.1.2"
@@ -1134,12 +1170,19 @@ color-convert@^1.9.0, color-convert@^1.9.3:
   dependencies:
     color-name "1.1.3"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@^1.0.0:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
@@ -1277,7 +1320,7 @@ cookie@0.3.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
   integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
 
-cookie@0.4.2:
+cookie@0.4.2, cookie@~0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
@@ -1315,6 +1358,15 @@ cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+cross-spawn@^7.0.2:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
 
 crypt@0.0.2, crypt@~0.0.1:
   version "0.0.2"
@@ -1365,7 +1417,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.6.8, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.3:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -1393,7 +1445,7 @@ debug@~4.1.0:
   dependencies:
     ms "^2.1.1"
 
-deep-is@~0.1.3:
+deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
@@ -1530,11 +1582,6 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-emoji-regex@^7.0.1:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
-  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
-
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -1584,6 +1631,23 @@ engine.io-client@~3.4.0:
     xmlhttprequest-ssl "~1.5.4"
     yeast "0.1.2"
 
+engine.io-client@~3.5.0:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-3.5.2.tgz#0ef473621294004e9ceebe73cef0af9e36f2f5fa"
+  integrity sha512-QEqIp+gJ/kMHeUun7f5Vv3bteRHppHH/FMBQX/esFj/fuYfjyUKWGMo3VCvIP/V8bE9KcjHmRZrhIz2Z9oNsDA==
+  dependencies:
+    component-emitter "~1.3.0"
+    component-inherit "0.0.3"
+    debug "~3.1.0"
+    engine.io-parser "~2.2.0"
+    has-cors "1.1.0"
+    indexof "0.0.1"
+    parseqs "0.0.6"
+    parseuri "0.0.6"
+    ws "~7.4.2"
+    xmlhttprequest-ssl "~1.6.2"
+    yeast "0.1.2"
+
 engine.io-parser@~2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-2.2.1.tgz#57ce5611d9370ee94f99641b589f94c97e4f5da7"
@@ -1606,6 +1670,18 @@ engine.io@~3.4.0:
     debug "~4.1.0"
     engine.io-parser "~2.2.0"
     ws "^7.1.2"
+
+engine.io@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-3.5.0.tgz#9d6b985c8a39b1fe87cd91eb014de0552259821b"
+  integrity sha512-21HlvPUKaitDGE4GXNtQ7PLP0Sz4aWLddMPw2VTyFz1FVZqu/kZsJUO8WNpKuE/OCL7nkfRaOui2ZCJloGznGA==
+  dependencies:
+    accepts "~1.3.4"
+    base64id "2.0.0"
+    cookie "~0.4.1"
+    debug "~4.1.0"
+    engine.io-parser "~2.2.0"
+    ws "~7.4.2"
 
 entities@~2.0.0:
   version "2.0.3"
@@ -1736,6 +1812,11 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
 eslint-config-airbnb-base@^13.1.0:
   version "13.2.0"
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz#f6ea81459ff4dec2dda200c35f1d8f7419d57943"
@@ -1768,7 +1849,7 @@ eslint-module-utils@^2.7.3:
     debug "^3.2.7"
     find-up "^2.1.0"
 
-eslint-plugin-import@^2.14.0, eslint-plugin-import@^2.25.4:
+eslint-plugin-import@^2.14.0:
   version "2.26.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz#f812dc47be4f2b72b478a021605a59fc6fe8b88b"
   integrity sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==
@@ -1787,100 +1868,99 @@ eslint-plugin-import@^2.14.0, eslint-plugin-import@^2.25.4:
     resolve "^1.22.0"
     tsconfig-paths "^3.14.1"
 
-eslint-scope@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
-  integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
+eslint-scope@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.1.tgz#fff34894c2f65e5226d3041ac480b4513a163642"
+  integrity sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==
   dependencies:
-    esrecurse "^4.1.0"
-    estraverse "^4.1.1"
+    esrecurse "^4.3.0"
+    estraverse "^5.2.0"
 
-eslint-utils@^1.3.1:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
-  integrity sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
+eslint-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
+  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
   dependencies:
-    eslint-visitor-keys "^1.1.0"
+    eslint-visitor-keys "^2.0.0"
 
-eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
-  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
+eslint-visitor-keys@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
+  integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint@^5.3.0:
-  version "5.16.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.16.0.tgz#a1e3ac1aae4a3fbd8296fcf8f7ab7314cbb6abea"
-  integrity sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==
+eslint-visitor-keys@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
+  integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
+
+eslint@^8.14.0:
+  version "8.14.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.14.0.tgz#62741f159d9eb4a79695b28ec4989fcdec623239"
+  integrity sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==
   dependencies:
-    "@babel/code-frame" "^7.0.0"
-    ajv "^6.9.1"
-    chalk "^2.1.0"
-    cross-spawn "^6.0.5"
-    debug "^4.0.1"
+    "@eslint/eslintrc" "^1.2.2"
+    "@humanwhocodes/config-array" "^0.9.2"
+    ajv "^6.10.0"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.3.2"
     doctrine "^3.0.0"
-    eslint-scope "^4.0.3"
-    eslint-utils "^1.3.1"
-    eslint-visitor-keys "^1.0.0"
-    espree "^5.0.1"
-    esquery "^1.0.1"
+    escape-string-regexp "^4.0.0"
+    eslint-scope "^7.1.1"
+    eslint-utils "^3.0.0"
+    eslint-visitor-keys "^3.3.0"
+    espree "^9.3.1"
+    esquery "^1.4.0"
     esutils "^2.0.2"
-    file-entry-cache "^5.0.1"
+    fast-deep-equal "^3.1.3"
+    file-entry-cache "^6.0.1"
     functional-red-black-tree "^1.0.1"
-    glob "^7.1.2"
-    globals "^11.7.0"
-    ignore "^4.0.6"
+    glob-parent "^6.0.1"
+    globals "^13.6.0"
+    ignore "^5.2.0"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
-    inquirer "^6.2.2"
-    js-yaml "^3.13.0"
+    is-glob "^4.0.0"
+    js-yaml "^4.1.0"
     json-stable-stringify-without-jsonify "^1.0.1"
-    levn "^0.3.0"
-    lodash "^4.17.11"
+    levn "^0.4.1"
+    lodash.merge "^4.6.2"
     minimatch "^3.0.4"
-    mkdirp "^0.5.1"
     natural-compare "^1.4.0"
-    optionator "^0.8.2"
-    path-is-inside "^1.0.2"
-    progress "^2.0.0"
-    regexpp "^2.0.1"
-    semver "^5.5.1"
-    strip-ansi "^4.0.0"
-    strip-json-comments "^2.0.1"
-    table "^5.2.3"
+    optionator "^0.9.1"
+    regexpp "^3.2.0"
+    strip-ansi "^6.0.1"
+    strip-json-comments "^3.1.0"
     text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
 
-espree@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz#5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a"
-  integrity sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==
+espree@^9.3.1:
+  version "9.3.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.3.1.tgz#8793b4bc27ea4c778c19908e0719e7b8f4115bcd"
+  integrity sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==
   dependencies:
-    acorn "^6.0.7"
-    acorn-jsx "^5.0.0"
-    eslint-visitor-keys "^1.0.0"
+    acorn "^8.7.0"
+    acorn-jsx "^5.3.1"
+    eslint-visitor-keys "^3.3.0"
 
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.0.1:
+esquery@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
   integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
   dependencies:
     estraverse "^5.1.0"
 
-esrecurse@^4.1.0:
+esrecurse@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
   integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
   dependencies:
     estraverse "^5.2.0"
-
-estraverse@^4.1.1:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
-  integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
 estraverse@^5.1.0, estraverse@^5.2.0:
   version "5.3.0"
@@ -1960,15 +2040,6 @@ extend@^3.0.1, extend@^3.0.2, extend@~3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
-external-editor@^3.0.3:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
-  integrity sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
-  dependencies:
-    chardet "^0.7.0"
-    iconv-lite "^0.4.24"
-    tmp "^0.0.33"
-
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -1979,7 +2050,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
   integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -1989,7 +2060,7 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-levenshtein@~2.0.6:
+fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -2007,19 +2078,12 @@ fecha@^4.2.0:
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.3.tgz#4d9ccdbc61e8629b259fdca67e65891448d569fd"
   integrity sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==
 
-figures@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
-  integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
+file-entry-cache@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
+  integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
-    escape-string-regexp "^1.0.5"
-
-file-entry-cache@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
-  integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
-  dependencies:
-    flat-cache "^2.0.1"
+    flat-cache "^3.0.4"
 
 file-uri-to-path@1.0.0:
   version "1.0.0"
@@ -2062,19 +2126,18 @@ find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-flat-cache@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
-  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
+flat-cache@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
+  integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
   dependencies:
-    flatted "^2.0.0"
-    rimraf "2.6.3"
-    write "1.0.3"
+    flatted "^3.1.0"
+    rimraf "^3.0.2"
 
-flatted@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
-  integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+flatted@^3.1.0:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
+  integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
 fn.name@1.x.x:
   version "1.1.0"
@@ -2209,6 +2272,13 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+glob-parent@^6.0.1:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
+  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
+  dependencies:
+    is-glob "^4.0.3"
+
 glob@3.2.11:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/glob/-/glob-3.2.11.tgz#4a973f635b9190f715d10987d5c00fd2815ebe3d"
@@ -2240,10 +2310,12 @@ glob@^7.0.3, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^11.7.0:
-  version "11.12.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
-  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+globals@^13.6.0, globals@^13.9.0:
+  version "13.13.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.13.0.tgz#ac32261060d8070e2719dd6998406e27d2b5727b"
+  integrity sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==
+  dependencies:
+    type-fest "^0.20.2"
 
 globals@^9.18.0:
   version "9.18.0"
@@ -2494,7 +2566,7 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
+iconv-lite@0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -2518,10 +2590,10 @@ ieee754@^1.1.13, ieee754@^1.1.4:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
-ignore@^4.0.6:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
-  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+ignore@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
+  integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
 immediate@^3.2.3:
   version "3.3.0"
@@ -2533,7 +2605,7 @@ immediate@~3.2.3:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.2.3.tgz#d140fa8f614659bd6541233097ddaac25cdd991c"
   integrity sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=
 
-import-fresh@^3.0.0:
+import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
   integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
@@ -2573,25 +2645,6 @@ inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, i
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
-inquirer@^6.2.2:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.2.tgz#ad50942375d036d327ff528c08bd5fab089928ca"
-  integrity sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==
-  dependencies:
-    ansi-escapes "^3.2.0"
-    chalk "^2.4.2"
-    cli-cursor "^2.1.0"
-    cli-width "^2.0.0"
-    external-editor "^3.0.3"
-    figures "^2.0.0"
-    lodash "^4.17.12"
-    mute-stream "0.0.7"
-    run-async "^2.2.0"
-    rxjs "^6.4.0"
-    string-width "^2.1.0"
-    strip-ansi "^5.1.0"
-    through "^2.3.6"
 
 internal-slot@^1.0.3:
   version "1.0.3"
@@ -2728,11 +2781,6 @@ is-finite@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.1.0.tgz#904135c77fb42c0641d6aa1bcdbc4daa8da082f3"
   integrity sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==
 
-is-fullwidth-code-point@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
-  integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
-
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
@@ -2745,7 +2793,7 @@ is-glob@^2.0.0:
   dependencies:
     is-extglob "^1.0.0"
 
-is-glob@^4.0.3:
+is-glob@^4.0.0, is-glob@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -2986,7 +3034,18 @@ jmespath@0.16.0:
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
   integrity sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==
 
-"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
+joi@^17.6.0:
+  version "17.6.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.6.0.tgz#0bb54f2f006c09a96e75ce687957bd04290054b2"
+  integrity sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.3"
+    "@sideway/formula" "^3.0.0"
+    "@sideway/pinpoint" "^2.0.0"
+
+"js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
@@ -2996,13 +3055,20 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@3.x, js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.14.0, js-yaml@^3.7.0:
+js-yaml@3.x, js-yaml@^3.13.1, js-yaml@^3.14.0, js-yaml@^3.7.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -3256,13 +3322,13 @@ levelup@~0.19.0:
     semver "~5.1.0"
     xtend "~3.0.0"
 
-levn@^0.3.0, levn@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
-  integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
+levn@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
+  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
   dependencies:
-    prelude-ls "~1.1.2"
-    type-check "~0.3.2"
+    prelude-ls "^1.2.1"
+    type-check "~0.4.0"
 
 linkify-it@^2.0.0:
   version "2.2.0"
@@ -3359,6 +3425,11 @@ lodash.isstring@^4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
 
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
 lodash.once@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
@@ -3369,7 +3440,7 @@ lodash.union@^4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
   integrity sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
+lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -3590,11 +3661,6 @@ mime@^2.2.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
   integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
-
-mimic-fn@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
-  integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
 minimatch@0.3:
   version "0.3.0"
@@ -3817,11 +3883,6 @@ multer@^1.4.1:
     type-is "^1.6.4"
     xtend "^4.0.0"
 
-mute-stream@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
-  integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
-
 nan@^2.14.0, nan@^2.3.2:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
@@ -3893,6 +3954,11 @@ node-forge@^0.7.1:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.6.tgz#fdf3b418aee1f94f0ef642cd63486c77ca9724ac"
   integrity sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==
+
+node-forge@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
+  integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
 
 node-gyp-build@^4.3.0:
   version "4.4.0"
@@ -4093,13 +4159,6 @@ one-time@^1.0.0:
   dependencies:
     fn.name "1.x.x"
 
-onetime@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
-  integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
-  dependencies:
-    mimic-fn "^1.0.0"
-
 opencollective-postinstall@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
@@ -4112,22 +4171,17 @@ optional-require@^1.1.8:
   dependencies:
     require-at "^1.0.6"
 
-optionator@^0.8.2:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
-  integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
+optionator@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
+  integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
   dependencies:
-    deep-is "~0.1.3"
-    fast-levenshtein "~2.0.6"
-    levn "~0.3.0"
-    prelude-ls "~1.1.2"
-    type-check "~0.3.2"
-    word-wrap "~1.2.3"
-
-os-tmpdir@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
-  integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
+    deep-is "^0.1.3"
+    fast-levenshtein "^2.0.6"
+    levn "^0.4.1"
+    prelude-ls "^1.2.1"
+    type-check "^0.4.0"
+    word-wrap "^1.2.3"
 
 p-limit@^1.1.0:
   version "1.3.0"
@@ -4214,15 +4268,15 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-path-is-inside@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
-  integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
-
 path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
+
+path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
 path-parse@^1.0.5, path-parse@^1.0.7:
   version "1.0.7"
@@ -4268,10 +4322,10 @@ pify@^4.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
-prelude-ls@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
-  integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
+prelude-ls@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
+  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
 process-nextick-args@~1.0.6:
   version "1.0.7"
@@ -4282,11 +4336,6 @@ process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
-
-progress@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
-  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 prom-client@10.2.3:
   version "10.2.3"
@@ -4558,10 +4607,10 @@ regenerator-runtime@^0.11.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
-regexpp@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
-  integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
+regexpp@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
+  integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
 repeating@^2.0.0:
   version "2.0.1"
@@ -4633,14 +4682,6 @@ resolve@^1.10.0, resolve@^1.20.0, resolve@^1.22.0:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
-restore-cursor@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
-  integrity sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
-  dependencies:
-    onetime "^2.0.0"
-    signal-exit "^3.0.2"
-
 retry-axios@0.3.2, retry-axios@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/retry-axios/-/retry-axios-0.3.2.tgz#5757c80f585b4cc4c4986aa2ffd47a60c6d35e13"
@@ -4650,13 +4691,6 @@ retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
-
-rimraf@2.6.3:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
-  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
-  dependencies:
-    glob "^7.1.3"
 
 rimraf@^2.6.1:
   version "2.7.1"
@@ -4671,18 +4705,6 @@ rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
-
-run-async@^2.2.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
-  integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
-
-rxjs@^6.4.0:
-  version "6.6.7"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
-  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
-  dependencies:
-    tslib "^1.9.0"
 
 safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
@@ -4736,7 +4758,7 @@ sax@>=0.6.0, sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -4799,10 +4821,22 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shell-quote@^1.6.1:
   version "1.7.3"
@@ -4823,7 +4857,7 @@ sigmund@~1.0.0:
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
   integrity sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=
 
-signal-exit@^3.0.2, signal-exit@^3.0.7:
+signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
@@ -4857,15 +4891,6 @@ sinon@^13.0.1:
     nise "^5.1.1"
     supports-color "^7.2.0"
 
-slice-ansi@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
-  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
-  dependencies:
-    ansi-styles "^3.2.0"
-    astral-regex "^1.0.0"
-    is-fullwidth-code-point "^2.0.0"
-
 smart-buffer@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
@@ -4893,6 +4918,23 @@ socket.io-client@2.3.0:
     object-component "0.0.3"
     parseqs "0.0.5"
     parseuri "0.0.5"
+    socket.io-parser "~3.3.0"
+    to-array "0.1.4"
+
+socket.io-client@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-2.4.0.tgz#aafb5d594a3c55a34355562fc8aea22ed9119a35"
+  integrity sha512-M6xhnKQHuuZd4Ba9vltCLT9oa+YvTsP8j9NcEiLElfIg8KeYPyhWOes6x4t+LTAC8enQbE/995AdTem2uNyKKQ==
+  dependencies:
+    backo2 "1.0.2"
+    component-bind "1.0.0"
+    component-emitter "~1.3.0"
+    debug "~3.1.0"
+    engine.io-client "~3.5.0"
+    has-binary2 "~1.0.2"
+    indexof "0.0.1"
+    parseqs "0.0.6"
+    parseuri "0.0.6"
     socket.io-parser "~3.3.0"
     to-array "0.1.4"
 
@@ -4930,6 +4972,18 @@ socket.io-parser@~3.4.0:
     component-emitter "1.2.1"
     debug "~4.1.0"
     isarray "2.0.1"
+
+socket.io@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-2.4.1.tgz#95ad861c9a52369d7f1a68acf0d4a1b16da451d2"
+  integrity sha512-Si18v0mMXGAqLqCVpTxBa8MGqriHGQh8ccEOhmsmNS3thNCGBwO8WGrwMibANsWtQQ5NStdZwHqZR3naJVFc3w==
+  dependencies:
+    debug "~4.1.0"
+    engine.io "~3.5.0"
+    has-binary2 "~1.0.2"
+    socket.io-adapter "~1.1.0"
+    socket.io-client "2.4.0"
+    socket.io-parser "~3.4.0"
 
 socket.io@~2.3.0:
   version "2.3.0"
@@ -5092,23 +5146,6 @@ streamsearch@0.1.2:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
-  integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
-  dependencies:
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^4.0.0"
-
-string-width@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
-  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
-  dependencies:
-    emoji-regex "^7.0.1"
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^5.1.0"
-
 string.prototype.padend@^3.0.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/string.prototype.padend/-/string.prototype.padend-3.1.3.tgz#997a6de12c92c7cb34dc8a201a6c53d9bd88a5f1"
@@ -5174,13 +5211,6 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
-  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
-  dependencies:
-    ansi-regex "^4.1.0"
-
 strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
@@ -5200,10 +5230,10 @@ strip-bom@^3.0.0:
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
   integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
 
-strip-json-comments@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
 supports-color@1.2.0:
   version "1.2.0"
@@ -5229,7 +5259,7 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.2.0:
+supports-color@^7.1.0, supports-color@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -5240,16 +5270,6 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
-
-table@^5.2.3:
-  version "5.4.6"
-  resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
-  integrity sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==
-  dependencies:
-    ajv "^6.10.2"
-    lodash "^4.17.14"
-    slice-ansi "^2.1.0"
-    string-width "^3.0.0"
 
 tar@^6.0.2, tar@^6.1.2:
   version "6.1.11"
@@ -5280,7 +5300,7 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-"through@>=2.2.7 <3", through@^2.3.6:
+"through@>=2.2.7 <3":
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -5289,13 +5309,6 @@ tiny-each-async@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/tiny-each-async/-/tiny-each-async-2.0.3.tgz#8ebbbfd6d6295f1370003fbb37162afe5a0a51d1"
   integrity sha1-jru/1tYpXxNwAD+7NxYq/loKUdE=
-
-tmp@^0.0.33:
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
-  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
-  dependencies:
-    os-tmpdir "~1.0.2"
 
 to-array@0.1.4:
   version "0.1.4"
@@ -5360,11 +5373,6 @@ tsconfig-paths@^3.14.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^1.9.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
@@ -5382,17 +5390,22 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
-type-check@~0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
-  integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
+type-check@^0.4.0, type-check@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
+  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
-    prelude-ls "~1.1.2"
+    prelude-ls "^1.2.1"
 
 type-detect@4.0.8, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
 type-is@^1.6.4, type-is@~1.6.18:
   version "1.6.18"
@@ -5582,6 +5595,11 @@ uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+v8-compile-cache@^2.0.3:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
+  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
+
 valid-url@~1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/valid-url/-/valid-url-1.0.9.tgz#1c14479b40f1397a75782f115e4086447433a200"
@@ -5620,12 +5638,12 @@ vaultclient@scality/vaultclient#8.2.2:
     werelogs scality/werelogs#8.1.0
     xml2js "0.4.19"
 
-vaultclient@scality/vaultclient#8.3.3:
-  version "8.3.3"
-  resolved "https://codeload.github.com/scality/vaultclient/tar.gz/bd48c69866d1377efc274b0cb969929f278410a0"
+vaultclient@scality/vaultclient#8.3.5:
+  version "8.3.4"
+  resolved "https://codeload.github.com/scality/vaultclient/tar.gz/6894a992ae8b5e702a7860403e12483bc22eb4d9"
   dependencies:
     agentkeepalive "^4.1.3"
-    arsenal scality/Arsenal#8.1.29
+    arsenal "git+https://github.com/scality/Arsenal#8.1.45"
     commander "2.20.0"
     werelogs scality/werelogs#8.1.0
     xml2js "0.4.19"
@@ -5687,7 +5705,7 @@ which@^1.1.1, which@^1.2.9:
   dependencies:
     isexe "^2.0.0"
 
-which@^2.0.2:
+which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
@@ -5726,7 +5744,7 @@ winston@^3.2.1:
     triple-beam "^1.3.0"
     winston-transport "^4.5.0"
 
-word-wrap@~1.2.3:
+word-wrap@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
@@ -5740,13 +5758,6 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
-
-write@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
-  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
-  dependencies:
-    mkdirp "^0.5.1"
 
 ws@^5.1.0:
   version "5.2.3"
@@ -5766,6 +5777,11 @@ ws@~6.1.0:
   integrity sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==
   dependencies:
     async-limiter "~1.0.0"
+
+ws@~7.4.2:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
+  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
 xml2js@0.2.8, xml2js@~0.2.8:
   version "0.2.8"
@@ -5824,6 +5840,11 @@ xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
   integrity sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=
+
+xmlhttprequest-ssl@~1.6.2:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz#03b713873b01659dfa2c1c5d056065b27ddc2de6"
+  integrity sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==
 
 xtend@^4.0.0, xtend@^4.0.2, xtend@~4.0.0:
   version "4.0.2"


### PR DESCRIPTION
use an arsenal commit hashtag for testing, will replace it with 8.1.45 once it's released.

this PR is mainly doing two things:
- update new arsenal error type: 
  - use `err.is.Error` instead of  `=== `error equal, 
  - use `assert.strictEqual(err.is.Error, true) ` instead of `deepStrictEqual(err, errors.Error)`
- after[ this change](https://github.com/scality/Arsenal/commit/b3ce76d7d8d2f62e7ebf8dbee46221923bac2c76) in arsenal, we can no longer use a random string to represent a non existing versionId for testing, it won't decode it successfully so will return `InvalidArgument` error instead of `NoSuchVersion` error that we expect. So even for non existing versionId, we have to give it a standard formated versionId, so I replaced several places where we use `000000000` for non existing versionId with a meaningful but also non existing versionId. https://github.com/scality/cloudserver/pull/4493/commits/b1d824c9aa573dfdd0b9d7b1509e7c18fbbd05c1


green build in zenko https://eve.devsca.com/github/scality/zenko/#/builders/4/builds/21334