### PR TITLE
feature: CLDSRV-162 update bad version ids to be proper

### DIFF
--- a/tests/functional/aws-node-sdk/test/object/getObjectLegalHold.js
+++ b/tests/functional/aws-node-sdk/test/object/getObjectLegalHold.js
@@ -86,7 +86,7 @@ describe('GET object legal hold', () => {
             s3.getObjectLegalHold({
                 Bucket: bucket,
                 Key: key,
-                VersionId: '000000000000',
+                VersionId: '012345678901234567890123456789012',
             }, err => {
                 checkError(err, 'NoSuchVersion', 404);
                 done();

--- a/tests/functional/aws-node-sdk/test/object/getRetention.js
+++ b/tests/functional/aws-node-sdk/test/object/getRetention.js
@@ -106,7 +106,7 @@ describe('GET object retention', () => {
             s3.getObjectRetention({
                 Bucket: bucketName,
                 Key: objectName,
-                VersionId: '000000000000',
+                VersionId: '012345678901234567890123456789012',
             }, err => {
                 checkError(err, 'NoSuchVersion', 404);
                 done();

--- a/tests/functional/aws-node-sdk/test/object/putObjectLegalHold.js
+++ b/tests/functional/aws-node-sdk/test/object/putObjectLegalHold.js
@@ -98,7 +98,7 @@ describe('PUT object legal hold', () => {
             s3.putObjectLegalHold({
                 Bucket: bucket,
                 Key: key,
-                VersionId: '000000000000',
+                VersionId: '012345678901234567890123456789012',
                 LegalHold: mockLegalHold.on,
             }, err => {
                 checkError(err, 'NoSuchVersion', 404);

--- a/tests/functional/aws-node-sdk/test/object/putRetention.js
+++ b/tests/functional/aws-node-sdk/test/object/putRetention.js
@@ -79,7 +79,7 @@ describe('PUT object retention', () => {
             s3.putObjectRetention({
                 Bucket: bucketName,
                 Key: objectName,
-                VersionId: '000000000000',
+                VersionId: '012345678901234567890123456789012',
                 Retention: retentionConfig,
             }, err => {
                 checkError(err, 'NoSuchVersion', 404);


### PR DESCRIPTION
(cherry picked from commit 5a6b01c4d5ddba2404f9960765c784890bda67d4)

# Pull request template

## Description

### Motivation and context

Why is this change required? What problem does it solve?

### Related issues

Please use the following link syntaxes #600 to reference issues in the
current repository

## Checklist

### Add tests to cover the changes

New tests added or existing tests modified to cover all changes

### Code conforms with the [style guide](https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#coding-style-guidelines)

### Sign your work

In order to contribute to the project, you must sign your work
https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#sign-your-work

Thank you again for contributing! We will try to test and integrate the change
as soon as we can.
