### PR TITLE
feature: CLDSRV-243 allow backbeat to update non versioned objects

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -472,13 +472,15 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
                 omVal[headerName] = objMd[headerName];
             });
         }
-        // specify both 'versioning' and 'versionId' to create a "new"
-        // version (updating master as well) but with specified
-        // versionId
-        const options = {
-            versioning: bucketInfo.isVersioningEnabled(),
-            versionId: omVal.versionId,
-        };
+        const options = {};
+        if (omVal.versionId || omVal.replicationInfo.isNFS) {
+            // specify both 'versioning' and 'versionId' to create a "new"
+            // version (updating master as well) but with specified
+            // versionId
+            options.versioning = bucketInfo.isVersioningEnabled();
+            options.versionId = omVal.versionId;
+        }
+
         // If the object is from a source bucket without versioning (i.e. NFS),
         // then we want to create a version for the replica object even though
         // none was provided in the object metadata value.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "8.5.5",
+  "version": "8.5.8",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Issue: [CLDSRV-243](https://scality.atlassian.net/browse/CLDSRV-243)

When replicating a non versioned OOB object, Backbeat’s ReplicationStatusProcessor needs to only update the master version of that object. 

The default behaviour was to call the `putObjectVerCase3` function of the MongoClient, this function is used when updating a version. This was done as we expected to have a versionId.

In OOB we expect to have a mirroring of metadata between S3C and zenko, hence we need to call `putObjectNoVer` that only acts on master objects. The choice of function used is determined by the options passed to the `putObject` function.

- [x] Tested in Zenko CI [Build Link](https://eve.devsca.com/github/scality/zenko/#/builders/12/builds/5627)
- [x] Tested in Local Artesca cluster the behaviour of replication with zero byte objects, normal non MPU objects, MPU objects. the objects where also tested as versioned, non versioned and versioning suspended