### PR TITLE
INTEGRATION [PR#4523 > development/8.5] CLDSRV-196: create new werelogs object over using global werelogs

### DIFF
--- a/lib/utilities/logger.js
+++ b/lib/utilities/logger.js
@@ -1,8 +1,8 @@
-const werelogs = require('werelogs');
+const { Werelogs } = require('werelogs');
 
 const _config = require('../Config.js').config;
 
-werelogs.configure({
+const werelogs = new Werelogs({
     level: _config.log.logLevel,
     dump: _config.log.dumpLevel,
 });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #4523.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.5/bugfix/CLDSRV-196/fixLoggerConfiguration`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.5/bugfix/CLDSRV-196/fixLoggerConfiguration
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.5/bugfix/CLDSRV-196/fixLoggerConfiguration
```

Please always comment pull request #4523 instead of this one.