### PR TITLE
bugfix: CLDSRV-282 handle object lock when creating a bucket

### DIFF
--- a/lib/api/bucketPut.js
+++ b/lib/api/bucketPut.js
@@ -124,7 +124,12 @@ function _handleAuthResults(locationConstraint, log, cb) {
         if (err) {
             return cb(err);
         }
-        if (!authorizationResults.every(res => res.isAllowed)) {
+        if (!authorizationResults.every(res => {
+            if (Array.isArray(res)) {
+                return res.every(subRes => subRes.isAllowed);
+            }
+            return res.isAllowed;
+        })) {
             log.trace(
                 'authorization check failed for user',
                 { locationConstraint },
@@ -138,6 +143,36 @@ function _handleAuthResults(locationConstraint, log, cb) {
 function _isObjectLockEnabled(headers) {
     const header = headers['x-amz-bucket-object-lock-enabled'];
     return header !== undefined && header.toLowerCase() === 'true';
+}
+
+function authBucketPut(authParams, bucketName, locationConstraint, request, authInfo) {
+    const ip = requestUtils.getClientIp(request, config);
+    const baseParams = {
+        authParams,
+        ip,
+        bucketName,
+        request,
+        authInfo,
+        locationConstraint,
+    };
+    const requestConstantParams = [Object.assign(
+        baseParams,
+        { apiMethod: 'bucketPut' },
+    )];
+
+    if (_isObjectLockEnabled(request.headers)) {
+        requestConstantParams.push(Object.assign(
+            {},
+            baseParams,
+            { apiMethod: 'bucketPutObjectLock' },
+        ));
+        requestConstantParams.push(Object.assign(
+            {},
+            baseParams,
+            { apiMethod: 'bucketPutVersioning' },
+        ));
+    }
+    return requestConstantParams;
 }
 
 /**
@@ -176,30 +211,9 @@ function bucketPut(authInfo, request, log, callback) {
             }
 
             const authParams = auth.server.extractParams(request, log, 's3', request.query);
-            const ip = requestUtils.getClientIp(request, config);
-            const baseParams = {
-                authParams,
-                ip,
-                bucketName,
-                request,
-                authInfo,
-                locationConstraint,
-            };
-            const requestConstantParams = [Object.assign(
-                baseParams,
-                { apiMethod: 'bucketPut' },
-            )];
-
-            if (!_isObjectLockEnabled(request.headers)) {
-                requestConstantParams.push(Object.assign(
-                    baseParams,
-                    { apiMethod: 'bucketPutObjectLock' },
-                ));
-                requestConstantParams.push(Object.assign(
-                    baseParams,
-                    { apiMethod: 'bucketPutVersioning' },
-                ));
-            }
+            const requestConstantParams = authBucketPut(
+                authParams, bucketName, locationConstraint, request, authInfo
+            );
 
             return vault.checkPolicies(
                 requestConstantParams.map(_buildConstantParams),
@@ -230,4 +244,5 @@ module.exports = {
     checkLocationConstraint,
     bucketPut,
     _handleAuthResults,
+    authBucketPut,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.10.13",
+  "version": "7.10.14",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {

--- a/tests/unit/api/bucketPut.js
+++ b/tests/unit/api/bucketPut.js
@@ -411,6 +411,28 @@ describe('bucketPut API', () => {
                 calledWith: [null, constraint],
             },
             {
+                description: 'array of arrays allowed auth',
+                error: undefined,
+                results: [
+                    { isAllowed: true },
+                    { isAllowed: true },
+                    [{ isAllowed: true }, { isAllowed: true }],
+                    { isAllowed: true },
+                ],
+                calledWith: [null, constraint],
+            },
+            {
+                description: 'array of arrays not allowed auth',
+                error: undefined,
+                results: [
+                    { isAllowed: true },
+                    { isAllowed: true },
+                    [{ isAllowed: true }, { isAllowed: false }],
+                    { isAllowed: true },
+                ],
+                calledWith: [errors.AccessDenied],
+            },
+            {
                 description: 'single not allowed auth',
                 error: undefined,
                 results: [{ isAllowed: false }],

--- a/tests/unit/policies.js
+++ b/tests/unit/policies.js
@@ -1,0 +1,39 @@
+const assert = require('assert');
+const DummyRequest = require('./DummyRequest');
+const { authBucketPut } = require('../../lib/api/bucketPut');
+
+function prepareDummyRequest(headers = {}) {
+    const request = new DummyRequest({
+        hostname: 'localhost',
+        port: 80,
+        headers,
+        socket: {
+            remoteAddress: '0.0.0.0',
+        },
+    });
+    return request;
+}
+
+describe('Policies: permission checks for S3 APIs', () => {
+    describe('PutBucket', () => {
+        function putBucketApiMethods(headers) {
+            const request = prepareDummyRequest(headers);
+            const result = authBucketPut(null, 'name', null, request, null);
+            return result.map(req => req.apiMethod);
+        }
+
+        it('should return s3:PutBucket without any provided header', () => {
+            assert.deepStrictEqual(
+                putBucketApiMethods(),
+                ['bucketPut'],
+            );
+        });
+
+        it('should return s3:PutBucket and s3:PutBucketObjectLockConfiguration with ACL headers', () => {
+            assert.deepStrictEqual(
+                putBucketApiMethods({ 'x-amz-bucket-object-lock-enabled': 'true' }),
+                ['bucketPut', 'bucketPutObjectLock', 'bucketPutVersioning'],
+            );
+        });
+    });
+});


### PR DESCRIPTION
* auth results can be an array of arrays
* Object.assign needs an empty object or it modifies the original
* should be `_isObjectLockEnabled` not `!_isObjectLockEnabled`
* add unit tests