### PR TITLE
CLDSRV-335: Build federation image in tests workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -154,6 +154,18 @@ jobs:
           cache-from: type=gha,scope=cloudserver
           cache-to: type=gha,mode=max,scope=cloudserver
 
+  build-federation-image:
+    uses: scality/workflows/.github/workflows/docker-build.yaml@v1
+    secrets: inherit
+    with:
+      push: true
+      registry: registry.scality.com
+      namespace: cloudserver-dev
+      name: cloudserver
+      context: .
+      file: images/svc-base/Dockerfile
+      tag: ${{ github.sha }}-svc-base
+
   multiple-backend:
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
When a commit is pushed (`tests` workflow) build the Federation docker image in parallel with the image used for tests.

This will allow us to build Federation with an image before doing a release. 

Issue: CLDSRV-335