### PR TITLE
[tests] CLDSRV-344 fix func test double callback

### DIFF
--- a/tests/functional/aws-node-sdk/test/object/completeMPU.js
+++ b/tests/functional/aws-node-sdk/test/object/completeMPU.js
@@ -164,9 +164,9 @@ describe('Complete MPU', () => {
                             if (test.error) {
                                 assert.strictEqual(err.code, test.error);
                                 assert.strictEqual(err.statusCode, 400);
-                                next('expected');
+                                return next('expected');
                             }
-                            next(null, data.UploadId);
+                            return next(err, data.UploadId);
                         }),
                         (uploadId, next) => s3.uploadPart({
                             Bucket: bucket,


### PR DESCRIPTION
In the completeMPU test of the aws-node-sdk test suite, fix a case of double callback being called, that can fail when launching locally with mocha.
