### PR TITLE
feat: CLDSRV-357 update versioningPreprocessing() helper for null keys

### DIFF
--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -257,6 +257,7 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
             metadataStoreParams.versionId = options.versionId;
             metadataStoreParams.versioning = options.versioning;
             metadataStoreParams.isNull = options.isNull;
+            metadataStoreParams.deleteNullKey = options.deleteNullKey;
             if (options.extraMD) {
                 Object.assign(metadataStoreParams, options.extraMD);
             }

--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -87,6 +87,9 @@ function _storeNullVersionMD(bucketName, objKey, nullVersionId, nullVersionMD, l
 */
 function _prepareNullVersionDeletion(bucketName, objKey, options, mst, log, cb) {
     const nullOptions = {};
+    if (!options.deleteData) {
+        return process.nextTick(cb, null, nullOptions);
+    }
     if (options.versionId === mst.versionId) {
         // no need to get another key as the master is the target
         nullOptions.dataToDelete = mst.objLocation;
@@ -96,9 +99,6 @@ function _prepareNullVersionDeletion(bucketName, objKey, options, mst, log, cb) 
         // deletion of the null key will be done by the main metadata
         // PUT via this option
         nullOptions.deleteNullKey = true;
-    }
-    if (!options.deleteData) {
-        return process.nextTick(cb, null, nullOptions);
     }
     return metadata.getObjectMD(bucketName, objKey, options, log,
         (err, versionMD) => {

--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -62,17 +62,19 @@ function checkQueryVersionId(query) {
     return undefined;
 }
 
-function _storeNullVersionMD(bucketName, objKey, objMD, options, log, cb) {
-    metadata.putObjectMD(bucketName, objKey, objMD, options, log, err => {
+function _storeNullVersionMD(bucketName, objKey, nullVersionId, nullVersionMD, log, cb) {
+    // In compatibility mode, create null versioned keys instead of null keys
+    // XXX CLDSRV-355: pass { versionId: 'null' } if compat mode is disabled
+    metadata.putObjectMD(bucketName, objKey, nullVersionMD, { versionId: nullVersionId }, log, err => {
         if (err) {
             log.debug('error from metadata storing null version as new version',
             { error: err });
         }
-        cb(err, options);
+        cb(err);
     });
 }
 
-/** get location of null version data for deletion
+/** check existence and get location of null version data for deletion
 * @param {string} bucketName - name of bucket
 * @param {string} objKey - name of object key
 * @param {object} options - metadata options for getting object MD
@@ -83,50 +85,53 @@ function _storeNullVersionMD(bucketName, objKey, objMD, options, log, cb) {
 * @param {function} cb - callback
 * @return {undefined} - and call callback with (err, dataToDelete)
 */
-function _getNullVersionsToDelete(bucketName, objKey, options, mst, log, cb) {
+function _prepareNullVersionDeletion(bucketName, objKey, options, mst, log, cb) {
+    const nullOptions = {};
     if (options.versionId === mst.versionId) {
-        // no need to get delete location, we already have the master's metadata
-        const dataToDelete = mst.objLocation;
-        return process.nextTick(cb, null, dataToDelete);
+        // no need to get another key as the master is the target
+        nullOptions.dataToDelete = mst.objLocation;
+        return process.nextTick(cb, null, nullOptions);
+    }
+    if (options.versionId === 'null') {
+        // deletion of the null key will be done by the main metadata
+        // PUT via this option
+        nullOptions.deleteNullKey = true;
+    }
+    if (!options.deleteData) {
+        return process.nextTick(cb, null, nullOptions);
     }
     return metadata.getObjectMD(bucketName, objKey, options, log,
         (err, versionMD) => {
+            // the null key may not exist, hence it's a normal
+            // situation to have a NoSuchKey error, in which case
+            // there is nothing to delete
+            if (err && err.is.NoSuchKey) {
+                return cb(null, {});
+            }
             if (err) {
-                log.debug('err from metadata getting specified version', {
+                log.warn('could not get null version metadata', {
                     error: err,
-                    method: '_getNullVersionsToDelete',
+                    method: '_prepareNullVersionDeletion',
                 });
                 return cb(err);
             }
-            if (!versionMD.location) {
-                return cb();
+            if (versionMD.location) {
+                const dataToDelete = Array.isArray(versionMD.location) ?
+                      versionMD.location : [versionMD.location];
+                nullOptions.dataToDelete = dataToDelete;
             }
-            const dataToDelete = Array.isArray(versionMD.location) ?
-                versionMD.location : [versionMD.location];
-            return cb(null, dataToDelete);
+            return cb(null, nullOptions);
         });
 }
 
-function _deleteNullVersionMD(bucketName, objKey, options, mst, log, cb) {
-    return _getNullVersionsToDelete(bucketName, objKey, options, mst, log,
-        (err, nullDataToDelete) => {
-            if (err) {
-                log.warn('could not find null version metadata', {
-                    error: err,
-                    method: '_deleteNullVersionMD',
-                });
-                return cb(err);
-            }
-            return metadata.deleteObjectMD(bucketName, objKey, options, log,
-                err => {
-                    if (err) {
-                        log.warn('metadata error deleting null version',
-                        { error: err, method: '_deleteNullVersionMD' });
-                        return cb(err);
-                    }
-                    return cb(null, nullDataToDelete);
-                });
-        });
+function _deleteNullVersionMD(bucketName, objKey, options, log, cb) {
+    return metadata.deleteObjectMD(bucketName, objKey, options, log, err => {
+        if (err) {
+            log.warn('metadata error deleting null versioned key',
+                     { bucketName, objKey, error: err, method: '_deleteNullVersionMD' });
+        }
+        return cb(err);
+    });
 }
 
 /**
@@ -283,9 +288,6 @@ function getMasterState(objMD) {
  *  ('' overwrites the master version)
  * options.versioning - (true/undefined) metadata instruction to create new ver
  * options.isNull - (true/undefined) whether new version is null or not
- * options.nullVersionId - if storing a null version in version history, the
- *  version id of the null version
- * options.deleteNullVersionData - whether to delete the data of the null ver
  */
 function versioningPreprocessing(bucketName, bucketMD, objectKey, objMD,
     log, callback) {
@@ -303,36 +305,36 @@ function versioningPreprocessing(bucketName, bucketMD, objectKey, objMD,
     const { options, nullVersionId, delOptions } =
           processVersioningState(mst, vCfg.Status, true);
     return async.series([
-        function storeVersion(next) {
+        function storeNullVersionMD(next) {
             if (!nullVersionId) {
                 return process.nextTick(next);
             }
-            const versionMD = Object.assign({}, objMD, { versionId: nullVersionId, isNull: true });
-            const params = { versionId: nullVersionId };
-            return _storeNullVersionMD(bucketName, objectKey, versionMD, params, log, next);
+            const nullVersionMD = Object.assign({}, objMD, { versionId: nullVersionId, isNull: true });
+            return _storeNullVersionMD(bucketName, objectKey, nullVersionId, nullVersionMD, log, next);
         },
-        function deleteNullVersion(next) {
+        function prepareNullVersionDeletion(next) {
             if (!delOptions) {
                 return process.nextTick(next);
             }
-            return _deleteNullVersionMD(bucketName, objectKey, delOptions, mst,
-                log, (err, nullDataToDelete) => {
+            return _prepareNullVersionDeletion(
+                bucketName, objectKey, delOptions, mst, log,
+                (err, nullOptions) => {
                     if (err) {
-                        log.warn('unexpected error deleting null version md', {
-                            error: err,
-                            method: 'versioningPreprocessing',
-                        });
-                        // it's possible there was a concurrent request to
-                        // delete the null version, so proceed with putting a
-                        // new version
-                        if (err.is.NoSuchKey) {
-                            return next(null, options);
-                        }
-                        return next(errors.InternalError);
+                        return next(err);
                     }
-                    Object.assign(options, { dataToDelete: nullDataToDelete });
+                    Object.assign(options, nullOptions);
                     return next();
                 });
+        },
+        function deleteNullVersionMD(next) {
+            if (delOptions &&
+                delOptions.versionId &&
+                delOptions.versionId !== 'null') {
+                // backward-compat: delete old null versioned key
+                return _deleteNullVersionMD(
+                    bucketName, objectKey, { versionId: delOptions.versionId }, log, next);
+            }
+            return process.nextTick(next);
         },
     ], err => callback(err, options));
 }

--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -102,17 +102,20 @@ function _prepareNullVersionDeletion(bucketName, objKey, options, mst, log, cb) 
     }
     return metadata.getObjectMD(bucketName, objKey, options, log,
         (err, versionMD) => {
-            // the null key may not exist, hence it's a normal
-            // situation to have a NoSuchKey error, in which case
-            // there is nothing to delete
-            if (err && err.is.NoSuchKey) {
-                return cb(null, {});
-            }
             if (err) {
-                log.warn('could not get null version metadata', {
-                    error: err,
-                    method: '_prepareNullVersionDeletion',
-                });
+                // the null key may not exist, hence it's a normal
+                // situation to have a NoSuchKey error, in which case
+                // there is nothing to delete
+                if (err.is.NoSuchKey) {
+                    log.debug('null version does not exist', {
+                        method: '_prepareNullVersionDeletion',
+                    });
+                } else {
+                    log.warn('could not get null version metadata', {
+                        error: err,
+                        method: '_prepareNullVersionDeletion',
+                    });
+                }
                 return cb(err);
             }
             if (versionMD.location) {
@@ -336,7 +339,14 @@ function versioningPreprocessing(bucketName, bucketMD, objectKey, objMD,
             }
             return process.nextTick(next);
         },
-    ], err => callback(err, options));
+    ], err => {
+        // it's possible there was a prior request that deleted the
+        // null version, so proceed with putting a new version
+        if (err && err.is.NoSuchKey) {
+            return callback(null, options);
+        }
+        return callback(err, options);
+    });
 }
 
 /** preprocessingVersioningDelete - return versioning information for S3 to

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -337,6 +337,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     metaStoreParams.versionId = options.versionId;
                     metaStoreParams.versioning = options.versioning;
                     metaStoreParams.isNull = options.isNull;
+                    metaStoreParams.deleteNullKey = options.deleteNullKey;
                     if (options.extraMD) {
                         Object.assign(metaStoreParams, options.extraMD);
                     }

--- a/lib/services.js
+++ b/lib/services.js
@@ -167,6 +167,9 @@ const services = {
 
         // information to store about the version and the null version id
         // in the object metadata
+
+        // NOTE nullVersionId and nullUploadId are only maintained in
+        // v0 metadata compatibility mode
         const { isNull, nullVersionId, nullUploadId, isDeleteMarker } = params;
         md.setIsNull(isNull)
             .setNullVersionId(nullVersionId)

--- a/lib/services.js
+++ b/lib/services.js
@@ -97,7 +97,7 @@ const services = {
             lastModifiedDate, versioning, versionId, uploadId,
             tagging, taggingCopy, replicationInfo, defaultRetention,
             dataStoreName, retentionMode, retentionDate, legalHold,
-            originOp, oldReplayId } = params;
+            originOp, oldReplayId, deleteNullKey } = params;
         log.trace('storing object in metadata');
         assert.strictEqual(typeof bucketName, 'string');
         const md = new ObjectMD();
@@ -163,6 +163,10 @@ const services = {
 
         if (oldReplayId) {
             options.oldReplayId = oldReplayId;
+        }
+
+        if (deleteNullKey) {
+            options.deleteNullKey = deleteNullKey;
         }
 
         // information to store about the version and the null version id

--- a/tests/functional/aws-node-sdk/lib/utility/versioning-util.js
+++ b/tests/functional/aws-node-sdk/lib/utility/versioning-util.js
@@ -82,8 +82,17 @@ function enableVersioningThenPutObject(bucket, object, callback) {
     });
 }
 
-/** createDualNullVersion - create a null version that is stored in metadata
- *  both in the master version and a separate version
+/** createDualNullVersion
+ *
+ * - PREVIOUSLY: created a null version that was stored in metadata
+ *   both in the master version and a separate version
+ *
+ * - CURRENTLY: only one null version key is present in metadata
+ *   after the second put, as the first null key is cleaned up
+ *
+ *  Even though there is only one key at the end, it is still useful
+ *  to keep this function for regression testing
+ *
  *  @param {AWS.S3} s3 - aws sdk s3 instance
  *  @param {string} bucketName - name of bucket in versioning suspended state
  *  @param {string} keyName - name of key

--- a/tests/functional/aws-node-sdk/test/versioning/objectPut.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectPut.js
@@ -218,7 +218,7 @@ describe('put and get object with versioning', function testSuite() {
                 });
             });
 
-            it('should create new versions but still keep nullVersionId',
+            it('should create new versions but still keep the null version',
             done => {
                 const versionIds = [];
                 const params = { Bucket: bucket, Key: key };


### PR DESCRIPTION
- Modify the code flow of versioningPreprocessing() to support null keys in addition to the legacy "null versioned keys".
    
  NOTE: The null version compatibility mode is still enforced for now until all pieces are updated to make functional tests pass without the compatibility mode.

- pass deleteNullKey param to backend

  Pass the 'deleteNullKey' param that processVersioningState() may set to the Metadata backend, which tells it to delete the null key as the PUT is executed.
