### PR TITLE
CLDSRV-366 Clear list orphan delete markers response

### DIFF
--- a/lib/api/apiUtils/object/lifecycle.js
+++ b/lib/api/apiUtils/object/lifecycle.js
@@ -124,16 +124,12 @@ function processOrphans(bucketName, listParams, list) {
         data.Contents.push({
             Key: item.key,
             LastModified: v.LastModified,
-            ETag: v.ETag,
-            Size: v.Size,
             Owner: {
                 ID: v.Owner.ID,
                 DisplayName: v.Owner.DisplayName
             },
-            StorageClass: v.StorageClass,
             VersionId: versionId,
             IsLatest: true, // for compatibility with AWS ListObjectVersions.
-            DataStoreName: v.dataStoreName,
             ListType: ORPHAN_DM_TYPE,
         });
     });

--- a/tests/functional/backbeat/listLifecycleOrphanDeleteMarkers.js
+++ b/tests/functional/backbeat/listLifecycleOrphanDeleteMarkers.js
@@ -18,16 +18,15 @@ function checkContents(contents) {
         assert(d.Key);
         assert(d.LastModified);
         assert(d.VersionId);
-        assert(d.ETag);
         assert(d.Owner.DisplayName);
         assert(d.Owner.ID);
-        assert(d.StorageClass);
-        assert.strictEqual(d.StorageClass, 'STANDARD');
-        assert(!d.TagSet);
         assert.strictEqual(d.IsLatest, true);
-        assert.strictEqual(d.DataStoreName, 'us-east-1');
         assert.strictEqual(d.ListType, 'orphan');
-        assert.strictEqual(d.Size, 0);
+        assert(!d.ETag);
+        assert(!d.Size);
+        assert(!d.StorageClass);
+        assert(!d.TagSet);
+        assert(!d.DataStoreName);
     });
 }
 


### PR DESCRIPTION
Etag, Size, StorageClass, and DataStoreName are worthless when listing orphan delete markers because:

- A delete marker does not hold any data.
- The listing of orphan delete markers is only used for expiration purposes.