### PR TITLE
Update region in rclone client example

### DIFF
--- a/docs/CLIENTS.rst
+++ b/docs/CLIENTS.rst
@@ -103,7 +103,7 @@ See all buckets:
     env_auth = false
     access_key_id = accessKey1
     secret_access_key = verySecretKey1
-    region = other-v2-signature
+    region = us-east-1
     endpoint = http://localhost:8000
     location_constraint =
     acl = private


### PR DESCRIPTION
# Pull request template

## Description
Changed the default region in the rclone example to `us-east-1`
### Motivation and context

Why is this change required? What problem does it solve?
The existing value in the region doesn't make sense. `us-east-1` is the default and most people will likely use this.
### Related issues

Please use the following link syntaxes #600 to reference issues in the
current repository

## Checklist

### Add tests to cover the changes

New tests added or existing tests modified to cover all changes

### Code conforms with the [style guide](https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#coding-style-guidelines)

### Sign your work

In order to contribute to the project, you must sign your work
https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#sign-your-work

Thank you again for contributing! We will try to test and integrate the change
as soon as we can.
