### PR TITLE
bugfix: CLDSRV-257 call tagConditionKeyAuth only once

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -156,14 +156,73 @@ const api = {
         }
 
         return async.waterfall([
-            next => auth.server.doAuth(request, log, (err, userInfo, authorizationResults, streamingV4Params) =>
-                next(err, userInfo, authorizationResults, streamingV4Params), 's3', requestContexts),
-            (userInfo, authorizationResults, streamingV4Params, next) =>
-                tagConditionKeyAuth(authorizationResults, request, requestContexts, apiMethod, log,
-                (err, tagAuthResults) => next(err, tagAuthResults, userInfo, streamingV4Params)),
-        ], (err, authorizationResults, userInfo, streamingV4Params) => {
+            next => auth.server.doAuth(
+                request, log, (err, userInfo, authorizationResults, streamingV4Params) => {
+                    if (err) {
+                        log.trace('authentication error', { error: err });
+                        return next(err);
+                    }
+                    return next(null, userInfo, authorizationResults, streamingV4Params);
+                }, 's3', requestContexts),
+            (userInfo, authorizationResults, streamingV4Params, next) => {
+                const authNames = { accountName: userInfo.getAccountDisplayName() };
+                if (userInfo.isRequesterAnIAMUser()) {
+                    authNames.userName = userInfo.getIAMdisplayName();
+                }
+                log.addDefaultFields(authNames);
+                if (apiMethod === 'objectPut' || apiMethod === 'objectPutPart') {
+                    return next(null, userInfo, authorizationResults, streamingV4Params);
+                }
+                // issue 100 Continue to the client
+                writeContinue(request, response);
+                const MAX_POST_LENGTH = request.method === 'POST' ?
+                      1024 * 1024 : 1024 * 1024 / 2; // 1 MB or 512 KB
+                const post = [];
+                let postLength = 0;
+                request.on('data', chunk => {
+                    postLength += chunk.length;
+                    // Sanity check on post length
+                    if (postLength <= MAX_POST_LENGTH) {
+                        post.push(chunk);
+                    }
+                });
+
+                request.on('error', err => {
+                    log.trace('error receiving request', {
+                        error: err,
+                    });
+                    return next(errors.InternalError);
+                });
+
+                request.on('end', () => {
+                    if (postLength > MAX_POST_LENGTH) {
+                        log.error('body length is too long for request type',
+                                  { postLength });
+                        return next(errors.InvalidRequest);
+                    }
+                    // Convert array of post buffers into one string
+                    request.post = Buffer.concat(post, postLength).toString();
+                    return next(null, userInfo, authorizationResults, streamingV4Params);
+                });
+                return undefined;
+            },
+            // Tag condition keys require information from CloudServer for evaluation
+            (userInfo, authorizationResults, streamingV4Params, next) => tagConditionKeyAuth(
+                authorizationResults,
+                request,
+                requestContexts,
+                apiMethod,
+                log,
+                (err, authResultsWithTags) => {
+                    if (err) {
+                        log.trace('tag authentication error', { error: err });
+                        return next(err);
+                    }
+                    return next(null, userInfo, authResultsWithTags, streamingV4Params);
+                },
+            ),
+        ], (err, userInfo, authorizationResults, streamingV4Params) => {
             if (err) {
-                log.trace('authentication error', { error: err });
                 return callback(err);
             }
             if (authorizationResults) {
@@ -173,74 +232,19 @@ const api = {
                 }
                 returnTagCount = checkedResults;
             }
-            const authNames = { accountName: userInfo.getAccountDisplayName() };
-            if (userInfo.isRequesterAnIAMUser()) {
-                authNames.userName = userInfo.getIAMdisplayName();
-            }
-            log.addDefaultFields(authNames);
             if (apiMethod === 'objectPut' || apiMethod === 'objectPutPart') {
                 request._response = response;
                 return this[apiMethod](userInfo, request, streamingV4Params,
                     log, callback, authorizationResults);
             }
-            // issue 100 Continue to the client
-            writeContinue(request, response);
-            const MAX_POST_LENGTH = request.method.toUpperCase() === 'POST' ?
-                1024 * 1024 : 1024 * 1024 / 2; // 1 MB or 512 KB
-            const post = [];
-            let postLength = 0;
-            request.on('data', chunk => {
-                postLength += chunk.length;
-                // Sanity check on post length
-                if (postLength <= MAX_POST_LENGTH) {
-                    post.push(chunk);
-                }
-                return undefined;
-            });
-
-            request.on('error', err => {
-                log.trace('error receiving request', {
-                    error: err,
-                });
-                return callback(errors.InternalError);
-            });
-
-            request.on('end', () => {
-                if (postLength > MAX_POST_LENGTH) {
-                    log.error('body length is too long for request type',
-                        { postLength });
-                    return callback(errors.InvalidRequest);
-                }
-                // Convert array of post buffers into one string
-                request.post = Buffer.concat(post, postLength).toString();
-
-                // IAM policy -Tag condition keys require information from CloudServer for evaluation
-                return tagConditionKeyAuth(authorizationResults, request, requestContexts,
-                apiMethod, log, (err, tagAuthResults) => {
-                    if (err) {
-                        log.trace('tag authentication error', { error: err });
-                        return callback(err);
-                    }
-                    if (tagAuthResults) {
-                        const checkedResults = checkAuthResults(tagAuthResults);
-                        if (checkedResults instanceof Error) {
-                            return callback(checkedResults);
-                        }
-                        returnTagCount = checkedResults;
-                    }
-                    if (apiMethod === 'objectCopy' ||
-                    apiMethod === 'objectPutCopyPart') {
-                        return this[apiMethod](userInfo, request, sourceBucket,
-                            sourceObject, sourceVersionId, log, callback);
-                    }
-                    if (apiMethod === 'objectGet') {
-                        return this[apiMethod](userInfo, request,
-                        returnTagCount, log, callback);
-                    }
-                    return this[apiMethod](userInfo, request, log, callback);
-                });
-            });
-            return undefined;
+            if (apiMethod === 'objectCopy' || apiMethod === 'objectPutCopyPart') {
+                return this[apiMethod](userInfo, request, sourceBucket,
+                    sourceObject, sourceVersionId, log, callback);
+            }
+            if (apiMethod === 'objectGet') {
+                return this[apiMethod](userInfo, request, returnTagCount, log, callback);
+            }
+            return this[apiMethod](userInfo, request, log, callback);
         });
     },
     bucketDelete,


### PR DESCRIPTION
For requests not of type "objectPut" or "objectPutPart", an extra call
to tagConditionKeyAuth was made, resulting in unnecessary requests.

Refactored callApiMethod() wrapper to first gather the POST data which
may contain request tags used for condition checks, then authorize the
request.
