### PR TITLE
Remove left-over tiny version id

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -17,9 +17,7 @@ const { azureAccountNameRegex, base64Regex,
     allowedUtapiEventFilterFields, allowedUtapiEventFilterStates,
 } = require('../constants');
 const { utapiVersion } = require('utapi');
-const { versioning } = require('arsenal');
 
-const versionIdUtils = versioning.VersionID;
 
 // config paths
 const configSearchPaths = [
@@ -1509,21 +1507,6 @@ class Config extends EventEmitter {
         if (config.requests !== undefined) {
             requestsConfigAssert(config.requests);
             this.requests = config.requests;
-        }
-        if (process.env.VERSION_ID_ENCODING_TYPE !== undefined) {
-            // override config
-            config.versionIdEncodingType = process.env.VERSION_ID_ENCODING_TYPE;
-        }
-        if (config.versionIdEncodingType) {
-            if (config.versionIdEncodingType === 'hex') {
-                this.versionIdEncodingType = versionIdUtils.ENC_TYPE_HEX;
-            } else if (config.versionIdEncodingType === 'base62') {
-                this.versionIdEncodingType = versionIdUtils.ENC_TYPE_BASE62;
-            } else {
-                throw new Error(`Invalid versionIdEncodingType: ${config.versionIdEncodingType}`);
-            }
-        } else {
-            this.versionIdEncodingType = versionIdUtils.ENC_TYPE_HEX;
         }
         if (config.bucketNotificationDestinations) {
             this.bucketNotificationDestinations = bucketNotifAssert(config.bucketNotificationDestinations);

--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -61,8 +61,7 @@ function getVersionIdResHeader(verCfg, objectMD) {
         if (objectMD.isNull || (objectMD && !objectMD.versionId)) {
             return 'null';
         }
-        return versionIdUtils.encode(objectMD.versionId,
-                                     config.versionIdEncodingType);
+        return versionIdUtils.encode(objectMD.versionId);
     }
     return undefined;
 }

--- a/lib/api/bucketGet.js
+++ b/lib/api/bucketGet.js
@@ -10,7 +10,6 @@ const versionIdUtils = versioning.VersionID;
 const monitoring = require('../utilities/monitoringHandler');
 const { generateToken, decryptToken }
     = require('../api/apiUtils/object/continueToken');
-const { config } = require('../Config');
 
 // do not url encode the continuation tokens
 const skipUrlEncoding = new Set([
@@ -105,7 +104,7 @@ const skipUrlEncoding = new Set([
 */
 /* eslint-enable max-len */
 
-function processVersions(bucketName, listParams, list, encType) {
+function processVersions(bucketName, listParams, list) {
     const xml = [];
     xml.push(
         '<?xml version="1.0" encoding="UTF-8"?>',
@@ -130,7 +129,7 @@ function processVersions(bucketName, listParams, list, encType) {
     xmlParams.forEach(p => {
         if (p.value) {
             const val = p.tag !== 'NextVersionIdMarker' || p.value === 'null' ?
-                p.value : versionIdUtils.encode(p.value, encType);
+                p.value : versionIdUtils.encode(p.value);
             xml.push(`<${p.tag}>${escapeXmlFn(val)}</${p.tag}>`);
         }
     });
@@ -146,7 +145,7 @@ function processVersions(bucketName, listParams, list, encType) {
             `<Key>${objectKey}</Key>`,
             '<VersionId>',
             (v.IsNull || v.VersionId === undefined) ?
-                'null' : versionIdUtils.encode(v.VersionId, encType),
+                'null' : versionIdUtils.encode(v.VersionId),
             '</VersionId>',
             `<IsLatest>${isLatest}</IsLatest>`,
             `<LastModified>${v.LastModified}</LastModified>`,
@@ -262,8 +261,7 @@ function handleResult(listParams, requestMaxKeys, encoding, authInfo,
     listParams.encoding = encoding;
     let res;
     if (listParams.listingType === 'DelimiterVersions') {
-        res = processVersions(bucketName, listParams, list,
-                              config.versionIdEncodingType);
+        res = processVersions(bucketName, listParams, list);
     } else {
         res = processMasterVersions(bucketName, listParams, list);
     }

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -23,7 +23,6 @@ const locationKeysHaveChanged
 const { setExpirationHeaders } = require('./apiUtils/object/expirationHeaders');
 
 const logger = require('../utilities/logger');
-const { config } = require('../Config');
 const { validatePutVersionId } = require('./apiUtils/object/coldStorage');
 
 const versionIdUtils = versioning.VersionID;
@@ -503,8 +502,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
         }
         if (generatedVersionId) {
             corsHeaders['x-amz-version-id'] =
-                versionIdUtils.encode(generatedVersionId,
-                                      config.versionIdEncodingType);
+                versionIdUtils.encode(generatedVersionId);
         }
         Object.assign(responseHeaders, corsHeaders);
 

--- a/lib/api/metadataSearch.js
+++ b/lib/api/metadataSearch.js
@@ -10,7 +10,6 @@ const versionIdUtils = versioning.VersionID;
 const monitoring = require('../utilities/monitoringHandler');
 const { decryptToken }
     = require('../api/apiUtils/object/continueToken');
-const { config } = require('../Config');
 const { processVersions, processMasterVersions } = require('./bucketGet');
 
 
@@ -22,8 +21,7 @@ function handleResult(listParams, requestMaxKeys, encoding, authInfo,
     listParams.encoding = encoding;
     let res;
     if (listParams.listingType === 'DelimiterVersions') {
-        res = processVersions(bucketName, listParams, list,
-            config.versionIdEncodingType);
+        res = processVersions(bucketName, listParams, list);
     } else {
         res = processMasterVersions(bucketName, listParams, list);
     }

--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -290,8 +290,7 @@ function getObjMetadataAndDelete(authInfo, canonicalID, request,
             // you just generated and DeleteMarker tag equals true
             if (deleteInfo.newDeleteMarker) {
                 isDeleteMarker = true;
-                deleteMarkerVersionId = versionIdUtils.encode(
-                    versionId, config.versionIdEncodingType);
+                deleteMarkerVersionId = versionIdUtils.encode(versionId);
                 // In this case we are putting a new object (i.e., the delete
                 // marker), so we decrement the numOfObjectsRemoved value.
                 numOfObjectsRemoved--;

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -563,14 +563,12 @@ function objectCopy(authInfo, request, sourceBucket,
         }
         if (sourceVersionId) {
             additionalHeaders['x-amz-copy-source-version-id'] =
-                versionIdUtils.encode(sourceVersionId,
-                                      config.versionIdEncodingType);
+                versionIdUtils.encode(sourceVersionId);
         }
         const isVersioned = storingNewMdResult && storingNewMdResult.versionId;
         if (isVersioned) {
             additionalHeaders['x-amz-version-id'] =
-                versionIdUtils.encode(storingNewMdResult.versionId,
-                                      config.versionIdEncodingType);
+                versionIdUtils.encode(storingNewMdResult.versionId);
         }
 
         Object.assign(responseHeaders, additionalHeaders);

--- a/lib/api/objectDelete.js
+++ b/lib/api/objectDelete.js
@@ -10,7 +10,6 @@ const { decodeVersionId, preprocessingVersioningDelete }
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const monitoring = require('../utilities/monitoringHandler');
 const { isObjectLocked } = require('./apiUtils/object/objectLockHelpers');
-const { config } = require('../Config');
 
 const versionIdUtils = versioning.VersionID;
 const objectLockedError = new Error('object locked');
@@ -178,8 +177,7 @@ function objectDelete(authInfo, request, log, cb) {
         // in the response headers, even in case of NoSuchVersion
         if (reqVersionId) {
             resHeaders['x-amz-version-id'] = reqVersionId === 'null' ?
-                reqVersionId : versionIdUtils.encode(
-                    reqVersionId, config.versionIdEncodingType);
+                reqVersionId : versionIdUtils.encode(reqVersionId);
             if (deleteInfo && deleteInfo.removeDeleteMarker) {
                 resHeaders['x-amz-delete-marker'] = true;
             }
@@ -206,8 +204,7 @@ function objectDelete(authInfo, request, log, cb) {
             if (result.versionId) {
                 resHeaders['x-amz-delete-marker'] = true;
                 resHeaders['x-amz-version-id'] = result.versionId === 'null' ?
-                    result.versionId : versionIdUtils.encode(
-                        result.versionId, config.versionIdEncodingType);
+                    result.versionId : versionIdUtils.encode(result.versionId);
             }
             pushMetric('putDeleteMarkerObject', log, {
                 authInfo,

--- a/lib/api/objectPut.js
+++ b/lib/api/objectPut.js
@@ -14,7 +14,6 @@ const { validateHeaders } = require('./apiUtils/object/objectLockHelpers');
 const { hasNonPrintables } = require('../utilities/stringChecks');
 const kms = require('../kms/wrapper');
 const monitoring = require('../utilities/monitoringHandler');
-const { config } = require('../Config');
 const { validatePutVersionId } = require('./apiUtils/object/coldStorage');
 const { setExpirationHeaders } = require('./apiUtils/object/expirationHeaders');
 
@@ -212,8 +211,7 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
             if (isVersionedObj) {
                 if (storingResult && storingResult.versionId) {
                     responseHeaders['x-amz-version-id'] =
-                        versionIdUtils.encode(storingResult.versionId,
-                                              config.versionIdEncodingType);
+                        versionIdUtils.encode(storingResult.versionId);
                 }
             }
 

--- a/lib/api/objectPutCopyPart.js
+++ b/lib/api/objectPutCopyPart.js
@@ -16,7 +16,6 @@ const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const monitoring = require('../utilities/monitoringHandler');
 
 const versionIdUtils = versioning.VersionID;
-const { config } = require('../Config');
 
 const skipError = new Error('skip');
 
@@ -171,9 +170,7 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
                             sourceVerId = 'null';
                         } else {
                             sourceVerId =
-                                versionIdUtils.encode(
-                                    sourceObjMD.versionId,
-                                    config.versionIdEncodingType);
+                                versionIdUtils.encode(sourceObjMD.versionId);
                         }
                     }
                     return next(null, copyLocator.dataLocator, destBucketMD,

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "utapi_reindex": "node lib/utapi/utapiReindex.js",
     "management_agent": "node managementAgent.js",
     "test": "CI=true S3BACKEND=mem mocha --reporter mocha-multi-reporters --reporter-options configFile=$INIT_CWD/tests/reporter-config.json --recursive tests/unit",
-    "test_versionid_base62": "VERSION_ID_ENCODING_TYPE=base62 CI=true S3BACKEND=mem mocha --reporter mocha-multi-reporters --reporter-options configFile=$INIT_CWD/tests/reporter-config.json --recursive tests/unit/api",
+    "test_versionid_base62": "S3_VERSION_ID_ENCODING_TYPE=base62 CI=true S3BACKEND=mem mocha --reporter mocha-multi-reporters --reporter-options configFile=$INIT_CWD/tests/reporter-config.json --recursive tests/unit/api",
     "test_legacy_location": "CI=true S3_LOCATION_FILE=tests/locationConfig/locationConfigLegacy.json S3BACKEND=mem mocha --reporter mocha-multi-reporters --reporter-options configFile=$INIT_CWD/tests/reporter-config.json --recursive tests/unit",
     "test_utapi_v2": "mocha --reporter mocha-multi-reporters --reporter-options configFile=$INIT_CWD/tests/reporter-config.json --recursive tests/utapi",
     "multiple_backend_test": "CI=true S3BACKEND=mem S3DATA=multiple mocha --reporter mocha-multi-reporters --reporter-options configFile=$INIT_CWD/tests/reporter-config.json -t 20000 --recursive tests/multipleBackend",

--- a/tests/unit/api/deleteMarker.js
+++ b/tests/unit/api/deleteMarker.js
@@ -12,7 +12,6 @@ const { multiObjectDelete } = require('../../../lib/api/multiObjectDelete');
 const metadata = require('../metadataswitch');
 const DummyRequest = require('../DummyRequest');
 const { cleanup, DummyRequestLogger, makeAuthInfo } = require('../helpers');
-const { config } = require('../../../lib/Config');
 
 const versionIdUtils = versioning.VersionID;
 
@@ -122,8 +121,7 @@ describe('delete marker creation', () => {
                 const mdVersionId = deleteMarkerMD.versionId;
                 assert.strictEqual(deleteMarkerMD.isDeleteMarker, true);
                 assert.strictEqual(
-                    versionIdUtils.encode(
-                        mdVersionId, config.versionIdEncodingType),
+                    versionIdUtils.encode(mdVersionId),
                     deleteResultVersionId);
                 assert.strictEqual(deleteMarkerMD['content-length'], 0);
                 assert.strictEqual(deleteMarkerMD.location, null);


### PR DESCRIPTION
Tiny version id code has been removed, there is only Short version id,
which is handled fully in Arsenal by setting `S3_VERSION_ID_ENCODING_TYPE`
variable.

The `VersionId.encode()` function does not even actually support passing
an encoding type anymore, so the code was of no use anymore.

Issue: CLDSRV-214
