### PR TITLE
CLDSRV-333: Handle delete and overwrite of MPUs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -143,10 +143,11 @@ jobs:
           username: ${{ secrets.REGISTRY_LOGIN }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - name: Build and push cloudserver image
-        uses: docker/build-push-action@v2.7.0
+        uses: docker/build-push-action@v3
         with:
           push: true
           context: .
+          provenance: false
           tags: |
             ghcr.io/${{ github.repository }}/cloudserver:${{ github.sha }}
             registry.scality.com/cloudserver-dev/cloudserver:${{ github.sha }}

--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -195,6 +195,10 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
         }
     }
 
+    if (objMD && objMD.uploadId) {
+        metadataStoreParams.oldReplayId = objMD.uploadId;
+    }
+
     /* eslint-disable camelcase */
     const dontSkipBackend = externalBackends;
     /* eslint-enable camelcase */

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -447,6 +447,11 @@ function objectCopy(authInfo, request, sourceBucket,
         },
         function storeNewMetadata(storeMetadataParams, destDataGetInfoArr,
             destObjMD, serverSideEncryption, destBucketMD, dataToDelete, next) {
+            if (destObjMD && destObjMD.uploadId) {
+                // eslint-disable-next-line
+                storeMetadataParams.oldReplayId = destObjMD.uploadId;
+            }
+
             return services.metadataStoreObject(destBucketName,
                 destDataGetInfoArr, serverSideEncryption,
                 storeMetadataParams, (err, result) => {

--- a/lib/api/objectDelete.js
+++ b/lib/api/objectDelete.js
@@ -157,6 +157,12 @@ function objectDelete(authInfo, request, log, cb) {
                     // response headers accordingly
                     deleteInfo.removeDeleteMarker = true;
                 }
+
+                if (objectMD && objectMD.uploadId) {
+                    // eslint-disable-next-line
+                    delOptions.replayId = objectMD.uploadId;
+                }
+
                 return services.deleteObject(bucketName, objectMD, objectKey,
                     delOptions, log, (err, delResult) => next(err, bucketMD,
                     objectMD, delResult, deleteInfo));

--- a/lib/services.js
+++ b/lib/services.js
@@ -97,7 +97,7 @@ const services = {
             lastModifiedDate, versioning, versionId, uploadId,
             tagging, taggingCopy, replicationInfo, defaultRetention,
             dataStoreName, retentionMode, retentionDate, legalHold,
-            originOp } = params;
+            originOp, oldReplayId } = params;
         log.trace('storing object in metadata');
         assert.strictEqual(typeof bucketName, 'string');
         const md = new ObjectMD();
@@ -160,6 +160,11 @@ const services = {
             md.setUploadId(uploadId);
             options.replayId = uploadId;
         }
+
+        if (oldReplayId) {
+            options.oldReplayId = oldReplayId;
+        }
+
         // information to store about the version and the null version id
         // in the object metadata
         const { isNull, nullVersionId, nullUploadId, isDeleteMarker } = params;

--- a/tests/multipleBackend/objectPutPart.js
+++ b/tests/multipleBackend/objectPutPart.js
@@ -103,6 +103,9 @@ errorDescription) {
             assert(err.description.indexOf(errorDescription) > -1);
             return cb();
         }
+
+        assert.ifError(err, 'Error initiating MPU');
+
         // Need to build request in here since do not have uploadId
         // until here
         const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];

--- a/tests/unit/api/objectCopy.js
+++ b/tests/unit/api/objectCopy.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const async = require('async');
+const sinon = require('sinon');
 
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const bucketPutVersioning = require('../../../lib/api/bucketPutVersioning');
@@ -9,6 +10,10 @@ const { ds } = require('arsenal').storage.data.inMemory.datastore;
 const DummyRequest = require('../DummyRequest');
 const { cleanup, DummyRequestLogger, makeAuthInfo, versioningTestUtils }
     = require('../helpers');
+const mpuUtils = require('../utils/mpuUtils');
+const metadata = require('../metadataswitch');
+
+const any = sinon.match.any;
 
 const log = new DummyRequestLogger();
 const canonicalID = 'accessKey1';
@@ -17,6 +22,7 @@ const namespace = 'default';
 const destBucketName = 'destbucketname';
 const sourceBucketName = 'sourcebucketname';
 const objectKey = 'objectName';
+const originalputObjectMD = metadata.putObjectMD;
 
 function _createBucketPutRequest(bucketName) {
     return new DummyRequest({
@@ -44,11 +50,11 @@ const enableVersioningRequest = versioningTestUtils
     .createBucketPutVersioningReq(destBucketName, 'Enabled');
 const suspendVersioningRequest = versioningTestUtils
     .createBucketPutVersioningReq(destBucketName, 'Suspended');
+const objData = ['foo0', 'foo1', 'foo2'].map(str =>
+    Buffer.from(str, 'utf8'));
+
 
 describe('objectCopy with versioning', () => {
-    const objData = ['foo0', 'foo1', 'foo2'].map(str =>
-        Buffer.from(str, 'utf8'));
-
     const testPutObjectRequests = objData.slice(0, 2).map(data =>
         versioningTestUtils.createPutObjectRequest(destBucketName, objectKey,
             data));
@@ -101,5 +107,52 @@ describe('objectCopy with versioning', () => {
                     done();
                 });
             });
+    });
+});
+
+describe('non-versioned objectCopy', () => {
+    const testPutObjectRequest = versioningTestUtils
+        .createPutObjectRequest(sourceBucketName, objectKey, objData[0]);
+
+    before(done => {
+        cleanup();
+        sinon.stub(metadata, 'putObjectMD')
+            .callsFake(originalputObjectMD);
+        async.series([
+            callback => bucketPut(authInfo, putDestBucketRequest, log,
+                callback),
+            callback => bucketPut(authInfo, putSourceBucketRequest, log,
+                callback),
+            // put source object in source bucket
+            callback => objectPut(authInfo, testPutObjectRequest,
+                undefined, log, callback),
+        ], err => {
+            if (err) {
+                return done(err);
+            }
+            versioningTestUtils.assertDataStoreValues(ds, objData.slice(0, 1));
+            return done();
+        });
+    });
+
+    after(() => {
+        cleanup();
+        sinon.restore();
+    });
+
+    const testObjectCopyRequest = _createObjectCopyRequest(destBucketName);
+
+    it('should not leave orphans in data when overwriting a multipart upload', done => {
+        mpuUtils.createMPU(namespace, destBucketName, objectKey, log,
+        (err, testUploadId) => {
+            assert.ifError(err);
+            objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey,
+                undefined, log, err => {
+                    assert.ifError(err);
+                    sinon.assert.calledWith(metadata.putObjectMD,
+                        any, any, any, { oldReplayId: testUploadId }, any, any);
+                    done();
+                });
+        });
     });
 });

--- a/tests/unit/api/objectDelete.js
+++ b/tests/unit/api/objectDelete.js
@@ -1,9 +1,8 @@
 const assert = require('assert');
-const async = require('async');
-const crypto = require('crypto');
 const { errors } = require('arsenal');
-const xml2js = require('xml2js');
+const sinon = require('sinon');
 
+const services = require('../../../lib/services');
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const bucketPutACL = require('../../../lib/api/bucketPutACL');
 const constants = require('../../../constants');
@@ -11,12 +10,11 @@ const { cleanup, DummyRequestLogger, makeAuthInfo } = require('../helpers');
 const objectPut = require('../../../lib/api/objectPut');
 const objectDelete = require('../../../lib/api/objectDelete');
 const objectGet = require('../../../lib/api/objectGet');
-const initiateMultipartUpload
-    = require('../../../lib/api/initiateMultipartUpload');
-const objectPutPart = require('../../../lib/api/objectPutPart');
-const completeMultipartUpload
-    = require('../../../lib/api/completeMultipartUpload');
 const DummyRequest = require('../DummyRequest');
+const mpuUtils = require('../utils/mpuUtils');
+
+const any = sinon.match.any;
+const originalDeleteObject = services.deleteObject;
 
 const log = new DummyRequestLogger();
 const canonicalID = 'accessKey1';
@@ -45,6 +43,11 @@ function testAuth(bucketOwner, authUser, bucketPutReq, objPutReq, objDelReq,
 describe('objectDelete API', () => {
     let testPutObjectRequest;
 
+    before(() => {
+        sinon.stub(services, 'deleteObject')
+            .callsFake(originalDeleteObject);
+    });
+
     beforeEach(() => {
         cleanup();
         testPutObjectRequest = new DummyRequest({
@@ -55,6 +58,11 @@ describe('objectDelete API', () => {
             url: `/${bucketName}/${objectKey}`,
         }, postBody);
     });
+
+    after(() => {
+        sinon.restore();
+    });
+
 
     const testBucketPutRequest = new DummyRequest({
         bucketName,
@@ -76,14 +84,6 @@ describe('objectDelete API', () => {
         headers: {},
         url: `/${bucketName}/${objectKey}`,
     });
-
-    const initiateMPURequest = {
-        bucketName,
-        namespace,
-        objectKey,
-        headers: { host: `${bucketName}.s3.amazonaws.com` },
-        url: `/${objectKey}?uploads`,
-    };
 
     it('should delete an object', done => {
         bucketPut(authInfo, testBucketPutRequest, log, () => {
@@ -128,55 +128,22 @@ describe('objectDelete API', () => {
         });
     });
 
-    it('should delete a multipart upload', done => {
-        const partBody = Buffer.from('I am a part\n', 'utf8');
-        let testUploadId;
-        let calculatedHash;
-        async.waterfall([
-            next => bucketPut(authInfo, testBucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateMPURequest, log, next),
-            (result, corsHeaders, next) => xml2js.parseString(result, next),
-            (json, next) => {
-                testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-                const md5Hash = crypto.createHash('md5').update(partBody);
-                calculatedHash = md5Hash.digest('hex');
-                const partRequest = new DummyRequest({
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                    query: {
-                        partNumber: '1',
-                        uploadId: testUploadId,
-                    },
-                    calculatedHash,
-                }, partBody);
-                objectPutPart(authInfo, partRequest, undefined, log, next);
-            },
-            (hexDigest, corsHeaders, next) => {
-                const completeBody = '<CompleteMultipartUpload>' +
-                      '<Part>' +
-                      '<PartNumber>1</PartNumber>' +
-                      `<ETag>"${calculatedHash}"</ETag>` +
-                      '</Part>' +
-                      '</CompleteMultipartUpload>';
-                const completeRequest = {
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    parsedHost: 's3.amazonaws.com',
-                    url: `/${objectKey}?uploadId=${testUploadId}`,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    query: { uploadId: testUploadId },
-                    post: completeBody,
-                };
-                completeMultipartUpload(authInfo, completeRequest, log, next);
-            },
-            (result, resHeaders, next) =>
-                objectDelete(authInfo, testDeleteRequest, log, next),
-        ], done);
+    it('should delete a multipart upload and send `uploadId` as `replayId` to deleteObject', done => {
+        bucketPut(authInfo, testBucketPutRequest, log, () => {
+            mpuUtils.createMPU(namespace, bucketName, objectKey, log,
+                (err, testUploadId) => {
+                    assert.ifError(err);
+                    objectDelete(authInfo, testDeleteRequest, log, err => {
+                        assert.strictEqual(err, null);
+                        sinon.assert.calledWith(services.deleteObject,
+                            any, any, any,
+                            { deleteData: true,
+                              replayId: testUploadId,
+                            }, any, any);
+                        done();
+                    });
+                });
+        });
     });
 
     it('should prevent anonymous user deleteObject API access', done => {

--- a/tests/unit/utils/mpuUtils.js
+++ b/tests/unit/utils/mpuUtils.js
@@ -1,0 +1,110 @@
+const assert = require('assert');
+const async = require('async');
+const crypto = require('crypto');
+const xml2js = require('xml2js');
+
+const DummyRequest = require('../DummyRequest');
+const initiateMultipartUpload
+    = require('../../../lib/api/initiateMultipartUpload');
+const objectPutPart = require('../../../lib/api/objectPutPart');
+const completeMultipartUpload
+    = require('../../../lib/api/completeMultipartUpload');
+
+const { makeAuthInfo }
+    = require('../helpers');
+
+const canonicalID = 'accessKey1';
+const authInfo = makeAuthInfo(canonicalID);
+
+// part 1
+const partBody = Buffer.from('I am a part\n', 'utf8');
+const md5Hash = crypto.createHash('md5').update(partBody);
+const calculatedHash = md5Hash.digest('hex');
+
+function createinitiateMPURequest(namespace, bucketName, objectKey) {
+    const request = {
+        bucketName,
+        namespace,
+        objectKey,
+        headers: { host: `${bucketName}.s3.amazonaws.com` },
+        url: `/${objectKey}?uploads`,
+    };
+
+    return request;
+}
+
+function createPutPartRequest(namespace, bucketName, objectKey, partNumber, testUploadId) {
+    const request = new DummyRequest({
+        bucketName,
+        namespace,
+        objectKey,
+        headers: { host: `${bucketName}.s3.amazonaws.com` },
+        url: `/${objectKey}?partNumber=${partNumber}&uploadId=${testUploadId}`,
+        query: {
+            partNumber,
+            uploadId: testUploadId,
+        },
+        calculatedHash,
+    }, partBody);
+
+    return request;
+}
+
+function createCompleteRequest(namespace, bucketName, objectKey, testUploadId) {
+  // only suports a single part for now
+    const completeBody = '<CompleteMultipartUpload>' +
+                         '<Part>' +
+                         '<PartNumber>1</PartNumber>' +
+                         `<ETag>"${calculatedHash}"</ETag>` +
+                         '</Part>' +
+                         '</CompleteMultipartUpload>';
+
+    const request = {
+        bucketName,
+        namespace,
+        objectKey,
+        parsedHost: 's3.amazonaws.com',
+        url: `/${objectKey}?uploadId=${testUploadId}`,
+        headers: { host: `${bucketName}.s3.amazonaws.com` },
+        query: { uploadId: testUploadId },
+        post: completeBody,
+    };
+
+    return request;
+}
+
+function createMPU(namespace, bucketName, objectKey, logger, cb) {
+    let testUploadId;
+    async.waterfall([
+        next => {
+            const initiateMPURequest = createinitiateMPURequest(namespace,
+                                                                bucketName,
+                                                                objectKey);
+            initiateMultipartUpload(authInfo, initiateMPURequest, logger, next);
+        },
+        (result, corsHeaders, next) => xml2js.parseString(result, next),
+        (json, next) => {
+            testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+            const partRequest =
+            createPutPartRequest(namespace, bucketName, objectKey, 1, testUploadId);
+            objectPutPart(authInfo, partRequest, undefined, logger, next);
+        },
+        (hexDigest, corsHeaders, next) => {
+            const completeRequest =
+                createCompleteRequest(namespace, bucketName, objectKey, testUploadId);
+            completeMultipartUpload(authInfo, completeRequest, logger, next);
+        },
+    ], (err) => {
+        assert.ifError(err);
+        cb(null, testUploadId);
+    });
+
+    return testUploadId;
+}
+
+
+module.exports = {
+    createPutPartRequest,
+    createCompleteRequest,
+    createMPU,
+};


### PR DESCRIPTION
When a MPU is deleted or overwritten, send its `uploadId` to the metadata backend.
This information is used to cleanup the replay key associated with the MPU.  

This PR is related to https://github.com/scality/MetaData/pull/2097

Issue: CLDSRV-333