### PR TITLE
feat: CLDSRV-353 processVersioningState() null key support

### DIFF
--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -209,6 +209,18 @@ function processVersioningState(mst, vstat, nullVersionCompatMode) {
             if (mst.uploadId) {
                 options.extraMD.nullUploadId = mst.uploadId;
             }
+            return { options, nullVersionId };
+        }
+        if (mst.isNull && !mst.isNull2) {
+            // if master null version was put with an older
+            // Cloudserver (or in compat mode), there is a
+            // possibility that it also has a null versioned key
+            // associated, so we need to delete it as we write the
+            // null key
+            const delOptions = {
+                versionId: nullVersionId,
+            };
+            return { options, nullVersionId, delOptions };
         }
         return { options, nullVersionId };
     }

--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -212,25 +212,15 @@ function processVersioningState(mst, vstat, nullVersionCompatMode) {
         }
         return { options, nullVersionId };
     }
-    if (nullVersionCompatMode) {
-        // backward-compat: in v0 compatibility mode, keep a reference
-        // to the existing null versioned key
-        if (mst.nullVersionId) {
-            options.extraMD = {
-                nullVersionId: mst.nullVersionId,
-            };
-            if (mst.nullUploadId) {
-                options.extraMD.nullUploadId = mst.nullUploadId;
-            }
-        }
-        return { options };
-    }
+    // backward-compat: keep a reference to the existing null
+    // versioned key
     if (mst.nullVersionId) {
-        // backward-compat: outside of v0 compatibility mode, transform
-        // the existing legacy null versioned key into a null key
-        const nullVersionId = mst.nullVersionId;
-        const delOptions = { versionId: nullVersionId };
-        return { options, nullVersionId, delOptions };
+        options.extraMD = {
+            nullVersionId: mst.nullVersionId,
+        };
+        if (mst.nullUploadId) {
+            options.extraMD.nullUploadId = mst.nullUploadId;
+        }
     }
     return { options };
 }

--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -136,6 +136,10 @@ function _deleteNullVersionMD(bucketName, objKey, options, mst, log, cb) {
  * @param {object} mst - state of master version, as returned by
  * getMasterState()
  * @param {string} vstat - bucket versioning status: 'Enabled' or 'Suspended'
+ * @param {boolean} nullVersionCompatMode - if true, behaves in null
+ * version compatibility mode and return appropriate values: this mode
+ * does not attempt to create null keys but create null versioned keys
+ * instead
  *
  * @return {object} result object with the following attributes:
  * - {object} options: versioning-related options to pass to the
@@ -145,7 +149,7 @@ function _deleteNullVersionMD(bucketName, objKey, options, mst, log, cb) {
  * - {object} [delOptions]: options for metadata to delete the null
      version key, if needed
  */
-function processVersioningState(mst, vstat) {
+function processVersioningState(mst, vstat, nullVersionCompatMode) {
     const versioningSuspended = (vstat === 'Suspended');
     const masterIsNull = mst.exists && (mst.isNull || !mst.versionId);
 
@@ -157,45 +161,71 @@ function processVersioningState(mst, vstat) {
             if (mst.objLocation) {
                 options.dataToDelete = mst.objLocation;
             }
+            // backward-compat: a null version key may exist even with
+            // a null master (due to S3C-7526), if so, delete it (its
+            // data will be deleted as part of the master cleanup, so
+            // no "deleteData" param is needed)
             if (mst.isNull) {
                 const delOptions = { versionId: mst.versionId };
-                if (mst.uploadId) {
-                    delOptions.replayId = mst.uploadId;
-                }
                 return { options, delOptions };
             }
             return { options };
         }
         if (mst.nullVersionId) {
-            const delOptions = { versionId: mst.nullVersionId };
+            // backward-compat: delete the null versioned key and data
+            const delOptions = { versionId: mst.nullVersionId, deleteData: true };
             if (mst.nullUploadId) {
                 delOptions.replayId = mst.nullUploadId;
             }
             return { options, delOptions };
         }
-        return { options };
+        // clean up the eventual null key's location data prior to put
+
+        // NOTE: due to metadata v1 internal format, we cannot guess
+        // from the master key whether there is an associated null
+        // key, because the master key may be removed whenever the
+        // latest version becomes a delete marker. Hence we need to
+        // pessimistically try to get the null key metadata and delete
+        // it if it exists.
+        const delOptions = { versionId: 'null', deleteData: true };
+        return { options, delOptions };
     }
+
     // versioning is enabled: create a new version
     const options = { versioning: true };
     if (masterIsNull) {
-        // store master version in a new key
+        // if master is a null version or a non-versioned key,
+        // copy it to a new null key
         const nullVersionId = mst.isNull ? mst.versionId : nonVersionedObjId;
-        options.extraMD = {
-            nullVersionId,
-        };
-        if (mst.uploadId) {
-            options.extraMD.nullUploadId = mst.uploadId;
+        if (nullVersionCompatMode) {
+            options.extraMD = {
+                nullVersionId,
+            };
+            if (mst.uploadId) {
+                options.extraMD.nullUploadId = mst.uploadId;
+            }
         }
         return { options, nullVersionId };
     }
-    // versioning is enabled, copy reference to null version ID if it exists
-    if (mst.nullVersionId) {
-        options.extraMD = {
-            nullVersionId: mst.nullVersionId,
-        };
-        if (mst.nullUploadId) {
-            options.extraMD.nullUploadId = mst.nullUploadId;
+    if (nullVersionCompatMode) {
+        // backward-compat: in v0 compatibility mode, keep a reference
+        // to the existing null versioned key
+        if (mst.nullVersionId) {
+            options.extraMD = {
+                nullVersionId: mst.nullVersionId,
+            };
+            if (mst.nullUploadId) {
+                options.extraMD.nullUploadId = mst.nullUploadId;
+            }
         }
+        return { options };
+    }
+    if (mst.nullVersionId) {
+        // backward-compat: outside of v0 compatibility mode, transform
+        // the existing legacy null versioned key into a null key
+        const nullVersionId = mst.nullVersionId;
+        const delOptions = { versionId: nullVersionId };
+        return { options, nullVersionId, delOptions };
     }
     return { options };
 }
@@ -259,8 +289,11 @@ function versioningPreprocessing(bucketName, bucketMD, objectKey, objMD,
         return process.nextTick(callback, null, options);
     }
     // bucket is versioning configured
+
+    // XXX CLDSRV-355: pass config.nullVersionCompatMode as last param
+    // to processVersioningState() when all operations support null keys
     const { options, nullVersionId, delOptions } =
-          processVersioningState(mst, vCfg.Status);
+          processVersioningState(mst, vCfg.Status, true);
     return async.series([
         function storeVersion(next) {
             if (!nullVersionId) {

--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -165,7 +165,12 @@ function processVersioningState(mst, vstat, nullVersionCompatMode) {
             // a null master (due to S3C-7526), if so, delete it (its
             // data will be deleted as part of the master cleanup, so
             // no "deleteData" param is needed)
-            if (mst.isNull) {
+            //
+            // "isNull2" attribute is set in master metadata when
+            // null keys are used, which is used as an optimization to
+            // avoid having to check the versioned key since there can
+            // be no more versioned key to clean up
+            if (mst.isNull && !mst.isNull2) {
                 const delOptions = { versionId: mst.versionId };
                 return { options, delOptions };
             }
@@ -252,6 +257,7 @@ function getMasterState(objMD) {
         versionId: objMD.versionId,
         uploadId: objMD.uploadId,
         isNull: objMD.isNull,
+        isNull2: objMD.isNull2,
         nullVersionId: objMD.nullVersionId,
         nullUploadId: objMD.nullUploadId,
     };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "git+https://github.com/scality/arsenal#7.10.46",
+    "arsenal": "git+https://github.com/scality/arsenal#7.70.4",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/tests/unit/api/apiUtils/versioning.js
+++ b/tests/unit/api/apiUtils/versioning.js
@@ -131,6 +131,11 @@ describe('versioning helpers', () => {
                     // instruct to first copy the null version onto a
                     // newly created null key with version ID in its metadata
                     nullVersionId: 'vnull',
+                    // delete possibly existing null versioned key
+                    // that is identical to the null master
+                    delOptions: {
+                        versionId: 'vnull',
+                    },
                 },
                 versioningSuspendedExpectedRes: {
                     options: {
@@ -215,6 +220,11 @@ describe('versioning helpers', () => {
                     // instruct to first copy the null version onto a
                     // newly created null key with version ID in its metadata
                     nullVersionId: 'vnull',
+                    // delete possibly existing null versioned key
+                    // that is identical to the null master
+                    delOptions: {
+                        versionId: 'vnull',
+                    },
                 },
                 versioningSuspendedExpectedRes: {
                     options: {

--- a/tests/unit/api/apiUtils/versioning.js
+++ b/tests/unit/api/apiUtils/versioning.js
@@ -163,7 +163,7 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                description: 'prior MPU object null version exists',
+                description: 'prior MPU object legacy null version exists',
                 objMD: {
                     versionId: 'vnull',
                     isNull: true,
@@ -205,6 +205,47 @@ describe('versioning helpers', () => {
                     },
                     delOptions: {
                         versionId: 'vnull',
+                    },
+                },
+            },
+            {
+                description: 'prior MPU object non-legacy null version exists',
+                objMD: {
+                    versionId: 'vnull',
+                    isNull: true,
+                    isNull2: true, // flag marking that it's a non-legacy null version
+                    uploadId: 'fooUploadId',
+                },
+                versioningEnabledExpectedRes: {
+                    options: {
+                        versioning: true,
+                    },
+                    // instruct to first copy the null version onto a
+                    // newly created null key with version ID in its metadata
+                    nullVersionId: 'vnull',
+                },
+                versioningSuspendedExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
+                    },
+                },
+                versioningEnabledCompatExpectedRes: {
+                    options: {
+                        versioning: true,
+                        extraMD: {
+                            nullVersionId: 'vnull',
+                            nullUploadId: 'fooUploadId',
+                        },
+                    },
+                    // instruct to first copy the null version onto a
+                    // newly created version key preserving the version ID
+                    nullVersionId: 'vnull',
+                },
+                versioningSuspendedCompatExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
                     },
                 },
             },

--- a/tests/unit/api/apiUtils/versioning.js
+++ b/tests/unit/api/apiUtils/versioning.js
@@ -119,7 +119,7 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                description: 'prior null object version exists',
+                description: 'prior legacy null object version exists',
                 objMD: {
                     versionId: 'vnull',
                     isNull: true,
@@ -159,6 +159,45 @@ describe('versioning helpers', () => {
                     },
                     delOptions: {
                         versionId: 'vnull',
+                    },
+                },
+            },
+            {
+                description: 'prior non-legacy null object version exists',
+                objMD: {
+                    versionId: 'vnull',
+                    isNull: true,
+                    isNull2: true, // flag marking that it's a non-legacy null version
+                },
+                versioningEnabledExpectedRes: {
+                    options: {
+                        versioning: true,
+                    },
+                    // instruct to first copy the null version onto a
+                    // newly created null key with version ID in its metadata
+                    nullVersionId: 'vnull',
+                },
+                versioningSuspendedExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
+                    },
+                },
+                versioningEnabledCompatExpectedRes: {
+                    options: {
+                        versioning: true,
+                        extraMD: {
+                            nullVersionId: 'vnull',
+                        },
+                    },
+                    // instruct to first copy the null version onto a
+                    // newly created version key preserving the version ID
+                    nullVersionId: 'vnull',
+                },
+                versioningSuspendedCompatExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
                     },
                 },
             },
@@ -331,13 +370,10 @@ describe('versioning helpers', () => {
                 versioningEnabledExpectedRes: {
                     options: {
                         versioning: true,
+                        extraMD: {
+                            nullVersionId: 'vnull',
+                        },
                     },
-                    // backward-compat: delete old null version key
-                    delOptions: {
-                        versionId: 'vnull',
-                    },
-                    // backward-compat: create new null key
-                    nullVersionId: 'vnull',
                 },
                 versioningSuspendedExpectedRes: {
                     options: {
@@ -363,6 +399,7 @@ describe('versioning helpers', () => {
                         isNull: true,
                         versionId: '',
                     },
+                    // backward-compat: delete old null version key
                     delOptions: {
                         versionId: 'vnull',
                         deleteData: true,
@@ -379,13 +416,10 @@ describe('versioning helpers', () => {
                 versioningEnabledExpectedRes: {
                     options: {
                         versioning: true,
+                        extraMD: {
+                            nullVersionId: 'vnull',
+                        },
                     },
-                    // backward-compat: delete old null version key
-                    delOptions: {
-                        versionId: 'vnull',
-                    },
-                    // backward-compat: create new null key
-                    nullVersionId: 'vnull',
                 },
                 versioningSuspendedExpectedRes: {
                     options: {
@@ -411,6 +445,7 @@ describe('versioning helpers', () => {
                         isNull: true,
                         versionId: '',
                     },
+                    // backward-compat: delete old null version key
                     delOptions: {
                         versionId: 'vnull',
                         deleteData: true,
@@ -427,13 +462,11 @@ describe('versioning helpers', () => {
                 versioningEnabledExpectedRes: {
                     options: {
                         versioning: true,
+                        extraMD: {
+                            nullVersionId: 'vnull',
+                            nullUploadId: 'nullFooUploadId',
+                        },
                     },
-                    // backward-compat: delete old null version key
-                    delOptions: {
-                        versionId: 'vnull',
-                    },
-                    // backward-compat: create new null key
-                    nullVersionId: 'vnull',
                 },
                 versioningSuspendedExpectedRes: {
                     options: {
@@ -461,6 +494,7 @@ describe('versioning helpers', () => {
                         isNull: true,
                         versionId: '',
                     },
+                    // backward-compat: delete old null version key
                     delOptions: {
                         versionId: 'vnull',
                         replayId: 'nullFooUploadId',

--- a/tests/unit/api/apiUtils/versioning.js
+++ b/tests/unit/api/apiUtils/versioning.js
@@ -24,6 +24,25 @@ describe('versioning helpers', () => {
                         isNull: true,
                         versionId: '',
                     },
+                    delOptions: {
+                        deleteData: true,
+                        versionId: 'null',
+                    },
+                },
+                versioningEnabledCompatExpectedRes: {
+                    options: {
+                        versioning: true,
+                    },
+                },
+                versioningSuspendedCompatExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
+                    },
+                    delOptions: {
+                        deleteData: true,
+                        versionId: 'null',
+                    },
                 },
             },
             {
@@ -40,6 +59,25 @@ describe('versioning helpers', () => {
                     options: {
                         isNull: true,
                         versionId: '',
+                    },
+                    delOptions: {
+                        deleteData: true,
+                        versionId: 'null',
+                    },
+                },
+                versioningEnabledCompatExpectedRes: {
+                    options: {
+                        versioning: true,
+                    },
+                },
+                versioningSuspendedCompatExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
+                    },
+                    delOptions: {
+                        deleteData: true,
+                        versionId: 'null',
                     },
                 },
             },
@@ -59,6 +97,25 @@ describe('versioning helpers', () => {
                         isNull: true,
                         versionId: '',
                     },
+                    delOptions: {
+                        deleteData: true,
+                        versionId: 'null',
+                    },
+                },
+                versioningEnabledCompatExpectedRes: {
+                    options: {
+                        versioning: true,
+                    },
+                },
+                versioningSuspendedCompatExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
+                    },
+                    delOptions: {
+                        deleteData: true,
+                        versionId: 'null',
+                    },
                 },
             },
             {
@@ -70,6 +127,23 @@ describe('versioning helpers', () => {
                 versioningEnabledExpectedRes: {
                     options: {
                         versioning: true,
+                    },
+                    // instruct to first copy the null version onto a
+                    // newly created null key with version ID in its metadata
+                    nullVersionId: 'vnull',
+                },
+                versioningSuspendedExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
+                    },
+                    delOptions: {
+                        versionId: 'vnull',
+                    },
+                },
+                versioningEnabledCompatExpectedRes: {
+                    options: {
+                        versioning: true,
                         extraMD: {
                             nullVersionId: 'vnull',
                         },
@@ -78,7 +152,7 @@ describe('versioning helpers', () => {
                     // newly created version key preserving the version ID
                     nullVersionId: 'vnull',
                 },
-                versioningSuspendedExpectedRes: {
+                versioningSuspendedCompatExpectedRes: {
                     options: {
                         isNull: true,
                         versionId: '',
@@ -98,6 +172,23 @@ describe('versioning helpers', () => {
                 versioningEnabledExpectedRes: {
                     options: {
                         versioning: true,
+                    },
+                    // instruct to first copy the null version onto a
+                    // newly created null key with version ID in its metadata
+                    nullVersionId: 'vnull',
+                },
+                versioningSuspendedExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
+                    },
+                    delOptions: {
+                        versionId: 'vnull',
+                    },
+                },
+                versioningEnabledCompatExpectedRes: {
+                    options: {
+                        versioning: true,
                         extraMD: {
                             nullVersionId: 'vnull',
                             nullUploadId: 'fooUploadId',
@@ -107,22 +198,34 @@ describe('versioning helpers', () => {
                     // newly created version key preserving the version ID
                     nullVersionId: 'vnull',
                 },
-                versioningSuspendedExpectedRes: {
+                versioningSuspendedCompatExpectedRes: {
                     options: {
                         isNull: true,
                         versionId: '',
                     },
                     delOptions: {
                         versionId: 'vnull',
-                        replayId: 'fooUploadId',
                     },
                 },
             },
             {
-                description:
-                'prior object exists, put before versioning was first enabled',
+                description: 'prior object exists, put before versioning was first enabled',
                 objMD: {},
                 versioningEnabledExpectedRes: {
+                    options: {
+                        versioning: true,
+                    },
+                    // instruct to first copy the null version onto a
+                    // newly created null key as the oldest version
+                    nullVersionId: INF_VID,
+                },
+                versioningSuspendedExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
+                    },
+                },
+                versioningEnabledCompatExpectedRes: {
                     options: {
                         versioning: true,
                         extraMD: {
@@ -133,7 +236,7 @@ describe('versioning helpers', () => {
                     // newly created version key as the oldest version
                     nullVersionId: INF_VID,
                 },
-                versioningSuspendedExpectedRes: {
+                versioningSuspendedCompatExpectedRes: {
                     options: {
                         isNull: true,
                         versionId: '',
@@ -141,12 +244,25 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                description: 'prior MPU object exists, put before versioning ' +
-                    'was first enabled',
+                description: 'prior MPU object exists, put before versioning was first enabled',
                 objMD: {
                     uploadId: 'fooUploadId',
                 },
                 versioningEnabledExpectedRes: {
+                    options: {
+                        versioning: true,
+                    },
+                    // instruct to first copy the null version onto a
+                    // newly created null key as the oldest version
+                    nullVersionId: INF_VID,
+                },
+                versioningSuspendedExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
+                    },
+                },
+                versioningEnabledCompatExpectedRes: {
                     options: {
                         versioning: true,
                         extraMD: {
@@ -158,7 +274,7 @@ describe('versioning helpers', () => {
                     // newly created version key as the oldest version
                     nullVersionId: INF_VID,
                 },
-                versioningSuspendedExpectedRes: {
+                versioningSuspendedCompatExpectedRes: {
                     options: {
                         isNull: true,
                         versionId: '',
@@ -166,8 +282,7 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                description:
-                'prior non-null object version exists with ref to null version',
+                description: 'prior non-null object version exists with ref to null version',
                 objMD: {
                     versionId: 'v1',
                     nullVersionId: 'vnull',
@@ -175,24 +290,46 @@ describe('versioning helpers', () => {
                 versioningEnabledExpectedRes: {
                     options: {
                         versioning: true,
-                        extraMD: {
-                            nullVersionId: 'vnull',
-                        },
                     },
+                    // backward-compat: delete old null version key
+                    delOptions: {
+                        versionId: 'vnull',
+                    },
+                    // backward-compat: create new null key
+                    nullVersionId: 'vnull',
                 },
                 versioningSuspendedExpectedRes: {
                     options: {
                         isNull: true,
                         versionId: '',
                     },
+                    // backward-compat: delete old null version key
                     delOptions: {
                         versionId: 'vnull',
+                        deleteData: true,
+                    },
+                },
+                versioningEnabledCompatExpectedRes: {
+                    options: {
+                        versioning: true,
+                        extraMD: {
+                            nullVersionId: 'vnull',
+                        },
+                    },
+                },
+                versioningSuspendedCompatExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
+                    },
+                    delOptions: {
+                        versionId: 'vnull',
+                        deleteData: true,
                     },
                 },
             },
             {
-                description: 'prior MPU object non-null version exists with ' +
-                    'ref to null version',
+                description: 'prior MPU object non-null version exists with ref to null version',
                 objMD: {
                     versionId: 'v1',
                     uploadId: 'fooUploadId',
@@ -201,24 +338,46 @@ describe('versioning helpers', () => {
                 versioningEnabledExpectedRes: {
                     options: {
                         versioning: true,
-                        extraMD: {
-                            nullVersionId: 'vnull',
-                        },
                     },
+                    // backward-compat: delete old null version key
+                    delOptions: {
+                        versionId: 'vnull',
+                    },
+                    // backward-compat: create new null key
+                    nullVersionId: 'vnull',
                 },
                 versioningSuspendedExpectedRes: {
                     options: {
                         isNull: true,
                         versionId: '',
                     },
+                    // backward-compat: delete old null version key
                     delOptions: {
                         versionId: 'vnull',
+                        deleteData: true,
+                    },
+                },
+                versioningEnabledCompatExpectedRes: {
+                    options: {
+                        versioning: true,
+                        extraMD: {
+                            nullVersionId: 'vnull',
+                        },
+                    },
+                },
+                versioningSuspendedCompatExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
+                    },
+                    delOptions: {
+                        versionId: 'vnull',
+                        deleteData: true,
                     },
                 },
             },
             {
-                description: 'prior object non-null version exists with ' +
-                    'ref to MPU null version',
+                description: 'prior object non-null version exists with ref to MPU null version',
                 objMD: {
                     versionId: 'v1',
                     nullVersionId: 'vnull',
@@ -227,13 +386,36 @@ describe('versioning helpers', () => {
                 versioningEnabledExpectedRes: {
                     options: {
                         versioning: true,
+                    },
+                    // backward-compat: delete old null version key
+                    delOptions: {
+                        versionId: 'vnull',
+                    },
+                    // backward-compat: create new null key
+                    nullVersionId: 'vnull',
+                },
+                versioningSuspendedExpectedRes: {
+                    options: {
+                        isNull: true,
+                        versionId: '',
+                    },
+                    // backward-compat: delete old null version key
+                    delOptions: {
+                        versionId: 'vnull',
+                        replayId: 'nullFooUploadId',
+                        deleteData: true,
+                    },
+                },
+                versioningEnabledCompatExpectedRes: {
+                    options: {
+                        versioning: true,
                         extraMD: {
                             nullVersionId: 'vnull',
                             nullUploadId: 'nullFooUploadId',
                         },
                     },
                 },
-                versioningSuspendedExpectedRes: {
+                versioningSuspendedCompatExpectedRes: {
                     options: {
                         isNull: true,
                         versionId: '',
@@ -241,18 +423,23 @@ describe('versioning helpers', () => {
                     delOptions: {
                         versionId: 'vnull',
                         replayId: 'nullFooUploadId',
+                        deleteData: true,
                     },
                 },
             },
         ].forEach(testCase =>
-            ['Enabled', 'Suspended'].forEach(versioningStatus => it(
-            `${testCase.description}, versioning Status=${versioningStatus}`,
-            () => {
-                const mst = getMasterState(testCase.objMD);
-                const res = processVersioningState(mst, versioningStatus);
-                const expectedRes = testCase[`versioning${versioningStatus}ExpectedRes`];
-                assert.deepStrictEqual(res, expectedRes);
-            })));
+            [false, true].forEach(nullVersionCompatMode =>
+                ['Enabled', 'Suspended'].forEach(versioningStatus => it(
+                `${testCase.description}${nullVersionCompatMode ? ' (null compat)' : ''}` +
+                `, versioning Status=${versioningStatus}`,
+                () => {
+                    const mst = getMasterState(testCase.objMD);
+                    const res = processVersioningState(mst, versioningStatus, nullVersionCompatMode);
+                    const resultName = `versioning${versioningStatus}` +
+                          `${nullVersionCompatMode ? 'Compat' : ''}ExpectedRes`;
+                    const expectedRes = testCase[resultName];
+                    assert.deepStrictEqual(res, expectedRes);
+                }))));
     });
 
     describe('preprocessingVersioningDelete', () => {

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -1937,13 +1937,13 @@ describe('complete mpu with versioning', () => {
                                         err => next(err, testUploadId));
             },
             (testUploadId, next) => {
-                const origDeleteObject = metadataBackend.deleteObject;
-                metadataBackend.deleteObject =
-                    (bucketName, objName, params, log, cb) => {
-                        assert.strictEqual(params.replayId, testUploadId);
-                        metadataBackend.deleteObject = origDeleteObject;
-                        metadataBackend.deleteObject(
-                            bucketName, objName, params, log, cb);
+                const origPutObject = metadataBackend.putObject;
+                metadataBackend.putObject =
+                    (putBucketName, objName, objVal, params, log, cb) => {
+                        assert.strictEqual(params.oldReplayId, testUploadId);
+                        metadataBackend.putObject = origPutObject;
+                        origPutObject(
+                            putBucketName, objName, objVal, params, log, cb);
                     };
                 // overwrite null version with a non-MPU object
                 objectPut(authInfo, testPutObjectRequests[1],
@@ -2012,13 +2012,13 @@ describe('complete mpu with versioning', () => {
                 versioningTestUtils.assertDataStoreValues(
                     ds, [undefined, objData[1], objData[2]]);
 
-                const origDeleteObject = metadataBackend.deleteObject;
-                metadataBackend.deleteObject =
-                    (bucketName, objName, params, log, cb) => {
-                        assert.strictEqual(params.replayId, testUploadId);
-                        metadataBackend.deleteObject = origDeleteObject;
-                        metadataBackend.deleteObject(
-                            bucketName, objName, params, log, cb);
+                const origPutObject = metadataBackend.putObject;
+                metadataBackend.putObject =
+                    (putBucketName, objName, objVal, params, log, cb) => {
+                        assert.strictEqual(params.oldReplayId, testUploadId);
+                        metadataBackend.putObject = origPutObject;
+                        origPutObject(
+                            putBucketName, objName, objVal, params, log, cb);
                     };
                 // overwrite null version with a non-MPU object
                 objectPut(authInfo, testPutObjectRequests[1],

--- a/yarn.lock
+++ b/yarn.lock
@@ -388,7 +388,6 @@ arraybuffer.slice@~0.0.7:
 
 "arsenal@git+https://github.com/scality/Arsenal#7.10.46":
   version "7.10.46"
-  uid bd76402586f1b5117ada9857a9e437727562d55a
   resolved "git+https://github.com/scality/Arsenal#bd76402586f1b5117ada9857a9e437727562d55a"
   dependencies:
     "@types/async" "^3.2.12"
@@ -427,9 +426,9 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#7.10.46":
-  version "7.10.46"
-  resolved "git+https://github.com/scality/arsenal#bd76402586f1b5117ada9857a9e437727562d55a"
+"arsenal@git+https://github.com/scality/arsenal#7.70.4":
+  version "7.70.4"
+  resolved "git+https://github.com/scality/arsenal#c4cc5a2c3dfa4a8d6d565c4029ec05cbb0bf1a3e"
   dependencies:
     "@types/async" "^3.2.12"
     "@types/utf8" "^3.0.1"


### PR DESCRIPTION
Add support for null key handling for the helper
processVersioningState(), and maintain the null version compatibility mode to keep the old behavior - for now, the calling code sets this flag to "true" without using the config to maintain current behavior, it will be changed with CLDSRV-355.
