### PR TITLE
ft: CLDSRV-354 handle null keys in metadata GET helpers

### DIFF
--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -40,7 +40,7 @@ function decodeVersionId(reqQuery) {
  */
 function getVersionIdResHeader(verCfg, objectMD) {
     if (verCfg) {
-        if (objectMD.isNull || (objectMD && !objectMD.versionId)) {
+        if (objectMD.isNull || !objectMD.versionId) {
             return 'null';
         }
         return versionIdUtils.encode(objectMD.versionId,

--- a/lib/metadata/metadataUtils.js
+++ b/lib/metadata/metadataUtils.js
@@ -118,6 +118,48 @@ function metadataGetObject(bucketName, objectKey, versionId, log, cb) {
         });
 }
 
+/**
+ * Validate that a bucket is accessible and authorized to the user,
+ * return a specific error code otherwise
+ *
+ * @param {BucketInfo} bucket - bucket info
+ * @param {object} params - function parameters
+ * @param {AuthInfo} params.authInfo - AuthInfo class instance, requester's info
+ * @param {string} params.requestType - type of request
+ * @param {string} [params.preciseRequestType] - precise type of request
+ * @param {object} params.request - http request object
+ * @param {RequestLogger} log - request logger
+ * @return {ArsenalError|null} returns a validation error, or null if validation OK
+ * The following errors may be returned:
+ * - NoSuchBucket: bucket is shielded
+ * - MethodNotAllowed: requester is not bucket owner and asking for a
+ *     bucket policy operation
+ * - AccessDenied: bucket is not authorized
+ */
+function validateBucket(bucket, params, log) {
+    const { authInfo, requestType, preciseRequestType, request } = params;
+    if (bucketShield(bucket, requestType)) {
+        log.debug('bucket is shielded from request', {
+            requestType,
+            method: 'validateBucket',
+        });
+        return errors.NoSuchBucket;
+    }
+    // if requester is not bucket owner, bucket policy actions should be denied with
+    // MethodNotAllowed error
+    const onlyOwnerAllowed = ['bucketDeletePolicy', 'bucketGetPolicy', 'bucketPutPolicy'];
+    const canonicalID = authInfo.getCanonicalID();
+    if (bucket.getOwner() !== canonicalID && onlyOwnerAllowed.includes(requestType)) {
+        return errors.MethodNotAllowed;
+    }
+    if (!isBucketAuthorized(bucket, (preciseRequestType || requestType), canonicalID,
+                            authInfo, log, request)) {
+        log.debug('access denied for user on bucket', { requestType });
+        return errors.AccessDenied;
+    }
+    return null;
+}
+
 /** metadataValidateBucketAndObj - retrieve bucket and object md from metadata
  * and check if user is authorized to access them.
  * @param {object} params - function parameters
@@ -236,6 +278,7 @@ function metadataValidateBucket(params, log, callback) {
 }
 
 module.exports = {
+    validateBucket,
     metadataGetObject,
     metadataValidateBucketAndObj,
     metadataValidateBucket,

--- a/lib/metadata/metadataUtils.js
+++ b/lib/metadata/metadataUtils.js
@@ -7,82 +7,53 @@ const { isBucketAuthorized, isObjAuthorized } =
     require('../api/apiUtils/authorization/permissionChecks');
 const bucketShield = require('../api/apiUtils/bucket/bucketShield');
 
-/** getNullVersion - return metadata of null version if it exists
- * @param {object} objMD - metadata of master version
+/** getNullVersionFromMaster - retrieves the null version
+ * metadata via retrieving the master key
+ *
+ * Used in the following cases:
+ *
+ * - master key is non-versioned (and hence is the 'null' version)
+ *
+ * - the null version is stored in a versioned key and its reference
+ *   is in the master key as 'nullVersionId' (compatibility mode with
+ *   old null version storage)
+ *
  * @param {string} bucketName - name of bucket
  * @param {string} objectKey - name of object key
  * @param {RequestLogger} log - request logger
- * @param {function} cb - callback
- * @return {undefined} - and call callback with params err, objMD of null ver
+ * @param {function} cb - callback(err: Error, nullMD: object)
+ * @return {undefined}
  */
-function getNullVersion(objMD, bucketName, objectKey, log, cb) {
-    const options = {};
-    if (objMD.isNull || !objMD.versionId) {
-        // null version is current version
-        log.debug('found null version');
-        return process.nextTick(() => cb(null, objMD));
-    }
-    if (objMD.nullVersionId) {
-        // the latest version is not the null version, but null version exists
-        log.debug('null version exists, get the null version');
-        options.versionId = objMD.nullVersionId;
-        return metadata.getObjectMD(bucketName, objectKey, options, log, (err, nullVersionMD) => {
-            if (err && err.is && err.is.NoSuchKey) {
-                log.debug('object does not exist in metadata');
-                return cb();
+function getNullVersionFromMaster(bucketName, objectKey, log, cb) {
+    async.waterfall([
+        next => metadata.getObjectMD(bucketName, objectKey, {}, log, next),
+        (masterMD, next) => {
+            if (masterMD.isNull || !masterMD.versionId) {
+                log.debug('null version is master version');
+                return process.nextTick(() => next(null, masterMD));
             }
-            return cb(err, nullVersionMD);
-        });
-    }
-    log.debug('could not find a null version');
-    return process.nextTick(() => cb());
-}
-
-/** metadataGetBucketAndObject - retrieves bucket and specified version
- * NOTE: If the value of `versionId` param is 'null', this function returns the
- * master version objMD. The null version object md must be retrieved in a
- * separate step using the master object md: see getNullVersion().
- * @param {string} requestType - type of request
- * @param {string} bucketName - name of bucket
- * @param {string} objectKey - name of object key
- * @param {string} [versionId] - version of object to retrieve
- * @param {RequestLogger} log - request logger
- * @param {function} cb - callback
- * @return {undefined} - and call callback with err, bucket md and object md
- */
-function metadataGetBucketAndObject(requestType, bucketName, objectKey,
-    versionId, log, cb) {
-    const options = {
-        // if attempting to get 'null' version, must retrieve null version id
-        // from most current object md (versionId = undefined)
-        versionId: versionId === 'null' ? undefined : versionId,
-    };
-    return metadata.getBucketAndObjectMD(bucketName, objectKey, options, log,
-        (err, data) => {
-            if (err) {
-                log.debug('metadata get failed', { error: err });
-                return cb(err);
+            if (masterMD.nullVersionId) {
+                // the latest version is not the null version, but null version exists
+                // NOTE: for backward-compat with old null version scheme
+                log.debug('get the null version via nullVersionId');
+                const getOptions = {
+                    versionId: masterMD.nullVersionId,
+                };
+                return metadata.getObjectMD(bucketName, objectKey, getOptions, log, next);
             }
-            const bucket = data.bucket ? BucketInfo.deSerialize(data.bucket) :
-                undefined;
-            const obj = data.obj ? JSON.parse(data.obj) : undefined;
-            if (!bucket) {
-                log.debug('bucketAttrs is undefined', {
-                    bucket: bucketName,
-                    method: 'metadataGetBucketAndObject',
-                });
-                return cb(errors.NoSuchBucket);
-            }
-            if (bucketShield(bucket, requestType)) {
-                log.debug('bucket is shielded from request', {
-                    requestType,
-                    method: 'metadataGetBucketAndObject',
-                });
-                return cb(errors.NoSuchBucket);
-            }
-            log.trace('found bucket in metadata');
-            return cb(null, bucket, obj);
-        });
+            return next(errors.NoSuchKey);
+        },
+    ], (err, nullMD) => {
+        if (err && err.is && err.is.NoSuchKey) {
+            log.debug('could not find a null version');
+            return cb();
+        }
+        if (err) {
+            log.debug('err getting object MD from metadata', { error: err });
+            return cb(err);
+        }
+        return cb(null, nullMD);
+    });
 }
 
 /** metadataGetObject - retrieves specified object or version from metadata
@@ -94,25 +65,20 @@ function metadataGetBucketAndObject(requestType, bucketName, objectKey,
  * @return {undefined} - and call callback with err, bucket md and object md
  */
 function metadataGetObject(bucketName, objectKey, versionId, log, cb) {
-    const options = {
-        // if attempting to get 'null' version, must first retrieve null version
-        // id from most current object md (by setting versionId as undefined
-        // we retrieve the most current object md)
-        versionId: versionId === 'null' ? undefined : versionId,
-    };
+    // versionId may be 'null', which asks metadata to fetch the null key specifically
+    const options = { versionId };
     return metadata.getObjectMD(bucketName, objectKey, options, log,
         (err, objMD) => {
-            if (err && err.is && err.is.NoSuchKey) {
-                log.debug('object does not exist in metadata');
-                return cb();
-            }
             if (err) {
-                log.debug('err getting object MD from metadata',
-                { error: err });
+                if (err.is && err.is.NoSuchKey && versionId === 'null') {
+                    return getNullVersionFromMaster(bucketName, objectKey, log, cb);
+                }
+                if (err.is && err.is.NoSuchKey) {
+                    log.debug('object does not exist in metadata');
+                    return cb();
+                }
+                log.debug('err getting object MD from metadata', { error: err });
                 return cb(err);
-            }
-            if (versionId === 'null') {
-                return getNullVersion(objMD, bucketName, objectKey, log, cb);
             }
             return cb(null, objMD);
         });
@@ -174,35 +140,36 @@ function validateBucket(bucket, params, log) {
  * @return {undefined} - and call callback with params err, bucket md
  */
 function metadataValidateBucketAndObj(params, log, callback) {
-    const { authInfo, bucketName, objectKey, versionId, requestType, preciseRequestType, request } = params;
-    const canonicalID = authInfo.getCanonicalID();
+    const { authInfo, bucketName, objectKey, versionId, requestType, request } = params;
     async.waterfall([
-        function getBucketAndObjectMD(next) {
-            return metadataGetBucketAndObject(requestType, bucketName,
-                objectKey, versionId, log, next);
+        next => {
+            // versionId may be 'null', which asks metadata to fetch the null key specifically
+            const getOptions = { versionId };
+            return metadata.getBucketAndObjectMD(bucketName, objectKey, getOptions, log, next);
         },
-        function checkBucketAuth(bucket, objMD, next) {
-            // if requester is not bucket owner, bucket policy actions should be denied with
-            // MethodNotAllowed error
-            const onlyOwnerAllowed = ['bucketDeletePolicy', 'bucketGetPolicy', 'bucketPutPolicy'];
-            if (bucket.getOwner() !== canonicalID && onlyOwnerAllowed.includes(requestType)) {
-                return next(errors.MethodNotAllowed, bucket);
+        (getResult, next) => {
+            const bucket = getResult.bucket ?
+                  BucketInfo.deSerialize(getResult.bucket) : undefined;
+            if (!bucket) {
+                log.debug('bucketAttrs is undefined', {
+                    bucket: bucketName,
+                    method: 'metadataValidateBucketAndObj',
+                });
+                return next(errors.NoSuchBucket);
             }
-            if (!isBucketAuthorized(bucket, (preciseRequestType || requestType), canonicalID,
-            authInfo, log, request)) {
-                log.debug('access denied for user on bucket', { requestType });
-                return next(errors.AccessDenied, bucket);
+            const validationError = validateBucket(bucket, params, log);
+            if (validationError) {
+                return next(validationError, bucket);
+            }
+            const objMD = getResult.obj ? JSON.parse(getResult.obj) : undefined;
+            if (!objMD && versionId === 'null') {
+                return getNullVersionFromMaster(bucketName, objectKey, log,
+                     (err, nullVer) => next(err, bucket, nullVer));
             }
             return next(null, bucket, objMD);
         },
-        function handleNullVersionGet(bucket, objMD, next) {
-            if (objMD && versionId === 'null') {
-                return getNullVersion(objMD, bucketName, objectKey, log,
-                    (err, nullVer) => next(err, bucket, nullVer));
-            }
-            return next(null, bucket, objMD);
-        },
-        function checkObjectAuth(bucket, objMD, next) {
+        (bucket, objMD, next) => {
+            const canonicalID = authInfo.getCanonicalID();
             if (!isObjAuthorized(bucket, objMD, requestType, canonicalID, authInfo, log, request)) {
                 log.debug('access denied for user on object', { requestType });
                 return next(errors.AccessDenied, bucket);
@@ -218,32 +185,6 @@ function metadataValidateBucketAndObj(params, log, callback) {
     });
 }
 
-/** metadataGetBucket - retrieves bucket from metadata, returning error if
- * bucket is shielded
- * @param {string} requestType - type of request
- * @param {string} bucketName - name of bucket
- * @param {RequestLogger} log - request logger
- * @param {function} cb - callback
- * @return {undefined} - and call callback with err, bucket md
- */
-function metadataGetBucket(requestType, bucketName, log, cb) {
-    return metadata.getBucket(bucketName, log, (err, bucket) => {
-        if (err) {
-            log.debug('metadata getbucket failed', { error: err });
-            return cb(err);
-        }
-        if (bucketShield(bucket, requestType)) {
-            log.debug('bucket is shielded from request', {
-                requestType,
-                method: 'metadataGetBucketAndObject',
-            });
-            return cb(errors.NoSuchBucket);
-        }
-        log.trace('found bucket in metadata');
-        return cb(null, bucket);
-    });
-}
-
 /** metadataValidateBucket - retrieve bucket from metadata and check if user
  * is authorized to access it
  * @param {object} params - function parameters
@@ -256,24 +197,14 @@ function metadataGetBucket(requestType, bucketName, log, cb) {
  * @return {undefined} - and call callback with params err, bucket md
  */
 function metadataValidateBucket(params, log, callback) {
-    const { authInfo, bucketName, requestType, preciseRequestType, request } = params;
-    const canonicalID = authInfo.getCanonicalID();
-    return metadataGetBucket(requestType, bucketName, log, (err, bucket) => {
+    const { bucketName } = params;
+    return metadata.getBucket(bucketName, log, (err, bucket) => {
         if (err) {
+            log.debug('metadata getbucket failed', { error: err });
             return callback(err);
         }
-        // if requester is not bucket owner, bucket policy actions should be denied with
-        // MethodNotAllowed error
-        const onlyOwnerAllowed = ['bucketDeletePolicy', 'bucketGetPolicy', 'bucketPutPolicy'];
-        if (bucket.getOwner() !== canonicalID && onlyOwnerAllowed.includes(requestType)) {
-            return callback(errors.MethodNotAllowed, bucket);
-        }
-        // still return bucket for cors headers
-        if (!isBucketAuthorized(bucket, (preciseRequestType || requestType), canonicalID, authInfo, log, request)) {
-            log.debug('access denied for user on bucket', { requestType });
-            return callback(errors.AccessDenied, bucket);
-        }
-        return callback(null, bucket);
+        const validationError = validateBucket(bucket, params, log);
+        return callback(validationError, bucket);
     });
 }
 

--- a/tests/unit/metadata/metadataUtils.spec.js
+++ b/tests/unit/metadata/metadataUtils.spec.js
@@ -1,0 +1,55 @@
+const assert = require('assert');
+
+const { models } = require('arsenal');
+const { BucketInfo } = models;
+const { DummyRequestLogger, makeAuthInfo } = require('../helpers');
+
+const creationDate = new Date().toJSON();
+const authInfo = makeAuthInfo('accessKey');
+const otherAuthInfo = makeAuthInfo('otherAccessKey');
+const ownerCanonicalId = authInfo.getCanonicalID();
+
+const bucket = new BucketInfo('niftyBucket', ownerCanonicalId,
+    authInfo.getAccountDisplayName(), creationDate);
+const log = new DummyRequestLogger();
+
+const { validateBucket } = require('../../../lib/metadata/metadataUtils');
+
+describe('validateBucket', () => {
+    it('action bucketPutPolicy by bucket owner', () => {
+        const validationResult = validateBucket(bucket, {
+            authInfo,
+            requestType: 'bucketPutPolicy',
+            request: null,
+        }, log);
+        assert.ifError(validationResult);
+    });
+    it('action bucketPutPolicy by other than bucket owner', () => {
+        const validationResult = validateBucket(bucket, {
+            authInfo: otherAuthInfo,
+            requestType: 'bucketPutPolicy',
+            request: null,
+        }, log);
+        assert(validationResult);
+        assert(validationResult.is.MethodNotAllowed);
+    });
+
+    it('action bucketGet by bucket owner', () => {
+        const validationResult = validateBucket(bucket, {
+            authInfo,
+            requestType: 'bucketGet',
+            request: null,
+        }, log);
+        assert.ifError(validationResult);
+    });
+
+    it('action bucketGet by other than bucket owner', () => {
+        const validationResult = validateBucket(bucket, {
+            authInfo: otherAuthInfo,
+            requestType: 'bucketGet',
+            request: null,
+        }, log);
+        assert(validationResult);
+        assert(validationResult.is.AccessDenied);
+    });
+});


### PR DESCRIPTION
Update the helpers in metadataUtils to handle null keys, as well as keeping backward compatibility with null versioned keys.

The main change in logic for null keys is that, instead of fetching first the master key then the null versioned key, we first attempt to fetch the null key, and if not found, we fetch the master key (we may then also have to fetch the null versioned key for backward compatibility).

Take the chance to reduce tech debt by reorganizing the helpers responsibilities in a better way, and by using the "validateBucket" helper.

**note for reviews**: it can make sense to review individual commits