### PR TITLE
bugfix: CLDSRV-365 fix legal hold can be deleted issue and add more t…

### DIFF
--- a/lib/api/apiUtils/object/objectLockHelpers.js
+++ b/lib/api/apiUtils/object/objectLockHelpers.js
@@ -202,7 +202,13 @@ class ObjectLockInfo {
      * @returns {bool} - True if the retention policy allows the objects data to be modified (overwritten/deleted)
      */
     canModifyObject(hasGovernanceBypass) {
-        return !this.isLocked() || (this.isGovernanceMode() && !!hasGovernanceBypass);
+        // can modify object if object is not locked
+        // cannot modify object in any cases if legal hold is enabled
+        // if no legal hold, can only modify object if bypassing governance when locked
+        if (!this.isLocked()) {
+            return true;
+        }
+        return !this.legalHold && this.isGovernanceMode() && !!hasGovernanceBypass;
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.10.24",
+  "version": "7.10.27",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {

--- a/tests/functional/aws-node-sdk/test/object/deleteObject.js
+++ b/tests/functional/aws-node-sdk/test/object/deleteObject.js
@@ -5,7 +5,6 @@ const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
 const changeObjectLock = require('../../../../utilities/objectLock-util');
 
-const bucketName = 'testdeletempu';
 const objectName = 'key';
 const objectNameTwo = 'secondkey';
 
@@ -17,6 +16,7 @@ describe('DELETE object', () => {
         const testfile = Buffer.alloc(1024 * 1024 * 54, 0);
 
         describe('with multipart upload', () => {
+            const bucketName = 'testdeletempu';
             before(() => {
                 process.stdout.write('creating bucket\n');
                 return s3.createBucket({ Bucket: bucketName }).promise()
@@ -96,6 +96,7 @@ describe('DELETE object', () => {
         });
 
         describe('with object lock', () => {
+            const bucketName = 'testdeleteobjectlockbucket';
             let versionIdOne;
             let versionIdTwo;
             const retainDate = moment().add(10, 'days').toISOString();
@@ -227,6 +228,99 @@ describe('DELETE object', () => {
                         }], '', done);
                 });
             });
+        });
+
+        describe('with object lock and legal hold', () => {
+            const bucketName = 'testdeletelocklegalholdbucket';
+            const objectName = 'key';
+            let versionId;
+            before(() => {
+                process.stdout.write('creating bucket\n');
+                return s3.createBucket({
+                    Bucket: bucketName,
+                    ObjectLockEnabledForBucket: true,
+                }).promise()
+                    .catch(err => {
+                        process.stdout.write(`Error creating bucket ${err}\n`);
+                        throw err;
+                    })
+                    .then(() => {
+                        process.stdout.write('putting object lock configuration\n');
+                        return s3.putObjectLockConfiguration({
+                            Bucket: bucketName,
+                            ObjectLockConfiguration: {
+                                ObjectLockEnabled: 'Enabled',
+                                Rule: {
+                                    DefaultRetention: {
+                                        Mode: 'GOVERNANCE',
+                                        Days: 1,
+                                    },
+                                },
+                            },
+                        }).promise();
+                    })
+                    .catch(err => {
+                        process.stdout.write('Error putting object lock configuration\n');
+                        throw err;
+                    })
+                    .then(() => {
+                        process.stdout.write('putting object\n');
+                        return s3.putObject({
+                            Bucket: bucketName,
+                            Key: objectName,
+                        }).promise();
+                    })
+                    .catch(err => {
+                        process.stdout.write('Error putting object');
+                        throw err;
+                    })
+                    .then(res => {
+                        versionId = res.VersionId;
+                        process.stdout.write('putting object legal hold\n');
+                        return s3.putObjectLegalHold({
+                            Bucket: bucketName,
+                            Key: objectName,
+                            LegalHold: {
+                                Status: 'ON',
+                            },
+                        }).promise();
+                    })
+                    .catch(err => {
+                        process.stdout.write('Err putting object legal hold\n');
+                        throw err;
+                    });
+            });
+
+            after(() => {
+                process.stdout.write('Emptying bucket\n');
+                return bucketUtil.empty(bucketName)
+                    .then(() => {
+                        process.stdout.write('Deleting bucket\n');
+                        return bucketUtil.deleteOne(bucketName);
+                    })
+                    .catch(err => {
+                        process.stdout.write('Error in after\n');
+                        throw err;
+                    });
+            });
+
+            it('should not delete locked object version with GOVERNANCE ' +
+                'retention mode and bypass header when object is legal-hold enabled', done =>
+                     s3.deleteObject({
+                         Bucket: bucketName,
+                         Key: objectName,
+                         VersionId: versionId,
+                         BypassGovernanceRetention: true,
+                     }, err => {
+                         assert.strictEqual(err.code, 'AccessDenied');
+                         changeObjectLock(
+                             [{
+                                 bucket: bucketName,
+                                 key: objectName,
+                                 versionId,
+                             }], '', done);
+                     }
+                ));
         });
     });
 });

--- a/tests/unit/api/apiUtils/objectLockHelpers.js
+++ b/tests/unit/api/apiUtils/objectLockHelpers.js
@@ -571,6 +571,24 @@ const canModifyObjectTestCases = [
         allowed: false,
         allowedWithBypass: false,
     },
+    {
+        desc: 'legal hold enabled',
+        policy: {
+            legalHold: true,
+        },
+        allowed: false,
+        allowedWithBypass: false,
+    },
+    {
+        desc: 'legal hold enabled with governance mode',
+        policy: {
+            legalHold: true,
+            mode: 'GOVERNANCE',
+            date: futureDate.toISOString(),
+        },
+        allowed: false,
+        allowedWithBypass: false,
+    },
 ];
 
 describe('objectLockHelpers: ObjectLockInfo', () => {


### PR DESCRIPTION
the previous checking ifCanModifyObject didn't take into account legalhold case, so caused the issue that object with legalhold can still be deleted with governance bypass.
the standard is whenever the object is legalhold enabled, in any case it should not be allowed to be modified(even with governance mode and bypass header)


tested working after doing a upgrade check:
- in governance mode
  - delete no
  - multi-deletes no
  - delete with bypass yes
  - multi-deletes with bypass yes
  - delete with legalhold with bypass no
  - multi-deletes with legalhold with by pass no

- in conpliance mode
  - delete no
  - multi-deletes no
  - delete with bypass no
  - multi-deletes with bypass no
  - delete with legalhold with bypass no
  - multi-deletes with legalhold with by pass no