### PR TITLE
bf(CLDSRV-232): Prevent empty NextContinuationToken from being sent at listing end

### DIFF
--- a/lib/api/bucketGet.js
+++ b/lib/api/bucketGet.js
@@ -218,7 +218,8 @@ function processMasterVersions(bucketName, listParams, list) {
         } else if (p.tag !== 'NextMarker' &&
                 p.tag !== 'EncodingType' &&
                 p.tag !== 'Delimiter' &&
-                p.tag !== 'StartAfter') {
+                p.tag !== 'StartAfter' &&
+                p.tag !== 'NextContinuationToken') {
             xml.push(`<${p.tag}/>`);
         }
     });

--- a/tests/unit/api/bucketGet.js
+++ b/tests/unit/api/bucketGet.js
@@ -313,6 +313,9 @@ describe('bucketGet API V2', () => {
                 assert.strictEqual(keyCount, keysReturned);
                 // assert the results from tests
                 test.assertion(result);
+                if (result.ListBucketResult.IsTruncated && result.ListBucketResult.IsTruncated[0] === 'false') {
+                    assert.strictEqual(result.ListBucketResult.NextContinuationToken, undefined);
+                }
                 done();
             });
         });

--- a/tests/unit/api/objectGet.js
+++ b/tests/unit/api/objectGet.js
@@ -99,7 +99,8 @@ describe('objectGet API', () => {
         url: `/${bucketName}/${objectName}`,
     }, postBody);
 
-    const testDate = new Date(2022, 6, 3).toISOString();
+    const threeDaysMilliSecs = 3 * 24 * 60 * 60 * 1000;
+    const testDate = new Date(Date.now() + threeDaysMilliSecs).toISOString();
 
     it('should get the object metadata with valid retention info', done => {
         bucketPut(authInfo, testPutBucketRequestObjectLock, log, () => {


### PR DESCRIPTION
Prevents listing v2 from adding an empty `<NextContinuationToken/>` tag on the final response