### PR TITLE
impr: CLDSRV-356 enhance processVersioningState() and fix replayId

### DIFF
--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -257,8 +257,9 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
             metadataStoreParams.versionId = options.versionId;
             metadataStoreParams.versioning = options.versioning;
             metadataStoreParams.isNull = options.isNull;
-            metadataStoreParams.nullVersionId = options.nullVersionId;
-            metadataStoreParams.nullUploadId = options.nullUploadId;
+            if (options.extraMD) {
+                Object.assign(metadataStoreParams, options.extraMD);
+            }
             return _storeInMDandDeleteData(bucketName, infoArr,
                 cipherBundle, metadataStoreParams,
                 options.dataToDelete, requestLogger, requestMethod, next);

--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -140,25 +140,25 @@ function _deleteNullVersionMD(bucketName, objKey, options, mst, log, cb) {
  * @return {object} result object with the following attributes:
  * - {object} options: versioning-related options to pass to the
      services.metadataStoreObject() call
- * - {object} [storeOptions]: options for metadata to create a new
-     null version key, if needed
+ * - {object} [options.extraMD]: extra attributes to set in object metadata
+ * - {string} [nullVersionId]: null version key to create, if needed
  * - {object} [delOptions]: options for metadata to delete the null
      version key, if needed
  */
 function processVersioningState(mst, vstat) {
-    const options = {};
-    const storeOptions = {};
-    const delOptions = {};
-    // object does not exist or is not versioned (before versioning)
-    if (mst.versionId === undefined || mst.isNull) {
-        // versioning is suspended, overwrite existing master version
-        if (vstat === 'Suspended') {
-            options.versionId = '';
-            options.isNull = true;
-            options.dataToDelete = mst.objLocation;
-            // if null version exists, clean it up prior to put
+    const versioningSuspended = (vstat === 'Suspended');
+    const masterIsNull = mst.exists && (mst.isNull || !mst.versionId);
+
+    if (versioningSuspended) {
+        // versioning is suspended: overwrite the existing null version
+        const options = { versionId: '', isNull: true };
+        if (masterIsNull) {
+            // if the null version exists, clean it up prior to put
+            if (mst.objLocation) {
+                options.dataToDelete = mst.objLocation;
+            }
             if (mst.isNull) {
-                delOptions.versionId = mst.versionId;
+                const delOptions = { versionId: mst.versionId };
                 if (mst.uploadId) {
                     delOptions.replayId = mst.uploadId;
                 }
@@ -166,43 +166,36 @@ function processVersioningState(mst, vstat) {
             }
             return { options };
         }
-        // versioning is enabled, create a new version
-        options.versioning = true;
-        if (mst.exists) {
-            // store master version in a new key
-            const versionId = mst.isNull ? mst.versionId : nonVersionedObjId;
-            storeOptions.versionId = versionId;
-            storeOptions.isNull = true;
-            options.nullVersionId = versionId;
-            // non-versioned (non-null) MPU objects don't have a
-            // replay ID, so don't reference their uploadId
-            if (mst.isNull && mst.uploadId) {
-                options.nullUploadId = mst.uploadId;
+        if (mst.nullVersionId) {
+            const delOptions = { versionId: mst.nullVersionId };
+            if (mst.nullUploadId) {
+                delOptions.replayId = mst.nullUploadId;
             }
-            return { options, storeOptions };
+            return { options, delOptions };
         }
         return { options };
     }
-    // master is versioned and is not a null version
-    const nullVersionId = mst.nullVersionId;
-    if (vstat === 'Suspended') {
-        // versioning is suspended, overwrite the existing master version
-        options.versionId = '';
-        options.isNull = true;
-        if (nullVersionId === undefined) {
-            return { options };
+    // versioning is enabled: create a new version
+    const options = { versioning: true };
+    if (masterIsNull) {
+        // store master version in a new key
+        const nullVersionId = mst.isNull ? mst.versionId : nonVersionedObjId;
+        options.extraMD = {
+            nullVersionId,
+        };
+        if (mst.uploadId) {
+            options.extraMD.nullUploadId = mst.uploadId;
         }
-        delOptions.versionId = nullVersionId;
-        if (mst.nullUploadId) {
-            delOptions.replayId = mst.nullUploadId;
-        }
-        return { options, delOptions };
+        return { options, nullVersionId };
     }
-    // versioning is enabled, put the new version
-    options.versioning = true;
-    options.nullVersionId = nullVersionId;
-    if (mst.nullUploadId) {
-        options.nullUploadId = mst.nullUploadId;
+    // versioning is enabled, copy reference to null version ID if it exists
+    if (mst.nullVersionId) {
+        options.extraMD = {
+            nullVersionId: mst.nullVersionId,
+        };
+        if (mst.nullUploadId) {
+            options.extraMD.nullUploadId = mst.nullUploadId;
+        }
     }
     return { options };
 }
@@ -266,17 +259,16 @@ function versioningPreprocessing(bucketName, bucketMD, objectKey, objMD,
         return process.nextTick(callback, null, options);
     }
     // bucket is versioning configured
-    const { options, storeOptions, delOptions } =
+    const { options, nullVersionId, delOptions } =
           processVersioningState(mst, vCfg.Status);
     return async.series([
         function storeVersion(next) {
-            if (!storeOptions) {
+            if (!nullVersionId) {
                 return process.nextTick(next);
             }
-            const versionMD = Object.assign({}, objMD, storeOptions);
-            const params = { versionId: storeOptions.versionId };
-            return _storeNullVersionMD(bucketName, objectKey, versionMD,
-                params, log, next);
+            const versionMD = Object.assign({}, objMD, { versionId: nullVersionId, isNull: true });
+            const params = { versionId: nullVersionId };
+            return _storeNullVersionMD(bucketName, objectKey, versionMD, params, log, next);
         },
         function deleteNullVersion(next) {
             if (!delOptions) {

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -337,8 +337,9 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     metaStoreParams.versionId = options.versionId;
                     metaStoreParams.versioning = options.versioning;
                     metaStoreParams.isNull = options.isNull;
-                    metaStoreParams.nullVersionId = options.nullVersionId;
-                    metaStoreParams.nullUploadId = options.nullUploadId;
+                    if (options.extraMD) {
+                        Object.assign(metaStoreParams, options.extraMD);
+                    }
                     return next(null, destBucket, dataLocations,
                         metaStoreParams, mpuBucket, keysToDelete, aggregateETag,
                         objMD, extraPartLocations, pseudoCipherBundle,

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -438,10 +438,9 @@ function objectCopy(authInfo, request, sourceBucket,
                     storeMetadataParams.versioning = options.versioning;
                     // eslint-disable-next-line
                     storeMetadataParams.isNull = options.isNull;
-                    // eslint-disable-next-line
-                    storeMetadataParams.nullVersionId = options.nullVersionId;
-                    // eslint-disable-next-line
-                    storeMetadataParams.nullUploadId = options.nullUploadId;
+                    if (options.extraMD) {
+                        Object.assign(storeMetadataParams, options.extraMD);
+                    }
                     const dataToDelete = options.dataToDelete;
                     return next(null, storeMetadataParams, destDataGetInfoArr,
                         destObjMD, serverSideEncryption, destBucketMD,

--- a/tests/unit/api/apiUtils/versioning.js
+++ b/tests/unit/api/apiUtils/versioning.js
@@ -70,14 +70,13 @@ describe('versioning helpers', () => {
                 versioningEnabledExpectedRes: {
                     options: {
                         versioning: true,
-                        nullVersionId: 'vnull',
+                        extraMD: {
+                            nullVersionId: 'vnull',
+                        },
                     },
                     // instruct to first copy the null version onto a
                     // newly created version key preserving the version ID
-                    storeOptions: {
-                        isNull: true,
-                        versionId: 'vnull',
-                    },
+                    nullVersionId: 'vnull',
                 },
                 versioningSuspendedExpectedRes: {
                     options: {
@@ -99,15 +98,14 @@ describe('versioning helpers', () => {
                 versioningEnabledExpectedRes: {
                     options: {
                         versioning: true,
-                        nullVersionId: 'vnull',
-                        nullUploadId: 'fooUploadId',
+                        extraMD: {
+                            nullVersionId: 'vnull',
+                            nullUploadId: 'fooUploadId',
+                        },
                     },
                     // instruct to first copy the null version onto a
                     // newly created version key preserving the version ID
-                    storeOptions: {
-                        isNull: true,
-                        versionId: 'vnull',
-                    },
+                    nullVersionId: 'vnull',
                 },
                 versioningSuspendedExpectedRes: {
                     options: {
@@ -127,14 +125,13 @@ describe('versioning helpers', () => {
                 versioningEnabledExpectedRes: {
                     options: {
                         versioning: true,
-                        nullVersionId: INF_VID,
+                        extraMD: {
+                            nullVersionId: INF_VID,
+                        },
                     },
                     // instruct to first copy the null version onto a
                     // newly created version key as the oldest version
-                    storeOptions: {
-                        isNull: true,
-                        versionId: INF_VID,
-                    },
+                    nullVersionId: INF_VID,
                 },
                 versioningSuspendedExpectedRes: {
                     options: {
@@ -152,14 +149,14 @@ describe('versioning helpers', () => {
                 versioningEnabledExpectedRes: {
                     options: {
                         versioning: true,
-                        nullVersionId: INF_VID,
+                        extraMD: {
+                            nullVersionId: INF_VID,
+                            nullUploadId: 'fooUploadId',
+                        },
                     },
                     // instruct to first copy the null version onto a
                     // newly created version key as the oldest version
-                    storeOptions: {
-                        isNull: true,
-                        versionId: INF_VID,
-                    },
+                    nullVersionId: INF_VID,
                 },
                 versioningSuspendedExpectedRes: {
                     options: {
@@ -178,7 +175,9 @@ describe('versioning helpers', () => {
                 versioningEnabledExpectedRes: {
                     options: {
                         versioning: true,
-                        nullVersionId: 'vnull',
+                        extraMD: {
+                            nullVersionId: 'vnull',
+                        },
                     },
                 },
                 versioningSuspendedExpectedRes: {
@@ -202,7 +201,9 @@ describe('versioning helpers', () => {
                 versioningEnabledExpectedRes: {
                     options: {
                         versioning: true,
-                        nullVersionId: 'vnull',
+                        extraMD: {
+                            nullVersionId: 'vnull',
+                        },
                     },
                 },
                 versioningSuspendedExpectedRes: {
@@ -226,8 +227,10 @@ describe('versioning helpers', () => {
                 versioningEnabledExpectedRes: {
                     options: {
                         versioning: true,
-                        nullVersionId: 'vnull',
-                        nullUploadId: 'nullFooUploadId',
+                        extraMD: {
+                            nullVersionId: 'vnull',
+                            nullUploadId: 'nullFooUploadId',
+                        },
                     },
                 },
                 versioningSuspendedExpectedRes: {
@@ -246,16 +249,8 @@ describe('versioning helpers', () => {
             `${testCase.description}, versioning Status=${versioningStatus}`,
             () => {
                 const mst = getMasterState(testCase.objMD);
-                // stringify and parse to get rid of the "undefined"
-                // properties, artifacts of how the function builds the
-                // result
-                const res = JSON.parse(
-                    JSON.stringify(
-                        processVersioningState(mst, versioningStatus)
-                    )
-                );
-                const expectedRes =
-                      testCase[`versioning${versioningStatus}ExpectedRes`];
+                const res = processVersioningState(mst, versioningStatus);
+                const expectedRes = testCase[`versioning${versioningStatus}ExpectedRes`];
                 assert.deepStrictEqual(res, expectedRes);
             })));
     });


### PR DESCRIPTION
- enhance general flow of processVersioningState(), to make it easier to read and update for null key handling

- fix an issue related to passing the uploadId for nonversioned buckets (linked to S3C-7361): remove a check "master.isNull" to also pass the uploadId as replayId when the master is non-versioned, so that it can be deleted by passing it to the metadata DELETE request

- make processVersioningState() return a 'nullVersionId' param rather than a "storeOptions", as it is always used to copy master to a null version, it simplifies a bit the API

- remove undefined params returned by the function to have clean unit tests
