### PR TITLE
CLDSRV-349 null version compat mode config and tests

### DIFF
--- a/.github/docker/docker-compose.yaml
+++ b/.github/docker/docker-compose.yaml
@@ -34,6 +34,7 @@ services:
       - S3KMIP_KEY
       - S3KMIP_CERT
       - S3KMIP_CA
+      - ENABLE_NULL_VERSION_COMPAT_MODE
     env_file:
       - creds.env
     depends_on:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -204,6 +204,14 @@ jobs:
       if: always()
 
   file-ft-tests:
+    strategy:
+      matrix:
+        include:
+          - enable-null-compat: ''
+            job-name: file-ft-tests
+          - enable-null-compat: 'true'
+            job-name: file-ft-tests-null-compat
+    name: ${{ matrix.job-name }}
     runs-on: ubuntu-latest
     needs: build
     env:
@@ -211,7 +219,8 @@ jobs:
       S3VAULT: mem
       CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}/cloudserver:${{ github.sha }}
       MPU_TESTING: "yes"
-      JOB_NAME: ${{ github.job }}
+      ENABLE_NULL_VERSION_COMPAT_MODE: "${{ matrix.enable-null-compat }}"
+      JOB_NAME: ${{ matrix.job-name }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -222,6 +231,11 @@ jobs:
           3.9
     - name: Setup CI environment
       uses: ./.github/actions/setup-ci
+    - name: Setup matrix job artifacts directory
+      shell: bash
+      run: |
+        set -exu
+        mkdir -p /tmp/artifacts/${{ matrix.job-name }}/
     - name: Setup python2 test environment
       run: |
         sudo apt-get install -y libdigest-hmac-perl
@@ -237,7 +251,7 @@ jobs:
         set -o pipefail;
         bash wait_for_local_port.bash 8000 40
         source ~/.virtualenv/py2/bin/activate
-        yarn run ft_test | tee /tmp/artifacts/${{ github.job }}/tests.log
+        yarn run ft_test | tee /tmp/artifacts/${{ matrix.job-name }}/tests.log
     - name: Upload logs to artifacts
       uses: scality/action-artifacts@v3
       with:

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1314,6 +1314,7 @@ class Config extends EventEmitter {
         } else {
             this.versionIdEncodingType = versionIdUtils.ENC_TYPE_HEX;
         }
+        this.nullVersionCompatMode = (process.env.ENABLE_NULL_VERSION_COMPAT_MODE === 'true');
         if (config.bucketNotificationDestinations) {
             this.bucketNotificationDestinations = bucketNotifAssert(config.bucketNotificationDestinations);
         }

--- a/lib/server.js
+++ b/lib/server.js
@@ -196,6 +196,9 @@ class S3Server {
                 serverIP: address,
                 serverPort: port,
             });
+            if (_config.nullVersionCompatMode) {
+                logger.warn('null version compatibility mode is enabled');
+            }
         });
 
         if (ipAddress !== undefined) {


### PR DESCRIPTION
- support ENABLE_NULL_VERSION_COMPAT_MODE env var

  Cloudserver sets a flag in its configuration when the ENABLE_NULL_VERSION_COMPAT_MODE environment variable is set to "true".

- [tests] func test stage for ENABLE_NULL_VERSION_COMPAT_MODE

  Turn the "file-ft-tests" job into a matrix, to duplicate the suite with and without the ENABLE_NULL_VERSION_COMPAT_MODE environment variable.

  This will make sure Cloudserver behaves correctly (versioning, null version handling etc.) when the compatibility mode is active.