### PR TITLE
CLDSRV-205 Update restore properties when putting object version

### DIFF
--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -4,6 +4,8 @@ const async = require('async');
 const metadata = require('../../../metadata/wrapper');
 const { config } = require('../../../Config');
 
+const oneDay = 24 * 60 * 60 * 1000;
+
 const versionIdUtils = versioning.VersionID;
 // Use Arsenal function to generate a version ID used internally by metadata
 // for null versions that are created before bucket versioning is configured
@@ -401,6 +403,18 @@ function overwritingVersioning(objMD, metadataStoreParams) {
     metadataStoreParams.creationTime = objMD['creation-time'];
     metadataStoreParams.lastModifiedDate = objMD['last-modified'];
     metadataStoreParams.updateMicroVersionId = true;
+
+    // update restore
+    const days = objMD.archive?.restoreRequestedDays;
+    const now = Date.now();
+    metadataStoreParams.archive = {
+        archiveInfo: objMD.archive?.archiveInfo,
+        restoreRequestedAt: objMD.archive?.restoreRequestedAt,
+        restoreRequestedDays: objMD.archive?.restoreRequestedDays,
+        restoreCompletedAt: new Date(now),
+        restoreWillExpireAt: new Date(now + (days * oneDay)),
+    };
+
     /* eslint-enable no-param-reassign */
 
     const versionId = objMD.versionId || undefined;

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -143,10 +143,26 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                 oldByteLength = objMD['content-length'];
             }
 
-            if (isPutVersion && !objMD) {
-                const err = putVersionId ? errors.NoSuchVersion : errors.NoSuchKey;
-                log.trace('error no object metadata found', { method: 'completeMultipartUpload', putVersionId });
-                return callback(err);
+            if (isPutVersion) {
+                if (!objMD) {
+                    const err = putVersionId ? errors.NoSuchVersion : errors.NoSuchKey;
+                    log.error('error no object metadata found', { method: 'completeMultipartUpload', putVersionId });
+                    return callback(err);
+                }
+
+                if (objMD.isDeleteMarker) {
+                    log.error('version is a delete marker', { method: 'completeMultipartUpload', putVersionId });
+                    return callback(errors.MethodNotAllowed);
+                }
+
+                // make sure object archive restoration is in progress
+                // NOTE: we do not use putObjectVersion to update the restoration period.
+                if (!objMD.archive || !objMD.archive.restoreRequestedAt || !objMD.archive.restoreRequestedDays
+                || objMD.archive.restoreCompletedAt || objMD.archive.restoreWillExpireAt) {
+                    log.error('object archive restoration is not in progress',
+                        { method: 'completeMultipartUpload', putVersionId });
+                    return callback(errors.InvalidObjectState);
+                }
             }
 
             return services.metadataValidateMultipart(metadataValParams,

--- a/lib/api/objectPut.js
+++ b/lib/api/objectPut.js
@@ -118,10 +118,25 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
             return callback(errors.NoSuchBucket);
         }
 
-        if (isPutVersion && !objMD) {
-            const err = putVersionId ? errors.NoSuchVersion : errors.NoSuchKey;
-            log.trace('error no object metadata found', { method: 'objectPut', putVersionId });
-            return callback(err);
+        if (isPutVersion) {
+            if (!objMD) {
+                const err = putVersionId ? errors.NoSuchVersion : errors.NoSuchKey;
+                log.error('error no object metadata found', { method: 'objectPut', putVersionId });
+                return callback(err);
+            }
+
+            if (objMD.isDeleteMarker) {
+                log.error('version is a delete marker', { method: 'objectPut', putVersionId });
+                return callback(errors.MethodNotAllowed);
+            }
+
+            // make sure object archive restoration is in progress
+            // NOTE: we do not use putObjectVersion to update the restoration period.
+            if (!objMD.archive || !objMD.archive.restoreRequestedAt || !objMD.archive.restoreRequestedDays
+            || objMD.archive.restoreCompletedAt || objMD.archive.restoreWillExpireAt) {
+                log.error('object archive restoration is not in progress', { method: 'objectPut', putVersionId });
+                return callback(errors.InvalidObjectState);
+            }
         }
 
         return async.waterfall([

--- a/lib/services.js
+++ b/lib/services.js
@@ -5,6 +5,7 @@ const { errors, s3middleware } = require('arsenal');
 
 const ObjectMD = require('arsenal').models.ObjectMD;
 const BucketInfo = require('arsenal').models.BucketInfo;
+const ObjectMDArchive = require('arsenal').models.ObjectMDArchive;
 const acl = require('./metadata/acl');
 const constants = require('../constants');
 const { data } = require('./data/wrapper');
@@ -97,7 +98,7 @@ const services = {
             lastModifiedDate, versioning, versionId, uploadId,
             tagging, taggingCopy, replicationInfo, defaultRetention,
             dataStoreName, creationTime, retentionMode, retentionDate,
-            legalHold, originOp, updateMicroVersionId } = params;
+            legalHold, originOp, updateMicroVersionId, archive } = params;
         log.trace('storing object in metadata');
         assert.strictEqual(typeof bucketName, 'string');
         const md = new ObjectMD();
@@ -166,6 +167,19 @@ const services = {
         // update microVersionId when overwriting metadata.
         if (updateMicroVersionId) {
             md.updateMicroVersionId();
+        }
+        // update restore
+        if (archive) {
+            md.setArchive(new ObjectMDArchive(
+                archive.archiveInfo,
+                archive.restoreRequestedAt,
+                archive.restoreRequestedDays,
+                archive.restoreCompletedAt,
+                archive.restoreWillExpireAt));
+            md.setAmzRestore({
+                'ongoing-request': false,
+                'expiry-date': archive.restoreWillExpireAt,
+            });
         }
         // information to store about the version and the null version id
         // in the object metadata


### PR DESCRIPTION
Update `archive.restoreCompletedAt` and  `archive.restoreWillExpireAt`
Note: we do not use `putObjectVersion` to update the restoration period.

Design information from https://github.com/scality/citadel/blob/development/1.0/docs/design/cold-storage.md:
- In Zenko, the lifecycle transition workflow will change the object location: metadata and not its storage class (which is ignored).