### PR TITLE
bugfix: CLDSRV-258 set 'originOp' in MD for tagging/ACL ops

### DIFF
--- a/lib/api/objectDeleteTagging.js
+++ b/lib/api/objectDeleteTagging.js
@@ -79,6 +79,8 @@ function objectDeleteTagging(authInfo, request, log, callback) {
                 objectMD.replicationInfo = Object.assign({},
                     objectMD.replicationInfo, replicationInfo);
             }
+            // eslint-disable-next-line no-param-reassign
+            objectMD.originOp = 's3:ObjectTagging:Delete';
             metadata.putObjectMD(bucket.getName(), objectKey, objectMD, params,
             log, err =>
                 next(err, bucket, objectMD));

--- a/lib/api/objectPutTagging.js
+++ b/lib/api/objectPutTagging.js
@@ -85,6 +85,8 @@ function objectPutTagging(authInfo, request, log, callback) {
                 objectMD.replicationInfo = Object.assign({},
                     objectMD.replicationInfo, replicationInfo);
             }
+            // eslint-disable-next-line no-param-reassign
+            objectMD.originOp = 's3:ObjectTagging:Put';
             metadata.putObjectMD(bucket.getName(), objectKey, objectMD, params,
             log, err =>
                 next(err, bucket, objectMD));

--- a/lib/metadata/acl.js
+++ b/lib/metadata/acl.js
@@ -17,6 +17,8 @@ const acl = {
         log.trace('updating object acl in metadata');
         // eslint-disable-next-line no-param-reassign
         objectMD.acl = addACLParams;
+        // eslint-disable-next-line no-param-reassign
+        objectMD.originOp = 's3:ObjectAcl:Put';
         const replicationInfo = getReplicationInfo(objectKey, bucket, true);
         if (replicationInfo) {
             // eslint-disable-next-line no-param-reassign

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "git+https://github.com/scality/Arsenal#7.10.29",
+    "arsenal": "git+https://github.com/scality/Arsenal#7.10.30",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/tests/unit/api/bucketPutNotification.js
+++ b/tests/unit/api/bucketPutNotification.js
@@ -21,7 +21,11 @@ const expectedNotifConfig = {
     queueConfig: [
         {
             id: 'notification-id',
-            events: ['s3:ObjectCreated:*'],
+            events: [
+                's3:ObjectCreated:*',
+                's3:ObjectTagging:*',
+                's3:ObjectAcl:Put',
+            ],
             queueArn: 'arn:scality:bucketnotif:::target1',
             filterRules: undefined,
         },
@@ -34,6 +38,8 @@ function getNotifRequest(empty) {
         '<Id>notification-id</Id>' +
         '<Queue>arn:scality:bucketnotif:::target1</Queue>' +
         '<Event>s3:ObjectCreated:*</Event>' +
+        '<Event>s3:ObjectTagging:*</Event>' +
+        '<Event>s3:ObjectAcl:Put</Event>' +
         '</QueueConfiguration>';
 
     const notifXml = '<NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +

--- a/tests/unit/api/objectDeleteTagging.js
+++ b/tests/unit/api/objectDeleteTagging.js
@@ -46,7 +46,7 @@ describe('deleteObjectTagging API', () => {
 
     afterEach(() => cleanup());
 
-    it('should delete tag set', done => {
+    it('should delete tag set and update originOp', done => {
         const taggingUtil = new TaggingConfigTester();
         const testObjectPutTaggingRequest = taggingUtil
             .createObjectTaggingRequest('PUT', bucketName, objectName);
@@ -62,6 +62,7 @@ describe('deleteObjectTagging API', () => {
         ], (err, objectMD) => {
             const uploadedTags = objectMD.tags;
             assert.deepStrictEqual(uploadedTags, {});
+            assert.strictEqual(objectMD.originOp, 's3:ObjectTagging:Delete');
             return done();
         });
     });

--- a/tests/unit/api/objectPutACL.js
+++ b/tests/unit/api/objectPutACL.js
@@ -91,6 +91,7 @@ describe('putObjectACL API', () => {
                         log, (err, md) => {
                             assert.strictEqual(md.acl.Canned,
                             'public-read-write');
+                            assert.strictEqual(md.originOp, 's3:ObjectAcl:Put');
                             done();
                         });
                     });
@@ -136,6 +137,7 @@ describe('putObjectACL API', () => {
                                             assert.strictEqual(md
                                                    .acl.Canned,
                                                    'authenticated-read');
+                                            assert.strictEqual(md.originOp, 's3:ObjectAcl:Put');
                                             done();
                                         });
                                 });
@@ -181,6 +183,7 @@ describe('putObjectACL API', () => {
                                     .indexOf(ownerID) > -1);
                                 assert(acls.WRITE_ACP[0]
                                     .indexOf(anotherID) > -1);
+                                assert.strictEqual(md.originOp, 's3:ObjectAcl:Put');
                                 done();
                             });
                     });
@@ -249,6 +252,7 @@ describe('putObjectACL API', () => {
                                 .acl.WRITE_ACP[0], ownerID);
                             assert.strictEqual(md
                                 .acl.READ_ACP[0], anotherID);
+                            assert.strictEqual(md.originOp, 's3:ObjectAcl:Put');
                             done();
                         });
                     });

--- a/tests/unit/api/objectPutTagging.js
+++ b/tests/unit/api/objectPutTagging.js
@@ -68,7 +68,7 @@ describe('putObjectTagging API', () => {
 
     afterEach(cleanup);
 
-    it('should update an object\'s metadata with tags resource', done => {
+    it('should update an object\'s metadata with tags resource and update originOp', done => {
         const taggingUtil = new TaggingConfigTester();
         const testObjectPutTaggingRequest = taggingUtil
             .createObjectTaggingRequest('PUT', bucketName, objectName);
@@ -85,6 +85,7 @@ describe('putObjectTagging API', () => {
                 }
                 const uploadedTags = objectMD.tags;
                 assert.deepStrictEqual(uploadedTags, taggingUtil.getTags());
+                assert.strictEqual(objectMD.originOp, 's3:ObjectTagging:Put');
                 return done();
             });
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -466,6 +466,46 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "^2.0.2"
 
+"arsenal@git+https://github.com/scality/Arsenal#7.10.30":
+  version "7.10.30"
+  resolved "git+https://github.com/scality/Arsenal#5a8372437b051df818b5702f80c24fb1d2877e40"
+  dependencies:
+    "@types/async" "^3.2.12"
+    "@types/utf8" "^3.0.1"
+    JSONStream "^1.0.0"
+    agentkeepalive "^4.1.3"
+    ajv "6.12.2"
+    async "~2.1.5"
+    aws-sdk "^2.1005.0"
+    azure-storage "~2.10.7"
+    backo "^1.1.0"
+    base-x "3.0.8"
+    base62 "2.0.1"
+    bson "4.0.0"
+    debug "~2.6.9"
+    diskusage "^1.1.1"
+    fcntl "github:scality/node-fcntl#0.2.0"
+    hdclient scality/hdclient#1.1.0
+    https-proxy-agent "^2.2.0"
+    ioredis "^4.28.5"
+    ipaddr.js "1.9.1"
+    joi "^17.6.0"
+    level "~5.0.1"
+    level-sublevel "~6.6.5"
+    mongodb "^3.0.1"
+    node-forge "^0.7.1"
+    prom-client "10.2.3"
+    simple-glob "^0.2"
+    socket.io "~2.3.0"
+    socket.io-client "~2.3.0"
+    sproxydclient "github:scality/sproxydclient#8.0.4"
+    utf8 "2.1.2"
+    uuid "^3.0.1"
+    werelogs scality/werelogs#8.1.0
+    xml2js "~0.4.23"
+  optionalDependencies:
+    ioctl "^2.0.2"
+
 asn1@~0.2.3:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.6.tgz#0d3a7bb6e64e02a90c0303b31f292868ea09a08d"


### PR DESCRIPTION
Set properly the 'originOp' field in object metadata to the
corresponding notification event type when doing tagging or ACL
operations, so that bucket notifications do not take this event for an
object creation (as the original field value was left as a create-type
event).

One commit was cherry-picked from the 8.1 branch for tagging operations.