### PR TITLE
CLDSRV-246 PutObjectVersion always returns 403

### DIFF
--- a/lib/api/apiUtils/authorization/prepareRequestContexts.js
+++ b/lib/api/apiUtils/authorization/prepareRequestContexts.js
@@ -103,28 +103,28 @@ function prepareRequestContexts(apiMethod, request, sourceBucket,
           generateRequestContext(objectGetTaggingAction);
         requestContexts.push(getRequestContext, getTaggingRequestContext);
     } else if (apiMethodAfterVersionCheck === 'objectPut') {
-        const putRequestContext =
-          generateRequestContext(apiMethodAfterVersionCheck);
-        requestContexts.push(putRequestContext);
-        // if put object (versioning) with tag set
-        if (request.headers['x-amz-tagging']) {
-            const putTaggingRequestContext =
-              generateRequestContext('objectPutTagging');
-            requestContexts.push(putTaggingRequestContext);
-        }
-        // if put object (versioning) with ACL
-        if (isHeaderAcl(request.headers)) {
-            const putAclRequestContext =
-              generateRequestContext('objectPutACL');
-            requestContexts.push(putAclRequestContext);
-        }
         // if put object with version
         if (request.headers['x-scal-s3-version-id'] ||
         request.headers['x-scal-s3-version-id'] === '') {
-            // CLDSRV-245
-            // const putVersionRequestContext =
-            //   generateRequestContext('objectPutVersion');
-            // requestContexts.push(putVersionRequestContext);
+            const putVersionRequestContext =
+              generateRequestContext('objectPutVersion');
+            requestContexts.push(putVersionRequestContext);
+        } else {
+            const putRequestContext =
+              generateRequestContext(apiMethodAfterVersionCheck);
+            requestContexts.push(putRequestContext);
+            // if put object (versioning) with tag set
+            if (request.headers['x-amz-tagging']) {
+                const putTaggingRequestContext =
+                  generateRequestContext('objectPutTagging');
+                requestContexts.push(putTaggingRequestContext);
+            }
+            // if put object (versioning) with ACL
+            if (isHeaderAcl(request.headers)) {
+                const putAclRequestContext =
+                  generateRequestContext('objectPutACL');
+                requestContexts.push(putAclRequestContext);
+            }
         }
     } else if (apiMethodAfterVersionCheck === 'initiateMultipartUpload' ||
       apiMethodAfterVersionCheck === 'objectPutPart' ||
@@ -132,10 +132,13 @@ function prepareRequestContexts(apiMethod, request, sourceBucket,
       ) {
         if (request.headers['x-scal-s3-version-id'] ||
         request.headers['x-scal-s3-version-id'] === '') {
-            // CLDSRV-245
-            // const putVersionRequestContext =
-            //   generateRequestContext('objectPutVersion');
-            // requestContexts.push(putVersionRequestContext);
+            const putVersionRequestContext =
+              generateRequestContext('objectPutVersion');
+            requestContexts.push(putVersionRequestContext);
+        } else {
+            const putRequestContext =
+              generateRequestContext(apiMethodAfterVersionCheck);
+            requestContexts.push(putRequestContext);
         }
     } else {
         const requestContext =

--- a/tests/unit/api/apiUtils/authorization/prepareRequestContexts.js
+++ b/tests/unit/api/apiUtils/authorization/prepareRequestContexts.js
@@ -1,0 +1,134 @@
+const assert = require('assert');
+const DummyRequest = require('../../../DummyRequest');
+const  prepareRequestContexts =
+      require('../../../../../lib/api/apiUtils/authorization/prepareRequestContexts.js');
+
+const makeRequest = (headers, query) => new DummyRequest({
+    headers,
+    url: '/',
+    parsedHost: 'localhost',
+    socket: {},
+    query,
+});
+const sourceBucket = 'bucketsource';
+const sourceObject = 'objectsource';
+const sourceVersionId = 'vid1';
+
+describe('prepareRequestContexts', () => {
+    it('should return null if multiObjectDelete method', () => {
+        const apiMethod = 'multiObjectDelete';
+        const request = makeRequest();
+        const results = prepareRequestContexts(apiMethod, request, sourceBucket,
+        sourceObject, sourceVersionId);
+
+        assert.strictEqual(results, null);
+    });
+
+    it('should return s3:PutObjectVersion request context action for objectPut method with x-scal-s3-version-id' +
+    ' header', () => {
+        const apiMethod = 'objectPut';
+        const request = makeRequest({
+            'x-scal-s3-version-id': 'vid',
+        });
+        const results = prepareRequestContexts(apiMethod, request, sourceBucket,
+        sourceObject, sourceVersionId);
+
+        assert.strictEqual(results.length, 1);
+        const expectedAction = 's3:PutObjectVersion';
+        assert.strictEqual(results[0].getAction(), expectedAction);
+    });
+
+    it('should return s3:PutObjectVersion request context action for objectPut method with empty x-scal-s3-version-id' +
+    ' header', () => {
+        const apiMethod = 'objectPut';
+        const request = makeRequest({
+            'x-scal-s3-version-id': '',
+        });
+        const results = prepareRequestContexts(apiMethod, request, sourceBucket,
+        sourceObject, sourceVersionId);
+
+        assert.strictEqual(results.length, 1);
+        const expectedAction = 's3:PutObjectVersion';
+        assert.strictEqual(results[0].getAction(), expectedAction);
+    });
+
+    it('should return s3:PutObject request context action for objectPut method and no header', () => {
+        const apiMethod = 'objectPut';
+        const request = makeRequest({});
+        const results = prepareRequestContexts(apiMethod, request, sourceBucket,
+        sourceObject, sourceVersionId);
+
+        assert.strictEqual(results.length, 1);
+        const expectedAction = 's3:PutObject';
+        assert.strictEqual(results[0].getAction(), expectedAction);
+    });
+
+    it('should return s3:PutObject and s3:PutObjectTagging actions for objectPut method with' +
+    ' x-amz-tagging header', () => {
+        const apiMethod = 'objectPut';
+        const request = makeRequest({
+            'x-amz-tagging': 'key1=value1&key2=value2',
+        });
+        const results = prepareRequestContexts(apiMethod, request, sourceBucket,
+        sourceObject, sourceVersionId);
+
+        assert.strictEqual(results.length, 2);
+        const expectedAction1 = 's3:PutObject';
+        const expectedAction2 = 's3:PutObjectTagging';
+        assert.strictEqual(results[0].getAction(), expectedAction1);
+        assert.strictEqual(results[1].getAction(), expectedAction2);
+    });
+
+    it('should return s3:PutObject and s3:PutObjectAcl actions for objectPut method with ACL header', () => {
+        const apiMethod = 'objectPut';
+        const request = makeRequest({
+            'x-amz-acl': 'private',
+        });
+        const results = prepareRequestContexts(apiMethod, request, sourceBucket,
+        sourceObject, sourceVersionId);
+
+        assert.strictEqual(results.length, 2);
+        const expectedAction1 = 's3:PutObject';
+        const expectedAction2 = 's3:PutObjectAcl';
+        assert.strictEqual(results[0].getAction(), expectedAction1);
+        assert.strictEqual(results[1].getAction(), expectedAction2);
+    });
+
+    ['initiateMultipartUpload', 'objectPutPart', 'completeMultipartUpload'].forEach(apiMethod => {
+        it(`should return s3:PutObjectVersion request context action for ${apiMethod} method ` +
+        'with x-scal-s3-version-id header', () => {
+            const request = makeRequest({
+                'x-scal-s3-version-id': '',
+            });
+            const results = prepareRequestContexts(apiMethod, request, sourceBucket,
+            sourceObject, sourceVersionId);
+
+            assert.strictEqual(results.length, 1);
+            const expectedAction = 's3:PutObjectVersion';
+            assert.strictEqual(results[0].getAction(), expectedAction);
+        });
+
+        it(`should return s3:PutObjectVersion request context action for ${apiMethod} method` +
+        'with empty x-scal-s3-version-id header', () => {
+            const request = makeRequest({
+                'x-scal-s3-version-id': '',
+            });
+            const results = prepareRequestContexts(apiMethod, request, sourceBucket,
+            sourceObject, sourceVersionId);
+
+            assert.strictEqual(results.length, 1);
+            const expectedAction = 's3:PutObjectVersion';
+            assert.strictEqual(results[0].getAction(), expectedAction);
+        });
+
+        it(`should return s3:PutObject request context action for ${apiMethod} method and no header`, () => {
+            const request = makeRequest({});
+            const results = prepareRequestContexts(apiMethod, request, sourceBucket,
+            sourceObject, sourceVersionId);
+
+            assert.strictEqual(results.length, 1);
+            const expectedAction = 's3:PutObject';
+            assert.strictEqual(results[0].getAction(), expectedAction);
+        });
+    });
+});


### PR DESCRIPTION
Behavior before merge:
`s3:PutObjectVersion` and `s3:PutObject` permissions were required to restore objects (put object version). 

Behavior after merge:
Only `s3:PutObjectVersion` permission is required to restore objects (put object version). 


Planning on adding e2e tests in Zenko about assumeRole with s3:PutObjectVersion permission policy cf https://scality.atlassian.net/browse/ZENKO-4303