### PR TITLE
bugfix: CLDSRV-266 prioritize "checkTagConditions" over "isAllowed"

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -158,35 +158,26 @@ const api = {
         return async.waterfall([
             next => auth.server.doAuth(request, log, (err, userInfo, authorizationResults, streamingV4Params) =>
                 next(err, userInfo, authorizationResults, streamingV4Params), 's3', requestContexts),
-            (userInfo, authorizationResults, streamingV4Params, next) => {
-                if (authorizationResults) {
-                    const checkedResults = checkAuthResults(authorizationResults);
-                    if (checkedResults instanceof Error) {
-                        return next(checkedResults);
-                    }
-                    returnTagCount = checkedResults;
-                }
-                return tagConditionKeyAuth(authorizationResults, request, requestContexts, apiMethod, log,
-                (err, tagAuthResults, updatedContexts) =>
-                    next(err, tagAuthResults, authorizationResults, userInfo, streamingV4Params, updatedContexts));
-            },
-        ], (err, tagAuthResults, authorizationResults, userInfo, streamingV4Params, updatedContexts) => {
+            (userInfo, authorizationResults, streamingV4Params, next) =>
+                tagConditionKeyAuth(authorizationResults, request, requestContexts, apiMethod, log,
+                (err, tagAuthResults) => next(err, tagAuthResults, userInfo, streamingV4Params)),
+        ], (err, authorizationResults, userInfo, streamingV4Params) => {
             if (err) {
                 log.trace('authentication error', { error: err });
                 return callback(err);
+            }
+            if (authorizationResults) {
+                const checkedResults = checkAuthResults(authorizationResults);
+                if (checkedResults instanceof Error) {
+                    return callback(checkedResults);
+                }
+                returnTagCount = checkedResults;
             }
             const authNames = { accountName: userInfo.getAccountDisplayName() };
             if (userInfo.isRequesterAnIAMUser()) {
                 authNames.userName = userInfo.getIAMdisplayName();
             }
             log.addDefaultFields(authNames);
-            if (tagAuthResults) {
-                const checkedResults = checkAuthResults(tagAuthResults);
-                if (checkedResults instanceof Error) {
-                    return callback(checkedResults);
-                }
-                returnTagCount = checkedResults;
-            }
             if (apiMethod === 'objectPut' || apiMethod === 'objectPutPart') {
                 request._response = response;
                 return this[apiMethod](userInfo, request, streamingV4Params,
@@ -224,7 +215,7 @@ const api = {
                 request.post = Buffer.concat(post, postLength).toString();
 
                 // IAM policy -Tag condition keys require information from CloudServer for evaluation
-                return tagConditionKeyAuth(authorizationResults, request, (updatedContexts || requestContexts),
+                return tagConditionKeyAuth(authorizationResults, request, requestContexts,
                 apiMethod, log, (err, tagAuthResults) => {
                     if (err) {
                         log.trace('tag authentication error', { error: err });

--- a/lib/api/apiUtils/authorization/tagConditionKeys.js
+++ b/lib/api/apiUtils/authorization/tagConditionKeys.js
@@ -78,7 +78,7 @@ function tagConditionKeyAuth(authorizationResults, request, requestContexts, api
         return cb();
     }
     if (!authorizationResults.some(authRes => authRes.checkTagConditions)) {
-        return cb();
+        return cb(null, authorizationResults);
     }
 
     return updateRequestContextsWithTags(request, requestContexts, apiMethod, log, err => {


### PR DESCRIPTION
In the generic API handler callApiMethod(), authorization checks are
done via a call to a local helper checkAuthResults(). When tag
conditions need to be checked, a flag "checkTagConditions" is set by
Vault in the authorization response, however, currently the flag
"isAllowed" is also set to true (but the request is not necessarily
allowed in the end, after tag conditions are checked later on).

In order to avoid requests being allowed by default when tag
conditions are present but cannot be checked yet, we need to
prioritize checking the "checkTagConditions" flag before checking the
"isAllowed" flag, and on the other hand, have Vault return "isAllowed:
false" for such requests. This commit is doing the first part: moving
the authorization check after tag condition checks.

Also: removed an extra argument "updatedContexts" to the callback of
tagConditionKeyAuth() since the function does not return such argument
(the code ignored the argument when it was missing, so it is only a
cleanup).
