### PR TITLE
CLDSRV-378 [8.x] force null version compat mode

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -270,10 +270,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - enable-null-compat: ''
-            job-name: file-ft-tests
-          - enable-null-compat: 'true'
-            job-name: file-ft-tests-null-compat
+          - job-name: file-ft-tests
     name: ${{ matrix.job-name }}
     runs-on: ubuntu-latest
     needs: build
@@ -282,7 +279,6 @@ jobs:
       S3VAULT: mem
       CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}/cloudserver:${{ github.sha }}
       MPU_TESTING: "yes"
-      ENABLE_NULL_VERSION_COMPAT_MODE: "${{ matrix.enable-null-compat }}"
       JOB_NAME: ${{ matrix.job-name }}
     steps:
     - name: Checkout

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1476,7 +1476,10 @@ class Config extends EventEmitter {
         } else {
             this.versionIdEncodingType = versionIdUtils.ENC_TYPE_HEX;
         }
-        this.nullVersionCompatMode = (process.env.ENABLE_NULL_VERSION_COMPAT_MODE === 'true');
+        // CLDSRV-378: on 8.x branches, null version compatibility
+        // mode is enforced because null keys are not supported by the
+        // MongoDB backend.
+        this.nullVersionCompatMode = true;
         if (config.bucketNotificationDestinations) {
             this.bucketNotificationDestinations = bucketNotifAssert(config.bucketNotificationDestinations);
         }

--- a/lib/server.js
+++ b/lib/server.js
@@ -249,9 +249,6 @@ class S3Server {
                 address, port,
                 pid: process.pid, serverIP: address, serverPort: port
             });
-            if (_config.nullVersionCompatMode) {
-                logger.warn('null version compatibility mode is enabled');
-            }
         });
 
         if (ipAddress !== undefined) {


### PR DESCRIPTION
force null version compatibility mode to be enabled, so that Cloudserver stays compatible with MongoDB backend not supporting null keys.

Remove the associated aws-sdk functional test suite related to compatibility mode
