### PR TITLE
bf(CLDSRV-250): Set replication status to `PENDING` when putting an ACL

### DIFF
--- a/lib/metadata/acl.js
+++ b/lib/metadata/acl.js
@@ -1,5 +1,6 @@
 const { errors } = require('arsenal');
 
+const getReplicationInfo = require('../api/apiUtils/object/getReplicationInfo');
 const aclUtils = require('../utilities/aclUtils');
 const constants = require('../../constants');
 const metadata = require('../metadata/wrapper');
@@ -16,6 +17,12 @@ const acl = {
         log.trace('updating object acl in metadata');
         // eslint-disable-next-line no-param-reassign
         objectMD.acl = addACLParams;
+        const replicationInfo = getReplicationInfo(objectKey, bucket, true);
+        if (replicationInfo) {
+            // eslint-disable-next-line no-param-reassign
+            objectMD.replicationInfo = Object.assign({},
+                objectMD.replicationInfo, replicationInfo);
+        }
         metadata.putObjectMD(bucket.getName(), objectKey, objectMD, params, log,
             cb);
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.10.6",
+  "version": "7.10.7",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {

--- a/tests/unit/api/objectReplicationMD.js
+++ b/tests/unit/api/objectReplicationMD.js
@@ -344,6 +344,19 @@ describe('Replication object MD without bucket replication config', () => {
                     return done();
                 }));
 
+        it("should update status to 'PENDING' and content to '['METADATA']' " +
+            'if putting object ACL', done =>
+            async.series([
+                next => putObjectAndCheckMD(keyA, newReplicationMD, next),
+                next => objectPutACL(authInfo, objectACLReq, log, next),
+            ], err => {
+                if (err) {
+                    return done(err);
+                }
+                checkObjectReplicationInfo(keyA, replicateMetadataOnly);
+                return done();
+            }));
+
         it('should update metadata if putting a delete marker', done =>
             async.series([
                 next => putObjectAndCheckMD(keyA, newReplicationMD, err => {
@@ -534,29 +547,19 @@ describe('Replication object MD without bucket replication config', () => {
                         return done();
                     }));
 
-                it('should update on a put object ACL request', done => {
-                    let completedReplicationInfo;
+                it('should update on a put object ACL request', done =>
                     async.series([
                         next => putObjectAndCheckMD(keyA,
                             expectedReplicationInfo, next),
-                        next => {
-                            const objectMD = metadata.keyMaps
-                                  .get(bucketName).get(keyA);
-                            // Update metadata to a status after replication
-                            // has occurred.
-                            objectMD.replicationInfo.status = 'COMPLETED';
-                            completedReplicationInfo = JSON.parse(
-                                JSON.stringify(objectMD.replicationInfo));
-                            objectPutACL(authInfo, objectACLReq, log, next);
-                        },
+                        next => objectPutACL(authInfo, objectACLReq, log, next),
                     ], err => {
                         if (err) {
                             return done(err);
                         }
-                        checkObjectReplicationInfo(keyA, completedReplicationInfo);
+                        checkObjectReplicationInfo(keyA,
+                            expectedReplicationInfoMD);
                         return done();
-                    });
-                });
+                    }));
 
                 it('should update on a put object tagging request', done =>
                     async.series([


### PR DESCRIPTION
rollback changes to objectPutACL and associated tests
