### PR TITLE
feat: CLDSRV-358 preprocessingVersioningDelete() update for null keys

### DIFF
--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -376,11 +376,22 @@ function preprocessingVersioningDelete(bucketName, bucketMD, objectMD, reqVersio
     }
     if (bucketMD.getVersioningConfiguration() && reqVersionId) {
         if (reqVersionId === 'null') {
-            // deleting the 'null' version if it exists: use its
-            // internal versionId if it exists
+            // deleting the 'null' version if it exists:
+            //
+            // - use its internal versionId if it is a "real" null
+            //   version (not non-versioned)
+            //
+            // - send the "isNull" param to Metadata if:
+            //
+            //   - in non-compat mode (mandatory for v1 format)
+            //
+            //   - OR if the version is already a null key put by a
+            //     non-compat mode Cloudserver, to let Metadata know that
+            //     the null key is to be deleted. This is the case if the
+            //     "isNull2" param is set.
             if (objectMD.versionId !== undefined) {
                 options.versionId = objectMD.versionId;
-                if (!nullVersionCompatMode) {
+                if (!nullVersionCompatMode || objectMD.isNull2) {
                     options.isNull = true;
                 }
             }

--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -355,12 +355,19 @@ function versioningPreprocessing(bucketName, bucketMD, objectKey, objMD,
  * @param {object} bucketMD - bucket metadata
  * @param {object} objectMD - obj metadata
  * @param {string} [reqVersionId] - specific version ID sent as part of request
+ * @param {boolean} nullVersionCompatMode - if true, behaves in null
+ * version compatibility mode and return appropriate values:
+ * - in normal mode, returns an 'isNull' boolean sent to Metadata (true or false)
+ * - in compatibility mode, does not return an 'isNull' property
  * @return {object} options object with params:
- * options.deleteData - (true/undefined) whether to delete data (if undefined
+ * {boolean} [options.deleteData=true|undefined] - whether to delete data (if undefined
  *  means creating a delete marker instead)
- * options.versionId - specific versionId to delete
+ * {string} [options.versionId] - specific versionId to delete
+ * {boolean} [options.isNull=true|false|undefined] - if set, tells the
+ * Metadata backend if we're deleting a null version or not a null
+ * version. Not set if `nullVersionCompatMode` is true.
  */
-function preprocessingVersioningDelete(bucketName, bucketMD, objectMD, reqVersionId) {
+function preprocessingVersioningDelete(bucketName, bucketMD, objectMD, reqVersionId, nullVersionCompatMode) {
     const options = {};
     if (!bucketMD.getVersioningConfiguration() || reqVersionId) {
         // delete data if bucket is non-versioned or the request
@@ -373,10 +380,16 @@ function preprocessingVersioningDelete(bucketName, bucketMD, objectMD, reqVersio
             // internal versionId if it exists
             if (objectMD.versionId !== undefined) {
                 options.versionId = objectMD.versionId;
+                if (!nullVersionCompatMode) {
+                    options.isNull = true;
+                }
             }
         } else {
             // deleting a specific version
             options.versionId = reqVersionId;
+            if (!nullVersionCompatMode) {
+                options.isNull = false;
+            }
         }
     }
     return options;

--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -391,7 +391,7 @@ function preprocessingVersioningDelete(bucketName, bucketMD, objectMD, reqVersio
             //     "isNull2" param is set.
             if (objectMD.versionId !== undefined) {
                 options.versionId = objectMD.versionId;
-                if (!nullVersionCompatMode || objectMD.isNull2) {
+                if (objectMD.isNull2) {
                     options.isNull = true;
                 }
             }

--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -285,7 +285,11 @@ function getObjMetadataAndDelete(authInfo, canonicalID, request,
                 return callback(null, objMD, versionId);
             },
             (objMD, versionId, callback) => {
-                const options = preprocessingVersioningDelete(bucketName, bucket, objMD, versionId);
+                // XXX CLDSRV-355: pass config.nullVersionCompatMode
+                // as last param to preprocessingVersioningDelete()
+                // when all operations support null keys
+                const options = preprocessingVersioningDelete(
+                    bucketName, bucket, objMD, versionId, true);
                 const deleteInfo = {};
                 if (options && options.deleteData) {
                     deleteInfo.deleted = true;

--- a/lib/api/objectDelete.js
+++ b/lib/api/objectDelete.js
@@ -142,7 +142,6 @@ function objectDelete(authInfo, request, log, cb) {
             const deleteInfo = {
                 removeDeleteMarker: false,
                 newDeleteMarker: false,
-                isNull: delOptions.isNull,
             };
             if (delOptions && delOptions.deleteData) {
                 if (objectMD.isDeleteMarker) {

--- a/lib/api/objectDelete.js
+++ b/lib/api/objectDelete.js
@@ -137,8 +137,11 @@ function objectDelete(authInfo, request, log, cb) {
             return next(null, bucketMD, objectMD);
         },
         function deleteOperation(bucketMD, objectMD, next) {
+            // XXX CLDSRV-355: pass config.nullVersionCompatMode as
+            // last param to preprocessingVersioningDelete() when all
+            // operations support null keys
             const delOptions = preprocessingVersioningDelete(
-                bucketName, bucketMD, objectMD, reqVersionId);
+                bucketName, bucketMD, objectMD, reqVersionId, true);
             const deleteInfo = {
                 removeDeleteMarker: false,
                 newDeleteMarker: false,

--- a/tests/functional/aws-node-sdk/test/versioning/objectDelete.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectDelete.js
@@ -138,7 +138,7 @@ describe('aws-node-sdk test delete object', () => {
         // delete bucket after testing
         after(done => {
             removeAllVersions({ Bucket: bucket }, err => {
-                if (err.code === 'NoSuchBucket') {
+                if (err && err.code === 'NoSuchBucket') {
                     return done();
                 } else if (err) {
                     return done(err);

--- a/tests/unit/api/apiUtils/versioning.js
+++ b/tests/unit/api/apiUtils/versioning.js
@@ -554,7 +554,7 @@ describe('versioning helpers', () => {
                 },
             },
             {
-                description: 'delete null object version',
+                description: 'delete legacy null object version',
                 objMD: {
                     versionId: 'vnull',
                     isNull: true,
@@ -568,6 +568,25 @@ describe('versioning helpers', () => {
                 expectedResCompat: {
                     deleteData: true,
                     versionId: 'vnull',
+                },
+            },
+            {
+                description: 'delete null object version in null key',
+                objMD: {
+                    versionId: 'vnull',
+                    isNull: true,
+                    isNull2: true,
+                },
+                reqVersionId: 'null',
+                expectedRes: {
+                    deleteData: true,
+                    versionId: 'vnull',
+                    isNull: true,
+                },
+                expectedResCompat: {
+                    deleteData: true,
+                    versionId: 'vnull',
+                    isNull: true,
                 },
             },
             {

--- a/tests/unit/api/apiUtils/versioning.js
+++ b/tests/unit/api/apiUtils/versioning.js
@@ -563,7 +563,6 @@ describe('versioning helpers', () => {
                 expectedRes: {
                     deleteData: true,
                     versionId: 'vnull',
-                    isNull: true,
                 },
                 expectedResCompat: {
                     deleteData: true,


### PR DESCRIPTION
- Add support for null keys in the preprocessingVersioningDelete() helper, essentially, set a 'isNull' boolean param that gets passed to Metadata, which tells whether the version to delete is a null version.
    
  NOTE: The null version compatibility mode is still enforced for now until all pieces are updated to make functional tests pass without the compatibility mode.

- [test] fix error code checking
    
  In functional tests of 'objectDelete', an "afterAll" cleanup can crash because it checks an error code before checking if there's an error object.
    
  It does not crash in normal circumstances because there is an actual error due to the last unit test trying to clean the bucket, but if anything changes in the unit tests that leaves the bucket existing would have triggered this issue

- [cleanup] objectDelete: remove unused assignment

  Remove unused assignment of 'deleteInfo.isNull'
