### PR TITLE
Feature/cldsrv 183 implement restore object api

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -104,7 +104,6 @@ const constants = {
         'policyStatus',
         'publicAccessBlock',
         'requestPayment',
-        'restore',
         'torrent',
     ],
 
@@ -198,6 +197,7 @@ const constants = {
         'bucket',
     ],
     allowedUtapiEventFilterStates: ['allow', 'deny'],
+    allowedRestoreObjectRequestTierValues: ['Standard'],
 };
 
 module.exports = constants;

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -56,6 +56,7 @@ const objectPutTagging = require('./objectPutTagging');
 const objectPutPart = require('./objectPutPart');
 const objectPutCopyPart = require('./objectPutCopyPart');
 const objectPutRetention = require('./objectPutRetention');
+const objectRestore = require('./objectRestore');
 const prepareRequestContexts
     = require('./apiUtils/authorization/prepareRequestContexts');
 const serviceGet = require('./serviceGet');
@@ -316,6 +317,7 @@ const api = {
     objectPutPart,
     objectPutCopyPart,
     objectPutRetention,
+    objectRestore,
     serviceGet,
     websiteGet,
     websiteHead,

--- a/lib/api/apiUtils/object/coldStorage.js
+++ b/lib/api/apiUtils/object/coldStorage.js
@@ -2,6 +2,10 @@
  * Code based on Yutaka Oishi (Fujifilm) contributions
  * Date: 11 Sep 2020
  */
+const ObjectMDArchive = require('arsenal').models.ObjectMDArchive;
+const errors = require('arsenal').errors;
+const { config } = require('../../../Config');
+const { locationConstraints } = config;
 
 /**
  * Get response header "x-amz-restore"
@@ -28,6 +32,130 @@ function getAmzRestoreResHeader(objMD) {
     return undefined;
 }
 
+
+/**
+ * Check if restore can be done.
+ *
+ * @param {ObjectMD} objectMD - object metadata
+ * @param {object} log - werelogs logger
+ * @return {ArsenalError|undefined} - undefined if the conditions for RestoreObject are fulfilled
+ */
+function _validateStartRestore(objectMD, log) {
+    const isLocationCold = locationConstraints[objectMD.dataStoreName]?.isCold;
+    if (!isLocationCold) {
+        // return InvalidObjectState error if the object is not in cold storage,
+        // not in cold storage means either location cold flag not exists or cold flag is explicit false
+        log.debug('The bucket of the object is not in a cold storage location.',
+            {
+                isLocationCold,
+                method: '_validateStartRestore',
+            });
+        return errors.InvalidObjectState;
+    }
+    if (objectMD.archive?.restoreCompletedAt
+        && new Date(objectMD.archive?.restoreWillExpireAt) < new Date(Date.now())) {
+        // return InvalidObjectState error if the restored object is expired
+        // but restore info md of this object has not yet been cleared
+        log.debug('The restored object already expired.',
+            {
+                archive: objectMD.archive,
+                method: '_validateStartRestore',
+            });
+        return errors.InvalidObjectState;
+    }
+    if (objectMD.archive?.restoreRequestedAt && !objectMD.archive?.restoreCompletedAt) {
+        // return RestoreAlreadyInProgress error if the object is currently being restored
+        // check if archive.restoreRequestAt exists and archive.restoreCompletedAt not yet exists
+        log.debug('The object is currently being restored.',
+            {
+                archive: objectMD.archive,
+                method: '_validateStartRestore',
+            });
+        return errors.RestoreAlreadyInProgress;
+    }
+    return undefined;
+}
+
+/**
+ * Check if the object is already restored
+ *
+ * @param {ObjectMD} objectMD - object metadata
+ * @param {object} log - werelogs logger
+ * @return {boolean} - true if the object is already restored
+ */
+function isObjectAlreadyRestored(objectMD, log) {
+    //  check if restoreCompletedAt field exists
+    //  and archive.restoreWillExpireAt > current time
+    const isObjectAlreadyRestored = objectMD.archive?.restoreCompletedAt
+        && new Date(objectMD.archive?.restoreWillExpireAt) >= new Date(Date.now());
+    log.debug('The restore status of the object.',
+        {
+            isObjectAlreadyRestored,
+            method: 'isObjectAlreadyRestored'
+        });
+    return isObjectAlreadyRestored;
+}
+
+/**
+ * update restore expiration date.
+ *
+ * @param {ObjectMD} objectMD - objectMD instance
+ * @param {object} restoreParam - restore param
+ * @param {object} log - werelogs logger
+ * @return {ArsenalError|undefined} internal error if object MD is not valid
+ *
+ */
+function _updateRestoreInfo(objectMD, restoreParam, log) {
+    if (!objectMD.archive) {
+        log.debug('objectMD.archive doesn\'t exits', {
+            objectMD,
+            method: '_updateRestoreInfo'
+        });
+        return errors.InternalError.customizeDescription('Archive metadata is missing.');
+    }
+    // eslint-disable-next-line no-param-reassign
+    objectMD.archive.restoreRequestedAt = new Date();
+    // eslint-disable-next-line no-param-reassign
+    objectMD.archive.restoreRequestedDays = restoreParam.days;
+    if (!ObjectMDArchive.isValid(objectMD.archive)) {
+        log.debug('archive is not valid', {
+            archive: objectMD.archive,
+            method: '_updateRestoreInfo'
+        });
+        return errors.InternalError.customizeDescription('Invalid archive metadata.');
+    }
+    return undefined;
+}
+
+/**
+ * start to restore object.
+ * If not exist x-amz-restore, add it to objectMD.(x-amz-restore = false)
+ * calculate restore expiry-date and add it to objectMD.
+ * Be called by objectRestore.js
+ *
+ * @param {ObjectMD} objectMD - objectMd instance
+ * @param {object} restoreParam - bucket name
+ * @param {object} log - werelogs logger
+ * @param {function} cb - bucket name
+ * @return {undefined}
+ *
+ */
+function startRestore(objectMD, restoreParam, log, cb) {
+    log.info('Validating if restore can be done or not.');
+    const checkResultError = _validateStartRestore(objectMD, log);
+    if (checkResultError) {
+        return cb(checkResultError);
+    }
+    log.info('Updating restore information.');
+    const updateResultError = _updateRestoreInfo(objectMD, restoreParam, log);
+    if (updateResultError) {
+        return cb(updateResultError);
+    }
+    return cb(null, isObjectAlreadyRestored(objectMD, log));
+}
+
+
 module.exports = {
-    getAmzRestoreResHeader,
+    startRestore,
+    getAmzRestoreResHeader
 };

--- a/lib/api/apiUtils/object/objectRestore.js
+++ b/lib/api/apiUtils/object/objectRestore.js
@@ -1,0 +1,153 @@
+const async = require('async');
+const { errors, s3middleware } = require('arsenal');
+
+const { allowedRestoreObjectRequestTierValues } = require('../../../../constants');
+const coldStorage = require('./coldStorage');
+const monitoring = require('../../../utilities/monitoringHandler');
+const { pushMetric } = require('../../../utapi/utilities');
+const { decodeVersionId } = require('./versioning');
+const collectCorsHeaders = require('../../../utilities/collectCorsHeaders');
+const { parseRestoreRequestXml } = s3middleware.objectRestore;
+
+
+/**
+ * Check if tier is supported
+ * @param {object} restoreInfo - restore information
+ * @returns {ArsenalError|undefined} return NotImplemented error if tier not support
+ */
+function checkTierSupported(restoreInfo) {
+    if (!allowedRestoreObjectRequestTierValues.includes(restoreInfo.tier)) {
+        return errors.NotImplemented;
+    }
+    return undefined;
+}
+
+/**
+ * POST Object restore process
+ *
+ * @param {MetadataWrapper} metadata - metadata wrapper
+ * @param {object} mdUtils - utility object to treat metadata
+ * @param {AuthInfo} userInfo - Instance of AuthInfo class with requester's info
+ * @param {IncomingMessage} request - request info
+ * @param {object} log - Werelogs logger
+ * @param {function} callback callback function
+ * @return {undefined}
+ */
+function objectRestore(metadata, mdUtils, userInfo, request, log, callback) {
+    const METHOD = 'objectRestore';
+
+    const { bucketName, objectKey } = request;
+
+    log.debug('processing request', { method: METHOD });
+
+    const decodedVidResult = decodeVersionId(request.query);
+    if (decodedVidResult instanceof Error) {
+        log.trace('invalid versionId query',
+            {
+                method: METHOD,
+                versionId: request.query.versionId,
+                error: decodedVidResult,
+            });
+        return process.nextTick(() => callback(decodedVidResult));
+    }
+
+    let isObjectRestored = false;
+
+    const mdValueParams = {
+        authInfo: userInfo,
+        bucketName,
+        objectKey,
+        versionId: decodedVidResult,
+        requestType: 'restoreObject',
+    };
+
+    return async.waterfall([
+            // get metadata of bucket and object
+            function validateBucketAndObject(next) {
+                return mdUtils.metadataValidateBucketAndObj(mdValueParams, log, (err, bucketMD, objectMD) => {
+                    if (err) {
+                        log.trace('request authorization failed', { method: METHOD, error: err });
+                        return next(err);
+                    }
+                    // Call back error if object metadata could not be obtained
+                    if (!objectMD) {
+                        const err = decodedVidResult ? errors.NoSuchVersion : errors.NoSuchKey;
+                        log.trace('error no object metadata found', { method: METHOD, error: err });
+                        return next(err, bucketMD);
+                    }
+                    // If object metadata is delete marker,
+                    // call back NoSuchKey or MethodNotAllowed depending on specifying versionId
+                    if (objectMD.isDeleteMarker) {
+                        let err = errors.NoSuchKey;
+                        if (decodedVidResult) {
+                            err = errors.MethodNotAllowed;
+                        }
+                        log.trace('version is a delete marker', { method: METHOD, error: err });
+                        return next(err, bucketMD, objectMD);
+                    }
+                    log.info('it acquired the object metadata.', {
+                        'method': METHOD,
+                    });
+                    return next(null, bucketMD, objectMD);
+                });
+            },
+
+            // generate restore param obj from xml of request body and check tier validity
+            function parseRequestXmlAndCheckTier(bucketMD, objectMD, next) {
+                log.trace('parsing object restore information');
+                return parseRestoreRequestXml(request.post, log, (err, restoreInfo) => {
+                    if (err) {
+                        return next(err, bucketMD, objectMD, restoreInfo);
+                    }
+                    log.info('it parsed xml of the request body.', { method: METHOD, value: restoreInfo });
+                    const checkTierResult = checkTierSupported(restoreInfo);
+                    if (checkTierResult instanceof Error) {
+                        return next(checkTierResult);
+                    }
+                    return next(null, bucketMD, objectMD, restoreInfo);
+                });
+            },
+            // start restore process
+            function startRestore(bucketMD, objectMD, restoreInfo, next) {
+                return coldStorage.startRestore(objectMD, restoreInfo, log,
+                    (err, _isObjectRestored) => {
+                        isObjectRestored = _isObjectRestored;
+                        return next(err, bucketMD, objectMD);
+                    });
+            },
+            function updateObjectMD(bucketMD, objectMD, next) {
+                const params = objectMD.versionId ? { versionId: objectMD.versionId } : {};
+                metadata.putObjectMD(bucketMD.getName(), objectKey, objectMD, params,
+                    log, err => next(err, bucketMD, objectMD));
+            },
+        ],
+        (err, bucketMD) => {
+            // generate CORS response header
+            const responseHeaders = collectCorsHeaders(request.headers.origin, request.method, bucketMD);
+            if (err) {
+                log.trace('error processing request',
+                    {
+                        method: METHOD,
+                        error: err,
+                    });
+                monitoring.promMetrics(
+                    'POST', bucketName, err.code, 'restoreObject');
+                return callback(err, err.code, responseHeaders);
+            }
+            pushMetric('restoreObject', log, {
+                userInfo,
+                bucket: bucketName,
+            });
+            if (isObjectRestored) {
+                monitoring.promMetrics(
+                    'POST', bucketName, '200', 'restoreObject');
+                return callback(null, 200, responseHeaders);
+            }
+            monitoring.promMetrics(
+                'POST', bucketName, '202', 'restoreObject');
+            return callback(null, 202, responseHeaders);
+        });
+}
+
+
+module.exports = objectRestore;

--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -396,7 +396,6 @@ function multiObjectDelete(authInfo, request, log, callback) {
             return vault.checkPolicies(requestContextParams, authInfo.getArn(),
                 log, (err, authorizationResults) => {
                     // there were no policies so received a blanket AccessDenied
-                    log.info('please see here: ', { err, authorizationResults });
                     if (err?.is.AccessDenied) {
                         objects.forEach(entry => {
                             errorResults.push({

--- a/lib/api/objectRestore.js
+++ b/lib/api/objectRestore.js
@@ -1,0 +1,29 @@
+/*
+ * Code based on Yutaka Oishi (Fujifilm) contributions
+ * Date: 11 Sep 2020
+ *
+ * This module handles POST Object restore.
+ *
+ * @module api/objectRestore
+ */
+
+const metadata = require('../metadata/wrapper');
+const metadataUtils = require('../metadata/metadataUtils');
+
+const sdtObjectRestore = require('./apiUtils/object/objectRestore');
+
+/**
+ * Process POST Object restore request.
+ *
+ * @param {AuthInfo} userInfo Instance of AuthInfo class with requester's info
+ * @param {object} request http request object
+ * @param {object} log - Werelogs logger
+ * @param {function} callback - callback to server
+ * @return {undefined}
+ */
+function objectRestore(userInfo, request, log, callback) {
+    return sdtObjectRestore(metadata, metadataUtils, userInfo, request,
+        log, callback);
+}
+
+module.exports = objectRestore;

--- a/tests/unit/api/objectRestore.js
+++ b/tests/unit/api/objectRestore.js
@@ -1,0 +1,159 @@
+const assert = require('assert');
+
+const { bucketPut } = require('../../../lib/api/bucketPut');
+const objectPut = require('../../../lib/api/objectPut');
+const objectRestore = require('../../../lib/api/objectRestore');
+const { cleanup, DummyRequestLogger, makeAuthInfo } = require('../helpers');
+const mdColdHelper = require('./utils/metadataMockColdStorage');
+const DummyRequest = require('../DummyRequest');
+const metadata = require('../metadataswitch');
+
+const log = new DummyRequestLogger();
+const authInfo = makeAuthInfo('accessKey1');
+const namespace = 'default';
+const bucketName = 'bucketname';
+const objectName = 'objectName';
+const postBody = Buffer.from('I am a body', 'utf8');
+const restoreDays = 1;
+
+const bucketPutRequest = {
+    bucketName,
+    headers: { host: `${bucketName}.s3.amazonaws.com` },
+    url: '/',
+};
+
+const putObjectRequest = new DummyRequest({
+    bucketName,
+    namespace,
+    objectKey: objectName,
+    headers: {},
+    url: `/${bucketName}/${objectName}`,
+}, postBody);
+
+const objectRestoreXml = '<RestoreRequest ' +
+    'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+    `<Days>${restoreDays}</Days>` +
+    '<Tier>Standard</Tier>' +
+    '</RestoreRequest>';
+
+const objectRestoreXmlBulkTier = '<RestoreRequest ' +
+    'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+    `<Days>${restoreDays}</Days>` +
+    '<Tier>Bulk</Tier>' +
+    '</RestoreRequest>';
+
+const objectRestoreXmlExpeditedTier = '<RestoreRequest ' +
+    'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+    `<Days>${restoreDays}</Days>` +
+    '<Tier>Expedited</Tier>' +
+    '</RestoreRequest>';
+
+const objectRestoreRequest = requestXml => ({
+        bucketName,
+        objectKey: objectName,
+        headers: { host: `${bucketName}.s3.amazonaws.com` },
+        post: requestXml,
+    });
+
+describe('restoreObject API', () => {
+    before(cleanup);
+
+    afterEach(() => cleanup());
+
+    it('should return InvalidObjectState error when object is not in cold storage', done => {
+        bucketPut(authInfo, bucketPutRequest, log, err => {
+            assert.ifError(err);
+            objectPut(authInfo, putObjectRequest, undefined, log, err => {
+                assert.ifError(err);
+                objectRestore(authInfo, objectRestoreRequest(objectRestoreXml), log, err => {
+                    assert.strictEqual(err.is.InvalidObjectState, true);
+                    done();
+                });
+            });
+        });
+    });
+
+    it('should return RestoreAlreadyInProgress error when object restore is already in progress', done => {
+        mdColdHelper.putBucketMock(bucketName, null, () => {
+            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getArchiveOngoingRequestMD(), () => {
+                objectRestore(authInfo, objectRestoreRequest(objectRestoreXml), log, err => {
+                    assert.strictEqual(err.is.RestoreAlreadyInProgress, true);
+                    done();
+                });
+            });
+        });
+    });
+
+    it('should return NotImplemented error when object restore Tier is \'Bulk\'', done => {
+        mdColdHelper.putBucketMock(bucketName, null, () => {
+            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getArchiveArchivedMD(), () => {
+                objectRestore(authInfo, objectRestoreRequest(objectRestoreXmlBulkTier), log, err => {
+                    assert.strictEqual(err.is.NotImplemented, true);
+                    done();
+                });
+            });
+        });
+    });
+
+    it('should return NotImplemented error when object restore Tier is \'Expedited\'', done => {
+        mdColdHelper.putBucketMock(bucketName, null, () => {
+            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getArchiveArchivedMD(), () => {
+                objectRestore(authInfo, objectRestoreRequest(objectRestoreXmlExpeditedTier), log, err => {
+                    assert.strictEqual(err.is.NotImplemented, true);
+                    done();
+                });
+            });
+        });
+    });
+
+    it('should return Accepted and update objectMD ' +
+        'while restoring an object from cold storage ' +
+        'and the object doesn\'t have a restored copy in bucket', done => {
+        const testStartTime = new Date(Date.now());
+        mdColdHelper.putBucketMock(bucketName, null, () => {
+            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getArchiveArchivedMD(), () => {
+                objectRestore(authInfo, objectRestoreRequest(objectRestoreXml), log, (err, statusCode) => {
+                    assert.ifError(err);
+                    assert.strictEqual(statusCode, 202);
+                    metadata.getObjectMD(bucketName, objectName, {}, log, (err, md) => {
+                        const testEndTime = new Date(Date.now());
+                        assert.strictEqual(md.archive.restoreRequestedDays, restoreDays);
+                        assert.strictEqual(testStartTime < md.archive.restoreRequestedAt < testEndTime, true);
+                        done();
+                        });
+                });
+            });
+        });
+    });
+
+    it('should update the expiry time and return OK ' +
+        'while restoring an object from cold storage ' +
+        'and the object have a restored copy in bucket', done => {
+        const testStartTime = new Date(Date.now());
+        mdColdHelper.putBucketMock(bucketName, null, () => {
+            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getArchiveRestoredMD(), () => {
+                objectRestore(authInfo, objectRestoreRequest(objectRestoreXml), log, (err, statusCode) => {
+                    assert.ifError(err);
+                    assert.strictEqual(statusCode, 200);
+                    metadata.getObjectMD(bucketName, objectName, {}, log, (err, md) => {
+                        const testEndTime = new Date(Date.now());
+                        assert.strictEqual(md.archive.restoreRequestedDays, restoreDays);
+                        assert.strictEqual(testStartTime < md.archive.restoreRequestedAt < testEndTime, true);
+                            done();
+                        });
+                });
+            });
+        });
+    });
+
+    it('should return InvalidObjectState ' +
+        'while restoring an expired restored object', () => {
+        mdColdHelper.putBucketMock(bucketName, null, () => {
+            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getArchiveExpiredMD(), () => {
+                objectRestore(authInfo, objectRestoreRequest(objectRestoreXml), log, err => {
+                    assert.strictEqual(err.is.InvalidObjectState, true);
+                });
+            });
+        });
+    });
+});

--- a/tests/unit/api/utils/metadataMockColdStorage.js
+++ b/tests/unit/api/utils/metadataMockColdStorage.js
@@ -68,8 +68,8 @@ const baseMd = {
 function putBucketMock(bucketName, location, cb) {
     const bucket = new BucketInfo(
         bucketName,
-        'ownerid',
-        'ownerdisplayname',
+        baseMd['owner-id'],
+        baseMd['owner-display-name'],
         new Date().toJSON(),
         null,
         null,
@@ -115,7 +115,7 @@ function getArchiveArchivedMD() {
  */
 function getArchiveOngoingRequestMD() {
     return {
-        archive: new ObjectMDArchive({}, new Date(0), 5).getValue(),
+        archive: new ObjectMDArchive({}, new Date(Date.now() - 60), 5).getValue(),
     };
 }
 
@@ -127,19 +127,37 @@ function getArchiveRestoredMD() {
     return {
         archive: new ObjectMDArchive(
             {},
-            new Date(0),
+            new Date(Date.now() - 60000),
             5,
-            new Date(1000),
-            new Date(10000)).getValue(),
-        'x-amz-restore': new ObjectMDAmzRestore(false, new Date(20000)),
+            new Date(Date.now() - 10000),
+            new Date(Date.now() + 60000 * 60 * 24)).getValue(),
+        'x-amz-restore': new ObjectMDAmzRestore(false, new Date(Date.now() + 60 * 60 * 24)),
     };
 }
+
+/**
+ * Computes the 'archive' field of the object MD as a restored object from cold storage
+ * @returns {ObjectMDArchive} the MD object
+ */
+function getArchiveExpiredMD() {
+    return {
+        archive: new ObjectMDArchive(
+            {},
+            new Date(Date.now() - 30000),
+            5,
+            new Date(Date.now() - 20000),
+            new Date(Date.now() - 10000)).getValue(),
+        'x-amz-restore': new ObjectMDAmzRestore(false, new Date(Date.now() + 60 * 60 * 24)),
+    };
+}
+
 
 module.exports = {
     putObjectMock,
     getArchiveArchivedMD,
     getArchiveOngoingRequestMD,
     getArchiveRestoredMD,
+    getArchiveExpiredMD,
     putBucketMock,
     defaultLocation,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -510,49 +510,8 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/Arsenal#8.1.48":
-  version "8.1.48"
-  resolved "git+https://github.com/scality/Arsenal#3ed46f2d16a1bf08b58f57fd7549ab4e7440dc6c"
-  dependencies:
-    "@types/async" "^3.2.12"
-    "@types/utf8" "^3.0.1"
-    JSONStream "^1.0.0"
-    agentkeepalive "^4.1.3"
-    ajv "6.12.3"
-    async "~2.6.4"
-    aws-sdk "2.80.0"
-    azure-storage "2.10.3"
-    backo "^1.1.0"
-    base-x "3.0.8"
-    base62 "2.0.1"
-    bson "4.0.0"
-    debug "~4.1.0"
-    diskusage "^1.1.1"
-    fcntl "github:scality/node-fcntl#0.2.0"
-    hdclient scality/hdclient#1.1.0
-    https-proxy-agent "^2.2.0"
-    ioredis "^4.28.5"
-    ipaddr.js "1.9.1"
-    joi "^17.6.0"
-    level "~5.0.1"
-    level-sublevel "~6.6.5"
-    mongodb "^3.0.1"
-    node-forge "^1.3.0"
-    prom-client "10.2.3"
-    simple-glob "^0.2.0"
-    socket.io "2.4.1"
-    socket.io-client "2.4.0"
-    sproxydclient "github:scality/sproxydclient#8.0.3"
-    utf8 "3.0.0"
-    uuid "^3.0.1"
-    werelogs scality/werelogs#8.1.0
-    xml2js "~0.4.23"
-  optionalDependencies:
-    ioctl "^2.0.2"
-
 "arsenal@git+https://github.com/scality/Arsenal.git#8.1.48":
   version "8.1.48"
-  uid "3ed46f2d16a1bf08b58f57fd7549ab4e7440dc6c"
   resolved "git+https://github.com/scality/Arsenal.git#3ed46f2d16a1bf08b58f57fd7549ab4e7440dc6c"
   dependencies:
     "@types/async" "^3.2.12"


### PR DESCRIPTION
commit1: bump arsenal (based on this pr https://github.com/scality/Arsenal/pull/1888)
commit2: add new API entrance (from Yutaka Oishi)
commit3: add general cold storage util functions (from Yutaka Oishi)
commit4: remove `restore` from unsupported API list
commit5: implement restoreObject api logic(workflow like the most of the other APIs): 
- decode versionId
- validate bucket and object existance
- check if isDeleteMarker, return error
- parse restore request XML (from arsenal, in this pr https://github.com/scality/Arsenal/pull/1888)
- check if tier param in request is supported
- startResotre
  - check error cases
  - update objectMD
commit 6: unit test