### PR TITLE
bugfix: CLDSRV-291 test for HEAD object with bucket policy

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "git+https://github.com/scality/Arsenal#7.10.37",
+    "arsenal": "git+https://github.com/scality/Arsenal#7.10.38",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/tests/unit/api/bucketPolicyAuth.js
+++ b/tests/unit/api/bucketPolicyAuth.js
@@ -377,6 +377,26 @@ describe('bucket policy authorization', () => {
             });
         });
 
+        it('should allow access to non-object owner for objectHead action with s3:GetObject permission',
+        function itFn(done) {
+            const newPolicy = this.test.basePolicy;
+            newPolicy.Statement[0].Action = ['s3:GetObject'];
+            bucket.setBucketPolicy(newPolicy);
+            const allowed = isObjAuthorized(bucket, object, 'objectHead',
+                                            altAcctCanonicalId, altAcctAuthInfo, log);
+            assert.equal(allowed, true);
+            done();
+        });
+        it('should deny access to non-object owner for objectHead action without s3:GetObject permission',
+        function itFn(done) {
+            const newPolicy = this.test.basePolicy;
+            newPolicy.Statement[0].Action = ['s3:PutObject'];
+            bucket.setBucketPolicy(newPolicy);
+            const allowed = isObjAuthorized(bucket, object, 'objectHead',
+                                            altAcctCanonicalId, altAcctAuthInfo, log);
+            assert.equal(allowed, false);
+            done();
+        });
         it('should deny access to non-object owner if two statements apply ' +
         'to principal but one denies access', function itFn(done) {
             const newPolicy = this.test.basePolicy;

--- a/yarn.lock
+++ b/yarn.lock
@@ -466,9 +466,9 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/Arsenal#7.10.37":
-  version "7.10.37"
-  resolved "git+https://github.com/scality/Arsenal#9d614a4ab30a200501681a2e80dc14d758ac9338"
+"arsenal@git+https://github.com/scality/Arsenal#7.10.38":
+  version "7.10.38"
+  resolved "git+https://github.com/scality/Arsenal#0f9da6a44e21984b463464ee6cdcbfff6c21e9c8"
   dependencies:
     "@types/async" "^3.2.12"
     "@types/utf8" "^3.0.1"


### PR DESCRIPTION
Add unit tests to show that HEAD object requests are allowed when bucket policy grants the `s3:GetObject` permission to another account or user
