### PR TITLE
bf(CLDSRV-321): Fix retention extension check to consider same date as extended

### DIFF
--- a/lib/api/apiUtils/object/objectLockHelpers.js
+++ b/lib/api/apiUtils/object/objectLockHelpers.js
@@ -193,7 +193,7 @@ class ObjectLockInfo {
      * @returns {bool} - True if the given timestamp is after the policy expiration date or if no expiration date is set
      */
     isExtended(timestamp) {
-        return timestamp !== undefined && (this.date === null || moment(timestamp).isAfter(this.date));
+        return timestamp !== undefined && (this.date === null || moment(timestamp).isSameOrAfter(this.date));
     }
 
     /**

--- a/tests/unit/api/apiUtils/objectLockHelpers.js
+++ b/tests/unit/api/apiUtils/objectLockHelpers.js
@@ -372,6 +372,19 @@ const policyChangeTestCases = [
         allowedWithBypass: true,
     },
     {
+        desc: 'extending governance policy using same date',
+        from: {
+            mode: 'GOVERNANCE',
+            date: futureDate.toISOString(),
+        },
+        to: {
+            mode: 'GOVERNANCE',
+            date: futureDate.toISOString(),
+        },
+        allowed: true,
+        allowedWithBypass: true,
+    },
+    {
         desc: 'removing governance policy',
         from: {
             mode: 'GOVERNANCE',
@@ -442,6 +455,19 @@ const policyChangeTestCases = [
         },
         allowed: false,
         allowedWithBypass: false,
+    },
+    {
+        desc: 'extending compliance policy with the same date',
+        from: {
+            mode: 'COMPLIANCE',
+            date: futureDate.toISOString(),
+        },
+        to: {
+            mode: 'COMPLIANCE',
+            date: futureDate.toISOString(),
+        },
+        allowed: true,
+        allowedWithBypass: true,
     },
     {
         desc: 'removing compliance policy',

--- a/tests/unit/api/objectPutRetention.js
+++ b/tests/unit/api/objectPutRetention.js
@@ -16,8 +16,8 @@ const bucketName = 'bucketname';
 const objectName = 'objectName';
 const postBody = Buffer.from('I am a body', 'utf8');
 
-const date = new Date();
-date.setDate(date.getDate() + 1);
+const expectedMode = 'GOVERNANCE';
+const expectedDate = moment().add(2, 'days').toISOString();
 
 const bucketPutRequest = {
     bucketName,
@@ -36,19 +36,25 @@ const putObjectRequest = new DummyRequest({
 const objectRetentionXmlGovernance = '<Retention ' +
     'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
     '<Mode>GOVERNANCE</Mode>' +
-    `<RetainUntilDate>${date.toISOString()}</RetainUntilDate>` +
+    `<RetainUntilDate>${expectedDate}</RetainUntilDate>` +
     '</Retention>';
 
 const objectRetentionXmlCompliance = '<Retention ' +
     'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
     '<Mode>COMPLIANCE</Mode>' +
-    `<RetainUntilDate>${moment().add(2, 'days').toISOString()}</RetainUntilDate>` +
+    `<RetainUntilDate>${expectedDate}</RetainUntilDate>` +
     '</Retention>';
 
 const objectRetentionXmlGovernanceLonger = '<Retention ' +
     'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
     '<Mode>GOVERNANCE</Mode>' +
     `<RetainUntilDate>${moment().add(5, 'days').toISOString()}</RetainUntilDate>` +
+    '</Retention>';
+
+const objectRetentionXmlGovernanceShorter = '<Retention ' +
+    'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+    '<Mode>GOVERNANCE</Mode>' +
+    `<RetainUntilDate>${moment().add(1, 'days').toISOString()}</RetainUntilDate>` +
     '</Retention>';
 
 const objectRetentionXmlComplianceShorter = '<Retention ' +
@@ -95,8 +101,12 @@ const putObjRetRequestGovernanceLonger = {
     post: objectRetentionXmlGovernanceLonger,
 };
 
-const expectedMode = 'GOVERNANCE';
-const expectedDate = date.toISOString();
+const putObjRetRequestGovernanceShorter = {
+    bucketName,
+    objectKey: objectName,
+    headers: { host: `${bucketName}.s3.amazonaws.com` },
+    post: objectRetentionXmlGovernanceShorter,
+};
 
 describe('putObjectRetention API', () => {
     before(() => cleanup());
@@ -178,8 +188,19 @@ describe('putObjectRetention API', () => {
             + 'GOVERNANCE mode is enabled', done => {
             objectPutRetention(authInfo, putObjRetRequestGovernance, log, err => {
                 assert.ifError(err);
-                return objectPutRetention(authInfo, putObjRetRequestGovernance, log, err => {
+                return objectPutRetention(authInfo, putObjRetRequestGovernanceShorter, log, err => {
                     assert.deepStrictEqual(err, errors.AccessDenied);
+                    done();
+                });
+            });
+        });
+
+        it('should allow update if the x-amz-bypass-governance-retention header is missing and '
+            + 'GOVERNANCE mode is enabled and the same date is used', done => {
+            objectPutRetention(authInfo, putObjRetRequestGovernance, log, err => {
+                assert.ifError(err);
+                return objectPutRetention(authInfo, putObjRetRequestGovernance, log, err => {
+                    assert.ifError(err);
                     done();
                 });
             });


### PR DESCRIPTION
Fixes the check when trying to extend object lock's retention period to consider the same date as extended and allow the request to succeed.