### PR TITLE
CLDSRV-273: skip delimiter as listing param if empty

### DIFF
--- a/lib/api/bucketGet.js
+++ b/lib/api/bucketGet.js
@@ -186,6 +186,7 @@ function processMasterVersions(bucketName, listParams, list) {
         { tag: 'EncodingType', value: listParams.encoding },
         { tag: 'IsTruncated', value: isTruncated },
     ];
+
     if (listParams.v2) {
         xmlParams.push(
             { tag: 'StartAfter', value: listParams.startAfter || '' });
@@ -327,9 +328,13 @@ function bucketGet(authInfo, request, log, callback) {
     const listParams = {
         listingType: 'DelimiterMaster',
         maxKeys: actualMaxKeys,
-        delimiter: params.delimiter,
         prefix: params.prefix,
     };
+
+    if (params.delimiter) {
+        listParams.delimiter = params.delimiter;
+    }
+
     if (v2) {
         listParams.v2 = true;
         listParams.startAfter = params['start-after'];


### PR DESCRIPTION
fixes: https://scality.atlassian.net/browse/CLDSRV-273

note: no tests in PR as the behavior is only observed when running against the `metadata` md backend; tests will be written in the integration PR.