### PR TITLE
CLDSRV-241 Allow updating object metadata with empty data location

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -501,6 +501,10 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
                 pushReplicationMetric(objMd, omVal, bucketName, objectKey, log);
                 if (objMd &&
                     headers['x-scal-replication-content'] !== 'METADATA' &&
+                    // The new data location is set to null when archiving to a Cold site.
+                    // In that case "removing old data location key" is handled by the lifecycle
+                    // transition processor.
+                    omVal.location && Array.isArray(omVal.location) &&
                     locationKeysHaveChanged(objMd.location, omVal.location)) {
                     log.info('removing old data locations', {
                         method: 'putMetadata',


### PR DESCRIPTION
Decided not to move this `omVal.location` check inside `locationKeysHaveChanged()` function since it is specific to putMetadata.

In `locationKeysHaveChanged(old, new)`,  the `new` (second) parameter is required to be an array.
Added a check for it.

- [x] Tested with lifecycle object transition process.