### PR TITLE
impr: CLDSRV-340 improve preprocessingVersioningDelete()

### DIFF
--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -310,66 +310,31 @@ function versioningPreprocessing(bucketName, bucketMD, objectKey, objMD,
  * @param {object} bucketMD - bucket metadata
  * @param {object} objectMD - obj metadata
  * @param {string} [reqVersionId] - specific version ID sent as part of request
- * @param {RequestLogger} log - logger instance
- * @param {function} callback - callback
- * @return {undefined} and call callback with params (err, options):
+ * @return {object} options object with params:
  * options.deleteData - (true/undefined) whether to delete data (if undefined
  *  means creating a delete marker instead)
  * options.versionId - specific versionId to delete
- * options.isNull - (true/undefined) whether version to be deleted/marked is null or not
  */
-function preprocessingVersioningDelete(bucketName, bucketMD, objectMD,
-    reqVersionId, log, callback) {
+function preprocessingVersioningDelete(bucketName, bucketMD, objectMD, reqVersionId) {
     const options = {};
-    // bucket is not versioning enabled
-    if (!bucketMD.getVersioningConfiguration()) {
+    if (!bucketMD.getVersioningConfiguration() || reqVersionId) {
+        // delete data if bucket is non-versioned or the request
+        // deletes a specific version
         options.deleteData = true;
-        return callback(null, options);
     }
-    // bucket is versioning enabled
-    if (reqVersionId && reqVersionId !== 'null') {
-        // deleting a specific version
-        options.deleteData = true;
-        options.versionId = reqVersionId;
-        if (objectMD.uploadId) {
-            options.replayId = objectMD.uploadId;
-        }
-        return callback(null, options);
-    }
-    if (reqVersionId) {
-        // deleting the 'null' version if it exists
-        if (objectMD.versionId === undefined) {
-            // object is not versioned, deleting it
-            options.deleteData = true;
-            // non-versioned (non-null) MPU objects don't have a
-            // replay ID, so don't reference their uploadId
-            return callback(null, options);
-        }
-        if (objectMD.isNull) {
-            // master is the null version
-            options.deleteData = true;
-            options.versionId = objectMD.versionId;
-            if (objectMD.uploadId) {
-                options.replayId = objectMD.uploadId;
+    if (bucketMD.getVersioningConfiguration() && reqVersionId) {
+        if (reqVersionId === 'null') {
+            // deleting the 'null' version if it exists: use its
+            // internal versionId if it exists
+            if (objectMD.versionId !== undefined) {
+                options.versionId = objectMD.versionId;
             }
-            return callback(null, options);
+        } else {
+            // deleting a specific version
+            options.versionId = reqVersionId;
         }
-        if (objectMD.nullVersionId) {
-            // null version exists, deleting it
-            options.deleteData = true;
-            options.versionId = objectMD.nullVersionId;
-            if (objectMD.nullUploadId) {
-                options.replayId = objectMD.nullUploadId;
-            }
-            return callback(null, options);
-        }
-        // null version does not exist, no deletion
-        // TODO check AWS behaviour for no deletion (seems having no error)
-        return callback(errors.NoSuchKey);
     }
-    // not deleting any specific version, making a delete marker instead
-    options.isNull = true;
-    return callback(null, options);
+    return options;
 }
 
 module.exports = {

--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -279,14 +279,15 @@ function getObjMetadataAndDelete(authInfo, canonicalID, request,
 
                 return callback(null, objMD, versionId);
             },
-            (objMD, versionId, callback) =>
-                preprocessingVersioningDelete(bucketName, bucket, objMD,
-                versionId, log, (err, options) => callback(err, options,
-                    objMD)),
-            (options, objMD, callback) => {
+            (objMD, versionId, callback) => {
+                const options = preprocessingVersioningDelete(bucketName, bucket, objMD, versionId);
                 const deleteInfo = {};
                 if (options && options.deleteData) {
                     deleteInfo.deleted = true;
+                    if (objMD.uploadId) {
+                        // eslint-disable-next-line
+                        options.replayId = objMD.uploadId;
+                    }
                     return services.deleteObject(bucketName, objMD,
                         entry.key, options, log, err =>
                         callback(err, objMD, deleteInfo));

--- a/lib/api/objectDelete.js
+++ b/lib/api/objectDelete.js
@@ -133,19 +133,9 @@ function objectDelete(authInfo, request, log, cb) {
 
             return next(null, bucketMD, objectMD);
         },
-        function getVersioningInfo(bucketMD, objectMD, next) {
-            return preprocessingVersioningDelete(bucketName,
-                bucketMD, objectMD, reqVersionId, log,
-                (err, options) => {
-                    if (err) {
-                        log.error('err processing versioning info',
-                        { error: err });
-                        return next(err, bucketMD);
-                    }
-                    return next(null, bucketMD, objectMD, options);
-                });
-        },
-        function deleteOperation(bucketMD, objectMD, delOptions, next) {
+        function deleteOperation(bucketMD, objectMD, next) {
+            const delOptions = preprocessingVersioningDelete(
+                bucketName, bucketMD, objectMD, reqVersionId);
             const deleteInfo = {
                 removeDeleteMarker: false,
                 newDeleteMarker: false,
@@ -158,7 +148,7 @@ function objectDelete(authInfo, request, log, cb) {
                     deleteInfo.removeDeleteMarker = true;
                 }
 
-                if (objectMD && objectMD.uploadId) {
+                if (objectMD.uploadId) {
                     // eslint-disable-next-line
                     delOptions.replayId = objectMD.uploadId;
                 }
@@ -223,9 +213,10 @@ function objectDelete(authInfo, request, log, cb) {
                 * The decrement accounts for the deletion of the master key when utapi reports
                 * on the number of objects.
             */
+            // FIXME: byteLength may be incorrect, see S3C-7440
             const versioningSuspended = bucketMD.getVersioningConfiguration()
                 && bucketMD.getVersioningConfiguration().Status === 'Suspended';
-            const deletedSuspendedMasterVersion = versioningSuspended && !!objectMD && deleteInfo.isNull;
+            const deletedSuspendedMasterVersion = versioningSuspended && !!objectMD;
             // Default to 0 content-length to cover deleting a DeleteMarker
             const objectByteLength = (objectMD && objectMD['content-length']) || 0;
             const byteLength = deletedSuspendedMasterVersion ? Number.parseInt(objectByteLength, 10) : null;

--- a/tests/unit/api/apiUtils/versioning.js
+++ b/tests/unit/api/apiUtils/versioning.js
@@ -267,9 +267,7 @@ describe('versioning helpers', () => {
                 objMD: {
                     versionId: 'v1',
                 },
-                expectedRes: {
-                    isNull: true,
-                },
+                expectedRes: {},
             },
             {
                 description: 'delete non-null object version',
@@ -280,19 +278,6 @@ describe('versioning helpers', () => {
                 expectedRes: {
                     deleteData: true,
                     versionId: 'v1',
-                },
-            },
-            {
-                description: 'delete MPU object non-null version',
-                objMD: {
-                    versionId: 'v1',
-                    uploadId: 'fooUploadId',
-                },
-                reqVersionId: 'v1',
-                expectedRes: {
-                    deleteData: true,
-                    versionId: 'v1',
-                    replayId: 'fooUploadId',
                 },
             },
             {
@@ -308,132 +293,20 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                description: 'delete MPU object null version',
-                objMD: {
-                    versionId: 'vnull',
-                    isNull: true,
-                    uploadId: 'fooUploadId',
-                },
-                reqVersionId: 'null',
-                expectedRes: {
-                    deleteData: true,
-                    versionId: 'vnull',
-                    replayId: 'fooUploadId',
-                },
-            },
-            {
-                description:
-                'delete object put before versioning was first enabled',
+                description: 'delete object put before versioning was first enabled',
                 objMD: {},
                 reqVersionId: 'null',
                 expectedRes: {
                     deleteData: true,
                 },
             },
-            {
-                description:
-                'delete MPU object put before versioning was first enabled',
-                objMD: {
-                    uploadId: 'fooUploadId',
-                },
-                reqVersionId: 'null',
-                expectedRes: {
-                    deleteData: true,
-                },
-            },
-            {
-                description:
-                'delete non-null object version with ref to null version',
-                objMD: {
-                    versionId: 'v1',
-                    nullVersionId: 'vnull',
-                },
-                reqVersionId: 'v1',
-                expectedRes: {
-                    deleteData: true,
-                    versionId: 'v1',
-                },
-            },
-            {
-                description:
-                'delete MPU object non-null version with ref to null version',
-                objMD: {
-                    versionId: 'v1',
-                    uploadId: 'fooUploadId',
-                    nullVersionId: 'vnull',
-                },
-                reqVersionId: 'v1',
-                expectedRes: {
-                    deleteData: true,
-                    versionId: 'v1',
-                    replayId: 'fooUploadId',
-                },
-            },
-            {
-                description:
-                'delete non-null object version with ref to MPU null version',
-                objMD: {
-                    versionId: 'v1',
-                    nullVersionId: 'vnull',
-                    nullUploadId: 'nullFooUploadId',
-                },
-                reqVersionId: 'v1',
-                expectedRes: {
-                    deleteData: true,
-                    versionId: 'v1',
-                },
-            },
-            {
-                description:
-                'delete null object version from ref to null version',
-                objMD: {
-                    versionId: 'v1',
-                    nullVersionId: 'vnull',
-                },
-                reqVersionId: 'null',
-                expectedRes: {
-                    deleteData: true,
-                    versionId: 'vnull',
-                },
-            },
-            {
-                description:
-                'delete MPU object null version from ref to null version',
-                objMD: {
-                    versionId: 'v1',
-                    nullVersionId: 'vnull',
-                    nullUploadId: 'nullFooUploadId',
-                },
-                reqVersionId: 'null',
-                expectedRes: {
-                    deleteData: true,
-                    versionId: 'vnull',
-                    replayId: 'nullFooUploadId',
-                },
-            },
-            {
-                description: 'delete null version that does not exist',
-                objMD: {
-                    versionId: 'v1',
-                },
-                reqVersionId: 'null',
-                expectedError: 'NoSuchKey',
-            },
-        ].forEach(testCase => it(testCase.description, done => {
+        ].forEach(testCase => it(testCase.description, () => {
             const mockBucketMD = {
                 getVersioningConfiguration: () => ({ Status: 'Enabled' }),
             };
-            preprocessingVersioningDelete(
-                'foobucket', mockBucketMD, testCase.objMD,
-                testCase.reqVersionId, null, (err, options) => {
-                    if (testCase.expectedError) {
-                        assert.strictEqual(err.is[testCase.expectedError], true);
-                    } else {
-                        assert.ifError(err);
-                        assert.deepStrictEqual(options, testCase.expectedRes);
-                    }
-                    done();
-                });
+            const options = preprocessingVersioningDelete(
+                'foobucket', mockBucketMD, testCase.objMD, testCase.reqVersionId);
+            assert.deepStrictEqual(options, testCase.expectedRes);
         }));
     });
 });


### PR DESCRIPTION
- remove dead code handling nullVersionId and when no reference to null version is found: the confusion is that the metadata is already coming from the null version fetch due to the "reqVersionId" being "null", so it can only be the null version itself.

- remove the "isNull" argument returned as it is misused (for metrics) and can be incorrect, see S3C-7440

- simplify the function by reorganizing the logic and removing the callback argument, just returning an options object

- delete replay keys on multiobject delete, instead of passing the replayId option via preprocessingVersioningDelete() (a similar change has been done in objectDelete but it resulted in duplication of replayId setting)

- remove all MPU-related tests for this helper, as the helper does not return replayId anymore, they became irrelevant
