### PR TITLE
feat: CLDSRV-359 pass getDeleteMarker flag to metadata when needed

### DIFF
--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -214,6 +214,7 @@ function objectCopy(authInfo, request, sourceBucket,
         bucketName: sourceBucket,
         objectKey: sourceObject,
         versionId: sourceVersionId,
+        getDeleteMarker: true,
         requestType: 'objectGet',
         request,
     };

--- a/lib/api/objectDeleteTagging.js
+++ b/lib/api/objectDeleteTagging.js
@@ -42,8 +42,9 @@ function objectDeleteTagging(authInfo, request, log, callback) {
         authInfo,
         bucketName,
         objectKey,
-        requestType: 'objectDeleteTagging',
         versionId: reqVersionId,
+        getDeleteMarker: true,
+        requestType: 'objectDeleteTagging',
         request,
     };
 
@@ -65,6 +66,8 @@ function objectDeleteTagging(authInfo, request, log, callback) {
               if (objectMD.isDeleteMarker) {
                   log.trace('version is a delete marker',
                   { method: 'objectDeleteTagging' });
+                  // FIXME we should return a `x-amz-delete-marker: true` header,
+                  // see S3C-7592
                   return next(errors.MethodNotAllowed, bucket);
               }
               return next(null, bucket, objectMD);

--- a/lib/api/objectGet.js
+++ b/lib/api/objectGet.js
@@ -45,6 +45,7 @@ function objectGet(authInfo, request, returnTagCount, log, callback) {
         bucketName,
         objectKey,
         versionId,
+        getDeleteMarker: true,
         requestType: 'objectGet',
         request,
     };

--- a/lib/api/objectGetACL.js
+++ b/lib/api/objectGetACL.js
@@ -54,6 +54,8 @@ function objectGetACL(authInfo, request, log, callback) {
     }
     const versionId = decodedVidResult;
 
+    // FIXME pass 'getDeleteMarker: true' option to set
+    // 'x-amz-delete-marker' header (see S3C-7592)
     const metadataValParams = {
         authInfo,
         bucketName,
@@ -90,10 +92,14 @@ function objectGetACL(authInfo, request, log, callback) {
                         if (versionId) {
                             log.trace('requested version is delete marker',
                                 { method: 'objectGetACL' });
+                            // FIXME we should return a `x-amz-delete-marker: true` header,
+                            // see S3C-7592
                             return next(errors.MethodNotAllowed);
                         }
                         log.trace('most recent version is delete marker',
                             { method: 'objectGetACL' });
+                        // FIXME we should return a `x-amz-delete-marker: true` header,
+                        // see S3C-7592
                         return next(errors.NoSuchKey);
                     }
                     return next(null, bucket, objectMD);

--- a/lib/api/objectGetLegalHold.js
+++ b/lib/api/objectGetLegalHold.js
@@ -33,12 +33,14 @@ function objectGetLegalHold(authInfo, request, log, callback) {
     }
     const versionId = decodedVidResult;
 
+    // FIXME pass 'getDeleteMarker: true' option to set
+    // 'x-amz-delete-marker' header (see S3C-7592)
     const metadataValParams = {
         authInfo,
         bucketName,
         objectKey,
-        requestType: 'objectGetLegalHold',
         versionId,
+        requestType: 'objectGetLegalHold',
         request,
     };
 
@@ -61,10 +63,14 @@ function objectGetLegalHold(authInfo, request, log, callback) {
                     if (versionId) {
                         log.trace('requested version is delete marker',
                             { method: 'objectGetLegalHold' });
+                        // FIXME we should return a `x-amz-delete-marker: true` header,
+                        // see S3C-7592
                         return next(errors.MethodNotAllowed);
                     }
                     log.trace('most recent version is delete marker',
                         { method: 'objectGetLegalHold' });
+                    // FIXME we should return a `x-amz-delete-marker: true` header,
+                    // see S3C-7592
                     return next(errors.NoSuchKey);
                 }
                 if (!bucket.isObjectLockEnabled()) {

--- a/lib/api/objectGetRetention.js
+++ b/lib/api/objectGetRetention.js
@@ -33,12 +33,14 @@ function objectGetRetention(authInfo, request, log, callback) {
     }
     const reqVersionId = decodedVidResult;
 
+    // FIXME pass 'getDeleteMarker: true' option to set
+    // 'x-amz-delete-marker' header (see S3C-7592)
     const metadataValParams = {
         authInfo,
         bucketName,
         objectKey,
-        requestType: 'objectGetRetention',
         versionId: reqVersionId,
+        requestType: 'objectGetRetention',
         request,
     };
 
@@ -61,10 +63,14 @@ function objectGetRetention(authInfo, request, log, callback) {
                     if (reqVersionId) {
                         log.trace('requested version is delete marker',
                             { method: 'objectGetRetention' });
+                        // FIXME we should return a `x-amz-delete-marker: true` header,
+                        // see S3C-7592
                         return next(errors.MethodNotAllowed);
                     }
                     log.trace('most recent version is delete marker',
                         { method: 'objectGetRetention' });
+                    // FIXME we should return a `x-amz-delete-marker: true` header,
+                    // see S3C-7592
                     return next(errors.NoSuchKey);
                 }
                 if (!bucket.isObjectLockEnabled()) {

--- a/lib/api/objectGetTagging.js
+++ b/lib/api/objectGetTagging.js
@@ -34,12 +34,14 @@ function objectGetTagging(authInfo, request, log, callback) {
     }
     const reqVersionId = decodedVidResult;
 
+    // FIXME pass 'getDeleteMarker: true' option to set
+    // 'x-amz-delete-marker' header (see S3C-7592)
     const metadataValParams = {
         authInfo,
         bucketName,
         objectKey,
-        requestType: 'objectGetTagging',
         versionId: reqVersionId,
+        requestType: 'objectGetTagging',
         request,
     };
 
@@ -63,9 +65,13 @@ function objectGetTagging(authInfo, request, log, callback) {
                       log.trace('requested version is delete marker',
                       { method: 'objectGetTagging' });
                       return next(errors.MethodNotAllowed);
+                      // FIXME we should return a `x-amz-delete-marker: true` header,
+                      // see S3C-7592
                   }
                   log.trace('most recent version is delete marker',
                   { method: 'objectGetTagging' });
+                  // FIXME we should return a `x-amz-delete-marker: true` header,
+                  // see S3C-7592
                   return next(errors.NoSuchKey);
               }
               return next(null, bucket, objectMD);

--- a/lib/api/objectHead.js
+++ b/lib/api/objectHead.js
@@ -45,6 +45,7 @@ function objectHead(authInfo, request, log, callback) {
         bucketName,
         objectKey,
         versionId,
+        getDeleteMarker: true,
         requestType: 'objectHead',
         request,
     };

--- a/lib/api/objectPutACL.js
+++ b/lib/api/objectPutACL.js
@@ -86,8 +86,9 @@ function objectPutACL(authInfo, request, log, cb) {
         authInfo,
         bucketName,
         objectKey,
-        requestType: 'objectPutACL',
         versionId: reqVersionId,
+        getDeleteMarker: true,
+        requestType: 'objectPutACL',
     };
 
     const possibleGrants = ['FULL_CONTROL', 'WRITE_ACP', 'READ', 'READ_ACP'];
@@ -124,6 +125,8 @@ function objectPutACL(authInfo, request, log, cb) {
                     if (objectMD.isDeleteMarker) {
                         log.trace('delete marker detected',
                         { method: 'objectPutACL' });
+                        // FIXME we should return a `x-amz-delete-marker: true` header,
+                        // see S3C-7592
                         return next(errors.MethodNotAllowed, bucket);
                     }
                     return next(null, bucket, objectMD);

--- a/lib/api/objectPutCopyPart.js
+++ b/lib/api/objectPutCopyPart.js
@@ -44,6 +44,7 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
         bucketName: sourceBucket,
         objectKey: sourceObject,
         versionId: reqVersionId,
+        getDeleteMarker: true,
         requestType: 'objectGet',
         request,
     };

--- a/lib/api/objectPutLegalHold.js
+++ b/lib/api/objectPutLegalHold.js
@@ -41,8 +41,9 @@ function objectPutLegalHold(authInfo, request, log, callback) {
         authInfo,
         bucketName,
         objectKey,
-        requestType: 'objectPutLegalHold',
         versionId,
+        getDeleteMarker: true,
+        requestType: 'objectPutLegalHold',
         request,
     };
 
@@ -64,6 +65,8 @@ function objectPutLegalHold(authInfo, request, log, callback) {
             if (objectMD.isDeleteMarker) {
                 log.trace('version is a delete marker',
                     { method: 'objectPutLegalHold' });
+                // FIXME we should return a `x-amz-delete-marker: true` header,
+                // see S3C-7592
                 return next(errors.MethodNotAllowed, bucket);
             }
             if (!bucket.isObjectLockEnabled()) {

--- a/lib/api/objectPutRetention.js
+++ b/lib/api/objectPutRetention.js
@@ -42,8 +42,9 @@ function objectPutRetention(authInfo, request, log, callback) {
         authInfo,
         bucketName,
         objectKey,
-        requestType: 'objectPutRetention',
         versionId: reqVersionId,
+        getDeleteMarker: true,
+        requestType: 'objectPutRetention',
         request,
     };
 
@@ -65,6 +66,8 @@ function objectPutRetention(authInfo, request, log, callback) {
             if (objectMD.isDeleteMarker) {
                 log.trace('version is a delete marker',
                     { method: 'objectPutRetention' });
+                // FIXME we should return a `x-amz-delete-marker: true` header,
+                // see S3C-7592
                 return next(errors.MethodNotAllowed, bucket);
             }
             if (!bucket.isObjectLockEnabled()) {

--- a/lib/api/objectPutTagging.js
+++ b/lib/api/objectPutTagging.js
@@ -43,8 +43,9 @@ function objectPutTagging(authInfo, request, log, callback) {
         authInfo,
         bucketName,
         objectKey,
-        requestType: 'objectPutTagging',
         versionId: reqVersionId,
+        getDeleteMarker: true,
+        requestType: 'objectPutTagging',
         request,
     };
 
@@ -66,6 +67,8 @@ function objectPutTagging(authInfo, request, log, callback) {
               if (objectMD.isDeleteMarker) {
                   log.trace('version is a delete marker',
                   { method: 'objectPutTagging' });
+                  // FIXME we should return a `x-amz-delete-marker: true` header,
+                  // see S3C-7592
                   return next(errors.MethodNotAllowed, bucket);
               }
               return next(null, bucket, objectMD);

--- a/lib/metadata/metadataUtils.js
+++ b/lib/metadata/metadataUtils.js
@@ -66,7 +66,7 @@ function getNullVersionFromMaster(bucketName, objectKey, log, cb) {
  */
 function metadataGetObject(bucketName, objectKey, versionId, log, cb) {
     // versionId may be 'null', which asks metadata to fetch the null key specifically
-    const options = { versionId };
+    const options = { versionId, getDeleteMarker: true };
     return metadata.getObjectMD(bucketName, objectKey, options, log,
         (err, objMD) => {
             if (err) {
@@ -140,11 +140,15 @@ function validateBucket(bucket, params, log) {
  * @return {undefined} - and call callback with params err, bucket md
  */
 function metadataValidateBucketAndObj(params, log, callback) {
-    const { authInfo, bucketName, objectKey, versionId, requestType, request } = params;
+    const { authInfo, bucketName, objectKey, versionId, getDeleteMarker,
+            requestType, request } = params;
     async.waterfall([
         next => {
             // versionId may be 'null', which asks metadata to fetch the null key specifically
             const getOptions = { versionId };
+            if (getDeleteMarker) {
+                getOptions.getDeleteMarker = true;
+            }
             return metadata.getBucketAndObjectMD(bucketName, objectKey, getOptions, log, next);
         },
         (getResult, next) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.70.19",
+  "version": "7.70.20",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {

--- a/tests/functional/aws-node-sdk/test/object/getObjectLegalHold.js
+++ b/tests/functional/aws-node-sdk/test/object/getObjectLegalHold.js
@@ -107,6 +107,19 @@ describe('GET object legal hold', () => {
             });
         });
 
+        it('should return NoSuchKey if latest version is delete marker', done => {
+            s3.deleteObject({ Bucket: bucket, Key: key }, err => {
+                assert.ifError(err);
+                s3.getObjectLegalHold({
+                    Bucket: bucket,
+                    Key: key,
+                }, err => {
+                    checkError(err, 'NoSuchKey', 404);
+                    done();
+                });
+            });
+        });
+
         it('should return InvalidRequest error getting legal hold of object ' +
             'inside object lock disabled bucket', done => {
             s3.getObjectLegalHold({

--- a/tests/functional/aws-node-sdk/test/versioning/objectCopy.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectCopy.js
@@ -688,7 +688,7 @@ describe('Object Version Copy', () => {
             });
 
         it('should return NoSuchKey if attempt to copy version with ' +
-        ' delete marker', done => {
+        'delete marker', done => {
             s3.deleteObject({
                 Bucket: sourceBucketName,
                 Key: sourceObjName,

--- a/tests/functional/aws-node-sdk/test/versioning/objectDelete.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectDelete.js
@@ -348,7 +348,7 @@ describe('aws-node-sdk test delete object', () => {
             });
         });
 
-        it('should delete the versionned object', done => {
+        it('should delete the versioned object', done => {
             const version = versionIds.shift();
             s3.deleteObject({
                 Bucket: bucket,
@@ -370,12 +370,15 @@ describe('aws-node-sdk test delete object', () => {
                 Bucket: bucket,
                 Key: key,
                 VersionId: version,
-            }, (err, res) => {
+            }, function test(err, res) {
                 if (err) {
                     return done(err);
                 }
                 assert.strictEqual(res.VersionId, version);
                 assert.equal(res.DeleteMarker, true);
+                // deleting a delete marker should set the x-amz-delete-marker header
+                const headers = this.httpResponse.headers;
+                assert.strictEqual(headers['x-amz-delete-marker'], 'true');
                 return done();
             });
         });

--- a/tests/functional/aws-node-sdk/test/versioning/objectDeleteTagging.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectDeleteTagging.js
@@ -131,7 +131,7 @@ describe('Delete object tagging with versioning', () => {
             });
         });
 
-        it('should return 405 MethodNotAllowed deletting tag set without ' +
+        it('should return 405 MethodNotAllowed deleting tag set without ' +
          'version id if version specified is a delete marker', done => {
             async.waterfall([
                 next => s3.putBucketVersioning({ Bucket: bucketName,

--- a/tests/functional/aws-node-sdk/test/versioning/objectGet.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectGet.js
@@ -137,9 +137,11 @@ describe('get behavior on versioning-enabled bucket', () => {
                 s3.getObject({
                     Bucket: bucket,
                     Key: key,
-                    VersionId: this.test.deleteVersionId },
-                err => {
+                    VersionId: this.test.deleteVersionId,
+                }, function test1(err) {
                     _assertError(err, 405, 'MethodNotAllowed');
+                    const headers = this.httpResponse.headers;
+                    assert.strictEqual(headers['x-amz-delete-marker'], 'true');
                     done();
                 });
             });
@@ -148,9 +150,11 @@ describe('get behavior on versioning-enabled bucket', () => {
             'latest version is a delete marker', done => {
                 s3.getObject({
                     Bucket: bucket,
-                    Key: key },
-                err => {
+                    Key: key,
+                }, function test2(err) {
                     _assertError(err, 404, 'NoSuchKey');
+                    const headers = this.httpResponse.headers;
+                    assert.strictEqual(headers['x-amz-delete-marker'], 'true');
                     done();
                 });
             });
@@ -175,9 +179,11 @@ describe('get behavior on versioning-enabled bucket', () => {
                 s3.getObject({
                     Bucket: bucket,
                     Key: key,
-                    VersionId: this.test.deleteVersionId },
-                err => {
+                    VersionId: this.test.deleteVersionId,
+                }, function test3(err) {
                     _assertError(err, 405, 'MethodNotAllowed');
+                    const headers = this.httpResponse.headers;
+                    assert.strictEqual(headers['x-amz-delete-marker'], 'true');
                     done();
                 });
             });
@@ -200,9 +206,11 @@ describe('get behavior on versioning-enabled bucket', () => {
             done => {
                 s3.getObject({
                     Bucket: bucket,
-                    Key: key },
-                err => {
+                    Key: key,
+                }, function test4(err) {
                     _assertError(err, 404, 'NoSuchKey');
+                    const headers = this.httpResponse.headers;
+                    assert.strictEqual(headers['x-amz-delete-marker'], 'true');
                     done();
                 });
             });


### PR DESCRIPTION
Pass the `getDeleteMarker` flag to the Metadata backend when the Cloudserver operation requires to distinguish if the target is a delete marker or does not exist, to set response header "x-amz-delete-marker" or return a specific error code.
