### PR TITLE
CLDSRV-196: create new werelogs object over using global werelogs

### DIFF
--- a/lib/utilities/logger.js
+++ b/lib/utilities/logger.js
@@ -1,8 +1,8 @@
-const werelogs = require('werelogs');
+const { Werelogs } = require('werelogs');
 
 const _config = require('../Config.js').config;
 
-werelogs.configure({
+const werelogs = new Werelogs({
     level: _config.log.logLevel,
     dump: _config.log.dumpLevel,
 });


### PR DESCRIPTION
Issue: configuring werelogs global object does not set the correct log levels for loggers

Change:
* create new werelogs object with defaults defined in config.json