### PR TITLE
CLDSRV-372 Current lifecycle versions should include version id

### DIFF
--- a/lib/api/apiUtils/object/lifecycle.js
+++ b/lib/api/apiUtils/object/lifecycle.js
@@ -16,7 +16,7 @@ function _makeTags(tags) {
     return res;
 }
 
-function processCurrents(bucketName, listParams, list) {
+function processCurrents(bucketName, listParams, isBucketVersioned, list) {
     const data = {
         Name: bucketName,
         Prefix: listParams.prefix,
@@ -46,6 +46,15 @@ function processCurrents(bucketName, listParams, list) {
             DataStoreName: v.dataStoreName,
             ListType: CURRENT_TYPE,
         };
+
+        // NOTE: The current versions listed to be lifecycle should include version id
+        // if the bucket is versioned.
+        if (isBucketVersioned) {
+            const versionId = (v.IsNull || v.VersionId === undefined) ?
+                'null' : versionIdUtils.encode(v.VersionId);
+            content.VersionId = versionId;
+        }
+
         data.Contents.push(content);
     });
 

--- a/lib/api/backbeat/listLifecycleCurrents.js
+++ b/lib/api/backbeat/listLifecycleCurrents.js
@@ -8,10 +8,10 @@ const { processCurrents } = require('../apiUtils/object/lifecycle');
 
 
 function handleResult(listParams, requestMaxKeys, authInfo,
-    bucketName, list, log, callback) {
+    bucketName, list, isBucketVersioned, log, callback) {
     // eslint-disable-next-line no-param-reassign
     listParams.maxKeys = requestMaxKeys;
-    const res = processCurrents(bucketName, listParams, list);
+    const res = processCurrents(bucketName, listParams, isBucketVersioned, list);
 
     pushMetric('listLifecycleCurrents', log, { authInfo, bucket: bucketName });
     monitoring.promMetrics('GET', bucketName, '200', 'listLifecycleCurrents');
@@ -56,7 +56,7 @@ function listLifecycleCurrents(authInfo, request, log, callback) {
         marker: params.marker,
     };
 
-    return metadataValidateBucket(metadataValParams, log, err => {
+    return metadataValidateBucket(metadataValParams, log, (err, bucket) => {
         if (err) {
             log.debug('error processing request', { method: 'metadataValidateBucket', error: err });
             monitoring.promMetrics(
@@ -64,13 +64,16 @@ function listLifecycleCurrents(authInfo, request, log, callback) {
             return callback(err, null);
         }
 
+        const vcfg = bucket.getVersioningConfiguration();
+        const isBucketVersioned = vcfg && (vcfg.Status === 'Enabled' || vcfg.Status === 'Suspended');
+
         if (!requestMaxKeys) {
             const emptyList = {
                 Contents: [],
                 IsTruncated: false,
             };
             return handleResult(listParams, requestMaxKeys, authInfo,
-                bucketName, emptyList, log, callback);
+                bucketName, emptyList, isBucketVersioned, log, callback);
         }
 
         return services.getLifecycleListing(bucketName, listParams, log,
@@ -81,8 +84,9 @@ function listLifecycleCurrents(authInfo, request, log, callback) {
                     'GET', bucketName, err.code, 'listLifecycleCurrents');
                 return callback(err, null);
             }
+
             return handleResult(listParams, requestMaxKeys, authInfo,
-                bucketName, list, log, callback);
+                bucketName, list, isBucketVersioned, log, callback);
         });
     });
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@azure/storage-blob": "^12.12.0",
     "@hapi/joi": "^17.1.0",
-    "arsenal": "git+https://github.com/scality/arsenal#8.1.88",
+    "arsenal": "git+https://github.com/scality/arsenal#8.1.92",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "bucketclient": "scality/bucketclient#8.1.9",

--- a/tests/functional/backbeat/listNullVersion.js
+++ b/tests/functional/backbeat/listNullVersion.js
@@ -1,0 +1,104 @@
+const assert = require('assert');
+const async = require('async');
+const BucketUtility = require('../aws-node-sdk/lib/utility/bucket-util');
+const { removeAllVersions } = require('../aws-node-sdk/lib/utility/versioning-util');
+const { makeBackbeatRequest, runIfMongoV1 } = require('./utils');
+
+const testBucket = 'bucket-for-list-lifecycle-null-tests';
+
+const credentials = {
+    accessKey: 'accessKey1',
+    secretKey: 'verySecretKey1',
+};
+
+runIfMongoV1('listLifecycle if null version', () => {
+    let bucketUtil;
+    let s3;
+    let versionForKey2;
+
+    before(done => {
+        bucketUtil = new BucketUtility('account1', { signatureVersion: 'v4' });
+        s3 = bucketUtil.s3;
+
+        return async.series([
+            next => s3.createBucket({ Bucket: testBucket }, next),
+            next => s3.putObject({ Bucket: testBucket, Key: 'key1', Body: '123' }, next),
+            next => s3.putObject({ Bucket: testBucket, Key: 'key2', Body: '123' }, next),
+            next => s3.putBucketVersioning({
+                Bucket: testBucket,
+                VersioningConfiguration: { Status: 'Enabled' },
+            }, next),
+            next => s3.putObject({ Bucket: testBucket, Key: 'key1', Body: '123' }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                // delete version to create a null current version for key1.
+                return s3.deleteObject({ Bucket: testBucket, Key: 'key1', VersionId: data.VersionId }, next);
+            }),
+            next => s3.putObject({ Bucket: testBucket, Key: 'key2', Body: '123' }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                versionForKey2 = data.VersionId;
+                return next();
+            }),
+        ], done);
+    });
+
+    after(done => async.series([
+        next => removeAllVersions({ Bucket: testBucket }, next),
+        next => s3.deleteBucket({ Bucket: testBucket }, next),
+    ], done));
+
+    it('should return the null noncurrent versions', done => {
+        makeBackbeatRequest({
+            method: 'GET',
+            bucket: testBucket,
+            queryObj: { 'list-type': 'noncurrent' },
+            authCredentials: credentials,
+        }, (err, response) => {
+            assert.ifError(err);
+            assert.strictEqual(response.statusCode, 200);
+            const data = JSON.parse(response.body);
+
+            assert.strictEqual(data.IsTruncated, false);
+            assert(!data.NextKeyMarker);
+            assert.strictEqual(data.MaxKeys, 1000);
+
+            const contents = data.Contents;
+            assert.strictEqual(contents.length, 1);
+            assert.strictEqual(contents[0].Key, 'key2');
+            assert.strictEqual(contents[0].VersionId, 'null');
+            return done();
+        });
+    });
+
+    it('should return the null current versions', done => {
+        makeBackbeatRequest({
+            method: 'GET',
+            bucket: testBucket,
+            queryObj: { 'list-type': 'current' },
+            authCredentials: credentials,
+        }, (err, response) => {
+            assert.ifError(err);
+            assert.strictEqual(response.statusCode, 200);
+            const data = JSON.parse(response.body);
+
+            assert.strictEqual(data.IsTruncated, false);
+            assert(!data.NextKeyMarker);
+            assert.strictEqual(data.MaxKeys, 1000);
+
+            const contents = data.Contents;
+            assert.strictEqual(contents.length, 2);
+
+            const firstKey = contents[0];
+            assert.strictEqual(firstKey.Key, 'key1');
+            assert.strictEqual(firstKey.VersionId, 'null');
+
+            const secondKey = contents[1];
+            assert.strictEqual(secondKey.Key, 'key2');
+            assert.strictEqual(secondKey.VersionId, versionForKey2);
+            return done();
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -694,9 +694,9 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#8.1.88":
-  version "8.1.88"
-  resolved "git+https://github.com/scality/arsenal#b02934bb392e6a59c67f34f8730ee68bc5e2db9d"
+"arsenal@git+https://github.com/scality/arsenal#8.1.92":
+  version "8.1.92"
+  resolved "git+https://github.com/scality/arsenal#7994bf7b967b334d09176261a09d0a66656a40d3"
   dependencies:
     "@azure/identity" "^3.1.1"
     "@azure/storage-blob" "^12.12.0"
@@ -728,7 +728,7 @@ arraybuffer.slice@~0.0.7:
     simple-glob "^0.2.0"
     socket.io "2.4.1"
     socket.io-client "2.4.0"
-    sproxydclient scality/sproxydclient#8.0.7
+    sproxydclient "github:scality/sproxydclient#8.0.8"
     utf8 "3.0.0"
     uuid "^3.0.1"
     werelogs scality/werelogs#8.1.2
@@ -5141,6 +5141,14 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
+
+"sproxydclient@github:scality/sproxydclient#8.0.8":
+  version "8.0.8"
+  resolved "https://codeload.github.com/scality/sproxydclient/tar.gz/4a87d745c6b78a87d7c0df9058d72d138716aa68"
+  dependencies:
+    async "^3.2.0"
+    httpagent "github:scality/httpagent#1.0.6"
+    werelogs scality/werelogs#8.1.2
 
 sproxydclient@scality/sproxydclient#8.0.7:
   version "8.0.7"


### PR DESCRIPTION
The current versions listed to be lifecycle should include version id if the bucket is versioned.

The version id is not used for Expiration.

This version id is used for Transitioning the current version: The “backbeat route putMetadata“ in Cloudserver specified the version id to update its location constraint once the object is transitioned.