### PR TITLE
bugfix/CLDSRV 310/cherryPickChangesForHotfix 7.10.8 part2

### DIFF
--- a/lib/api/apiUtils/object/objectLockHelpers.js
+++ b/lib/api/apiUtils/object/objectLockHelpers.js
@@ -1,5 +1,9 @@
-const { errors } = require('arsenal');
+const { errors, auth, policies } = require('arsenal');
 const moment = require('moment');
+
+const { config } = require('../../../Config');
+const vault = require('../../../auth/vault');
+
 /**
  * Calculates retain until date for the locked object version
  * @param {object} retention - includes days or years retention period
@@ -43,7 +47,7 @@ function validateHeaders(bucket, headers, log) {
         !(objectLockMode && objectLockDate)) {
         return errors.InvalidArgument.customizeDescription(
             'x-amz-object-lock-retain-until-date and ' +
-            'x-amz-object-lock-mode must both be supplied'
+            'x-amz-object-lock-mode must both be supplied',
         );
     }
     const validModes = new Set(['GOVERNANCE', 'COMPLIANCE']);
@@ -126,101 +130,190 @@ function setObjectLockInformation(headers, md, defaultRetention) {
 }
 
 /**
- * isObjectLocked - checks whether object is locked or not
- * @param {obect} bucket - bucket metadata
- * @param {object} objectMD - object metadata
- * @param {array} headers - request headers
- * @return {boolean} - indicates whether object is locked or not
+ *  Helper class for check object lock state checks
  */
-function isObjectLocked(bucket, objectMD, headers) {
-    if (bucket.isObjectLockEnabled()) {
-        const objectLegalHold = objectMD.legalHold;
-        if (objectLegalHold) {
+class ObjectLockInfo {
+    /**
+     *
+     * @param {object} retentionInfo - The object lock retention policy
+     * @param {"GOVERNANCE" | "COMPLIANCE" | null} retentionInfo.mode - Retention policy mode.
+     * @param {string} retentionInfo.date - Expiration date of retention policy. A string in ISO-8601 format
+     * @param {bool} retentionInfo.legalHold - Whether a legal hold is enable for the object
+     */
+    constructor(retentionInfo) {
+        this.mode = retentionInfo.mode || null;
+        this.date = retentionInfo.date || null;
+        this.legalHold = retentionInfo.legalHold || false;
+    }
+
+    /**
+     * ObjectLockInfo.isLocked
+     * @returns {bool} - Whether the retention policy is active and protecting the object
+     */
+    isLocked() {
+        if (this.legalHold) {
             return true;
         }
-        const retentionMode = objectMD.retentionMode;
-        const retentionDate = objectMD.retentionDate;
-        if (!retentionMode || !retentionDate) {
+
+        if (!this.mode || !this.date) {
             return false;
         }
-        if (retentionMode === 'GOVERNANCE' &&
-        headers['x-amz-bypass-governance-retention']) {
-            return false;
-        }
-        const objectDate = moment(retentionDate);
-        const now = moment();
-        // indicates retain until date has expired
-        if (now.isSameOrAfter(objectDate)) {
-            return false;
-        }
-        return true;
+
+        return !this.isExpired();
     }
-    return false;
-}
 
+    /**
+     * ObjectLockInfo.isGovernanceMode
+     * @returns {bool} - true if retention mode is GOVERNANCE
+     */
+    isGovernanceMode() {
+        return this.mode === 'GOVERNANCE';
+    }
 
-/* objectLockRequiresBypass will return true if the retention info change
- * would require a bypass governance flag to be true.
- * In order for this to be true the action must be valid as well, so going from
- * COMPLIANCE to GOVERNANCE would return false unless it expired.
- */
-function objectLockRequiresBypass(objectMD, retentionInfo) {
-    const { retentionMode: existingMode, retentionDate: existingDateISO } = objectMD;
-    if (!existingMode) {
+    /**
+     * ObjectLockInfo.isComplianceMode
+     * @returns {bool} - True if retention mode is COMPLIANCE
+     */
+    isComplianceMode() {
+        return this.mode === 'COMPLIANCE';
+    }
+
+    /**
+     * ObjectLockInfo.isExpired
+     * @returns {bool} - True if the retention policy has expired
+     */
+    isExpired() {
+        const now = moment();
+        return this.date === null || now.isSameOrAfter(this.date);
+    }
+
+    /**
+     * ObjectLockInfo.isExtended
+     * @param {string} timestamp - Timestamp in ISO-8601 format
+     * @returns {bool} - True if the given timestamp is after the policy expiration date or if no expiration date is set
+     */
+    isExtended(timestamp) {
+        return timestamp !== undefined && (this.date === null || moment(timestamp).isAfter(this.date));
+    }
+
+    /**
+     * ObjectLockInfo.canModifyObject
+     * @param {bool} hasGovernanceBypass - Whether to bypass governance retention policies
+     * @returns {bool} - True if the retention policy allows the objects data to be modified (overwritten/deleted)
+     */
+    canModifyObject(hasGovernanceBypass) {
+        return !this.isLocked() || (this.isGovernanceMode() && !!hasGovernanceBypass);
+    }
+
+    /**
+     * ObjectLockInfo.canModifyPolicy
+     * @param {object} policyChanges - Proposed changes to the retention policy
+     * @param {"GOVERNANCE" | "COMPLIANCE" | undefined} policyChanges.mode - Retention policy mode.
+     * @param {string} policyChanges.date - Expiration date of retention policy. A string in ISO-8601 format
+     * @param {bool} hasGovernanceBypass - Whether to bypass governance retention policies
+     * @returns {bool} - True if the changes are allowed to be applied to the retention policy
+     */
+    canModifyPolicy(policyChanges, hasGovernanceBypass) {
+        // If an object does not have a retention policy or it is expired then all changes are allowed
+        if (!this.isLocked()) {
+            return true;
+        }
+
+        // The only allowed change in compliance mode is extending the retention period
+        if (this.isComplianceMode()) {
+            if (policyChanges.mode === 'COMPLIANCE' && this.isExtended(policyChanges.date)) {
+                return true;
+            }
+        }
+
+        if (this.isGovernanceMode()) {
+            // Extensions are always allowed in governance mode
+            if (policyChanges.mode === 'GOVERNANCE' && this.isExtended(policyChanges.date)) {
+                return true;
+            }
+
+            // All other changes in governance mode require a bypass
+            if (hasGovernanceBypass) {
+                return true;
+            }
+        }
+
         return false;
     }
-
-    const existingDate = new Date(existingDateISO);
-    const isExpired = existingDate < Date.now();
-    const isExtended = new Date(retentionInfo.date) > existingDate;
-
-    if (existingMode === 'GOVERNANCE' && !isExpired) {
-        if (retentionInfo.mode === 'GOVERNANCE' && isExtended) {
-            return false;
-        }
-        return true;
-    }
-
-    // an invalid retention change or unrelated to bypass
-    return false;
 }
 
-function validateObjectLockUpdate(objectMD, retentionInfo, bypassGovernance) {
-    const { retentionMode: existingMode, retentionDate: existingDateISO } = objectMD;
-    if (!existingMode) {
-        return null;
-    }
+/**
+ *
+ * @param {object} headers - s3 request headers
+ * @returns {bool} - True if the headers is present and === "true"
+ */
+function hasGovernanceBypassHeader(headers) {
+    const bypassHeader = headers['x-amz-bypass-governance-retention'] || '';
+    return bypassHeader.toLowerCase() === 'true';
+}
 
-    const existingDate = new Date(existingDateISO);
-    const isExpired = existingDate < Date.now();
-    const isExtended = new Date(retentionInfo.date) > existingDate;
 
-    if (existingMode === 'GOVERNANCE' && !isExpired && !bypassGovernance) {
-        if (retentionInfo.mode === 'GOVERNANCE' && isExtended) {
-            return null;
-        }
-        return errors.AccessDenied;
-    }
+/**
+ * checkUserGovernanceBypass
+ *
+ *  Checks for the presence of the s3:BypassGovernanceRetention permission for a given user
+ *
+ * @param {object} request - Incoming s3 request
+ * @param {object} authInfo - s3 authentication info
+ * @param {object} bucketMD - bucket metadata
+ * @param {string} objectKey - object key
+ * @param {object} log - Werelogs logger
+ * @param {function} cb - callback returns errors.AccessDenied if the authorization fails
+ * @returns {undefined} -
+ */
+function checkUserGovernanceBypass(request, authInfo, bucketMD, objectKey, log, cb) {
+    log.trace(
+        'object in GOVERNANCE mode and is user, checking for attached policies',
+        { method: 'checkUserPolicyGovernanceBypass' },
+    );
 
-    if (existingMode === 'COMPLIANCE') {
-        if (retentionInfo.mode === 'GOVERNANCE' && !isExpired) {
-            return errors.AccessDenied;
-        }
-
-        if (!isExtended) {
-            return errors.AccessDenied;
-        }
-    }
-
-    return null;
+    const authParams = auth.server.extractParams(request, log, 's3', request.query);
+    const ip = policies.requestUtils.getClientIp(request, config);
+    const requestContextParams = {
+        constantParams: {
+            headers: request.headers,
+            query: request.query,
+            generalResource: bucketMD.getName(),
+            specificResource: { key: objectKey },
+            requesterIp: ip,
+            sslEnabled: request.connection.encrypted,
+            apiMethod: 'bypassGovernanceRetention',
+            awsService: 's3',
+            locationConstraint: bucketMD.getLocationConstraint(),
+            requesterInfo: authInfo,
+            signatureVersion: authParams.params.data.signatureVersion,
+            authType: authParams.params.data.authType,
+            signatureAge: authParams.params.data.signatureAge,
+        },
+    };
+    return vault.checkPolicies(requestContextParams,
+        authInfo.getArn(), log, (err, authorizationResults) => {
+            if (err) {
+                return cb(err);
+            }
+            if (authorizationResults[0].isAllowed !== true) {
+                log.trace('authorization check failed for user',
+                    {
+                        'method': 'checkUserPolicyGovernanceBypass',
+                        's3:BypassGovernanceRetention': false,
+                    });
+                return cb(errors.AccessDenied);
+            }
+            return cb(null);
+        });
 }
 
 module.exports = {
     calculateRetainUntilDate,
     compareObjectLockInformation,
     setObjectLockInformation,
-    isObjectLocked,
     validateHeaders,
-    validateObjectLockUpdate,
-    objectLockRequiresBypass,
+    hasGovernanceBypassHeader,
+    checkUserGovernanceBypass,
+    ObjectLockInfo,
 };

--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -18,7 +18,8 @@ const { preprocessingVersioningDelete }
 const createAndStoreObject = require('./apiUtils/object/createAndStoreObject');
 const { metadataGetObject } = require('../metadata/metadataUtils');
 const { config } = require('../Config');
-const { isObjectLocked } = require('./apiUtils/object/objectLockHelpers');
+const { hasGovernanceBypassHeader, checkUserGovernanceBypass, ObjectLockInfo }
+    = require('./apiUtils/object/objectLockHelpers');
 const requestUtils = policies.requestUtils;
 
 const versionIdUtils = versioning.VersionID;
@@ -229,10 +230,6 @@ function getObjMetadataAndDelete(authInfo, canonicalID, request,
                         successfullyDeleted.push({ entry });
                         return callback(skipError);
                     }
-                    if (versionId && isObjectLocked(bucket, objMD, request.headers)) {
-                        log.debug('trying to delete locked object');
-                        return callback(objectLockedError);
-                    }
                     if (versionId && objMD.location &&
                         Array.isArray(objMD.location) && objMD.location[0]) {
                         // we need this information for data deletes to AWS
@@ -241,6 +238,47 @@ function getObjMetadataAndDelete(authInfo, canonicalID, request,
                     }
                     return callback(null, objMD, versionId);
                 }),
+            (objMD, versionId, callback) => {
+                // AWS only returns an object lock error if a version id
+                // is specified, else continue to create a delete marker
+                if (!versionId || !bucket.isObjectLockEnabled()) {
+                    return callback(null, null, objMD, versionId);
+                }
+                const hasGovernanceBypass = hasGovernanceBypassHeader(request.headers);
+                if (hasGovernanceBypass && authInfo.isRequesterAnIAMUser()) {
+                    return checkUserGovernanceBypass(request, authInfo, bucket, entry.key, log, error => {
+                        if (error && error.is.AccessDenied) {
+                            log.debug('user does not have BypassGovernanceRetention and object is locked', { error });
+                            return callback(objectLockedError);
+                        }
+                        if (error) {
+                            return callback(error);
+                        }
+                        return callback(null, hasGovernanceBypass, objMD, versionId);
+                    });
+                }
+                return callback(null, hasGovernanceBypass, objMD, versionId);
+            },
+            (hasGovernanceBypass, objMD, versionId, callback) => {
+                // AWS only returns an object lock error if a version id
+                // is specified, else continue to create a delete marker
+                if (!versionId || !bucket.isObjectLockEnabled()) {
+                    return callback(null, objMD, versionId);
+                }
+                const objLockInfo = new ObjectLockInfo({
+                    mode: objMD.retentionMode,
+                    date: objMD.retentionDate,
+                    legalHold: objMD.legalHold || false,
+                });
+
+                // If the object can not be deleted raise an error
+                if (!objLockInfo.canModifyObject(hasGovernanceBypass)) {
+                    log.debug('trying to delete locked object');
+                    return callback(objectLockedError);
+                }
+
+                return callback(null, objMD, versionId);
+            },
             (objMD, versionId, callback) =>
                 preprocessingVersioningDelete(bucketName, bucket, objMD,
                 versionId, log, (err, options) => callback(err, options,

--- a/lib/api/objectDelete.js
+++ b/lib/api/objectDelete.js
@@ -1,3 +1,4 @@
+/* eslint-disable indent */
 const async = require('async');
 const { errors, versioning } = require('arsenal');
 
@@ -8,7 +9,8 @@ const createAndStoreObject = require('./apiUtils/object/createAndStoreObject');
 const { decodeVersionId, preprocessingVersioningDelete }
     = require('./apiUtils/object/versioning');
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
-const { isObjectLocked } = require('./apiUtils/object/objectLockHelpers');
+const { hasGovernanceBypassHeader, checkUserGovernanceBypass, ObjectLockInfo }
+    = require('./apiUtils/object/objectLockHelpers');
 const { config } = require('../Config');
 
 const versionIdUtils = versioning.VersionID;
@@ -78,13 +80,6 @@ function objectDelete(authInfo, request, log, cb) {
                     // versioning has been configured
                     return next(null, bucketMD, objMD);
                 }
-                // AWS only returns an object lock error if a version id
-                // is specified, else continue to create a delete marker
-                if (reqVersionId &&
-                isObjectLocked(bucketMD, objMD, request.headers)) {
-                    log.debug('trying to delete locked object');
-                    return next(objectLockedError, bucketMD);
-                }
                 if (reqVersionId && objMD.location &&
                     Array.isArray(objMD.location) && objMD.location[0]) {
                     // we need this information for data deletes to AWS
@@ -98,6 +93,45 @@ function objectDelete(authInfo, request, log, cb) {
                 }
                 return next(null, bucketMD, objMD);
             });
+        },
+        function checkGovernanceBypassHeader(bucketMD, objectMD, next) {
+            // AWS only returns an object lock error if a version id
+            // is specified, else continue to create a delete marker
+            if (!reqVersionId) {
+                return next(null, null, bucketMD, objectMD);
+            }
+            const hasGovernanceBypass = hasGovernanceBypassHeader(request.headers);
+            if (hasGovernanceBypass && authInfo.isRequesterAnIAMUser()) {
+                return checkUserGovernanceBypass(request, authInfo, bucketMD, objectKey, log, err => {
+                    if (err) {
+                        log.debug('user does not have BypassGovernanceRetention and object is locked');
+                        return next(err, bucketMD);
+                    }
+                    return next(null, hasGovernanceBypass, bucketMD, objectMD);
+                });
+            }
+            return next(null, hasGovernanceBypass, bucketMD, objectMD);
+        },
+        function evaluateObjectLockPolicy(hasGovernanceBypass, bucketMD, objectMD, next) {
+            // AWS only returns an object lock error if a version id
+            // is specified, else continue to create a delete marker
+            if (!reqVersionId) {
+                return next(null, bucketMD, objectMD);
+            }
+
+            const objLockInfo = new ObjectLockInfo({
+                mode: objectMD.retentionMode,
+                date: objectMD.retentionDate,
+                legalHold: objectMD.legalHold || false,
+            });
+
+            // If the object can not be deleted raise an error
+            if (!objLockInfo.canModifyObject(hasGovernanceBypass)) {
+                log.debug('trying to delete locked object');
+                return next(objectLockedError, bucketMD);
+            }
+
+            return next(null, bucketMD, objectMD);
         },
         function getVersioningInfo(bucketMD, objectMD, next) {
             return preprocessingVersioningDelete(bucketName,

--- a/lib/api/objectPutRetention.js
+++ b/lib/api/objectPutRetention.js
@@ -1,17 +1,15 @@
 const async = require('async');
-const { errors, s3middleware, auth, policies } = require('arsenal');
+const { errors, s3middleware } = require('arsenal');
 
-const vault = require('../auth/vault');
 const { decodeVersionId, getVersionIdResHeader } =
   require('./apiUtils/object/versioning');
-const { validateObjectLockUpdate, objectLockRequiresBypass } =
+const { ObjectLockInfo, checkUserGovernanceBypass, hasGovernanceBypassHeader } =
     require('./apiUtils/object/objectLockHelpers');
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
 const getReplicationInfo = require('./apiUtils/object/getReplicationInfo');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const metadata = require('../metadata/wrapper');
-const { config } = require('../Config');
 
 const { parseRetentionXml } = s3middleware.retention;
 const REPLICATION_ACTION = 'PUT_RETENTION';
@@ -83,54 +81,31 @@ function objectPutRetention(authInfo, request, log, callback) {
                 (err, retentionInfo) => next(err, bucket, retentionInfo, objectMD));
         },
         (bucket, retentionInfo, objectMD, next) => {
-            if (objectLockRequiresBypass(objectMD, retentionInfo) && authInfo.isRequesterAnIAMUser()) {
-                log.trace('object in GOVERNANCE mode and is user, checking for attached policies',
-                    { method: 'objectPutRetention' });
-                const authParams = auth.server.extractParams(request, log, 's3',
-                    request.query);
-                const ip = policies.requestUtils.getClientIp(request, config);
-                const requestContextParams = {
-                    constantParams: {
-                        headers: request.headers,
-                        query: request.query,
-                        generalResource: bucketName,
-                        specificResource: { key: objectKey },
-                        requesterIp: ip,
-                        sslEnabled: request.connection.encrypted,
-                        apiMethod: 'bypassGovernanceRetention',
-                        awsService: 's3',
-                        locationConstraint: bucket.getLocationConstraint(),
-                        requesterInfo: authInfo,
-                        signatureVersion: authParams.params.data.signatureVersion,
-                        authType: authParams.params.data.authType,
-                        signatureAge: authParams.params.data.signatureAge,
-                    },
-                };
-                return vault.checkPolicies(requestContextParams,
-                    authInfo.getArn(), log, (err, authorizationResults) => {
-                        if (err) {
-                            return next(err);
+            const hasGovernanceBypass = hasGovernanceBypassHeader(request.headers);
+            if (hasGovernanceBypass && authInfo.isRequesterAnIAMUser()) {
+                return checkUserGovernanceBypass(request, authInfo, bucket, objectKey, log, err => {
+                    if (err) {
+                        if (err.is.AccessDenied) {
+                            log.debug('user does not have BypassGovernanceRetention and object is locked');
                         }
-                        if (authorizationResults[0].isAllowed !== true) {
-                            log.trace('authorization check failed for user',
-                                {
-                                    'method': 'objectPutRetention',
-                                    's3:BypassGovernanceRetention': false,
-                                });
-                            return next(errors.AccessDenied);
-                        }
-                        return next(null, bucket, retentionInfo, objectMD);
-                    });
+                        return next(err, bucket);
+                    }
+                    return next(null, bucket, retentionInfo, hasGovernanceBypass, objectMD);
+                });
             }
-            return next(null, bucket, retentionInfo, objectMD);
+            return next(null, bucket, retentionInfo, hasGovernanceBypass, objectMD);
         },
-        (bucket, retentionInfo, objectMD, next) => {
-            const bypassHeader = request.headers['x-amz-bypass-governance-retention'] || '';
-            const bypassGovernance = bypassHeader.toLowerCase() === 'true';
-            const validationError = validateObjectLockUpdate(objectMD, retentionInfo, bypassGovernance);
-            if (validationError) {
-                return next(validationError, bucket, objectMD);
+        (bucket, retentionInfo, hasGovernanceBypass, objectMD, next) => {
+            const objLockInfo = new ObjectLockInfo({
+                mode: objectMD.retentionMode,
+                date: objectMD.retentionDate,
+                legalHold: objectMD.legalHold,
+            });
+
+            if (!objLockInfo.canModifyPolicy(retentionInfo, hasGovernanceBypass)) {
+                return next(errors.AccessDenied, bucket);
             }
+
             return next(null, bucket, retentionInfo, objectMD);
         },
         (bucket, retentionInfo, objectMD, next) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.10.8",
+  "version": "7.10.8-1",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {

--- a/tests/unit/api/apiUtils/objectLockHelpers.js
+++ b/tests/unit/api/apiUtils/objectLockHelpers.js
@@ -6,9 +6,8 @@ const { DummyRequestLogger } = require('../../helpers');
 const {
     calculateRetainUntilDate,
     validateHeaders,
-    validateObjectLockUpdate,
     compareObjectLockInformation,
-    objectLockRequiresBypass,
+    ObjectLockInfo,
 } = require('../../../../lib/api/apiUtils/object/objectLockHelpers');
 
 const mockName = 'testbucket';
@@ -180,199 +179,6 @@ describe('objectLockHelpers: calculateRetainUntilDate', () => {
     });
 });
 
-describe('objectLockHelpers: objectLockRequiresBypass', () => {
-    it('should not require bypass if extending non-expired GOVERNANCE', () => {
-        const objMD = {
-            retentionMode: 'GOVERNANCE',
-            retentionDate: moment().add(1, 'days').toISOString(),
-        };
-
-        const retentionInfo = {
-            mode: 'GOVERNANCE',
-            date: moment().add(2, 'days').toISOString(),
-        };
-
-        assert.strictEqual(objectLockRequiresBypass(objMD, retentionInfo), false);
-    });
-
-    it('should not require bypass if previous mode is undefined', () => {
-        const objMD = {
-            retentionDate: moment().add(1, 'days').toISOString(),
-        };
-
-        const retentionInfo = {
-            mode: 'GOVERNANCE',
-            date: moment().add(2, 'days').toISOString(),
-        };
-
-        assert.strictEqual(objectLockRequiresBypass(objMD, retentionInfo), false);
-    });
-
-    it('should not require bypass if previous mode was COMPLIANCE', () => {
-        const objMD = {
-            retentionMode: 'COMPLIANCE',
-            retentionDate: moment().add(1, 'days').toISOString(),
-        };
-
-        const retentionInfo = {
-            mode: 'GOVERNANCE',
-            date: moment().add(2, 'days').toISOString(),
-        };
-
-        assert.strictEqual(objectLockRequiresBypass(objMD, retentionInfo), false);
-    });
-
-    it('should require bypass if new mode is COMPLIANCE', () => {
-        const objMD = {
-            retentionMode: 'GOVERNANCE',
-            retentionDate: moment().add(1, 'days').toISOString(),
-        };
-
-        const retentionInfo = {
-            mode: 'COMPLIANCE',
-            date: moment().add(2, 'days').toISOString(),
-        };
-
-        assert.strictEqual(objectLockRequiresBypass(objMD, retentionInfo), true);
-    });
-
-    it('should require bypass if we are shortening retention', () => {
-        const objMD = {
-            retentionMode: 'GOVERNANCE',
-            retentionDate: moment().add(1, 'days').toISOString(),
-        };
-
-        const retentionInfo = {
-            mode: 'GOVERNANCE',
-            date: moment().toISOString(),
-        };
-
-        assert.strictEqual(objectLockRequiresBypass(objMD, retentionInfo), true);
-    });
-});
-
-describe('objectLockHelpers: validateObjectLockUpdate', () => {
-    it('should allow GOVERNANCE => COMPLIANCE if bypassGovernanceRetention is true', () => {
-        const objMD = {
-            retentionMode: 'GOVERNANCE',
-            retentionDate: moment().add(1, 'days').toISOString(),
-        };
-
-        const retentionInfo = {
-            mode: 'COMPLIANCE',
-            date: moment().add(1, 'days').toISOString(),
-        };
-
-        const error = validateObjectLockUpdate(objMD, retentionInfo, true);
-        assert.strictEqual(error, null);
-    });
-
-    it('should disallow GOVERNANCE => COMPLIANCE if bypassGovernanceRetention is false', () => {
-        const objMD = {
-            retentionMode: 'GOVERNANCE',
-            retentionDate: moment().add(1, 'days').toISOString(),
-        };
-
-        const retentionInfo = {
-            mode: 'COMPLIANCE',
-            date: moment().add(1, 'days').toISOString(),
-        };
-
-        const error = validateObjectLockUpdate(objMD, retentionInfo, false);
-        assert.deepStrictEqual(error, errors.AccessDenied);
-    });
-
-    it('should disallow COMPLIANCE => GOVERNANCE if retention is not expired', () => {
-        const objMD = {
-            retentionMode: 'COMPLIANCE',
-            retentionDate: moment().add(1, 'days').toISOString(),
-        };
-
-        const retentionInfo = {
-            mode: 'GOVERNANCE',
-            date: moment().add(1, 'days').toISOString(),
-        };
-
-        const error = validateObjectLockUpdate(objMD, retentionInfo);
-        assert.deepStrictEqual(error, errors.AccessDenied);
-    });
-
-    it('should allow COMPLIANCE => GOVERNANCE if retention is expired', () => {
-        const objMD = {
-            retentionMode: 'COMPLIANCE',
-            retentionDate: moment().subtract(1, 'days').toISOString(),
-        };
-
-        const retentionInfo = {
-            mode: 'GOVERNANCE',
-            date: moment().add(1, 'days').toISOString(),
-        };
-
-        const error = validateObjectLockUpdate(objMD, retentionInfo);
-        assert.strictEqual(error, null);
-    });
-
-    it('should allow extending retention period if in COMPLIANCE', () => {
-        const objMD = {
-            retentionMode: 'COMPLIANCE',
-            retentionDate: moment().add(1, 'days').toISOString(),
-        };
-
-        const retentionInfo = {
-            mode: 'COMPLIANCE',
-            date: moment().add(2, 'days').toISOString(),
-        };
-
-        const error = validateObjectLockUpdate(objMD, retentionInfo);
-        assert.strictEqual(error, null);
-    });
-
-    it('should allow extending retention period if in GOVERNANCE if bypassGovernanceRetention is false', () => {
-        const objMD = {
-            retentionMode: 'GOVERNANCE',
-            retentionDate: moment().add(1, 'days').toISOString(),
-        };
-
-        const retentionInfo = {
-            mode: 'GOVERNANCE',
-            date: moment().add(2, 'days').toISOString(),
-        };
-
-        const error = validateObjectLockUpdate(objMD, retentionInfo, false);
-        assert.strictEqual(error, null);
-    });
-
-    it('should disallow shortening retention period if in COMPLIANCE', () => {
-        const objMD = {
-            retentionMode: 'COMPLIANCE',
-            retentionDate: moment().add(2, 'days').toISOString(),
-        };
-
-        const retentionInfo = {
-            mode: 'COMPLIANCE',
-            date: moment().add(1, 'days').toISOString(),
-        };
-
-        const error = validateObjectLockUpdate(objMD, retentionInfo);
-        assert.deepStrictEqual(error, errors.AccessDenied);
-    });
-
-    it('should allow shortening retention period if in GOVERNANCE', () => {
-        const objMD = {
-            retentionMode: 'GOVERNANCE',
-            retentionDate: moment().add(2, 'days').toISOString(),
-        };
-
-        const retentionInfo = {
-            mode: 'GOVERNANCE',
-            date: moment().add(1, 'days').toISOString(),
-        };
-
-        const error = validateObjectLockUpdate(objMD, retentionInfo, true);
-        assert.strictEqual(error, null);
-    });
-});
-
 describe('objectLockHelpers: compareObjectLockInformation', () => {
     const mockDate = new Date();
     let origNow = null;
@@ -461,4 +267,343 @@ describe('objectLockHelpers: compareObjectLockInformation', () => {
         const res = compareObjectLockInformation(headers, defaultRetention);
         assert.deepStrictEqual(res, { legalHold: true });
     });
+});
+
+
+const pastDate = moment().subtract(1, 'days');
+const futureDate = moment().add(100, 'days');
+
+const isLockedTestCases = [
+    {
+        desc: 'no mode and no date',
+        policy: {},
+        expected: false,
+    },
+    {
+        desc: 'mode and no date',
+        policy: {
+            mode: 'GOVERNANCE',
+        },
+        expected: false,
+    },
+    {
+        desc: 'mode and past date',
+        policy: {
+            mode: 'GOVERNANCE',
+            date: pastDate.toISOString(),
+        },
+        expected: false,
+    },
+    {
+        desc: 'mode and future date',
+        policy: {
+            mode: 'GOVERNANCE',
+            date: futureDate.toISOString(),
+        },
+        expected: true,
+    },
+];
+
+const isExpiredTestCases = [
+    {
+        desc: 'should return true, no date is the same as expired',
+        expected: true,
+    },
+    {
+        desc: 'should return true, past date.',
+        date: pastDate.toISOString(),
+        expected: true,
+    },
+    {
+        desc: 'should return false, future date.',
+        date: futureDate.toISOString(),
+        expected: false,
+    },
+];
+
+const policyChangeTestCases = [
+    {
+        desc: 'enable governance policy',
+        from: {},
+        to: {
+            mode: 'GOVERNANCE',
+            date: futureDate.toISOString(),
+        },
+        allowed: true,
+        allowedWithBypass: true,
+    },
+    {
+        desc: 'modifying expired governance policy',
+        from: {
+            mode: 'GOVERNANCE',
+            date: pastDate.toISOString(),
+        },
+        to: {
+            mode: 'GOVERNANCE',
+            date: futureDate.toISOString(),
+        },
+        allowed: true,
+        allowedWithBypass: true,
+    },
+    {
+        desc: 'extending governance policy',
+        from: {
+            mode: 'GOVERNANCE',
+            date: futureDate.toISOString(),
+        },
+        to: {
+            mode: 'GOVERNANCE',
+            date: futureDate.add(1, 'days').toISOString(),
+        },
+        allowed: true,
+        allowedWithBypass: true,
+    },
+    {
+        desc: 'shortening governance policy',
+        from: {
+            mode: 'GOVERNANCE',
+            date: futureDate.toISOString(),
+        },
+        to: {
+            mode: 'GOVERNANCE',
+            date: futureDate.subtract(1, 'days').toISOString(),
+        },
+        allowed: false,
+        allowedWithBypass: true,
+    },
+    {
+        desc: 'removing governance policy',
+        from: {
+            mode: 'GOVERNANCE',
+            date: futureDate.toISOString(),
+        },
+        to: {},
+        allowed: false,
+        allowedWithBypass: true,
+    },
+    {
+        desc: 'changing governance policy to compliance',
+        from: {
+            mode: 'GOVERNANCE',
+            date: futureDate.toISOString(),
+        },
+        to: {
+            mode: 'COMPLIANCE',
+            date: futureDate.toISOString(),
+        },
+        allowed: false,
+        allowedWithBypass: true,
+    },
+    {
+        desc: 'enable compliance policy',
+        from: {},
+        to: {
+            mode: 'COMPLIANCE',
+            date: futureDate.toISOString(),
+        },
+        allowed: true,
+        allowedWithBypass: true,
+    },
+    {
+        desc: 'modifying expired compliance policy',
+        from: {
+            mode: 'COMPLIANCE',
+            date: pastDate.toISOString(),
+        },
+        to: {
+            mode: 'COMPLIANCE',
+            date: futureDate.toISOString(),
+        },
+        allowed: true,
+        allowedWithBypass: true,
+    },
+    {
+        desc: 'extending compliance policy',
+        from: {
+            mode: 'COMPLIANCE',
+            date: futureDate.toISOString(),
+        },
+        to: {
+            mode: 'COMPLIANCE',
+            date: futureDate.add(1, 'days').toISOString(),
+        },
+        allowed: true,
+        allowedWithBypass: true,
+    },
+    {
+        desc: 'shortening compliance policy',
+        from: {
+            mode: 'COMPLIANCE',
+            date: futureDate.toISOString(),
+        },
+        to: {
+            mode: 'COMPLIANCE',
+            date: futureDate.subtract(1, 'days').toISOString(),
+        },
+        allowed: false,
+        allowedWithBypass: false,
+    },
+    {
+        desc: 'removing compliance policy',
+        from: {
+            mode: 'COMPLIANCE',
+            date: futureDate.toISOString(),
+        },
+        to: {},
+        allowed: false,
+        allowedWithBypass: false,
+    },
+    {
+        desc: 'changing compliance to governance policy',
+        from: {
+            mode: 'COMPLIANCE',
+            date: futureDate.toISOString(),
+        },
+        to: {
+            mode: 'GOVERNANCE',
+            date: futureDate.toISOString(),
+        },
+        allowed: false,
+        allowedWithBypass: false,
+    },
+    {
+        desc: 'invalid starting mode',
+        from: {
+            mode: 'IM_AN_INVALID_MODE',
+            date: futureDate.toISOString(),
+        },
+        to: {
+            mode: 'GOVERNANCE',
+            date: futureDate.toISOString(),
+        },
+        allowed: false,
+        allowedWithBypass: false,
+    },
+    {
+        desc: 'date with no mode',
+        from: {
+            date: futureDate.toISOString(),
+        },
+        to: {
+            mode: 'GOVERNANCE',
+            date: futureDate.toISOString(),
+        },
+        allowed: true,
+        allowedWithBypass: true,
+    },
+];
+
+const canModifyObjectTestCases = [
+    {
+        desc: 'No object lock config',
+        policy: {},
+        allowed: true,
+        allowedWithBypass: true,
+    },
+    {
+        desc: 'active governance mode',
+        policy: {
+            mode: 'GOVERNANCE',
+            date: futureDate.toISOString(),
+        },
+        allowed: false,
+        allowedWithBypass: true,
+    },
+    {
+        desc: 'expired governance mode',
+        policy: {
+            mode: 'GOVERNANCE',
+            date: pastDate.toISOString(),
+        },
+        allowed: true,
+        allowedWithBypass: true,
+    },
+    {
+        desc: 'active compliance mode',
+        policy: {
+            mode: 'COMPLIANCE',
+            date: futureDate.toISOString(),
+        },
+        allowed: false,
+        allowedWithBypass: false,
+    },
+    {
+        desc: 'expired compliance mode',
+        policy: {
+            mode: 'COMPLIANCE',
+            date: pastDate.toISOString(),
+        },
+        allowed: true,
+        allowedWithBypass: true,
+    },
+    {
+        desc: 'invalid mode',
+        policy: {
+            mode: 'IM_AN_INVALID_MODE',
+            date: futureDate.toISOString(),
+        },
+        allowed: false,
+        allowedWithBypass: false,
+    },
+];
+
+describe('objectLockHelpers: ObjectLockInfo', () => {
+    ['GOVERNANCE', 'COMPLIANCE'].forEach(mode => {
+        it(`should return ${mode === 'GOVERNANCE'} for isGovernance`, () => {
+            const info = new ObjectLockInfo({
+                mode,
+            });
+            assert.strictEqual(info.isGovernanceMode(), mode === 'GOVERNANCE');
+        });
+
+        it(`should return ${mode === 'COMPLIANCE'} for isCompliance`, () => {
+            const info = new ObjectLockInfo({
+                mode,
+            });
+            assert.strictEqual(info.isComplianceMode(), mode === 'COMPLIANCE');
+        });
+    });
+
+    describe('isExpired: ', () => isExpiredTestCases.forEach(testCase => {
+        const objLockInfo = new ObjectLockInfo({ date: testCase.date });
+        it(testCase.desc, () => assert.strictEqual(objLockInfo.isExpired(), testCase.expected));
+    }));
+
+    describe('isLocked: ', () => isLockedTestCases.forEach(testCase => {
+        describe(`${testCase.desc}`, () => {
+            it(`should show policy as ${testCase.expected ? '' : 'not'} locked without legal hold`, () => {
+                const objLockInfo = new ObjectLockInfo(testCase.policy);
+                assert.strictEqual(objLockInfo.isLocked(), testCase.expected);
+            });
+
+            // legal hold should show as locked regardless of policy
+            it('should show policy as locked with legal hold', () => {
+                const policy = Object.assign({}, testCase.policy, { legalHold: true });
+                const objLockInfo = new ObjectLockInfo(policy);
+                assert.strictEqual(objLockInfo.isLocked(), true);
+            });
+        });
+    }));
+
+    describe('canModifyPolicy: ', () => policyChangeTestCases.forEach(testCase => {
+        describe(testCase.desc, () => {
+            const objLockInfo = new ObjectLockInfo(testCase.from);
+            it(`should ${testCase.allowed ? 'allow' : 'deny'} modifying the policy without bypass`,
+                () => assert.strictEqual(objLockInfo.canModifyPolicy(testCase.to), testCase.allowed));
+
+            it(`should ${testCase.allowedWithBypass ? 'allow' : 'deny'} modifying the policy with bypass`,
+                () => assert.strictEqual(objLockInfo.canModifyPolicy(testCase.to, true), testCase.allowedWithBypass));
+        });
+    }));
+
+    describe('canModifyObject: ', () => canModifyObjectTestCases.forEach(testCase => {
+        describe(testCase.desc, () => {
+            const objLockInfo = new ObjectLockInfo(testCase.policy);
+            it(`should ${testCase.allowed ? 'allow' : 'deny'} modifying object without bypass`,
+                () => assert.strictEqual(objLockInfo.canModifyObject(), testCase.allowed));
+
+            it(`should ${testCase.allowedWithBypass ? 'allow' : 'deny'} modifying object with bypass`,
+                () => assert.strictEqual(objLockInfo.canModifyObject(true), testCase.allowedWithBypass));
+        });
+    }));
 });


### PR DESCRIPTION
- bf(CLDSRV-293): Refactor object lock helpers to centralize logic
- bf(CLDSRV-293): Add tests for object lock refactor
- bf(CLDSRV-293): convert objectPutRetention to use ObjectLockInfo helper
- bf(CLDSRV-293): convert objectDelete to use ObjectLockInfo helper
- bf(CLDSRV-293): convert multiObjectDelete to use ObjectLockInfo helper
