### PR TITLE
bugfix: CLDSRV-361 fix exception with batch delete of null version

### DIFF
--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -211,10 +211,10 @@ function getObjMetadataAndDelete(authInfo, canonicalID, request,
             (versionId, callback) => metadataGetObject(bucketName, entry.key,
                 versionId, log, (err, objMD) => {
                     // if general error from metadata return error
-                    if (err && !err.is.NoSuchKey) {
+                    if (err) {
                         return callback(err);
                     }
-                    if (err && err.is.NoSuchKey) {
+                    if (!objMD) {
                         const verCfg = bucket.getVersioningConfiguration();
                         // To adhere to AWS behavior, create a delete marker
                         // if trying to delete an object that does not exist

--- a/lib/metadata/metadataUtils.js
+++ b/lib/metadata/metadataUtils.js
@@ -26,7 +26,13 @@ function getNullVersion(objMD, bucketName, objectKey, log, cb) {
         // the latest version is not the null version, but null version exists
         log.debug('null version exists, get the null version');
         options.versionId = objMD.nullVersionId;
-        return metadata.getObjectMD(bucketName, objectKey, options, log, cb);
+        return metadata.getObjectMD(bucketName, objectKey, options, log, (err, nullVersionMD) => {
+            if (err && err.is.NoSuchKey) {
+                log.debug('object does not exist in metadata');
+                return cb();
+            }
+            return cb(err, nullVersionMD);
+        });
     }
     log.debug('could not find a null version');
     return process.nextTick(() => cb());
@@ -96,6 +102,10 @@ function metadataGetObject(bucketName, objectKey, versionId, log, cb) {
     };
     return metadata.getObjectMD(bucketName, objectKey, options, log,
         (err, objMD) => {
+            if (err && err.is.NoSuchKey) {
+                log.debug('object does not exist in metadata');
+                return cb();
+            }
             if (err) {
                 log.debug('err getting object MD from metadata',
                 { error: err });

--- a/lib/metadata/metadataUtils.js
+++ b/lib/metadata/metadataUtils.js
@@ -27,7 +27,7 @@ function getNullVersion(objMD, bucketName, objectKey, log, cb) {
         log.debug('null version exists, get the null version');
         options.versionId = objMD.nullVersionId;
         return metadata.getObjectMD(bucketName, objectKey, options, log, (err, nullVersionMD) => {
-            if (err && err.is.NoSuchKey) {
+            if (err && err.is && err.is.NoSuchKey) {
                 log.debug('object does not exist in metadata');
                 return cb();
             }
@@ -102,7 +102,7 @@ function metadataGetObject(bucketName, objectKey, versionId, log, cb) {
     };
     return metadata.getObjectMD(bucketName, objectKey, options, log,
         (err, objMD) => {
-            if (err && err.is.NoSuchKey) {
+            if (err && err.is && err.is.NoSuchKey) {
                 log.debug('object does not exist in metadata');
                 return cb();
             }

--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -869,6 +869,9 @@ function putObjectTagging(request, response, log, callback) {
                 if (err) {
                     return callback(err);
                 }
+                if (!objMD) {
+                    return callback(errors.NoSuchKey);
+                }
                 const backend = objMD.replicationInfo.backends.find(o =>
                     o.site === site);
                 dataStoreVersionId = backend.dataStoreVersionId;
@@ -897,6 +900,9 @@ function deleteObjectTagging(request, response, log, callback) {
             sourceVersionId, log, (err, objMD) => {
                 if (err) {
                     return callback(err);
+                }
+                if (!objMD) {
+                    return callback(errors.NoSuchKey);
                 }
                 const backend = objMD.replicationInfo.backends.find(o =>
                     o.site === site);

--- a/tests/functional/aws-node-sdk/test/versioning/multiObjectDelete.js
+++ b/tests/functional/aws-node-sdk/test/versioning/multiObjectDelete.js
@@ -170,6 +170,22 @@ describe('Multi-Object Versioning Delete Success', function success() {
                 checkNoError(err);
             });
         });
+
+        it('should not crash when deleting a null versionId that does not exist', () => {
+            const objects = [{ Key: objectsRes[0].Key, VersionId: 'null' }];
+            return s3.deleteObjects({
+                Bucket: bucketName,
+                Delete: {
+                    Objects: objects,
+                },
+            }).promise().then(res => {
+                assert.deepStrictEqual(res.Deleted, [{ Key: objectsRes[0].Key, VersionId: 'null' }]);
+                assert.strictEqual(res.Errors.length, 0);
+            })
+            .catch(err => {
+                checkNoError(err);
+            });
+        });
     });
 });
 


### PR DESCRIPTION
Fix an exception in Cloudserver when doing a batch delete containing a deletion of a null version that does not exist on a versioned object
