### PR TITLE
CLDSRV-317 Implement listLifecycleOrphans

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -200,6 +200,11 @@ const constants = {
     validStorageClasses: [
         'STANDARD',
     ],
+    lifecycleListing: {
+        CURRENT_TYPE: 'current',
+        NON_CURRENT_TYPE: 'noncurrent',
+        ORPHAN_DM_TYPE: 'orphan',
+    },
 };
 
 module.exports = constants;

--- a/lib/api/apiUtils/object/lifecycle.js
+++ b/lib/api/apiUtils/object/lifecycle.js
@@ -1,8 +1,8 @@
 const { versioning } = require('arsenal');
 const versionIdUtils = versioning.VersionID;
 
-const CURRENT_TYPE = 'current';
-const NON_CURRENT_TYPE = 'noncurrent';
+const { lifecycleListing } = require('../../../../constants');
+const { CURRENT_TYPE, NON_CURRENT_TYPE, ORPHAN_DM_TYPE } = lifecycleListing;
 
 function _makeTags(tags) {
     const res = [];
@@ -42,7 +42,7 @@ function processCurrents(bucketName, listParams, list) {
             },
             StorageClass: v.StorageClass,
             TagSet: _makeTags(v.tags),
-            IsLatest: true, // for compatibily
+            IsLatest: true, // for compatibility with AWS ListObjectVersions.
             DataStoreName: v.dataStoreName,
             ListType: CURRENT_TYPE,
         };
@@ -105,7 +105,44 @@ function processNonCurrents(bucketName, listParams, list) {
     return data;
 }
 
+function processOrphans(bucketName, listParams, list) {
+    const data = {
+        Name: bucketName,
+        Prefix: listParams.prefix,
+        MaxKeys: listParams.maxKeys,
+        IsTruncated: !!list.IsTruncated,
+        Marker: listParams.marker,
+        BeforeDate: listParams.beforeDate,
+        NextMarker: list.NextMarker,
+        Contents: [],
+    };
+
+    list.Contents.forEach(item => {
+        const v = item.value;
+        const versionId = (v.IsNull || v.VersionId === undefined) ?
+            'null' : versionIdUtils.encode(v.VersionId);
+        data.Contents.push({
+            Key: item.key,
+            LastModified: v.LastModified,
+            Etag: v.ETag,
+            Size: v.Size,
+            Owner: {
+                ID: v.Owner.ID,
+                DisplayName: v.Owner.DisplayName
+            },
+            StorageClass: v.StorageClass,
+            VersionId: versionId,
+            IsLatest: true, // for compatibility with AWS ListObjectVersions.
+            DataStoreName: v.dataStoreName,
+            ListType: ORPHAN_DM_TYPE,
+        });
+    });
+
+    return data;
+}
+
 module.exports = {
     processCurrents,
     processNonCurrents,
+    processOrphans,
 };

--- a/lib/api/backbeat/listLifecycleOrphanDeleteMarkers.js
+++ b/lib/api/backbeat/listLifecycleOrphanDeleteMarkers.js
@@ -1,0 +1,99 @@
+const { errors } = require('arsenal');
+const constants = require('../../../constants');
+const services = require('../../services');
+const { metadataValidateBucket } = require('../../metadata/metadataUtils');
+const { pushMetric } = require('../../utapi/utilities');
+const monitoring = require('../../utilities/monitoringHandler');
+const { processOrphans } = require('../apiUtils/object/lifecycle');
+
+function handleResult(listParams, requestMaxKeys, authInfo,
+    bucketName, list, log, callback) {
+    // eslint-disable-next-line no-param-reassign
+    listParams.maxKeys = requestMaxKeys;
+    const res = processOrphans(bucketName, listParams, list);
+
+    pushMetric('listLifecycleOrphanDeleteMarkers', log, { authInfo, bucket: bucketName });
+    monitoring.promMetrics('GET', bucketName, '200', 'listLifecycleOrphanDeleteMarkers');
+    return callback(null, res);
+}
+
+/**
+ * listLifecycleOrphanDeleteMarkers - Return list of expired object delete marker in bucket
+ * @param  {AuthInfo} authInfo - Instance of AuthInfo class with
+ *                               requester's info
+ * @param  {object} request    - http request object
+ * @param  {function} log      - Werelogs request logger
+ * @param  {function} callback - callback to respond to http request
+ *                               with either error code or xml response body
+ * @return {undefined}
+ */
+function listLifecycleOrphanDeleteMarkers(authInfo, request, log, callback) {
+    const params = request.query;
+    const bucketName = request.bucketName;
+
+    log.debug('processing request', { method: 'listLifecycleOrphanDeleteMarkers' });
+    const requestMaxKeys = params['max-keys'] ?
+        Number.parseInt(params['max-keys'], 10) : 1000;
+    if (Number.isNaN(requestMaxKeys) || requestMaxKeys < 0) {
+        monitoring.promMetrics(
+            'GET', bucketName, 400, 'listBucket');
+        return callback(errors.InvalidArgument);
+    }
+    const actualMaxKeys = Math.min(constants.listingHardLimit, requestMaxKeys);
+
+    const metadataValParams = {
+        authInfo,
+        bucketName,
+        requestType: 'listLifecycleOrphanDeleteMarkers',
+        request,
+    };
+    const listParams = {
+        listingType: 'DelimiterOrphanDeleteMarker',
+        maxKeys: actualMaxKeys,
+        prefix: params.prefix,
+        beforeDate: params['before-date'],
+        marker: params.marker,
+    };
+
+    return metadataValidateBucket(metadataValParams, log, (err, bucket) => {
+        if (err) {
+            log.debug('error processing request', { method: 'metadataValidateBucket', error: err });
+            monitoring.promMetrics(
+                'GET', bucketName, err.code, 'listLifecycleOrphanDeleteMarkers');
+            return callback(err, null);
+        }
+
+        const vcfg = bucket.getVersioningConfiguration();
+        const isBucketVersioned = vcfg && (vcfg.Status === 'Enabled' || vcfg.Status === 'Suspended');
+        if (!isBucketVersioned) {
+            log.debug('bucket is not versioned or suspended');
+            return callback(errors.InvalidRequest.customizeDescription(
+                'bucket is not versioned'), null);
+        }
+
+        if (!requestMaxKeys) {
+            const emptyList = {
+                Contents: [],
+                IsTruncated: false,
+            };
+            return handleResult(listParams, requestMaxKeys, authInfo,
+                bucketName, emptyList, log, callback);
+        }
+
+        return services.getLifecycleListing(bucketName, listParams, log,
+        (err, list) => {
+            if (err) {
+                log.debug('error processing request', { error: err });
+                monitoring.promMetrics(
+                    'GET', bucketName, err.code, 'listLifecycleOrphanDeleteMarkers');
+                return callback(err, null);
+            }
+            return handleResult(listParams, requestMaxKeys, authInfo,
+                bucketName, list, log, callback);
+        });
+    });
+}
+
+module.exports = {
+    listLifecycleOrphanDeleteMarkers,
+};

--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -34,10 +34,13 @@ const { pushReplicationMetric } = require('./utilities/pushReplicationMetric');
 const kms = require('../kms/wrapper');
 const { listLifecycleCurrents } = require('../api/backbeat/listLifecycleCurrents');
 const { listLifecycleNonCurrents } = require('../api/backbeat/listLifecycleNonCurrents');
+const { listLifecycleOrphanDeleteMarkers } = require('../api/backbeat/listLifecycleOrphanDeleteMarkers');
+const { CURRENT_TYPE, NON_CURRENT_TYPE, ORPHAN_DM_TYPE } = constants.lifecycleListing;
 
 const lifecycleTypeCalls = {
-    'current': listLifecycleCurrents,
-    'noncurrent': listLifecycleNonCurrents,
+    [CURRENT_TYPE]: listLifecycleCurrents,
+    [NON_CURRENT_TYPE]: listLifecycleNonCurrents,
+    [ORPHAN_DM_TYPE]: listLifecycleOrphanDeleteMarkers,
 };
 
 auth.setHandler(vault);
@@ -329,6 +332,7 @@ GET /_/backbeat/multiplebackendmetadata/<bucket name>/<object key>
 POST /_/backbeat/batchdelete
 GET /_/backbeat/lifecycle/<bucket name>?list-type=current
 GET /_/backbeat/lifecycle/<bucket name>?list-type=noncurrent
+GET /_/backbeat/lifecycle/<bucket name>?list-type=orphan
 */
 
 function _getLastModified(locations, log, cb) {

--- a/tests/functional/backbeat/listLifecycleCurrents.js
+++ b/tests/functional/backbeat/listLifecycleCurrents.js
@@ -119,6 +119,26 @@ function checkContents(contents) {
             });
         });
 
+        it('should return empty list if max-keys is set to 0', done => {
+            makeBackbeatRequest({
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: { 'list-type': 'current', 'max-keys': '0' },
+                authCredentials: credentials,
+            }, (err, response) => {
+                assert.ifError(err);
+                assert.strictEqual(response.statusCode, 200);
+                const data = JSON.parse(response.body);
+
+                assert.strictEqual(data.IsTruncated, false);
+                assert(!data.NextMarker);
+                assert.strictEqual(data.MaxKeys, 0);
+                assert.strictEqual(data.Contents.length, 0);
+
+                return done();
+            });
+        });
+
         it('should return NoSuchBucket error if bucket does not exist', done => {
             makeBackbeatRequest({
                 method: 'GET',

--- a/tests/functional/backbeat/listLifecycleNonCurrents.js
+++ b/tests/functional/backbeat/listLifecycleNonCurrents.js
@@ -135,6 +135,26 @@ runIfMongoV1('listLifecycleNonCurrents', () => {
         });
     });
 
+    it('should return empty list if max-keys is set to 0', done => {
+        makeBackbeatRequest({
+            method: 'GET',
+            bucket: testBucket,
+            queryObj: { 'list-type': 'noncurrent', 'max-keys': '0' },
+            authCredentials: credentials,
+        }, (err, response) => {
+            assert.ifError(err);
+            assert.strictEqual(response.statusCode, 200);
+            const data = JSON.parse(response.body);
+
+            assert.strictEqual(data.IsTruncated, false);
+            assert(!data.NextMarker);
+            assert.strictEqual(data.MaxKeys, 0);
+            assert.strictEqual(data.Contents.length, 0);
+
+            return done();
+        });
+    });
+
     it('should return error if bucket does not exist', done => {
         makeBackbeatRequest({
             method: 'GET',

--- a/tests/functional/backbeat/listLifecycleOrphanDeleteMarkers.js
+++ b/tests/functional/backbeat/listLifecycleOrphanDeleteMarkers.js
@@ -1,0 +1,358 @@
+const assert = require('assert');
+const async = require('async');
+const BucketUtility = require('../aws-node-sdk/lib/utility/bucket-util');
+const { removeAllVersions } = require('../aws-node-sdk/lib/utility/versioning-util');
+const { makeBackbeatRequest, runIfMongoV1 } = require('./utils');
+
+const testBucket = 'bucket-for-list-lifecycle-orphans-tests';
+const emptyBucket = 'empty-bucket-for-list-lifecycle-orphans-tests';
+const nonVersionedBucket = 'non-versioned-bucket-for-list-lifecycle-orphans-tests';
+
+const credentials = {
+    accessKey: 'accessKey1',
+    secretKey: 'verySecretKey1',
+};
+
+function checkContents(contents) {
+    contents.forEach(d => {
+        assert(d.Key);
+        assert(d.LastModified);
+        assert(d.VersionId);
+        assert(d.Etag);
+        assert(d.Owner.DisplayName);
+        assert(d.Owner.ID);
+        assert(d.StorageClass);
+        assert.strictEqual(d.StorageClass, 'STANDARD');
+        assert(!d.TagSet);
+        assert.strictEqual(d.IsLatest, true);
+        assert.strictEqual(d.DataStoreName, 'us-east-1');
+        assert.strictEqual(d.ListType, 'orphan');
+        assert.strictEqual(d.Size, 0);
+    });
+}
+
+function createOrphanDeleteMarker(s3, bucketName, keyName, cb) {
+    let versionId;
+    return async.series([
+        next => s3.putObject({ Bucket: bucketName, Key: keyName, Body: '123', Tagging: 'mykey=myvalue' },
+            (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                versionId = data.VersionId;
+                return next();
+            }),
+        next => s3.deleteObject({ Bucket: bucketName, Key: keyName }, next),
+        next => s3.deleteObject({ Bucket: bucketName, Key: keyName, VersionId: versionId }, next),
+    ], cb);
+}
+
+runIfMongoV1('listLifecycleOrphanDeleteMarkers', () => {
+    let bucketUtil;
+    let s3;
+    let date;
+
+    before(done => {
+        bucketUtil = new BucketUtility('account1', { signatureVersion: 'v4' });
+        s3 = bucketUtil.s3;
+
+        return async.series([
+            next => s3.createBucket({ Bucket: testBucket }, next),
+            next => s3.createBucket({ Bucket: emptyBucket }, next),
+            next => s3.createBucket({ Bucket: nonVersionedBucket }, next),
+            next => s3.putBucketVersioning({
+                Bucket: testBucket,
+                VersioningConfiguration: { Status: 'Enabled' },
+            }, next),
+            next => s3.putBucketVersioning({
+                Bucket: emptyBucket,
+                VersioningConfiguration: { Status: 'Enabled' },
+            }, next),
+            next => async.times(3, (n, cb) => {
+                createOrphanDeleteMarker(s3, testBucket, `key${n}old`, cb);
+            }, next),
+            next => {
+                date = new Date(Date.now()).toISOString();
+                return async.times(5, (n, cb) => {
+                    createOrphanDeleteMarker(s3, testBucket, `key${n}`, cb);
+                }, next);
+            },
+        ], done);
+    });
+
+    after(done => async.series([
+        next => removeAllVersions({ Bucket: testBucket }, next),
+        next => s3.deleteBucket({ Bucket: testBucket }, next),
+        next => s3.deleteBucket({ Bucket: emptyBucket }, next),
+        next => s3.deleteBucket({ Bucket: nonVersionedBucket }, next),
+    ], done));
+
+    it('should return empty list of orphan delete markers if bucket is empty', done => {
+        makeBackbeatRequest({
+            method: 'GET',
+            bucket: emptyBucket,
+            queryObj: { 'list-type': 'orphan' },
+            authCredentials: credentials,
+        }, (err, response) => {
+            assert.ifError(err);
+            assert.strictEqual(response.statusCode, 200);
+
+            const data = JSON.parse(response.body);
+            assert.strictEqual(data.IsTruncated, false);
+            assert(!data.NextMarker);
+            assert.strictEqual(data.MaxKeys, 1000);
+            assert.strictEqual(data.Contents.length, 0);
+
+            return done();
+        });
+    });
+
+    it('should return empty list of orphan delete markers if prefix does not apply', done => {
+        makeBackbeatRequest({
+            method: 'GET',
+            bucket: testBucket,
+            queryObj: { 'list-type': 'orphan', prefix: 'unknown' },
+            authCredentials: credentials,
+        }, (err, response) => {
+            assert.ifError(err);
+            assert.strictEqual(response.statusCode, 200);
+
+            const data = JSON.parse(response.body);
+            assert.strictEqual(data.IsTruncated, false);
+            assert(!data.NextMarker);
+            assert.strictEqual(data.MaxKeys, 1000);
+            assert.strictEqual(data.Contents.length, 0);
+
+            return done();
+        });
+    });
+
+    it('should return empty list if max-keys is set to 0', done => {
+        makeBackbeatRequest({
+            method: 'GET',
+            bucket: testBucket,
+            queryObj: { 'list-type': 'orphan', 'max-keys': '0' },
+            authCredentials: credentials,
+        }, (err, response) => {
+            assert.ifError(err);
+            assert.strictEqual(response.statusCode, 200);
+
+            const data = JSON.parse(response.body);
+            assert.strictEqual(data.IsTruncated, false);
+            assert(!data.NextMarker);
+            assert.strictEqual(data.MaxKeys, 0);
+            assert.strictEqual(data.Contents.length, 0);
+
+            return done();
+        });
+    });
+
+    it('should return InvalidArgument error if max-keys is invalid', done => {
+        makeBackbeatRequest({
+            method: 'GET',
+            bucket: testBucket,
+            queryObj: { 'list-type': 'orphan', 'max-keys': 'a' },
+            authCredentials: credentials,
+        }, err => {
+            assert.strictEqual(err.code, 'InvalidArgument');
+            return done();
+        });
+    });
+
+    it('should return error if bucket does not exist', done => {
+        makeBackbeatRequest({
+            method: 'GET',
+            bucket: 'idonotexist',
+            queryObj: { 'list-type': 'orphan' },
+            authCredentials: credentials,
+        }, err => {
+            assert.strictEqual(err.code, 'NoSuchBucket');
+            return done();
+        });
+    });
+
+    it('should return all the orphan delete markers', done => {
+        makeBackbeatRequest({
+            method: 'GET',
+            bucket: testBucket,
+            queryObj: { 'list-type': 'orphan' },
+            authCredentials: credentials,
+        }, (err, response) => {
+            assert.ifError(err);
+            assert.strictEqual(response.statusCode, 200);
+
+            const data = JSON.parse(response.body);
+            assert.strictEqual(data.IsTruncated, false);
+            assert(!data.NextMarker);
+            assert.strictEqual(data.MaxKeys, 1000);
+
+            const contents = data.Contents;
+            assert.strictEqual(contents.length, 8);
+            checkContents(contents);
+
+            return done();
+        });
+    });
+
+    it('should return all the orphan delete markers with prefix key1', done => {
+        const prefix = 'key1';
+
+        makeBackbeatRequest({
+            method: 'GET',
+            bucket: testBucket,
+            queryObj: { 'list-type': 'orphan', prefix },
+            authCredentials: credentials,
+        }, (err, response) => {
+            assert.ifError(err);
+            assert.strictEqual(response.statusCode, 200);
+
+            const data = JSON.parse(response.body);
+            assert.strictEqual(data.IsTruncated, false);
+            assert(!data.NextMarker);
+            assert.strictEqual(data.MaxKeys, 1000);
+            assert.strictEqual(data.Prefix, prefix);
+
+            const contents = data.Contents;
+            assert.strictEqual(contents.length, 2);
+            checkContents(contents);
+            assert.strictEqual(contents[0].Key, 'key1');
+            assert.strictEqual(contents[1].Key, 'key1old');
+
+            return done();
+        });
+    });
+
+    it('should return the orphan delete markers before a defined date', done => {
+        makeBackbeatRequest({
+            method: 'GET',
+            bucket: testBucket,
+            queryObj: {
+                'list-type': 'orphan',
+                'before-date': date,
+            },
+            authCredentials: credentials,
+        }, (err, response) => {
+            assert.ifError(err);
+            assert.strictEqual(response.statusCode, 200);
+
+            const data = JSON.parse(response.body);
+            assert.strictEqual(data.IsTruncated, false);
+            assert(!data.NextMarker);
+            assert.strictEqual(data.MaxKeys, 1000);
+            assert.strictEqual(data.Contents.length, 3);
+            assert.strictEqual(data.BeforeDate, date);
+
+            const contents = data.Contents;
+            checkContents(contents);
+            assert.strictEqual(contents[0].Key, 'key0old');
+            assert.strictEqual(contents[1].Key, 'key1old');
+            assert.strictEqual(contents[2].Key, 'key2old');
+
+            return done();
+        });
+    });
+
+    it('should truncate list of orphan delete markers before a defined date', done => {
+        makeBackbeatRequest({
+            method: 'GET',
+            bucket: testBucket,
+            queryObj: {
+                'list-type': 'orphan',
+                'before-date': date,
+                'max-keys': '1',
+            },
+            authCredentials: credentials,
+        }, (err, response) => {
+            assert.ifError(err);
+            assert.strictEqual(response.statusCode, 200);
+
+            const data = JSON.parse(response.body);
+            assert.strictEqual(data.IsTruncated, true);
+            assert.strictEqual(data.NextMarker, 'key0old');
+            assert.strictEqual(data.MaxKeys, 1);
+            assert.strictEqual(data.BeforeDate, date);
+            assert.strictEqual(data.Contents.length, 1);
+
+            const contents = data.Contents;
+            checkContents(contents);
+            assert.strictEqual(contents[0].Key, 'key0old');
+
+            return done();
+        });
+    });
+
+    it('should return the second truncate list of orphan delete markers before a defined date', done => {
+        makeBackbeatRequest({
+            method: 'GET',
+            bucket: testBucket,
+            queryObj: { 'list-type': 'orphan', 'before-date': date, 'max-keys': '1', 'marker': 'key0old' },
+            authCredentials: credentials,
+        }, (err, response) => {
+            assert.ifError(err);
+            assert.strictEqual(response.statusCode, 200);
+
+            const data = JSON.parse(response.body);
+            assert.strictEqual(data.IsTruncated, true);
+            assert.strictEqual(data.Marker, 'key0old');
+            assert.strictEqual(data.NextMarker, 'key1old');
+            assert.strictEqual(data.MaxKeys, 1);
+            assert.strictEqual(data.Contents.length, 1);
+
+            const contents = data.Contents;
+            checkContents(contents);
+            assert.strictEqual(contents[0].Key, 'key1old');
+            assert.strictEqual(data.BeforeDate, date);
+
+            return done();
+        });
+    });
+
+    it('should return the third truncate list of orphan delete markers before a defined date', done => {
+        makeBackbeatRequest({
+            method: 'GET',
+            bucket: testBucket,
+            queryObj: { 'list-type': 'orphan', 'before-date': date, 'max-keys': '1', 'marker': 'key1old' },
+            authCredentials: credentials,
+        }, (err, response) => {
+            assert.ifError(err);
+            assert.strictEqual(response.statusCode, 200);
+
+            const data = JSON.parse(response.body);
+            assert.strictEqual(data.IsTruncated, true);
+            assert.strictEqual(data.MaxKeys, 1);
+            assert.strictEqual(data.Marker, 'key1old');
+            assert.strictEqual(data.BeforeDate, date);
+            assert.strictEqual(data.NextMarker, 'key2old');
+
+            const contents = data.Contents;
+            assert.strictEqual(contents.length, 1);
+            checkContents(contents);
+            assert.strictEqual(contents[0].Key, 'key2old');
+
+            return done();
+        });
+    });
+
+    it('should return the fourth and last truncate list of orphan delete markers before a defined date', done => {
+        makeBackbeatRequest({
+            method: 'GET',
+            bucket: testBucket,
+            queryObj: { 'list-type': 'orphan', 'before-date': date, 'max-keys': '1', 'marker': 'key2old' },
+            authCredentials: credentials,
+        }, (err, response) => {
+            assert.ifError(err);
+            assert.strictEqual(response.statusCode, 200);
+
+            const data = JSON.parse(response.body);
+            assert.strictEqual(data.IsTruncated, false);
+            assert.strictEqual(data.MaxKeys, 1);
+            assert.strictEqual(data.Marker, 'key2old');
+            assert.strictEqual(data.BeforeDate, date);
+
+            const contents = data.Contents;
+            assert.strictEqual(contents.length, 0);
+
+            return done();
+        });
+    });
+});


### PR DESCRIPTION
listLifecycleOrphans API will be used by Backbeat Lifecycle Bucket Processor to list the orphan delete markers before a defined date.

GET /_/backbeat/lifecycle/bucketname?list-type=orphan&before-date=<time_stamp>