### PR TITLE
utapi-v1 delete inconsistency with versioning suspended

### DIFF
--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -316,6 +316,7 @@ function versioningPreprocessing(bucketName, bucketMD, objectKey, objMD,
  * options.deleteData - (true/undefined) whether to delete data (if undefined
  *  means creating a delete marker instead)
  * options.versionId - specific versionId to delete
+ * options.isNull - (true/undefined) whether version to be deleted/marked is null or not
  */
 function preprocessingVersioningDelete(bucketName, bucketMD, objectMD,
     reqVersionId, log, callback) {
@@ -367,6 +368,7 @@ function preprocessingVersioningDelete(bucketName, bucketMD, objectMD,
         return callback(errors.NoSuchKey);
     }
     // not deleting any specific version, making a delete marker instead
+    options.isNull = true;
     return callback(null, options);
 }
 

--- a/lib/api/objectDelete.js
+++ b/lib/api/objectDelete.js
@@ -115,6 +115,7 @@ function objectDelete(authInfo, request, log, cb) {
             const deleteInfo = {
                 removeDeleteMarker: false,
                 newDeleteMarker: false,
+                isNull: delOptions.isNull,
             };
             if (delOptions && delOptions.deleteData) {
                 if (objectMD.isDeleteMarker) {
@@ -130,8 +131,9 @@ function objectDelete(authInfo, request, log, cb) {
             deleteInfo.newDeleteMarker = true;
             return createAndStoreObject(bucketName, bucketMD,
                 objectKey, objectMD, authInfo, canonicalID, null, request,
-                deleteInfo.newDeleteMarker, null, log, (err, newDelMarkerRes) =>
-                next(err, bucketMD, objectMD, newDelMarkerRes, deleteInfo));
+                deleteInfo.newDeleteMarker, null, log, (err, newDelMarkerRes) => {
+                    next(err, bucketMD, objectMD, newDelMarkerRes, deleteInfo);
+                });
         },
     ], (err, bucketMD, objectMD, result, deleteInfo) => {
         const resHeaders = collectCorsHeaders(request.headers.origin,
@@ -169,8 +171,18 @@ function objectDelete(authInfo, request, log, cb) {
                     result.versionId : versionIdUtils.encode(
                         result.versionId, config.versionIdEncodingType);
             }
+            const versioningSuspended = bucketMD
+                && bucketMD._versioningConfiguration
+                && bucketMD._versioningConfiguration.Status === 'Suspended';
+            const hasByteLength = objectMD && objectMD['content-length'];
+            const byteLength = versioningSuspended
+                && deleteInfo.isNull
+                && hasByteLength
+                ? objectMD['content-length'] : null;
+
             pushMetric('putDeleteMarkerObject', log, {
                 authInfo,
+                byteLength: byteLength ? Number.parseInt(byteLength, 10) : null,
                 bucket: bucketName,
                 keys: [objectKey],
                 versionId: result.versionId,

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "level-mem": "^5.0.1",
     "moment": "^2.26.0",
     "npm-run-all": "~4.1.5",
-    "utapi": "git+https://github.com/scality/utapi#7.10.7",
+    "utapi": "git+https://github.com/scality/utapi#7.10.9",
     "utf8": "~2.1.1",
     "uuid": "^3.0.1",
     "vaultclient": "scality/vaultclient#7.10.10",

--- a/tests/unit/api/apiUtils/versioning.js
+++ b/tests/unit/api/apiUtils/versioning.js
@@ -267,7 +267,9 @@ describe('versioning helpers', () => {
                 objMD: {
                     versionId: 'v1',
                 },
-                expectedRes: {},
+                expectedRes: {
+                    isNull: true,
+                },
             },
             {
                 description: 'delete non-null object version',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5208,9 +5208,9 @@ user-home@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
 
-"utapi@git+https://github.com/scality/utapi#7.10.7":
-  version "7.10.7"
-  resolved "git+https://github.com/scality/utapi#a072535050c84c30719cfe258333940750240614"
+"utapi@git+https://github.com/scality/utapi#7.10.9":
+  version "7.10.9"
+  resolved "git+https://github.com/scality/utapi#f3a9a57f589a2b428cde415f626844fbd2d5d27c"
   dependencies:
     "@hapi/joi" "^17.1.1"
     "@senx/warp10" "^1.0.14"


### PR DESCRIPTION

## Description

### Motivation and context
Addresses https://scality.atlassian.net/browse/S3C-5741.
Passes in a byteLength when versioning is suspended and the object exists. This allows Utapi to properly decrement the object count and storage utilized for various metrics.

### Related issues

Please use the following link syntaxes #600 to reference issues in the
current repository

## Checklist

### Add tests to cover the changes

New tests added or existing tests modified to cover all changes

### Code conforms with the [style guide](https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#coding-style-guidelines)

### Sign your work

In order to contribute to the project, you must sign your work
https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#sign-your-work

Thank you again for contributing! We will try to test and integrate the change
as soon as we can.
