### PR TITLE
Use node:16.17.1 bulleye slim base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,19 @@
-FROM node:16.17-slim
-MAINTAINER Giorgio Regni <gr@scality.com>
+ARG NODE_VERSION=16.17.1-bullseye-slim
 
-ENV NO_PROXY localhost,127.0.0.1
-ENV no_proxy localhost,127.0.0.1
-
-EXPOSE 8000
-EXPOSE 8002
-
-COPY ./package.json /usr/src/app/
-COPY ./yarn.lock /usr/src/app/
+FROM node:${NODE_VERSION} as builder
 
 WORKDIR /usr/src/app
-
-RUN apt-get update \
-    && apt-get install -y \
-    curl \
-    gnupg2
-
-RUN curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-    && echo "deb http://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
         ca-certificates \
+        curl \
         git \
+        gnupg2 \
         jq \
         python3 \
         ssh \
-        yarn \
         wget \
         libffi-dev \
         zlib1g-dev \
@@ -37,15 +22,34 @@ RUN apt-get update \
     && ssh-keyscan -H github.com > /root/ssh/known_hosts
 
 ENV PYTHON=python3
-RUN yarn cache clean \
-    && yarn install --production --ignore-optional --ignore-engines --network-concurrency 1 \
-    && apt-get autoremove --purge -y python git build-essential \
-    && rm -rf /var/lib/apt/lists/* \
-    && yarn cache clean \
-    && rm -rf ~/.node-gyp \
-    && rm -rf /tmp/yarn-*
+COPY package.json yarn.lock /usr/src/app/
+RUN yarn install --production --ignore-optional --frozen-lockfile --ignore-engines --network-concurrency 1
 
+################################################################################
+FROM node:${NODE_VERSION}
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        jq \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV NO_PROXY localhost,127.0.0.1
+ENV no_proxy localhost,127.0.0.1
+
+EXPOSE 8000
+EXPOSE 8002
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        jq \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/app
+
+# Keep the .git directory in order to properly report version
 COPY . /usr/src/app
+COPY --from=builder /usr/src/app/node_modules ./node_modules/
+
 
 VOLUME ["/usr/src/app/localData","/usr/src/app/localMetadata"]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "8.5.16",
+  "version": "8.6.0",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
* Use more recent base image to get CVE fixes
* Use separate builder image to minimize the prod image

Issue: CLDSRV-287
