### PR TITLE
CLDSRV-202 Put object version with x-scal-s3-version-id

### DIFF
--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -8,7 +8,7 @@ const services = require('../../../services');
 const logger = require('../../../utilities/logger');
 const { dataStore } = require('./storeObject');
 const locationConstraintCheck = require('./locationConstraintCheck');
-const { versioningPreprocessing } = require('./versioning');
+const { versioningPreprocessing, overwritingVersioning } = require('./versioning');
 const removeAWSChunked = require('./removeAWSChunked');
 const getReplicationInfo = require('./getReplicationInfo');
 const { config } = require('../../../Config');
@@ -60,6 +60,9 @@ function _storeInMDandDeleteData(bucketName, dataGetInfo, cipherBundle,
 function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
         canonicalID, cipherBundle, request, isDeleteMarker, streamingV4Params,
         log, callback) {
+    const putVersionId = request.headers['x-scal-s3-version-id'];
+    const isPutVersion = putVersionId || putVersionId === '';
+
     const size = isDeleteMarker ? 0 : request.parsedContentLength;
     // although the request method may actually be 'DELETE' if creating a
     // delete marker, for our purposes we consider this to be a 'PUT'
@@ -257,6 +260,11 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
             return next(null, dataGetInfoArr);
         },
         function getVersioningInfo(infoArr, next) {
+            // if x-scal-s3-version-id header is specified, we overwrite the object/version metadata.
+            if (isPutVersion) {
+                const options = overwritingVersioning(objMD, metadataStoreParams);
+                return process.nextTick(() => next(null, options, infoArr));
+            }
             return versioningPreprocessing(bucketName, bucketMD,
                 metadataStoreParams.objectKey, objMD, log, (err, options) => {
                     if (err) {

--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -10,7 +10,32 @@ const versionIdUtils = versioning.VersionID;
 const nonVersionedObjId =
     versionIdUtils.getInfVid(config.replicationGroupId);
 
-/** decodedVidResult - decode the version id from a query object
+/** decodeVID - decode the version id
+ * @param {string} versionId - version ID
+ * @return {(Error|string|undefined)} - return Invalid Argument if decryption
+ * fails due to improper format, otherwise undefined or the decoded version id
+ */
+function decodeVID(versionId) {
+    if (versionId === 'null') {
+        return versionId;
+    }
+
+    let decoded;
+    const invalidErr = errors.InvalidArgument.customizeDescription('Invalid version id specified');
+    try {
+        decoded = versionIdUtils.decode(versionId);
+    } catch (err) {
+        return invalidErr;
+    }
+
+    if (decoded instanceof Error) {
+        return invalidErr;
+    }
+
+    return decoded;
+}
+
+/** decodeVersionId - decode the version id from a query object
  * @param {object} [reqQuery] - request query object
  * @param {string} [reqQuery.versionId] - version ID sent in request query
  * @return {(Error|string|undefined)} - return Invalid Argument if decryption
@@ -20,16 +45,7 @@ function decodeVersionId(reqQuery) {
     if (!reqQuery || !reqQuery.versionId) {
         return undefined;
     }
-    let versionId = reqQuery.versionId;
-    if (versionId === 'null') {
-        return versionId;
-    }
-    versionId = versionIdUtils.decode(versionId);
-    if (versionId instanceof Error) {
-        return errors.InvalidArgument
-            .customizeDescription('Invalid version id specified');
-    }
-    return versionId;
+    return decodeVID(reqQuery.versionId);
 }
 
 /** getVersionIdResHeader - return encrypted version ID if appropriate
@@ -370,6 +386,32 @@ function preprocessingVersioningDelete(bucketName, bucketMD, objectMD,
     return callback(null, options);
 }
 
+/** overwritingVersioning - return versioning information for S3 to handle
+ * storing version metadata with a specific version id.
+ * @param {object} objMD - obj metadata
+ * @param {object} metadataStoreParams - custom built object containing resource details.
+ * @return {object} options
+ * options.versionId - specific versionId to overwrite in metadata
+ * options.isNull - (true/undefined) whether new version is null or not
+ * options.nullVersionId - if storing a null version in version history, the
+ *  version id of the null version
+ */
+function overwritingVersioning(objMD, metadataStoreParams) {
+    /* eslint-disable no-param-reassign */
+    metadataStoreParams.creationTime = objMD['creation-time'];
+    metadataStoreParams.lastModifiedDate = objMD['last-modified'];
+    /* eslint-enable no-param-reassign */
+
+    const versionId = objMD.versionId || undefined;
+    const options = {
+        versionId,
+        isNull: objMD.isNull,
+        nullVersionId: objMD.nullVersionId,
+    };
+
+    return options;
+}
+
 module.exports = {
     decodeVersionId,
     getVersionIdResHeader,
@@ -378,4 +420,6 @@ module.exports = {
     getMasterState,
     versioningPreprocessing,
     preprocessingVersioningDelete,
+    overwritingVersioning,
+    decodeVID,
 };

--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -400,6 +400,7 @@ function overwritingVersioning(objMD, metadataStoreParams) {
     /* eslint-disable no-param-reassign */
     metadataStoreParams.creationTime = objMD['creation-time'];
     metadataStoreParams.lastModifiedDate = objMD['last-modified'];
+    metadataStoreParams.updateMicroVersionId = true;
     /* eslint-enable no-param-reassign */
 
     const versionId = objMD.versionId || undefined;

--- a/lib/api/objectPut.js
+++ b/lib/api/objectPut.js
@@ -7,7 +7,7 @@ const { cleanUpBucket } = require('./apiUtils/bucket/bucketCreation');
 const { getObjectSSEConfiguration } = require('./apiUtils/bucket/bucketEncryption');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const createAndStoreObject = require('./apiUtils/object/createAndStoreObject');
-const { checkQueryVersionId } = require('./apiUtils/object/versioning');
+const { checkQueryVersionId, decodeVID } = require('./apiUtils/object/versioning');
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
 const { validateHeaders } = require('./apiUtils/object/objectLockHelpers');
@@ -41,6 +41,24 @@ const versionIdUtils = versioning.VersionID;
  */
 function objectPut(authInfo, request, streamingV4Params, log, callback) {
     log.debug('processing request', { method: 'objectPut' });
+
+    const putVersionId = request.headers['x-scal-s3-version-id'];
+    const isPutVersion = putVersionId || putVersionId === '';
+
+    let versionId;
+
+    if (putVersionId) {
+        const decodedVidResult = decodeVID(putVersionId);
+        if (decodedVidResult instanceof Error) {
+            log.trace('invalid x-scal-s3-version-id header', {
+                versionId: putVersionId,
+                error: decodedVidResult,
+            });
+            return process.nextTick(() => callback(decodedVidResult));
+        }
+        versionId = decodedVidResult;
+    }
+
     const {
         bucketName,
         headers,
@@ -69,7 +87,8 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
     const invalidSSEError = errors.InvalidArgument.customizeDescription(
         'The encryption method specified is not supported');
     const requestType = 'objectPut';
-    const valParams = { authInfo, bucketName, objectKey, requestType, request };
+    const valParams = { authInfo, bucketName, objectKey, versionId,
+        requestType, request };
     const canonicalID = authInfo.getCanonicalID();
 
     if (hasNonPrintables(objectKey)) {
@@ -97,6 +116,12 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
                 'from non-owner account');
             monitoring.promMetrics('PUT', bucketName, 404, 'putObject');
             return callback(errors.NoSuchBucket);
+        }
+
+        if (isPutVersion && !objMD) {
+            const err = putVersionId ? errors.NoSuchVersion : errors.NoSuchKey;
+            log.trace('error no object metadata found', { method: 'objectPut', putVersionId });
+            return callback(err);
         }
 
         return async.waterfall([

--- a/lib/services.js
+++ b/lib/services.js
@@ -97,7 +97,7 @@ const services = {
             lastModifiedDate, versioning, versionId, uploadId,
             tagging, taggingCopy, replicationInfo, defaultRetention,
             dataStoreName, creationTime, retentionMode, retentionDate,
-            legalHold, originOp } = params;
+            legalHold, originOp, updateMicroVersionId } = params;
         log.trace('storing object in metadata');
         assert.strictEqual(typeof bucketName, 'string');
         const md = new ObjectMD();
@@ -162,6 +162,10 @@ const services = {
         if (uploadId) {
             md.setUploadId(uploadId);
             options.replayId = uploadId;
+        }
+        // update microVersionId when overwriting metadata.
+        if (updateMicroVersionId) {
+            md.updateMicroVersionId();
         }
         // information to store about the version and the null version id
         // in the object metadata

--- a/tests/functional/aws-node-sdk/test/object/putVersion.js
+++ b/tests/functional/aws-node-sdk/test/object/putVersion.js
@@ -1,0 +1,651 @@
+const assert = require('assert');
+const async = require('async');
+const { versioning } = require('arsenal');
+
+const { config } = require('../../../../../lib/Config');
+const withV4 = require('../support/withV4');
+const BucketUtility = require('../../lib/utility/bucket-util');
+const metadata = require('../../../../../lib/metadata/wrapper');
+const { DummyRequestLogger } = require('../../../../unit/helpers');
+const checkError = require('../../lib/utility/checkError');
+
+const versionIdUtils = versioning.VersionID;
+
+const log = new DummyRequestLogger();
+
+const nonVersionedObjId =
+    versionIdUtils.getInfVid(config.replicationGroupId);
+const bucketName = 'bucket1putversion31';
+const objectName = 'object1putversion';
+const mdListingParams = { listingType: 'DelimiterVersions', maxKeys: 1000 };
+
+function _getMetadata(bucketName, objectName, versionId, cb) {
+    let decodedVersionId;
+    if (versionId) {
+        if (versionId === 'null') {
+            decodedVersionId = nonVersionedObjId;
+        } else {
+            decodedVersionId = versionIdUtils.decode(versionId);
+        }
+        if (decodedVersionId instanceof Error) {
+            return cb(new Error('Invalid version id specified'));
+        }
+    }
+    return metadata.getObjectMD(bucketName, objectName, { versionId: decodedVersionId },
+        log, (err, objMD) => {
+            if (err) {
+                assert.equal(err, null, 'Getting object metadata: expected success, ' +
+                    `got error ${JSON.stringify(err)}`);
+            }
+            return cb(null, objMD);
+    });
+}
+
+function putObjectVersion(s3, params, vid, next) {
+    const paramsWithBody = { ...params, Body: '123' };
+    const request = s3.putObject(paramsWithBody);
+    request.on('build', () => {
+        request.httpRequest.headers['x-scal-s3-version-id'] = vid;
+    });
+    return request.send(next);
+}
+
+function checkVersionsAndUpdate(versionsBefore, versionsAfter, indexes) {
+    indexes.forEach(i => {
+        assert.notEqual(versionsAfter[i].value.Size, versionsBefore[i].value.Size);
+        assert.notEqual(versionsAfter[i].value.ETag, versionsBefore[i].value.ETag);
+        /* eslint-disable no-param-reassign */
+        versionsAfter[i].value.Size = versionsBefore[i].value.Size;
+        versionsAfter[i].value.ETag = versionsBefore[i].value.ETag;
+        /* eslint-enable no-param-reassign */
+    });
+}
+
+function checkObjMdAndUpdate(objMDBefore, objMDAfter, props) {
+    props.forEach(p => {
+        assert.notEqual(objMDAfter[p], objMDBefore[p]);
+        // eslint-disable-next-line no-param-reassign
+        objMDAfter[p] = objMDBefore[p];
+    });
+}
+
+describe('PUT object with x-scal-s3-version-id header', () => {
+    withV4(sigCfg => {
+        let bucketUtil;
+        let s3;
+
+        beforeEach(done => {
+            bucketUtil = new BucketUtility('default', sigCfg);
+            s3 = bucketUtil.s3;
+            return metadata.setup(() =>
+                s3.createBucket({ Bucket: bucketName }, err => {
+                    if (err) {
+                        assert.equal(err, null, 'Creating bucket: Expected success, ' +
+                            `got error ${JSON.stringify(err)}`);
+                    }
+                    done();
+                }));
+        });
+
+        afterEach(() => {
+            process.stdout.write('Emptying bucket');
+            return bucketUtil.empty(bucketName)
+            .then(() => {
+                process.stdout.write('Deleting bucket');
+                return bucketUtil.deleteOne(bucketName);
+            })
+            .catch(err => {
+                process.stdout.write('Error in afterEach');
+                throw err;
+            });
+        });
+
+        it('should overwrite an object', done => {
+            const params = { Bucket: bucketName, Key: objectName };
+            let objMDBefore;
+            let objMDAfter;
+            let versionsBefore;
+            let versionsAfter;
+
+            async.waterfall([
+                next => s3.putObject(params, err => next(err)),
+                next => _getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                    objMDBefore = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsBefore = res.Versions;
+                    next(err);
+                }),
+                next => putObjectVersion(s3, params, '', err => next(err)),
+                next => _getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                    objMDAfter = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsAfter = res.Versions;
+                    next(err);
+                }),
+            ], err => {
+                assert.equal(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'content-md5']);
+                assert.deepStrictEqual(objMDAfter, objMDBefore);
+                return done();
+            });
+        });
+
+        it('should overwrite a version', done => {
+            const vParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                }
+            };
+            const params = { Bucket: bucketName, Key: objectName };
+            let objMDBefore;
+            let objMDAfter;
+            let versionsBefore;
+            let versionsAfter;
+            let vId;
+
+            async.waterfall([
+                next => s3.putBucketVersioning(vParams, err => next(err)),
+                next => s3.putObject(params, (err, res) => {
+                    vId = res.VersionId;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsBefore = res.Versions;
+                    next(err);
+                }),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDBefore = objMD;
+                    return next(err);
+                }),
+                next => putObjectVersion(s3, params, vId, err => next(err)),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDAfter = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsAfter = res.Versions;
+                    next(err);
+                }),
+            ], err => {
+                assert.equal(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'content-md5']);
+                assert.deepStrictEqual(objMDAfter, objMDBefore);
+                return done();
+            });
+        });
+
+        it('should overwrite the current version if empty version id header', done => {
+            const vParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                }
+            };
+            const params = { Bucket: bucketName, Key: objectName };
+            let objMDBefore;
+            let objMDAfter;
+            let versionsBefore;
+            let versionsAfter;
+            let vId;
+
+            async.waterfall([
+                next => s3.putBucketVersioning(vParams, err => next(err)),
+                next => s3.putObject(params, (err, res) => {
+                    vId = res.VersionId;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsBefore = res.Versions;
+                    next(err);
+                }),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDBefore = objMD;
+                    return next(err);
+                }),
+                next => putObjectVersion(s3, params, '', err => next(err)),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDAfter = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsAfter = res.Versions;
+                    next(err);
+                }),
+            ], err => {
+                assert.equal(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'content-md5']);
+                assert.deepStrictEqual(objMDAfter, objMDBefore);
+                return done();
+            });
+        });
+
+
+        it('should fail if version id is invalid', done => {
+            const vParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                }
+            };
+            const params = { Bucket: bucketName, Key: objectName };
+
+            async.waterfall([
+                next => s3.putBucketVersioning(vParams, err => next(err)),
+                next => s3.putObject(params, err => next(err)),
+                next => putObjectVersion(s3, params, 'aJLWKz4Ko9IjBBgXKj5KQT.G9UHv0g7P', err => {
+                    checkError(err, 'InvalidArgument', 400);
+                    return next();
+                }),
+            ], err => {
+                assert.equal(err, null, `Expected success got error ${JSON.stringify(err)}`);
+                return done();
+            });
+        });
+
+        it('should fail if key does not exist', done => {
+            const params = { Bucket: bucketName, Key: objectName };
+
+            async.waterfall([
+                next => putObjectVersion(s3, params, '', err => {
+                    checkError(err, 'NoSuchKey', 404);
+                    return next();
+                }),
+            ], err => {
+                assert.equal(err, null, `Expected success got error ${JSON.stringify(err)}`);
+                return done();
+            });
+        });
+
+        it('should fail if version does not exist', done => {
+            const vParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                }
+            };
+            const params = { Bucket: bucketName, Key: objectName };
+
+            async.waterfall([
+                next => s3.putBucketVersioning(vParams, err => next(err)),
+                next => s3.putObject(params, err => next(err)),
+                next => putObjectVersion(s3, params,
+                '393833343735313131383832343239393939393952473030312020313031', err => {
+                    checkError(err, 'NoSuchVersion', 404);
+                    return next();
+                }),
+            ], err => {
+                assert.equal(err, null, `Expected success got error ${JSON.stringify(err)}`);
+                return done();
+            });
+        });
+
+        it('should overwrite a non-current null version', done => {
+            const vParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                }
+            };
+            const params = { Bucket: bucketName, Key: objectName };
+            let versionsBefore;
+            let versionsAfter;
+            let objMDBefore;
+            let objMDAfter;
+
+            async.waterfall([
+                next => s3.putObject(params, err => next(err)),
+                next => s3.putBucketVersioning(vParams, err => next(err)),
+                next => s3.putObject(params, err => next(err)),
+                next => _getMetadata(bucketName, objectName, 'null', (err, objMD) => {
+                    objMDBefore = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsBefore = res.Versions;
+                    next(err);
+                }),
+                next => putObjectVersion(s3, params, 'null', err => next(err)),
+                next => _getMetadata(bucketName, objectName, 'null', (err, objMD) => {
+                    objMDAfter = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsAfter = res.Versions;
+                    next(err);
+                }),
+            ], err => {
+                assert.equal(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                checkVersionsAndUpdate(versionsBefore, versionsAfter, [1]);
+                assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'content-md5']);
+                assert.deepStrictEqual(objMDAfter, objMDBefore);
+                return done();
+            });
+        });
+
+        it('should overwrite the lastest version and keep nullVersionId', done => {
+            const vParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                }
+            };
+            const params = { Bucket: bucketName, Key: objectName };
+            let versionsBefore;
+            let versionsAfter;
+            let objMDBefore;
+            let objMDAfter;
+            let vId;
+
+            async.waterfall([
+                next => s3.putObject(params, err => next(err)),
+                next => s3.putBucketVersioning(vParams, err => next(err)),
+                next => s3.putObject(params, (err, res) => {
+                    vId = res.VersionId;
+                    return next(err);
+                }),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDBefore = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsBefore = res.Versions;
+                    next(err);
+                }),
+                next => putObjectVersion(s3, params, vId, err => next(err)),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDAfter = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsAfter = res.Versions;
+                    next(err);
+                }),
+            ], err => {
+                assert.equal(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'content-md5']);
+                assert.deepStrictEqual(objMDAfter, objMDBefore);
+                return done();
+            });
+        });
+
+        it('should overwrite a current null version', done => {
+            const vParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                }
+            };
+            const sParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Suspended',
+                }
+            };
+            const params = { Bucket: bucketName, Key: objectName };
+            let objMDBefore;
+            let objMDAfter;
+            let versionsBefore;
+            let versionsAfter;
+
+            async.waterfall([
+                next => s3.putBucketVersioning(vParams, err => next(err)),
+                next => s3.putObject(params, err => next(err)),
+                next => s3.putBucketVersioning(sParams, err => next(err)),
+                next => s3.putObject(params, err => next(err)),
+                next => _getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                    objMDBefore = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsBefore = res.Versions;
+                    next(err);
+                }),
+                next => putObjectVersion(s3, params, '', err => next(err)),
+                next => _getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                    objMDAfter = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsAfter = res.Versions;
+                    next(err);
+                }),
+            ], err => {
+                assert.equal(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'content-md5']);
+                assert.deepStrictEqual(objMDAfter, objMDBefore);
+                return done();
+            });
+        });
+
+        it('should overwrite a non-current version', done => {
+            const vParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                }
+            };
+            const params = { Bucket: bucketName, Key: objectName };
+            let objMDBefore;
+            let objMDAfter;
+            let versionsBefore;
+            let versionsAfter;
+            let vId;
+
+            async.waterfall([
+                next => s3.putBucketVersioning(vParams, err => next(err)),
+                next => s3.putObject(params, err => next(err)),
+                next => s3.putObject(params, (err, res) => {
+                    vId = res.VersionId;
+                    return next(err);
+                }),
+                next => s3.putObject(params, err => next(err)),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsBefore = res.Versions;
+                    next(err);
+                }),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDBefore = objMD;
+                    return next(err);
+                }),
+                next => putObjectVersion(s3, params, vId, err => next(err)),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDAfter = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsAfter = res.Versions;
+                    next(err);
+                }),
+            ], err => {
+                assert.equal(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                checkVersionsAndUpdate(versionsBefore, versionsAfter, [1]);
+                assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'content-md5']);
+                assert.deepStrictEqual(objMDAfter, objMDBefore);
+                return done();
+            });
+        });
+
+        it('should overwrite the current version', done => {
+            const vParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                }
+            };
+            const params = { Bucket: bucketName, Key: objectName };
+            let objMDBefore;
+            let objMDAfter;
+            let versionsBefore;
+            let versionsAfter;
+            let vId;
+
+            async.waterfall([
+                next => s3.putBucketVersioning(vParams, err => next(err)),
+                next => s3.putObject(params, err => next(err)),
+                next => s3.putObject(params, (err, res) => {
+                    vId = res.VersionId;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsBefore = res.Versions;
+                    next(err);
+                }),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDBefore = objMD;
+                    return next(err);
+                }),
+                next => putObjectVersion(s3, params, vId, err => next(err)),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDAfter = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsAfter = res.Versions;
+                    next(err);
+                }),
+            ], err => {
+                assert.equal(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'content-md5']);
+                assert.deepStrictEqual(objMDAfter, objMDBefore);
+                return done();
+            });
+        });
+
+        it('should overwrite the current version after bucket version suspended', done => {
+            const vParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                }
+            };
+            const sParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Suspended',
+                }
+            };
+            const params = { Bucket: bucketName, Key: objectName };
+            let objMDBefore;
+            let objMDAfter;
+            let versionsBefore;
+            let versionsAfter;
+            let vId;
+
+            async.waterfall([
+                next => s3.putBucketVersioning(vParams, err => next(err)),
+                next => s3.putObject(params, err => next(err)),
+                next => s3.putObject(params, (err, res) => {
+                    vId = res.VersionId;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsBefore = res.Versions;
+                    next(err);
+                }),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDBefore = objMD;
+                    return next(err);
+                }),
+                next => s3.putBucketVersioning(sParams, err => next(err)),
+                next => putObjectVersion(s3, params, vId, err => next(err)),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDAfter = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsAfter = res.Versions;
+                    next(err);
+                }),
+            ], err => {
+                assert.equal(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'content-md5']);
+                assert.deepStrictEqual(objMDAfter, objMDBefore);
+                return done();
+            });
+        });
+
+        it('should overwrite the current null version after bucket version enabled', done => {
+            const vParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                }
+            };
+            const params = { Bucket: bucketName, Key: objectName };
+            let objMDBefore;
+            let objMDAfter;
+            let versionsBefore;
+            let versionsAfter;
+
+            async.waterfall([
+                next => s3.putObject(params, err => next(err)),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsBefore = res.Versions;
+                    next(err);
+                }),
+                next => _getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                    objMDBefore = objMD;
+                    return next(err);
+                }),
+                next => s3.putBucketVersioning(vParams, err => next(err)),
+                next => putObjectVersion(s3, params, 'null', err => next(err)),
+                next => _getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                    objMDAfter = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsAfter = res.Versions;
+                    next(err);
+                }),
+            ], err => {
+                assert.equal(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'content-md5']);
+                assert.deepStrictEqual(objMDAfter, objMDBefore);
+                return done();
+            });
+        });
+    });
+});

--- a/tests/functional/aws-node-sdk/test/object/putVersion.js
+++ b/tests/functional/aws-node-sdk/test/object/putVersion.js
@@ -55,8 +55,8 @@ function checkVersionsAndUpdate(versionsBefore, versionsAfter, indexes) {
         assert.notEqual(versionsAfter[i].value.Size, versionsBefore[i].value.Size);
         assert.notEqual(versionsAfter[i].value.ETag, versionsBefore[i].value.ETag);
         /* eslint-disable no-param-reassign */
-        versionsAfter[i].value.Size = versionsBefore[i].value.Size;
-        versionsAfter[i].value.ETag = versionsBefore[i].value.ETag;
+        versionsBefore[i].value.Size = versionsAfter[i].value.Size;
+        versionsBefore[i].value.ETag = versionsAfter[i].value.ETag;
         /* eslint-enable no-param-reassign */
     });
 }
@@ -65,7 +65,7 @@ function checkObjMdAndUpdate(objMDBefore, objMDAfter, props) {
     props.forEach(p => {
         assert.notEqual(objMDAfter[p], objMDBefore[p]);
         // eslint-disable-next-line no-param-reassign
-        objMDAfter[p] = objMDBefore[p];
+        objMDBefore[p] = objMDAfter[p];
     });
 }
 
@@ -132,7 +132,8 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'content-md5']);
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'content-md5',
+                'microVersionId']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
             });
@@ -181,7 +182,8 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'content-md5']);
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length',
+                'content-md5', 'microVersionId']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
             });
@@ -230,7 +232,8 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'content-md5']);
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length',
+                'content-md5', 'microVersionId']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
             });
@@ -336,7 +339,8 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 checkVersionsAndUpdate(versionsBefore, versionsAfter, [1]);
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'content-md5']);
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length',
+                'content-md5', 'microVersionId']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
             });
@@ -386,7 +390,8 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'content-md5']);
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length',
+                'content-md5', 'microVersionId']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
             });
@@ -439,7 +444,8 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'content-md5']);
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length',
+                'content-md5', 'microVersionId']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
             });
@@ -490,7 +496,8 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 checkVersionsAndUpdate(versionsBefore, versionsAfter, [1]);
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'content-md5']);
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length',
+                'content-md5', 'microVersionId']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
             });
@@ -540,7 +547,8 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'content-md5']);
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length',
+                'content-md5', 'microVersionId']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
             });
@@ -597,7 +605,8 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'content-md5']);
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length',
+                'content-md5', 'microVersionId']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
             });
@@ -642,7 +651,8 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'content-md5']);
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length',
+                'content-md5', 'microVersionId']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
             });


### PR DESCRIPTION
When restoring an object, the tape library will send a S3 put object with `x-scal-s3-version-id` header.

This PR:
- supports the new header
- writes new location
- ensures that the rest of the original object properties remain intact ie last-modified date etc.

_Note: We recalculate content MD5, content length to make sure the metadata is accurate._

_Next: multi-part upload supports `x-scal-s3-version-id` header._

_Next: update object metadata restore_