### PR TITLE
Feature: CLDSRV-304 support object restore completed notification

### DIFF
--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -405,6 +405,9 @@ function overwritingVersioning(objMD, metadataStoreParams) {
     metadataStoreParams.lastModifiedDate = objMD['last-modified'];
     metadataStoreParams.updateMicroVersionId = true;
 
+    // set correct originOp
+    metadataStoreParams.originOp = 's3:ObjectRestore:Completed';
+
     // update restore
     const days = objMD.archive?.restoreRequestedDays;
     const now = Date.now();

--- a/tests/functional/aws-node-sdk/test/object/mpuVersion.js
+++ b/tests/functional/aws-node-sdk/test/object/mpuVersion.js
@@ -159,7 +159,8 @@ describe('MPU with x-scal-s3-version-id header', () => {
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
                 checkObjMdAndUpdate(objMDBefore, objMDAfter,
-                    ['location', 'uploadId', 'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
+                    ['location', 'uploadId', 'microVersionId', 'x-amz-restore',
+                    'archive', 'dataStoreName', 'originOp']);
 
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();

--- a/tests/functional/aws-node-sdk/test/object/putVersion.js
+++ b/tests/functional/aws-node-sdk/test/object/putVersion.js
@@ -112,7 +112,7 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
                 checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'content-md5',
-                'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
+                'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName', 'originOp']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
             });
@@ -162,7 +162,7 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length',
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
                 'content-md5', 'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
@@ -213,7 +213,7 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length',
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
                 'content-md5', 'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
@@ -326,7 +326,7 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 checkVersionsAndUpdate(versionsBefore, versionsAfter, [1]);
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length',
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
                 'content-md5', 'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
@@ -378,7 +378,7 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length',
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
                 'content-md5', 'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
@@ -433,7 +433,7 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length',
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
                 'content-md5', 'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
@@ -486,7 +486,7 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 checkVersionsAndUpdate(versionsBefore, versionsAfter, [1]);
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length',
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
                 'content-md5', 'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
@@ -538,7 +538,7 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length',
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
                 'content-md5', 'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
@@ -597,7 +597,7 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length',
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
                 'content-md5', 'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
@@ -644,7 +644,7 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length',
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
                 'content-md5', 'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();


### PR DESCRIPTION
Issue: [CLDSRV-304](https://scality.atlassian.net/browse/CLDSRV-304)

`overwritingVersioning()` is executed at the end of each restore operation, we set the originOp to `s3:ObjectRestore:Completed` at that level