### PR TITLE
feat: CLDSRV-355 activate null keys behavior

### DIFF
--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -62,9 +62,24 @@ function checkQueryVersionId(query) {
     return undefined;
 }
 
-function _storeNullVersionMD(bucketName, objKey, nullVersionId, nullVersionMD, log, cb) {
+function _storeNullVersionMD(bucketName, objKey, nullVersionId, objMD, log, cb) {
     // In compatibility mode, create null versioned keys instead of null keys
-    const versionId = config.nullVersionCompatMode ? nullVersionId : 'null';
+    let versionId;
+    let nullVersionMD;
+    if (config.nullVersionCompatMode) {
+        versionId = nullVersionId;
+        nullVersionMD = Object.assign({}, objMD, {
+            versionId: nullVersionId,
+            isNull: true,
+        });
+    } else {
+        versionId = 'null';
+        nullVersionMD = Object.assign({}, objMD, {
+            versionId: nullVersionId,
+            isNull: true,
+            isNull2: true,
+        });
+    }
     metadata.putObjectMD(bucketName, objKey, nullVersionMD, { versionId }, log, err => {
         if (err) {
             log.debug('error from metadata storing null version as new version',
@@ -309,8 +324,7 @@ function versioningPreprocessing(bucketName, bucketMD, objectKey, objMD,
             if (!nullVersionId) {
                 return process.nextTick(next);
             }
-            const nullVersionMD = Object.assign({}, objMD, { versionId: nullVersionId, isNull: true });
-            return _storeNullVersionMD(bucketName, objectKey, nullVersionId, nullVersionMD, log, next);
+            return _storeNullVersionMD(bucketName, objectKey, nullVersionId, objMD, log, next);
         },
         function prepareNullVersionDeletion(next) {
             if (!delOptions) {

--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -64,8 +64,8 @@ function checkQueryVersionId(query) {
 
 function _storeNullVersionMD(bucketName, objKey, nullVersionId, nullVersionMD, log, cb) {
     // In compatibility mode, create null versioned keys instead of null keys
-    // XXX CLDSRV-355: pass { versionId: 'null' } if compat mode is disabled
-    metadata.putObjectMD(bucketName, objKey, nullVersionMD, { versionId: nullVersionId }, log, err => {
+    const versionId = config.nullVersionCompatMode ? nullVersionId : 'null';
+    metadata.putObjectMD(bucketName, objKey, nullVersionMD, { versionId }, log, err => {
         if (err) {
             log.debug('error from metadata storing null version as new version',
             { error: err });
@@ -302,11 +302,8 @@ function versioningPreprocessing(bucketName, bucketMD, objectKey, objMD,
         return process.nextTick(callback, null, options);
     }
     // bucket is versioning configured
-
-    // XXX CLDSRV-355: pass config.nullVersionCompatMode as last param
-    // to processVersioningState() when all operations support null keys
     const { options, nullVersionId, delOptions } =
-          processVersioningState(mst, vCfg.Status, true);
+          processVersioningState(mst, vCfg.Status, config.nullVersionCompatMode);
     return async.series([
         function storeNullVersionMD(next) {
             if (!nullVersionId) {

--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -285,11 +285,8 @@ function getObjMetadataAndDelete(authInfo, canonicalID, request,
                 return callback(null, objMD, versionId);
             },
             (objMD, versionId, callback) => {
-                // XXX CLDSRV-355: pass config.nullVersionCompatMode
-                // as last param to preprocessingVersioningDelete()
-                // when all operations support null keys
                 const options = preprocessingVersioningDelete(
-                    bucketName, bucket, objMD, versionId, true);
+                    bucketName, bucket, objMD, versionId, config.nullVersionCompatMode);
                 const deleteInfo = {};
                 if (options && options.deleteData) {
                     deleteInfo.deleted = true;

--- a/lib/api/objectDelete.js
+++ b/lib/api/objectDelete.js
@@ -137,11 +137,8 @@ function objectDelete(authInfo, request, log, cb) {
             return next(null, bucketMD, objectMD);
         },
         function deleteOperation(bucketMD, objectMD, next) {
-            // XXX CLDSRV-355: pass config.nullVersionCompatMode as
-            // last param to preprocessingVersioningDelete() when all
-            // operations support null keys
             const delOptions = preprocessingVersioningDelete(
-                bucketName, bucketMD, objectMD, reqVersionId, true);
+                bucketName, bucketMD, objectMD, reqVersionId, config.nullVersionCompatMode);
             const deleteInfo = {
                 removeDeleteMarker: false,
                 newDeleteMarker: false,

--- a/lib/api/objectDeleteTagging.js
+++ b/lib/api/objectDeleteTagging.js
@@ -11,6 +11,7 @@ const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const metadata = require('../metadata/wrapper');
 const getReplicationInfo = require('./apiUtils/object/getReplicationInfo');
 const { data } = require('../data/wrapper');
+const { config } = require('../Config');
 const REPLICATION_ACTION = 'DELETE_TAGGING';
 
 /**
@@ -71,8 +72,13 @@ function objectDeleteTagging(authInfo, request, log, callback) {
         (bucket, objectMD, next) => {
             // eslint-disable-next-line no-param-reassign
             objectMD.tags = {};
-            const params = objectMD.versionId ? { versionId:
-              objectMD.versionId } : {};
+            const params = {};
+            if (objectMD.versionId) {
+                params.versionId = objectMD.versionId;
+                if (!config.nullVersionCompatMode) {
+                    params.isNull = objectMD.isNull || false;
+                }
+            }
             const replicationInfo = getReplicationInfo(objectKey, bucket, true,
                 0, REPLICATION_ACTION, objectMD);
             if (replicationInfo) {

--- a/lib/api/objectPutACL.js
+++ b/lib/api/objectPutACL.js
@@ -11,6 +11,7 @@ const { decodeVersionId, getVersionIdResHeader }
     = require('./apiUtils/object/versioning');
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const monitoring = require('../utilities/metrics');
+const { config } = require('../Config');
 
 /*
    Format of xml request:
@@ -129,7 +130,6 @@ function objectPutACL(authInfo, request, log, cb) {
                 });
         },
         function parseAclFromXml(bucket, objectMD, next) {
-            metadataValParams.versionId = objectMD.versionId;
             // If not setting acl through headers, parse body
             let jsonGrants;
             let aclOwnerID;
@@ -278,8 +278,13 @@ function objectPutACL(authInfo, request, log, cb) {
         },
         function addAclsToObjMD(bucket, objectMD, ACLParams, next) {
             // Add acl's to object metadata
-            const params = metadataValParams.versionId ?
-                { versionId: metadataValParams.versionId } : {};
+            const params = {};
+            if (objectMD.versionId) {
+                params.versionId = objectMD.versionId;
+                if (!config.nullVersionCompatMode) {
+                    params.isNull = objectMD.isNull || false;
+                }
+            }
             acl.addObjectACL(bucket, objectKey, objectMD,
                 ACLParams, params, log, err => next(err, bucket, objectMD));
         },

--- a/lib/api/objectPutLegalHold.js
+++ b/lib/api/objectPutLegalHold.js
@@ -8,6 +8,7 @@ const getReplicationInfo = require('./apiUtils/object/getReplicationInfo');
 const metadata = require('../metadata/wrapper');
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
+const { config } = require('../Config');
 
 const { parseLegalHoldXml } = s3middleware.objectLegalHold;
 
@@ -82,8 +83,13 @@ function objectPutLegalHold(authInfo, request, log, callback) {
         (bucket, legalHold, objectMD, next) => {
             // eslint-disable-next-line no-param-reassign
             objectMD.legalHold = legalHold;
-            const params = objectMD.versionId ?
-                { versionId: objectMD.versionId } : {};
+            const params = {};
+            if (objectMD.versionId) {
+                params.versionId = objectMD.versionId;
+                if (!config.nullVersionCompatMode) {
+                    params.isNull = objectMD.isNull || false;
+                }
+            }
             const replicationInfo = getReplicationInfo(objectKey, bucket, true,
                 0, REPLICATION_ACTION, objectMD);
             if (replicationInfo) {

--- a/lib/api/objectPutRetention.js
+++ b/lib/api/objectPutRetention.js
@@ -10,6 +10,7 @@ const { pushMetric } = require('../utapi/utilities');
 const getReplicationInfo = require('./apiUtils/object/getReplicationInfo');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const metadata = require('../metadata/wrapper');
+const { config } = require('../Config');
 
 const { parseRetentionXml } = s3middleware.retention;
 const REPLICATION_ACTION = 'PUT_RETENTION';
@@ -112,8 +113,13 @@ function objectPutRetention(authInfo, request, log, callback) {
             /* eslint-disable no-param-reassign */
             objectMD.retentionMode = retentionInfo.mode;
             objectMD.retentionDate = retentionInfo.date;
-            const params = objectMD.versionId ?
-                { versionId: objectMD.versionId } : {};
+            const params = {};
+            if (objectMD.versionId) {
+                params.versionId = objectMD.versionId;
+                if (!config.nullVersionCompatMode) {
+                    params.isNull = objectMD.isNull || false;
+                }
+            }
             const replicationInfo = getReplicationInfo(objectKey, bucket, true,
                 0, REPLICATION_ACTION, objectMD);
             if (replicationInfo) {

--- a/lib/api/objectPutTagging.js
+++ b/lib/api/objectPutTagging.js
@@ -12,6 +12,7 @@ const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const metadata = require('../metadata/wrapper');
 const { data } = require('../data/wrapper');
 const { parseTagXml } = s3middleware.tagging;
+const { config } = require('../Config');
 const REPLICATION_ACTION = 'PUT_TAGGING';
 
 /**
@@ -77,8 +78,13 @@ function objectPutTagging(authInfo, request, log, callback) {
         (bucket, tags, objectMD, next) => {
             // eslint-disable-next-line no-param-reassign
             objectMD.tags = tags;
-            const params = objectMD.versionId ? { versionId:
-              objectMD.versionId } : {};
+            const params = {};
+            if (objectMD.versionId) {
+                params.versionId = objectMD.versionId;
+                if (!config.nullVersionCompatMode) {
+                    params.isNull = objectMD.isNull || false;
+                }
+            }
             const replicationInfo = getReplicationInfo(objectKey, bucket, true,
                 0, REPLICATION_ACTION, objectMD);
             if (replicationInfo) {

--- a/lib/services.js
+++ b/lib/services.js
@@ -7,6 +7,7 @@ const ObjectMD = require('arsenal').models.ObjectMD;
 const BucketInfo = require('arsenal').models.BucketInfo;
 const acl = require('./metadata/acl');
 const constants = require('../constants');
+const { config } = require('./Config');
 const { data } = require('./data/wrapper');
 const metadata = require('./metadata/wrapper');
 const logger = require('./utilities/logger');
@@ -181,6 +182,9 @@ const services = {
             .setIsDeleteMarker(isDeleteMarker);
         if (versionId && versionId !== 'null') {
             md.setVersionId(versionId);
+        }
+        if (isNull && !config.nullVersionCompatMode) {
+            md.setIsNull2(true);
         }
         if (taggingCopy) {
             // If copying tags to an object (taggingCopy) we do not

--- a/tests/utilities/objectLock-util.js
+++ b/tests/utilities/objectLock-util.js
@@ -19,7 +19,8 @@ function changeObjectLock(objects, newConfig, cb) {
             objMD.retentionMode = newConfig.mode;
             objMD.retentionDate = newConfig.date;
             objMD.legalHold = false;
-            metadata.putObjectMD(bucket, key, objMD, { versionId: objMD.versionId }, log, err => {
+            const params = { versionId: objMD.versionId, isNull: false };
+            metadata.putObjectMD(bucket, key, objMD, params, log, err => {
                 assert.ifError(err);
                 next();
             });


### PR DESCRIPTION
Activate the use of null keys in place of null versioned keys by Cloudserver:

- allow processVersioningState() and preprocessingVersioningDelete() helpers to return the associated fields for null key handling, which tells Cloudserver to set its behavior to create/delete null keys, via sending PUT/DELETE requests with `versionId="null"` to the Metadata backend

- pass 'isNull' parameter in version-specific requests to hint the Metadata backend on what to do (most useful for V1 backend, but also to hint V0 backend that it should handle null keys appropriately)

- set "isNull2" metadata attribute when writing a null master, for optimization purpose (allows to avoid checking the null versioned key on update)
