### PR TITLE
bf(CLDSRV-289): Fix putDeleteMarkerObject metric for version suspende…

### DIFF
--- a/lib/api/objectDelete.js
+++ b/lib/api/objectDelete.js
@@ -171,18 +171,28 @@ function objectDelete(authInfo, request, log, cb) {
                     result.versionId : versionIdUtils.encode(
                         result.versionId, config.versionIdEncodingType);
             }
-            const versioningSuspended = bucketMD
-                && bucketMD._versioningConfiguration
-                && bucketMD._versioningConfiguration.Status === 'Suspended';
-            const hasByteLength = objectMD && objectMD['content-length'];
-            const byteLength = versioningSuspended
-                && deleteInfo.isNull
-                && hasByteLength
-                ? objectMD['content-length'] : null;
+
+            /* byteLength is passed under the following conditions:
+                * - bucket versioning is suspended
+                * - object version id is null
+                * and one of:
+                * - the content length of the object exists
+                *        - or -
+                * - it is a delete marker
+                * In this case, the master key is deleted and replaced with a delete marker.
+                * The decrement accounts for the deletion of the master key when utapi reports
+                * on the number of objects.
+            */
+            const versioningSuspended = bucketMD.getVersioningConfiguration()
+                && bucketMD.getVersioningConfiguration().Status === 'Suspended';
+            const deletedSuspendedMasterVersion = versioningSuspended && !!objectMD && deleteInfo.isNull;
+            // Default to 0 content-length to cover deleting a DeleteMarker
+            const objectByteLength = (objectMD && objectMD['content-length']) || 0;
+            const byteLength = deletedSuspendedMasterVersion ? Number.parseInt(objectByteLength, 10) : null;
 
             pushMetric('putDeleteMarkerObject', log, {
                 authInfo,
-                byteLength: byteLength ? Number.parseInt(byteLength, 10) : null,
+                byteLength,
                 bucket: bucketName,
                 keys: [objectKey],
                 versionId: result.versionId,

--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -280,11 +280,13 @@ function pushMetric(action, log, metricObj) {
             sizeDelta = -oldByteLength;
         } else if (action === 'abortMultipartUpload' && byteLength) {
             sizeDelta = -byteLength;
+        } else if (action === 'putDeleteMarkerObject' && byteLength) {
+            sizeDelta = -byteLength;
         }
 
         let objectDelta = isDelete ? -numberOfObjects : numberOfObjects;
         // putDeleteMarkerObject does not pass numberOfObjects
-        if (action === 'putDeleteMarkerObject'
+        if ((action === 'putDeleteMarkerObject' && byteLength === null)
             || action === 'replicateDelete'
             || action === 'replicateObject') {
             objectDelta = 1;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.10.17",
+  "version": "7.10.18",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "level-mem": "^5.0.1",
     "moment": "^2.26.0",
     "npm-run-all": "~4.1.5",
-    "utapi": "git+https://github.com/scality/utapi#7.10.10",
+    "utapi": "git+https://github.com/scality/utapi#7.10.11",
     "utf8": "~2.1.1",
     "uuid": "^3.0.1",
     "vaultclient": "scality/vaultclient#7.10.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5208,9 +5208,9 @@ user-home@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
 
-"utapi@git+https://github.com/scality/utapi#7.10.10":
-  version "7.10.10"
-  resolved "git+https://github.com/scality/utapi#71f162169dce15c668b9a9431c65d2be5ff2920c"
+"utapi@git+https://github.com/scality/utapi#7.10.11":
+  version "7.10.11"
+  resolved "git+https://github.com/scality/utapi#3ec818bca133f71cfc7819c5f4319802d2851dc3"
   dependencies:
     "@hapi/joi" "^17.1.1"
     "@senx/warp10" "^1.0.14"


### PR DESCRIPTION
For versioning suspended buckets the storageUtilized should be decremented the size of the obj, with numberOfObjects remaining unchanged, Since the data is deleted, but a DeleteMarker is still present