### PR TITLE
Remove default replication endpoint mandate

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -560,12 +560,6 @@ class Config extends EventEmitter {
             const { replicationEndpoints } = config;
             assert(replicationEndpoints instanceof Array, 'bad config: ' +
                 '`replicationEndpoints` property must be an array');
-            if (replicationEndpoints.length > 1) {
-                const hasDefault = replicationEndpoints.some(
-                    replicationEndpoint => replicationEndpoint.default);
-                assert(hasDefault, 'bad config: `replicationEndpoints` must ' +
-                    'contain a default endpoint');
-            }
             replicationEndpoints.forEach(replicationEndpoint => {
                 assert.strictEqual(typeof replicationEndpoint, 'object',
                     'bad config: `replicationEndpoints` property must be an ' +

--- a/lib/api/apiUtils/object/getReplicationInfo.js
+++ b/lib/api/apiUtils/object/getReplicationInfo.js
@@ -23,12 +23,12 @@ function _getStorageClasses(rule) {
     }
     const { replicationEndpoints } = s3config;
     // If no storage class, use the given default endpoint or the sole endpoint
-    if (replicationEndpoints.length > 1) {
+    if (replicationEndpoints.length > 0) {
         const endPoint =
-            replicationEndpoints.find(endpoint => endpoint.default);
+            replicationEndpoints.find(endpoint => endpoint.default) || replicationEndpoints[0];
         return [endPoint.site];
     }
-    return [replicationEndpoints[0].site];
+    return undefined;
 }
 
 function _getReplicationInfo(rule, replicationConfig, content, operationType,
@@ -36,6 +36,9 @@ function _getReplicationInfo(rule, replicationConfig, content, operationType,
     const storageTypes = [];
     const backends = [];
     const storageClasses = _getStorageClasses(rule);
+    if (!storageClasses) {
+        return undefined;
+    }
     storageClasses.forEach(storageClass => {
         const storageClassName =
               storageClass.endsWith(':preferred_read') ?


### PR DESCRIPTION
The default replication endpoint should not be needed, esp. since the
one we use (in zenko) does not relate to an existing location: it is
used only to let Cloudserver start.

Issue: CLDSRV-211
