### PR TITLE
Feature: CLDSRV-303 support object restore post notification

### DIFF
--- a/lib/api/apiUtils/object/coldStorage.js
+++ b/lib/api/apiUtils/object/coldStorage.js
@@ -159,7 +159,7 @@ function _updateRestoreInfo(objectMD, restoreParam, log) {
     /* eslint-disable no-param-reassign */
     objectMD.archive.restoreRequestedAt = new Date();
     objectMD.archive.restoreRequestedDays = restoreParam.days;
-    objectMD.originOp = 's3:ObjectRestore';
+    objectMD.originOp = 's3:ObjectRestore:Post';
     /* eslint-enable no-param-reassign */
     if (!ObjectMDArchive.isValid(objectMD.archive)) {
         log.debug('archive is not valid', {


### PR DESCRIPTION
Issue: [CLDSRV-303](https://scality.atlassian.net/browse/CLDSRV-303)

Bucket notification listens to oplog events, so simply setting the correct originOp will trigger the `s3:ObjectRestore:Post `
notification