### PR TITLE
feature: CLDSRV-178 match aws putBucketNotification error

### DIFF
--- a/lib/api/apiUtils/bucket/getNotificationConfiguration.js
+++ b/lib/api/apiUtils/bucket/getNotificationConfiguration.js
@@ -15,11 +15,21 @@ function getNotificationConfiguration(parsedXml) {
     }
     const targets = new Set(config.bucketNotificationDestinations.map(t => t.resource));
     const notifConfigTargets = notifConfig.queueConfig.map(t => t.queueArn.split(':')[5]);
-    if (!notifConfigTargets.every(t => targets.has(t))) {
-        // TODO: match the error message to AWS's response along with
-        // the request destination name in the response
-        const errDesc = 'Unable to validate the destination configuration';
-        return { error: errors.InvalidArgument.customizeDescription(errDesc) };
+    // getting invalid targets
+    const invalidTargets = [];
+    notifConfigTargets.forEach((t, i) => {
+        if (!targets.has(t)) {
+            invalidTargets.push({
+                ArgumentName: notifConfig.queueConfig[i].queueArn,
+                ArgumentValue: 'The destination queue does not exist',
+            });
+        }
+    });
+    if (invalidTargets.length > 0) {
+        const errDesc = 'Unable to validate the following destination configurations';
+        let error = errors.InvalidArgument.customizeDescription(errDesc);
+        error = error.addMetadataEntry('invalidArguments', invalidTargets);
+        return { error };
     }
     return notifConfig;
 }

--- a/tests/unit/api/apiUtils/getNotificationConfiguration.js
+++ b/tests/unit/api/apiUtils/getNotificationConfiguration.js
@@ -1,0 +1,85 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const { config } = require('../../../../lib/Config');
+const errors = require('arsenal').errors;
+
+const getNotificationConfiguration =
+    require('../../../../lib/api/apiUtils/bucket/getNotificationConfiguration');
+
+const parsedXml = {
+    NotificationConfiguration: {
+        QueueConfiguration: [
+            {
+                Id: ['notification-id'],
+                Event: ['s3:ObjectCreated:*'],
+                Queue: ['arn:scality:bucketnotif:::target1'],
+            },
+        ],
+    }
+};
+
+const expectedConfig = {
+    queueConfig: [
+        {
+          events: ['s3:ObjectCreated:*'],
+          queueArn: 'arn:scality:bucketnotif:::target1',
+          id: 'notification-id',
+          filterRules: undefined
+        }
+      ]
+};
+
+const destination1 = [
+    {
+        resource: 'target1',
+        type: 'dummy',
+        host: 'localhost:6000',
+    }
+];
+
+const destinations2 = [
+    {
+        resource: 'target2',
+        type: 'dummy',
+        host: 'localhost:6000',
+    }
+];
+
+describe('getNotificationConfiguration', () => {
+    afterEach(() => sinon.restore());
+
+    it('should return notification configuration', done => {
+        sinon.stub(config, 'bucketNotificationDestinations').value(destination1);
+        const notifConfig = getNotificationConfiguration(parsedXml);
+        assert.deepEqual(notifConfig, expectedConfig);
+        return done();
+    });
+
+    it('should return empty notification configuration', done => {
+        sinon.stub(config, 'bucketNotificationDestinations').value(destination1);
+        const notifConfig = getNotificationConfiguration({
+            NotificationConfiguration: {}
+        });
+        assert.deepEqual(notifConfig, {});
+        return done();
+    });
+
+    it('should return error if no destinations found', done => {
+        sinon.stub(config, 'bucketNotificationDestinations').value([]);
+        const notifConfig = getNotificationConfiguration(parsedXml);
+        assert.deepEqual(notifConfig.error, errors.InvalidArgument);
+        return done();
+    });
+
+    it('should return error if destination invalid', done => {
+        sinon.stub(config, 'bucketNotificationDestinations').value(destinations2);
+        const notifConfig = getNotificationConfiguration(parsedXml);
+        assert.deepEqual(notifConfig.error, errors.InvalidArgument);
+        const invalidArguments = notifConfig.error.metadata.get('invalidArguments');
+        assert.deepEqual(invalidArguments, [{
+            ArgumentName: 'arn:scality:bucketnotif:::target1',
+            ArgumentValue: 'The destination queue does not exist',
+        }]);
+        return done();
+    });
+});


### PR DESCRIPTION
Issue: [CLDSRV-178](https://scality.atlassian.net/browse/CLDSRV-178)

Match AWS putBucketNotification error when notification destinations are invalid by including the invalid destinations in the error