### PR TITLE
bugfix: CLDSRV-290 fix `PUT /_/backbeat/metadata` versioning logic

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -472,12 +472,13 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
                 omVal[headerName] = objMd[headerName];
             });
         }
+        const versionId = decodeVersionId(request.query);
         // specify both 'versioning' and 'versionId' to create a "new"
         // version (updating master as well) but with specified
         // versionId
         const options = {
             versioning: bucketInfo.isVersioningEnabled(),
-            versionId: omVal.versionId,
+            versionId,
         };
         // If the object is from a source bucket without versioning (i.e. NFS),
         // then we want to create a version for the replica object even though
@@ -501,6 +502,7 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
                 pushReplicationMetric(objMd, omVal, bucketName, objectKey, log);
                 if (objMd &&
                     headers['x-scal-replication-content'] !== 'METADATA' &&
+                    versionId &&
                     locationKeysHaveChanged(objMd.location, omVal.location)) {
                     log.info('removing old data locations', {
                         method: 'putMetadata',


### PR DESCRIPTION
- fix `PUT /_/backbeat/metadata` versioning logic
  - Fix the logic by always using the provided `versionId` in the query string as the version to put, instead of relying on the version stored in the metadata. Not passing a `versionId` now amounts to creating a new version. The previous logic was causing a possible confusion when no `versionId` was passed in the query string, that allowed valid data locations to be removed as if it was an overwrite.
- update `PUT /_/backbeat/metadata` tests
  - modify existing `PUT /_/backbeat/metadata` tests to always pass the `versionId` in the query string, as it should be with the updated API contract
  - create a new test that does not pass the `versionId` in the query string on an update, and expects a new version to be created (and both versions to be readable to ensure no cleanup occurred)
  - general tech debt cleanup: update the test `versionId` to be in the new base64 format when encoded by removing the extra info, making it exactly 27 characters long
