### PR TITLE
bugfix/CLDSRV-264/ignore_lifecycle_event_in_utapi

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1297,6 +1297,8 @@ class Config extends EventEmitter {
         if (config.bucketNotificationDestinations) {
             this.bucketNotificationDestinations = bucketNotifAssert(config.bucketNotificationDestinations);
         }
+
+        this.lifecycleRoleName = config.lifecycleRoleName || null;
     }
 
     _configureBackends() {

--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -249,7 +249,8 @@ function listMetrics(metricType) {
  * added/deleted
  * @param {boolean} [metricObject.isDelete] - (optional) Indicates whether this
  * is a delete operation
- * @return {function} - `utapi.pushMetric`
+ * @return {function | undefined} - `utapi.pushMetric` or undefined if the action is
+ * filtered out and not pushed to utapi.
  */
 function pushMetric(action, log, metricObj) {
     const {
@@ -300,12 +301,22 @@ function pushMetric(action, log, metricObj) {
             incomingBytes,
             outgoingBytes: action === 'getObject' ? newByteLength : 0,
         };
+
+        // Any operation from lifecycle that does not change object count or size is dropped
+        const isLifecycle = _config.lifecycleRoleName
+            && authInfo && authInfo.arn.endsWith(`:assumed-role/${_config.lifecycleRoleName}/backbeat-lifecycle`);
+        if (isLifecycle && !objectDelta && !sizeDelta) {
+            log.trace('ignoring pushMetric from lifecycle service user', { action, bucket, keys });
+            return undefined;
+        }
+
         if (keys && keys.length === 1) {
             [utapiObj.object] = keys;
             if (versionId) {
                 utapiObj.versionId = versionId;
             }
         }
+
         utapiObj.account = authInfo ? evalAuthInfo(authInfo, canonicalID, action).accountId : canonicalID;
         utapiObj.user = authInfo ? evalAuthInfo(authInfo, canonicalID, action).userId : undefined;
         return utapi.pushMetric(utapiObj);

--- a/tests/utapi/utilities.js
+++ b/tests/utapi/utilities.js
@@ -1,6 +1,8 @@
 const assert = require('assert');
 const sinon = require('sinon');
 const werelogs = require('werelogs');
+const _config = require('../../lib/Config').config;
+const { makeAuthInfo } = require('../unit/helpers');
 
 const testEvents = [{
     action: 'getObject',
@@ -494,6 +496,10 @@ describe('utapi v2 pushmetrics utility', () => {
         pushMetric = require('../../lib/utapi/utilities').pushMetric;
     });
 
+    beforeEach(() => {
+        _config.lifecycleRoleName = null;
+    });
+
     after(() => {
         sinon.restore();
     });
@@ -505,6 +511,53 @@ describe('utapi v2 pushmetrics utility', () => {
             Object.keys(event.expected).forEach(key => {
                 assert.strictEqual(eventPushed[key], event.expected[key]);
             });
+        });
+    });
+
+    describe('with lifecycle enabled', () => {
+        _config.lifecycleRoleName = 'lifecycleTestRoleName';
+        const eventFilterList = new Set([
+            'getBucketAcl',
+            'getBucketCors',
+            'getBucketLocation',
+            'getBucketNotification',
+            'getBucketObjectLock',
+            'getBucketReplication',
+            'getBucketVersioning',
+            'getBucketWebsite',
+            'getObjectTagging',
+            'headObject',
+        ]);
+
+        testEvents
+        .map(event => {
+            const modifiedEvent = event;
+            const authInfo = makeAuthInfo('accesskey1', 'Bart');
+            authInfo.arn = `foo:assumed-role/${_config.lifecycleRoleName}/backbeat-lifecycle`;
+            modifiedEvent.metrics.authInfo = authInfo;
+            modifiedEvent.metrics.canonicalID = 'accesskey1';
+            return modifiedEvent;
+        })
+        .map(event => {
+            if (eventFilterList.has(event.action)) {
+                it(`should skip action ${event.action}`, () => {
+                    _config.lifecycleRoleName = 'lifecycleTestRoleName';
+                    const eventPushed = pushMetric(event.action, log, event.metrics);
+                    assert.strictEqual(eventPushed, undefined);
+                });
+            }
+            return event;
+        })
+        .forEach(event => {
+            if (!eventFilterList.has(event.action)) {
+                it(`should compute and push metrics for ${event.action}`, () => {
+                    const eventPushed = pushMetric(event.action, log, event.metrics);
+                    assert(eventPushed);
+                    Object.keys(event.expected).forEach(key => {
+                        assert.strictEqual(eventPushed[key], event.expected[key]);
+                    });
+                });
+            }
         });
     });
 });


### PR DESCRIPTION
# Pull request template

## Description

### Motivation and context

Addresses https://scality.atlassian.net/browse/S3C-5994. Drops lifecycle events so they are not pushed to utapi when the computed event objectDelta and sizeDelta are both 0.

## Checklist

### Add tests to cover the changes

New tests added or existing tests modified to cover all changes

### Code conforms with the [style guide](https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#coding-style-guidelines)

### Sign your work

In order to contribute to the project, you must sign your work
https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#sign-your-work

Thank you again for contributing! We will try to test and integrate the change
as soon as we can.
