### PR TITLE
Support alternate azure auth methods

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -135,26 +135,71 @@ function gcpLocationConstraintAssert(location, locationObj) {
     });
 }
 
-function azureLocationConstraintAssert(location, locationObj) {
-    const {
-        azureStorageEndpoint,
-        azureStorageAccountName,
-        azureStorageAccessKey,
-        azureContainerName,
-    } = locationObj.details;
-    const storageEndpointFromEnv =
-        process.env[`${location}_AZURE_STORAGE_ENDPOINT`];
+function azureGetStorageAccountName(location, locationDetails) {
+    const { azureStorageAccountName } = locationDetails;
     const storageAccountNameFromEnv =
         process.env[`${location}_AZURE_STORAGE_ACCOUNT_NAME`];
-    const storageAccessKeyFromEnv =
-        process.env[`${location}_AZURE_STORAGE_ACCESS_KEY`];
+    return storageAccountNameFromEnv || azureStorageAccountName;
+}
+
+function azureGetLocationCredentials(location, locationDetails) {
+    const storageAccessKey =
+        process.env[`${location}_AZURE_STORAGE_ACCESS_KEY`] ||
+        locationDetails.azureStorageAccessKey;
+    const sasToken =
+        process.env[`${location}_AZURE_SAS_TOKEN`] ||
+        locationDetails.sasToken;
+    const clientKey =
+        process.env[`${location}_AZURE_CLIENT_KEY`] ||
+        locationDetails.clientKey;
+
+    const authMethod =
+        process.env[`${location}_AZURE_AUTH_METHOD`] ||
+        locationDetails.authMethod ||
+        (storageAccessKey && 'shared-key') ||
+        (sasToken && 'shared-access-signature') ||
+        (clientKey && 'client-secret') ||
+        'shared-key';
+
+    switch (authMethod) {
+    case 'shared-key':
+    default:
+        return {
+            authMethod,
+            storageAccountName:
+                azureGetStorageAccountName(location, locationDetails),
+            storageAccessKey,
+        };
+
+    case 'shared-access-signature':
+        return {
+            authMethod,
+            sasToken,
+        };
+
+    case 'client-secret':
+        return {
+            authMethod,
+            tenantId:
+                process.env[`${location}_AZURE_TENANT_ID`] ||
+                locationDetails.tenantId,
+            clientId:
+                process.env[`${location}_AZURE_CLIENT_ID`] ||
+                locationDetails.clientId,
+            clientKey,
+        };
+    }
+}
+
+function azureLocationConstraintAssert(location, locationObj) {
     const locationParams = {
-        azureStorageEndpoint: storageEndpointFromEnv || azureStorageEndpoint,
-        azureStorageAccountName:
-            storageAccountNameFromEnv || azureStorageAccountName,
-        azureStorageAccessKey: storageAccessKeyFromEnv || azureStorageAccessKey,
-        azureContainerName,
+        ...azureGetLocationCredentials(location, locationObj.details),
+        azureStorageEndpoint:
+            process.env[`${location}_AZURE_STORAGE_ENDPOINT`] ||
+            locationObj.details.azureStorageEndpoint,
+        azureContainerName: locationObj.details.azureContainerName,
     };
+
     Object.keys(locationParams).forEach(param => {
         const value = locationParams[param];
         assert.notEqual(value, undefined,
@@ -164,13 +209,16 @@ function azureLocationConstraintAssert(location, locationObj) {
             `bad location constraint: "${location}" ${param} ` +
             `"${value}" must be a string`);
     });
-    assert(azureAccountNameRegex.test(locationParams.azureStorageAccountName),
-        `bad location constraint: "${location}" azureStorageAccountName ` +
-        `"${locationParams.storageAccountName}" is an invalid value`);
-    assert(base64Regex.test(locationParams.azureStorageAccessKey),
-        `bad location constraint: "${location}" ` +
-        'azureStorageAccessKey is not a valid base64 string');
-    assert(isValidBucketName(azureContainerName, []),
+
+    if (locationParams.authMethod === 'shared-key') {
+        assert(azureAccountNameRegex.test(locationParams.storageAccountName),
+            `bad location constraint: "${location}" azureStorageAccountName ` +
+            `"${locationParams.storageAccountName}" is an invalid value`);
+        assert(base64Regex.test(locationParams.storageAccessKey),
+            `bad location constraint: "${location}" ` +
+            'azureStorageAccessKey is not a valid base64 string');
+    }
+    assert(isValidBucketName(locationParams.azureContainerName, []),
         `bad location constraint: "${location}" ` +
         'azureContainerName is an invalid container name');
 }
@@ -1642,9 +1690,8 @@ class Config extends EventEmitter {
 
     getAzureEndpoint(locationConstraint) {
         let azureStorageEndpoint =
-        process.env[`${locationConstraint}_AZURE_STORAGE_ENDPOINT`] ||
-        this.locationConstraints[locationConstraint]
-            .details.azureStorageEndpoint;
+            process.env[`${locationConstraint}_AZURE_STORAGE_ENDPOINT`] ||
+            this.locationConstraints[locationConstraint].details.azureStorageEndpoint;
         if (!azureStorageEndpoint.endsWith('/')) {
             // append the trailing slash
             azureStorageEndpoint = `${azureStorageEndpoint}/`;
@@ -1653,23 +1700,22 @@ class Config extends EventEmitter {
     }
 
     getAzureStorageAccountName(locationConstraint) {
-        const { azureStorageAccountName } =
-            this.locationConstraints[locationConstraint].details;
-        const storageAccountNameFromEnv =
-            process.env[`${locationConstraint}_AZURE_STORAGE_ACCOUNT_NAME`];
-        return storageAccountNameFromEnv || azureStorageAccountName;
+        return azureGetStorageAccountName(
+            locationConstraint,
+            this.locationConstraints[locationConstraint].details
+        );
+        // TODO: else, get storageAccountName from endpoint, needed for 'isSameAccount'
+        //  - <STORAGE_ACCOUNT>.blob.*
+        //  - localhost/<STORAGE_ACCOUNT>
+        //  - <ip>/<STORAGE_ACCOUNT>
+        //  - <host:port>/<STORAGE_ACCOUNT>
     }
 
     getAzureStorageCredentials(locationConstraint) {
-        const { azureStorageAccessKey } =
-            this.locationConstraints[locationConstraint].details;
-        const storageAccessKeyFromEnv =
-            process.env[`${locationConstraint}_AZURE_STORAGE_ACCESS_KEY`];
-        return {
-            storageAccountName:
-                this.getAzureStorageAccountName(locationConstraint),
-            storageAccessKey: storageAccessKeyFromEnv || azureStorageAccessKey,
-        };
+        return azureGetLocationCredentials(
+            locationConstraint,
+            this.locationConstraints[locationConstraint].details
+        );
     }
 
     getPfsDaemonEndpoint(locationConstraint) {

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1757,4 +1757,6 @@ module.exports = {
     config: new Config(),
     requestsConfigAssert,
     bucketNotifAssert,
+    azureGetStorageAccountName,
+    azureGetLocationCredentials,
 };

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1700,15 +1700,33 @@ class Config extends EventEmitter {
     }
 
     getAzureStorageAccountName(locationConstraint) {
-        return azureGetStorageAccountName(
+        const accountName = azureGetStorageAccountName(
             locationConstraint,
             this.locationConstraints[locationConstraint].details
         );
-        // TODO: else, get storageAccountName from endpoint, needed for 'isSameAccount'
-        //  - <STORAGE_ACCOUNT>.blob.*
-        //  - localhost/<STORAGE_ACCOUNT>
-        //  - <ip>/<STORAGE_ACCOUNT>
-        //  - <host:port>/<STORAGE_ACCOUNT>
+        if (accountName) {
+            return accountName;
+        }
+
+        // For SAS & ServicePrincipal, retrieve the accountName from the endpoint
+        const endpoint = this.getAzureEndpoint(locationConstraint);
+        const url = new URL(endpoint);
+        const fragments = url.hostname.split('.', 3);
+        if (fragments.length === 3 && fragments[1] === 'blob') {
+            return fragments[0];
+        }
+
+        // We should always reach here, though it may not be the case for "mock" servers,
+        // where the accoutName is in the path
+        const path = url.pathname.replace(/^\//, '').replace(/\/$/, '');
+        if (path) {
+            return path;
+        }
+
+        // We should not reach here; if that happens, use the endpoint itself, which
+        // should be close-enough since this function is used for detecting when two
+        // locations actually point to the same account
+        return endpoint;
     }
 
     getAzureStorageCredentials(locationConstraint) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "8.6.3",
+  "version": "8.6.4",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {

--- a/tests/locationConfig/locationConfigTests.json
+++ b/tests/locationConfig/locationConfigTests.json
@@ -152,6 +152,17 @@
             "azureContainerName": "s3test4"
         }
     },
+    "azuritebackend": {
+        "type": "azure",
+        "objectId": "azuritebackend",
+        "legacyAwsBehavior": true,
+        "details": {
+            "azureStorageEndpoint": "http://localhost/myfakeaccount",
+            "sasToken": "?sig=Fake00Sig002&sv=2021-04-21&sp=rw",
+            "bucketMatch": true,
+            "azureContainerName": "s3test5"
+        }
+    },
     "azurebackendmismatch": {
         "type": "azure",
         "objectId": "azurebackendmismatch",

--- a/tests/locationConfig/locationConfigTests.json
+++ b/tests/locationConfig/locationConfigTests.json
@@ -128,6 +128,30 @@
             "azureContainerName": "s3test2"
         }
     },
+    "azurebackend3": {
+        "type": "azure",
+        "objectId": "azurebackend3",
+        "legacyAwsBehavior": true,
+        "details": {
+            "azureStorageEndpoint": "https://fakeaccountname3.blob.core.fake.net/",
+            "sasToken": "?sig=Fake00Sig002&sv=2021-04-21&sp=rw",
+            "bucketMatch": true,
+            "azureContainerName": "s3test3"
+        }
+    },
+    "azurebackend4": {
+        "type": "azure",
+        "objectId": "azurebackend4",
+        "legacyAwsBehavior": true,
+        "details": {
+            "azureStorageEndpoint": "https://fakeaccountname4.blob.core.fake.net/",
+            "tenantId": "fakeTenant",
+            "clientId": "fakeClient",
+            "clientKey": "Fake00Key002",
+            "bucketMatch": true,
+            "azureContainerName": "s3test4"
+        }
+    },
     "azurebackendmismatch": {
         "type": "azure",
         "objectId": "azurebackendmismatch",

--- a/tests/unit/Config.js
+++ b/tests/unit/Config.js
@@ -1,6 +1,20 @@
 const assert = require('assert');
 
 describe('Config', () => {
+    const envToRestore = [];
+    const setEnv = (key, value) => {
+        if (key in process.env) {
+            const v = process.env[key];
+            envToRestore.push(() => { process.env[key] = v; });
+        } else {
+            envToRestore.push(() => { delete process.env[key]; });
+        }
+        process.env[key] = value;
+    };
+
+    beforeEach(() => { envToRestore.length = 0; });
+    afterEach(() => { envToRestore.reverse().forEach(cb => cb()); });
+
     it('should load default config.json without errors', done => {
         require('../../lib/Config');
         done();
@@ -18,6 +32,176 @@ describe('Config', () => {
             return done();
         }
         return done(new Error('authdata-update event was not emitted'));
+    });
+
+    describe('azureGetStorageAccountName', () => {
+        const { azureGetStorageAccountName } = require('../../lib/Config');
+
+        it('should return the azureStorageAccountName', done => {
+            const accountName = azureGetStorageAccountName('us-west-1', {
+                azureStorageAccountName: 'someaccount'
+            });
+            assert.deepStrictEqual(accountName, 'someaccount');
+            return done();
+        });
+
+        it('should use the azureStorageAccountName', done => {
+            setEnv('us-west-1_AZURE_STORAGE_ACCOUNT_NAME', 'other');
+            setEnv('fr-east-2_AZURE_STORAGE_ACCOUNT_NAME', 'wrong');
+            const accountName = azureGetStorageAccountName('us-west-1', {
+                azureStorageAccountName: 'someaccount'
+            });
+            assert.deepStrictEqual(accountName, 'other');
+            return done();
+        });
+    });
+
+    describe('azureGetLocationCredentials', () => {
+        const { azureGetLocationCredentials } = require('../../lib/Config');
+
+        const locationDetails = {
+            azureStorageAccountName: 'someaccount',
+            azureStorageAccessKey: 'ZW5jcnlwdGVkCg==',
+            sasToken: '?sig=pouygfcxvbnom&sp=09876',
+            tenantId: 'mytenant',
+            clientId: 'myclient',
+            clientKey: 'sgrecvavwegreqv4t24efeqvqc',
+        };
+
+        it('should return shared-key credentials from details', () => {
+            const creds = azureGetLocationCredentials('us-west-1', {
+                azureStorageAccountName: 'someaccount',
+                azureStorageAccessKey: 'ZW5jcnlwdGVkCg==',
+            });
+            assert.deepStrictEqual(creds, {
+                authMethod: 'shared-key',
+                storageAccountName: 'someaccount',
+                storageAccessKey: 'ZW5jcnlwdGVkCg==',
+            });
+        });
+
+        it('should return shared-key credentials from env', () => {
+            setEnv('us-west-1_AZURE_STORAGE_ACCOUNT_NAME', 'something');
+            setEnv('us-west-1_AZURE_STORAGE_ACCESS_KEY', 'ZW5jcnlwdGVkCg==');
+            const creds = azureGetLocationCredentials('us-west-1', {});
+            assert.deepStrictEqual(creds, {
+                authMethod: 'shared-key',
+                storageAccountName: 'something',
+                storageAccessKey: 'ZW5jcnlwdGVkCg==',
+            });
+        });
+
+        it('should return shared-key credentials with authMethod from details', () => {
+            const creds = azureGetLocationCredentials('us-west-1', {
+                authMode: 'shared-key',
+                ...locationDetails
+            });
+            assert.deepStrictEqual(creds, {
+                authMethod: 'shared-key',
+                storageAccountName: 'someaccount',
+                storageAccessKey: 'ZW5jcnlwdGVkCg==',
+            });
+        });
+
+        it('should return shared-key credentials with authMethod from env', () => {
+            setEnv('us-west-1_AZURE_AUTH_METHOD', 'shared-key');
+            const creds = azureGetLocationCredentials('us-west-1', locationDetails);
+            assert.deepStrictEqual(creds, {
+                authMethod: 'shared-key',
+                storageAccountName: 'someaccount',
+                storageAccessKey: 'ZW5jcnlwdGVkCg==',
+            });
+        });
+
+        it('should return shared-access-signature-token credentials from details', () => {
+            const creds = azureGetLocationCredentials('us-west-1', {
+                sasToken: '?sig=pouygfcxvbnom&sp=09876',
+            });
+            assert.deepStrictEqual(creds, {
+                authMethod: 'shared-access-signature',
+                sasToken: '?sig=pouygfcxvbnom&sp=09876',
+            });
+        });
+
+        it('should return shared-access-signature-token credentials from env', () => {
+            setEnv('us-west-1_AZURE_SAS_TOKEN', '?sig=pouygfcxvbnom&sp=09876');
+            const creds = azureGetLocationCredentials('us-west-1', {});
+            assert.deepStrictEqual(creds, {
+                authMethod: 'shared-access-signature',
+                sasToken: '?sig=pouygfcxvbnom&sp=09876',
+            });
+        });
+
+        it('should return shared-access-signature-token credentials with authMethod from details', () => {
+            const creds = azureGetLocationCredentials('us-west-1', {
+                authMethod: 'shared-access-signature',
+                ...locationDetails
+            });
+            assert.deepStrictEqual(creds, {
+                authMethod: 'shared-access-signature',
+                sasToken: '?sig=pouygfcxvbnom&sp=09876',
+            });
+        });
+
+        it('should return shared-access-signature token credentials with authMethod from env', () => {
+            setEnv('us-west-1_AZURE_AUTH_METHOD', 'shared-access-signature');
+            const creds = azureGetLocationCredentials('us-west-1', locationDetails);
+            assert.deepStrictEqual(creds, {
+                authMethod: 'shared-access-signature',
+                sasToken: '?sig=pouygfcxvbnom&sp=09876',
+            });
+        });
+
+        it('should return client-secret credentials from details', () => {
+            const creds = azureGetLocationCredentials('us-west-1', {
+                tenantId: 'mytenant',
+                clientId: 'myclient',
+                clientKey: 'sgrecvavwegreqv4t24efeqvqc',
+            });
+            assert.deepStrictEqual(creds, {
+                authMethod: 'client-secret',
+                tenantId: 'mytenant',
+                clientId: 'myclient',
+                clientKey: 'sgrecvavwegreqv4t24efeqvqc',
+            });
+        });
+
+        it('should return client-secret credentials from env', () => {
+            setEnv('us-west-1_AZURE_TENANT_ID', 'mytenant');
+            setEnv('us-west-1_AZURE_CLIENT_ID', 'myclient');
+            setEnv('us-west-1_AZURE_CLIENT_KEY', 'sgrecvavwegreqv4t24efeqvqc');
+            const creds = azureGetLocationCredentials('us-west-1', {});
+            assert.deepStrictEqual(creds, {
+                authMethod: 'client-secret',
+                tenantId: 'mytenant',
+                clientId: 'myclient',
+                clientKey: 'sgrecvavwegreqv4t24efeqvqc',
+            });
+        });
+
+        it('should return client-secret credentials with authMethod from details', () => {
+            const creds = azureGetLocationCredentials('us-west-1', {
+                authMethod: 'client-secret',
+                ...locationDetails
+            });
+            assert.deepStrictEqual(creds, {
+                authMethod: 'client-secret',
+                tenantId: 'mytenant',
+                clientId: 'myclient',
+                clientKey: 'sgrecvavwegreqv4t24efeqvqc',
+            });
+        });
+
+        it('should return client-secret credentials with authMethod from env', () => {
+            setEnv('us-west-1_AZURE_AUTH_METHOD', 'client-secret');
+            const creds = azureGetLocationCredentials('us-west-1', locationDetails);
+            assert.deepStrictEqual(creds, {
+                authMethod: 'client-secret',
+                tenantId: 'mytenant',
+                clientId: 'myclient',
+                clientKey: 'sgrecvavwegreqv4t24efeqvqc',
+            });
+        });
     });
 
     describe('utapi option setup', () => {

--- a/tests/unit/Config.js
+++ b/tests/unit/Config.js
@@ -204,6 +204,55 @@ describe('Config', () => {
         });
     });
 
+    describe('getAzureStorageAccountName', () => {
+        const { ConfigObject } = require('../../lib/Config');
+
+        it('should return account name from config', () => {
+            setEnv('azurebackend_AZURE_STORAGE_ACCOUNT_NAME', '');
+            const config = new ConfigObject();
+            assert.deepStrictEqual(
+                config.getAzureStorageAccountName('azurebackend'),
+                'fakeaccountname'
+            );
+        });
+
+        it('should return account name from env', () => {
+            setEnv('azurebackend_AZURE_STORAGE_ACCOUNT_NAME', 'foooo');
+            const config = new ConfigObject();
+            assert.deepStrictEqual(
+                config.getAzureStorageAccountName('azurebackend'),
+                'foooo'
+            );
+        });
+
+        it('should return account name from shared-access-signature auth', () => {
+            setEnv('S3_LOCATION_FILE', 'tests/locationConfig/locationConfigTests.json');
+            const config = new ConfigObject();
+            assert.deepStrictEqual(
+                config.getAzureStorageAccountName('azurebackend3'),
+                'fakeaccountname3'
+            );
+        });
+
+        it('should return account name from client-secret auth', () => {
+            setEnv('S3_LOCATION_FILE', 'tests/locationConfig/locationConfigTests.json');
+            const config = new ConfigObject();
+            assert.deepStrictEqual(
+                config.getAzureStorageAccountName('azurebackend4'),
+                'fakeaccountname4',
+            );
+        });
+
+        it('should return account name from endpoint', () => {
+            setEnv('S3_LOCATION_FILE', 'tests/locationConfig/locationConfigTests.json');
+            const config = new ConfigObject();
+            assert.deepStrictEqual(
+                config.getAzureStorageAccountName('azuritebackend'),
+                'myfakeaccount',
+            );
+        });
+    });
+
     describe('utapi option setup', () => {
         let oldConfig;
 


### PR DESCRIPTION
- Support alternate azure auth methods in config
- Add unit tests for azure auth config
- Handle isSameAzureAccount() for other auth methods

Issue: CLDSRV-306
