### PR TITLE
CLDSRV-204 Complete MPU with x-scal-s3-version-id header

### DIFF
--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -9,7 +9,7 @@ const getReplicationInfo = require('./apiUtils/object/getReplicationInfo');
 const { data } = require('../data/wrapper');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const constants = require('../../constants');
-const { versioningPreprocessing, checkQueryVersionId }
+const { versioningPreprocessing, checkQueryVersionId, decodeVID, overwritingVersioning }
     = require('./apiUtils/object/versioning');
 const services = require('../services');
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
@@ -94,6 +94,21 @@ function completeMultipartUpload(authInfo, request, log, callback) {
     let oldByteLength = null;
     const responseHeaders = {};
 
+    let versionId;
+    const putVersionId = request.headers['x-scal-s3-version-id'];
+    const isPutVersion = putVersionId || putVersionId === '';
+    if (putVersionId) {
+        const decodedVidResult = decodeVID(putVersionId);
+        if (decodedVidResult instanceof Error) {
+            log.trace('invalid x-scal-s3-version-id header', {
+                versionId: putVersionId,
+                error: decodedVidResult,
+            });
+            return process.nextTick(() => callback(decodedVidResult));
+        }
+        versionId = decodedVidResult;
+    }
+
     const queryContainsVersionId = checkQueryVersionId(request.query);
     if (queryContainsVersionId instanceof Error) {
         return callback(queryContainsVersionId);
@@ -119,6 +134,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                 // Required permissions for this action
                 // at the destinationBucket level are same as objectPut
                 requestType: 'objectPut',
+                versionId,
             };
             metadataValidateBucketAndObj(metadataValParams, log, next);
         },
@@ -126,7 +142,14 @@ function completeMultipartUpload(authInfo, request, log, callback) {
             if (objMD) {
                 oldByteLength = objMD['content-length'];
             }
-            services.metadataValidateMultipart(metadataValParams,
+
+            if (isPutVersion && !objMD) {
+                const err = putVersionId ? errors.NoSuchVersion : errors.NoSuchKey;
+                log.trace('error no object metadata found', { method: 'completeMultipartUpload', putVersionId });
+                return callback(err);
+            }
+
+            return services.metadataValidateMultipart(metadataValParams,
                 (err, mpuBucket, mpuOverview, storedMetadata) => {
                     if (err) {
                         return next(err, destBucket);
@@ -297,6 +320,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                 contentMD5: aggregateETag,
                 size: calculatedSize,
                 multipart: true,
+                isDeleteMarker: false,
                 replicationInfo: getReplicationInfo(objectKey, destBucket,
                     false, calculatedSize, REPLICATION_ACTION),
                 originOp: 's3:ObjectCreated:CompleteMultipartUpload',
@@ -334,6 +358,14 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     masterKeyId: destBucket.getSseMasterKeyId(),
                 };
             }
+            // if x-scal-s3-version-id header is specified, we overwrite the object/version metadata.
+            if (isPutVersion) {
+                const options = overwritingVersioning(objMD, metaStoreParams);
+                return process.nextTick(() => next(null, destBucket, dataLocations,
+                    metaStoreParams, mpuBucket, keysToDelete, aggregateETag,
+                    objMD, extraPartLocations, pseudoCipherBundle,
+                    completeObjData, options));
+            }
             return versioningPreprocessing(bucketName,
                 destBucket, objectKey, objMD, log, (err, options) => {
                     if (err) {
@@ -347,22 +379,25 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                         });
                         return next(err, destBucket);
                     }
-                    const dataToDelete = options.dataToDelete;
-                    metaStoreParams.versionId = options.versionId;
-                    metaStoreParams.versioning = options.versioning;
-                    metaStoreParams.isNull = options.isNull;
-                    metaStoreParams.nullVersionId = options.nullVersionId;
-                    metaStoreParams.nullUploadId = options.nullUploadId;
                     return next(null, destBucket, dataLocations,
                         metaStoreParams, mpuBucket, keysToDelete, aggregateETag,
                         objMD, extraPartLocations, pseudoCipherBundle,
-                        dataToDelete, completeObjData);
+                        completeObjData, options);
                 });
         },
         function storeAsNewObj(destinationBucket, dataLocations,
             metaStoreParams, mpuBucket, keysToDelete, aggregateETag, objMD,
-            extraPartLocations, pseudoCipherBundle, dataToDelete,
-            completeObjData, next) {
+            extraPartLocations, pseudoCipherBundle,
+            completeObjData, options, next) {
+            const dataToDelete = options.dataToDelete;
+            /* eslint-disable no-param-reassign */
+            metaStoreParams.versionId = options.versionId;
+            metaStoreParams.versioning = options.versioning;
+            metaStoreParams.isNull = options.isNull;
+            metaStoreParams.nullVersionId = options.nullVersionId;
+            metaStoreParams.nullUploadId = options.nullUploadId;
+            /* eslint-enable no-param-reassign */
+
             // For external backends (where completeObjData is not
             // null), the backend key does not change for new versions
             // of the same object (or rewrites for nonversioned

--- a/tests/functional/aws-node-sdk/test/object/mpuVersion.js
+++ b/tests/functional/aws-node-sdk/test/object/mpuVersion.js
@@ -1,0 +1,748 @@
+const assert = require('assert');
+const async = require('async');
+const { versioning } = require('arsenal');
+
+const { config } = require('../../../../../lib/Config');
+const withV4 = require('../support/withV4');
+const BucketUtility = require('../../lib/utility/bucket-util');
+const metadata = require('../../../../../lib/metadata/wrapper');
+const { DummyRequestLogger } = require('../../../../unit/helpers');
+const checkError = require('../../lib/utility/checkError');
+
+const versionIdUtils = versioning.VersionID;
+
+const log = new DummyRequestLogger();
+
+const nonVersionedObjId =
+    versionIdUtils.getInfVid(config.replicationGroupId);
+const bucketName = 'bucket1putversion31';
+const objectName = 'object1putversion';
+const mdListingParams = { listingType: 'DelimiterVersions', maxKeys: 1000 };
+
+function _getMetadata(bucketName, objectName, versionId, cb) {
+    let decodedVersionId;
+    if (versionId) {
+        if (versionId === 'null') {
+            decodedVersionId = nonVersionedObjId;
+        } else {
+            decodedVersionId = versionIdUtils.decode(versionId);
+        }
+        if (decodedVersionId instanceof Error) {
+            return cb(new Error('Invalid version id specified'));
+        }
+    }
+    return metadata.getObjectMD(bucketName, objectName, { versionId: decodedVersionId },
+        log, (err, objMD) => {
+            if (err) {
+                assert.strictEqual(err, null, 'Getting object metadata: expected success, ' +
+                    `got error ${JSON.stringify(err)}`);
+            }
+            return cb(null, objMD);
+    });
+}
+
+function putMPUVersion(s3, bucketName, objectName, vId, cb) {
+    async.waterfall([
+        next => {
+            const params = { Bucket: bucketName, Key: objectName };
+            const request = s3.createMultipartUpload(params);
+            if (vId !== undefined) {
+                request.on('build', () => {
+                    request.httpRequest.headers['x-scal-s3-version-id'] = vId;
+                });
+            }
+            return request.send(next);
+        },
+        (resCreation, next) => {
+            const uploadId = resCreation.UploadId;
+            const params = {
+                Body: 'okok',
+                Bucket: bucketName,
+                Key: objectName,
+                PartNumber: 1,
+                UploadId: uploadId,
+            };
+            const request = s3.uploadPart(params);
+            if (vId !== undefined) {
+                request.on('build', () => {
+                    request.httpRequest.headers['x-scal-s3-version-id'] = vId;
+                });
+            }
+            return request.send((err, res) => next(err, res, uploadId));
+        },
+        (res, uploadId, next) => {
+            const params = {
+                Bucket: bucketName,
+                Key: objectName,
+                MultipartUpload: {
+                    Parts: [
+                        {
+                            ETag: res.ETag,
+                            PartNumber: 1
+                        },
+                    ]
+                },
+                UploadId: uploadId,
+            };
+            const request = s3.completeMultipartUpload(params);
+            if (vId !== undefined) {
+                request.on('build', () => {
+                    request.httpRequest.headers['x-scal-s3-version-id'] = vId;
+                });
+            }
+            return request.send(next);
+        },
+    ], err => cb(err));
+}
+
+function putMPU(s3, bucketName, objectName, cb) {
+    return putMPUVersion(s3, bucketName, objectName, undefined, cb);
+}
+
+function checkVersionsAndUpdate(versionsBefore, versionsAfter, indexes) {
+    indexes.forEach(i => {
+        assert.notStrictEqual(versionsAfter[i].value.Size, versionsBefore[i].value.Size);
+        assert.notStrictEqual(versionsAfter[i].value.ETag, versionsBefore[i].value.ETag);
+        /* eslint-disable no-param-reassign */
+        versionsBefore[i].value.Size = versionsAfter[i].value.Size;
+        versionsBefore[i].value.ETag = versionsAfter[i].value.ETag;
+        /* eslint-enable no-param-reassign */
+    });
+}
+
+function checkObjMdAndUpdate(objMDBefore, objMDAfter, props) {
+    props.forEach(p => {
+        assert.notStrictEqual(objMDAfter[p], objMDBefore[p]);
+        // eslint-disable-next-line no-param-reassign
+        objMDBefore[p] = objMDAfter[p];
+    });
+}
+
+describe('MPU with x-scal-s3-version-id header', () => {
+    withV4(sigCfg => {
+        let bucketUtil;
+        let s3;
+
+        beforeEach(done => {
+            bucketUtil = new BucketUtility('default', sigCfg);
+            s3 = bucketUtil.s3;
+            return metadata.setup(() =>
+                s3.createBucket({ Bucket: bucketName }, err => {
+                    if (err) {
+                        assert.strictEqual(err, null, 'Creating bucket: Expected success, ' +
+                            `got error ${JSON.stringify(err)}`);
+                    }
+                    done();
+                }));
+        });
+
+        afterEach(() => {
+            process.stdout.write('Emptying bucket');
+            return bucketUtil.empty(bucketName)
+            .then(() => {
+                process.stdout.write('Deleting bucket');
+                return bucketUtil.deleteOne(bucketName);
+            })
+            .catch(err => {
+                process.stdout.write('Error in afterEach');
+                throw err;
+            });
+        });
+
+        it('should overwrite an MPU object', done => {
+            let objMDBefore;
+            let objMDAfter;
+            let versionsBefore;
+            let versionsAfter;
+
+            async.series([
+                next => putMPU(s3, bucketName, objectName, next),
+                next => _getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                    objMDBefore = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsBefore = res.Versions;
+                    return next(err);
+                }),
+                next => putMPUVersion(s3, bucketName, objectName, '', next),
+                next => _getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                    objMDAfter = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsAfter = res.Versions;
+                    return next(err);
+                }),
+            ], err => {
+                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                checkObjMdAndUpdate(objMDBefore, objMDAfter,
+                    ['location', 'uploadId', 'microVersionId']);
+
+                assert.deepStrictEqual(objMDAfter, objMDBefore);
+                return done();
+            });
+        });
+
+        it('should overwrite an object', done => {
+            const params = { Bucket: bucketName, Key: objectName };
+            let objMDBefore;
+            let objMDAfter;
+            let versionsBefore;
+            let versionsAfter;
+
+            async.series([
+                next => s3.putObject(params, next),
+                next => _getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                    objMDBefore = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsBefore = res.Versions;
+                    return next(err);
+                }),
+                next => putMPUVersion(s3, bucketName, objectName, '', next),
+                next => _getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                    objMDAfter = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsAfter = res.Versions;
+                    return next(err);
+                }),
+            ], err => {
+                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                checkObjMdAndUpdate(objMDBefore, objMDAfter,
+                    ['location', 'content-length', 'content-md5', 'originOp', 'uploadId', 'microVersionId']);
+
+                assert.deepStrictEqual(objMDAfter, objMDBefore);
+                return done();
+            });
+        });
+
+        it('should overwrite a version', done => {
+            const vParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                }
+            };
+            const params = { Bucket: bucketName, Key: objectName };
+            let objMDBefore;
+            let objMDAfter;
+            let versionsBefore;
+            let versionsAfter;
+            let vId;
+
+            async.series([
+                next => s3.putBucketVersioning(vParams, next),
+                next => s3.putObject(params, (err, res) => {
+                    vId = res.VersionId;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsBefore = res.Versions;
+                    return next(err);
+                }),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDBefore = objMD;
+                    return next(err);
+                }),
+                next => putMPUVersion(s3, bucketName, objectName, vId, next),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDAfter = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsAfter = res.Versions;
+                    return next(err);
+                }),
+            ], err => {
+                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                checkObjMdAndUpdate(objMDBefore, objMDAfter,
+                    ['location', 'content-length', 'content-md5', 'originOp', 'uploadId', 'microVersionId']);
+                assert.deepStrictEqual(objMDAfter, objMDBefore);
+                return done();
+            });
+        });
+
+        it('should overwrite the current version if empty version id header', done => {
+            const vParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                }
+            };
+            const params = { Bucket: bucketName, Key: objectName };
+            let objMDBefore;
+            let objMDAfter;
+            let versionsBefore;
+            let versionsAfter;
+            let vId;
+
+            async.series([
+                next => s3.putBucketVersioning(vParams, next),
+                next => s3.putObject(params, (err, res) => {
+                    vId = res.VersionId;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsBefore = res.Versions;
+                    return next(err);
+                }),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDBefore = objMD;
+                    return next(err);
+                }),
+                next => putMPUVersion(s3, bucketName, objectName, '', next),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDAfter = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsAfter = res.Versions;
+                    return next(err);
+                }),
+            ], err => {
+                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                checkObjMdAndUpdate(objMDBefore, objMDAfter,
+                    ['location', 'content-length', 'content-md5', 'originOp', 'uploadId', 'microVersionId']);
+                assert.deepStrictEqual(objMDAfter, objMDBefore);
+                return done();
+            });
+        });
+
+
+        it('should fail if version is invalid', done => {
+            const vParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                }
+            };
+            const params = { Bucket: bucketName, Key: objectName };
+
+            async.series([
+                next => s3.putBucketVersioning(vParams, next),
+                next => s3.putObject(params, next),
+                next => putMPUVersion(s3, bucketName, objectName, 'aJLWKz4Ko9IjBBgXKj5KQT.G9UHv0g7P', err => {
+                    checkError(err, 'InvalidArgument', 400);
+                    return next();
+                }),
+            ], err => {
+                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+                return done();
+            });
+        });
+
+        it('should fail if key does not exist', done => {
+            async.series([
+                next => putMPUVersion(s3, bucketName, objectName, '', err => {
+                    checkError(err, 'NoSuchKey', 404);
+                    return next();
+                }),
+            ], err => {
+                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+                return done();
+            });
+        });
+
+        it('should fail if version does not exist', done => {
+            const vParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                }
+            };
+            const params = { Bucket: bucketName, Key: objectName };
+
+            async.series([
+                next => s3.putBucketVersioning(vParams, next),
+                next => s3.putObject(params, next),
+                next => putMPUVersion(s3, bucketName, objectName,
+                '393833343735313131383832343239393939393952473030312020313031', err => {
+                    checkError(err, 'NoSuchVersion', 404);
+                    return next();
+                }),
+            ], err => {
+                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+                return done();
+            });
+        });
+
+        it('should overwrite a non-current null version', done => {
+            const vParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                }
+            };
+            const params = { Bucket: bucketName, Key: objectName };
+            let versionsBefore;
+            let versionsAfter;
+            let objMDBefore;
+            let objMDAfter;
+
+            async.series([
+                next => s3.putObject(params, next),
+                next => s3.putBucketVersioning(vParams, next),
+                next => s3.putObject(params, next),
+                next => _getMetadata(bucketName, objectName, 'null', (err, objMD) => {
+                    objMDBefore = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsBefore = res.Versions;
+                    return next(err);
+                }),
+                next => putMPUVersion(s3, bucketName, objectName, 'null', next),
+                next => _getMetadata(bucketName, objectName, 'null', (err, objMD) => {
+                    objMDAfter = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsAfter = res.Versions;
+                    return next(err);
+                }),
+            ], err => {
+                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                checkVersionsAndUpdate(versionsBefore, versionsAfter, [1]);
+                assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                checkObjMdAndUpdate(objMDBefore, objMDAfter,
+                    ['location', 'content-length', 'content-md5', 'originOp', 'uploadId', 'microVersionId']);
+                assert.deepStrictEqual(objMDAfter, objMDBefore);
+                return done();
+            });
+        });
+
+        it('should overwrite the lastest version and keep nullVersionId', done => {
+            const vParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                }
+            };
+            const params = { Bucket: bucketName, Key: objectName };
+            let versionsBefore;
+            let versionsAfter;
+            let objMDBefore;
+            let objMDAfter;
+            let vId;
+
+            async.series([
+                next => s3.putObject(params, next),
+                next => s3.putBucketVersioning(vParams, next),
+                next => s3.putObject(params, (err, res) => {
+                    vId = res.VersionId;
+                    return next(err);
+                }),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDBefore = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsBefore = res.Versions;
+                    next(err);
+                }),
+                next => putMPUVersion(s3, bucketName, objectName, vId, next),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDAfter = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsAfter = res.Versions;
+                    return next(err);
+                }),
+            ], err => {
+                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                checkObjMdAndUpdate(objMDBefore, objMDAfter,
+                    ['location', 'content-length', 'content-md5', 'originOp', 'uploadId', 'microVersionId']);
+                assert.deepStrictEqual(objMDAfter, objMDBefore);
+                return done();
+            });
+        });
+
+        it('should overwrite a current null version', done => {
+            const vParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                }
+            };
+            const sParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Suspended',
+                }
+            };
+            const params = { Bucket: bucketName, Key: objectName };
+            let objMDBefore;
+            let objMDAfter;
+            let versionsBefore;
+            let versionsAfter;
+
+            async.series([
+                next => s3.putBucketVersioning(vParams, next),
+                next => s3.putObject(params, next),
+                next => s3.putBucketVersioning(sParams, next),
+                next => s3.putObject(params, next),
+                next => _getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                    objMDBefore = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsBefore = res.Versions;
+                    next(err);
+                }),
+                next => putMPUVersion(s3, bucketName, objectName, '', next),
+                next => _getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                    objMDAfter = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsAfter = res.Versions;
+                    return next(err);
+                }),
+            ], err => {
+                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                checkObjMdAndUpdate(objMDBefore, objMDAfter,
+                    ['location', 'content-length', 'content-md5', 'originOp', 'uploadId', 'microVersionId']);
+                assert.deepStrictEqual(objMDAfter, objMDBefore);
+                return done();
+            });
+        });
+
+        it('should overwrite a non-current version', done => {
+            const vParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                }
+            };
+            const params = { Bucket: bucketName, Key: objectName };
+            let objMDBefore;
+            let objMDAfter;
+            let versionsBefore;
+            let versionsAfter;
+            let vId;
+
+            async.series([
+                next => s3.putBucketVersioning(vParams, next),
+                next => s3.putObject(params, next),
+                next => s3.putObject(params, (err, res) => {
+                    vId = res.VersionId;
+                    return next(err);
+                }),
+                next => s3.putObject(params, next),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsBefore = res.Versions;
+                    return next(err);
+                }),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDBefore = objMD;
+                    return next(err);
+                }),
+                next => putMPUVersion(s3, bucketName, objectName, vId, next),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDAfter = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsAfter = res.Versions;
+                    return next(err);
+                }),
+            ], err => {
+                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                checkVersionsAndUpdate(versionsBefore, versionsAfter, [1]);
+                assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                checkObjMdAndUpdate(objMDBefore, objMDAfter,
+                    ['location', 'content-length', 'content-md5', 'originOp', 'uploadId', 'microVersionId']);
+                assert.deepStrictEqual(objMDAfter, objMDBefore);
+                return done();
+            });
+        });
+
+        it('should overwrite the current version', done => {
+            const vParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                }
+            };
+            const params = { Bucket: bucketName, Key: objectName };
+            let objMDBefore;
+            let objMDAfter;
+            let versionsBefore;
+            let versionsAfter;
+            let vId;
+
+            async.series([
+                next => s3.putBucketVersioning(vParams, next),
+                next => s3.putObject(params, next),
+                next => s3.putObject(params, (err, res) => {
+                    vId = res.VersionId;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsBefore = res.Versions;
+                    return next(err);
+                }),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDBefore = objMD;
+                    return next(err);
+                }),
+                next => putMPUVersion(s3, bucketName, objectName, vId, next),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDAfter = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsAfter = res.Versions;
+                    return next(err);
+                }),
+            ], err => {
+                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                checkObjMdAndUpdate(objMDBefore, objMDAfter,
+                    ['location', 'content-length', 'content-md5', 'originOp', 'uploadId', 'microVersionId']);
+                assert.deepStrictEqual(objMDAfter, objMDBefore);
+                return done();
+            });
+        });
+
+        it('should overwrite the current version after bucket version suspended', done => {
+            const vParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                }
+            };
+            const sParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Suspended',
+                }
+            };
+            const params = { Bucket: bucketName, Key: objectName };
+            let objMDBefore;
+            let objMDAfter;
+            let versionsBefore;
+            let versionsAfter;
+            let vId;
+
+            async.series([
+                next => s3.putBucketVersioning(vParams, next),
+                next => s3.putObject(params, next),
+                next => s3.putObject(params, (err, res) => {
+                    vId = res.VersionId;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsBefore = res.Versions;
+                    return next(err);
+                }),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDBefore = objMD;
+                    return next(err);
+                }),
+                next => s3.putBucketVersioning(sParams, next),
+                next => putMPUVersion(s3, bucketName, objectName, vId, next),
+                next => _getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                    objMDAfter = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsAfter = res.Versions;
+                    return next(err);
+                }),
+            ], err => {
+                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                checkObjMdAndUpdate(objMDBefore, objMDAfter,
+                    ['location', 'content-length', 'content-md5', 'originOp', 'uploadId', 'microVersionId']);
+                assert.deepStrictEqual(objMDAfter, objMDBefore);
+                return done();
+            });
+        });
+
+        it('should overwrite the current null version after bucket version enabled', done => {
+            const vParams = {
+                Bucket: bucketName,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                }
+            };
+            const params = { Bucket: bucketName, Key: objectName };
+            let objMDBefore;
+            let objMDAfter;
+            let versionsBefore;
+            let versionsAfter;
+
+            async.series([
+                next => s3.putObject(params, next),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsBefore = res.Versions;
+                    return next(err);
+                }),
+                next => _getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                    objMDBefore = objMD;
+                    return next(err);
+                }),
+                next => s3.putBucketVersioning(vParams, next),
+                next => putMPUVersion(s3, bucketName, objectName, 'null', next),
+                next => _getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                    objMDAfter = objMD;
+                    return next(err);
+                }),
+                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                    versionsAfter = res.Versions;
+                    return next(err);
+                }),
+            ], err => {
+                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                checkObjMdAndUpdate(objMDBefore, objMDAfter,
+                    ['location', 'content-length', 'content-md5', 'originOp', 'uploadId', 'microVersionId']);
+
+                assert.deepStrictEqual(objMDAfter, objMDBefore);
+                return done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
When restoring a large object, the tape library will send a S3 initiate/putpart/complete MPU  with `x-scal-s3-version-id` header.

This PR:
- supports the new header
- writes new location
- ensures that the rest of the original object properties remain intact ie last-modified date etc.

_Note: We recalculate content MD5, content length to make sure the metadata is accurate._

_Next: check and update object metadata restore_