### PR TITLE
CLDSRV-375 Exclude already transitioned keys from lifecycle listings

### DIFF
--- a/lib/api/apiUtils/object/lifecycle.js
+++ b/lib/api/apiUtils/object/lifecycle.js
@@ -146,8 +146,14 @@ function processOrphans(bucketName, listParams, list) {
     return data;
 }
 
+function getLocationConstraintErrorMessage(locationName) {
+    return 'value of the location you are attempting to set ' +
+        `- ${locationName} - is not listed in the locationConstraint config`;
+}
+
 module.exports = {
     processCurrents,
     processNonCurrents,
     processOrphans,
+    getLocationConstraintErrorMessage,
 };

--- a/lib/api/backbeat/listLifecycleCurrents.js
+++ b/lib/api/backbeat/listLifecycleCurrents.js
@@ -4,7 +4,7 @@ const services = require('../../services');
 const { metadataValidateBucket } = require('../../metadata/metadataUtils');
 const { pushMetric } = require('../../utapi/utilities');
 const monitoring = require('../../utilities/monitoringHandler');
-const { processCurrents } = require('../apiUtils/object/lifecycle');
+const { getLocationConstraintErrorMessage, processCurrents } = require('../apiUtils/object/lifecycle');
 
 
 function handleResult(listParams, requestMaxKeys, authInfo,
@@ -20,15 +20,16 @@ function handleResult(listParams, requestMaxKeys, authInfo,
 
 /**
  * listLifecycleCurrents - Return list of current versions/masters in bucket
- * @param  {AuthInfo} authInfo - Instance of AuthInfo class with
- *                               requester's info
- * @param  {object} request    - http request object
- * @param  {function} log      - Werelogs request logger
- * @param  {function} callback - callback to respond to http request
- *                               with either error code or xml response body
+ * @param {AuthInfo} authInfo            - Instance of AuthInfo class with
+ *                                          requester's info
+ * @param {array} locationConstraints    - array of location contraint
+ * @param {object} request               - http request object
+ * @param {function} log                 - Werelogs request logger
+ * @param {function} callback            - callback to respond to http request
+ *                                          with either error code or xml response body
  * @return {undefined}
  */
-function listLifecycleCurrents(authInfo, request, log, callback) {
+function listLifecycleCurrents(authInfo, locationConstraints, request, log, callback) {
     const params = request.query;
     const bucketName = request.bucketName;
 
@@ -37,10 +38,19 @@ function listLifecycleCurrents(authInfo, request, log, callback) {
         Number.parseInt(params['max-keys'], 10) : 1000;
     if (Number.isNaN(requestMaxKeys) || requestMaxKeys < 0) {
         monitoring.promMetrics(
-            'GET', bucketName, 400, 'listBucket');
+            'GET', bucketName, 400, 'listLifecycleCurrents');
         return callback(errors.InvalidArgument);
     }
     const actualMaxKeys = Math.min(constants.listingHardLimit, requestMaxKeys);
+
+    const excludedDataStoreName = params['excluded-data-store-name'];
+    if (excludedDataStoreName && !locationConstraints[excludedDataStoreName]) {
+        const errMsg = getLocationConstraintErrorMessage(excludedDataStoreName);
+        log.error(`locationConstraint is invalid - ${errMsg}`, { locationConstraint: excludedDataStoreName });
+        monitoring.promMetrics('GET', bucketName, 400, 'listLifecycleCurrents');
+
+        return callback(errors.InvalidLocationConstraint.customizeDescription(errMsg));
+    }
 
     const metadataValParams = {
         authInfo,
@@ -54,6 +64,7 @@ function listLifecycleCurrents(authInfo, request, log, callback) {
         prefix: params.prefix,
         beforeDate: params['before-date'],
         marker: params.marker,
+        excludedDataStoreName,
     };
 
     return metadataValidateBucket(metadataValParams, log, (err, bucket) => {

--- a/lib/api/backbeat/listLifecycleNonCurrents.js
+++ b/lib/api/backbeat/listLifecycleNonCurrents.js
@@ -5,7 +5,7 @@ const { metadataValidateBucket } = require('../../metadata/metadataUtils');
 const { pushMetric } = require('../../utapi/utilities');
 const versionIdUtils = versioning.VersionID;
 const monitoring = require('../../utilities/monitoringHandler');
-const { processNonCurrents } = require('../apiUtils/object/lifecycle');
+const { getLocationConstraintErrorMessage, processNonCurrents } = require('../apiUtils/object/lifecycle');
 
 function handleResult(listParams, requestMaxKeys, authInfo,
     bucketName, list, log, callback) {
@@ -20,15 +20,16 @@ function handleResult(listParams, requestMaxKeys, authInfo,
 
 /**
  * listLifecycleNonCurrents - Return list of non-current versions in bucket
- * @param  {AuthInfo} authInfo - Instance of AuthInfo class with
- *                               requester's info
- * @param  {object} request    - http request object
- * @param  {function} log      - Werelogs request logger
- * @param  {function} callback - callback to respond to http request
- *                               with either error code or xml response body
+ * @param {AuthInfo} authInfo           - Instance of AuthInfo class with
+ *                                         requester's info
+ * @param {array} locationConstraints    - array of location contraint
+ * @param {object} request              - http request object
+ * @param {function} log                - Werelogs request logger
+ * @param {function} callback           - callback to respond to http request
+ *                                          with either error code or xml response body
  * @return {undefined}
  */
-function listLifecycleNonCurrents(authInfo, request, log, callback) {
+function listLifecycleNonCurrents(authInfo, locationConstraints, request, log, callback) {
     const params = request.query;
     const bucketName = request.bucketName;
 
@@ -37,10 +38,19 @@ function listLifecycleNonCurrents(authInfo, request, log, callback) {
         Number.parseInt(params['max-keys'], 10) : 1000;
     if (Number.isNaN(requestMaxKeys) || requestMaxKeys < 0) {
         monitoring.promMetrics(
-            'GET', bucketName, 400, 'listBucket');
+            'GET', bucketName, 400, 'listLifecycleNonCurrents');
         return callback(errors.InvalidArgument);
     }
     const actualMaxKeys = Math.min(constants.listingHardLimit, requestMaxKeys);
+
+    const excludedDataStoreName = params['excluded-data-store-name'];
+    if (excludedDataStoreName && !locationConstraints[excludedDataStoreName]) {
+        const errMsg = getLocationConstraintErrorMessage(excludedDataStoreName);
+        log.error(`locationConstraint is invalid - ${errMsg}`, { locationConstraint: excludedDataStoreName });
+        monitoring.promMetrics('GET', bucketName, 400, 'listLifecycleCurrents');
+
+        return callback(errors.InvalidLocationConstraint.customizeDescription(errMsg));
+    }
 
     const metadataValParams = {
         authInfo,
@@ -54,6 +64,7 @@ function listLifecycleNonCurrents(authInfo, request, log, callback) {
         prefix: params.prefix,
         beforeDate: params['before-date'],
         keyMarker: params['key-marker'],
+        excludedDataStoreName,
     };
 
     listParams.versionIdMarker = params['version-id-marker'] ?

--- a/lib/api/backbeat/listLifecycleOrphanDeleteMarkers.js
+++ b/lib/api/backbeat/listLifecycleOrphanDeleteMarkers.js
@@ -19,15 +19,16 @@ function handleResult(listParams, requestMaxKeys, authInfo,
 
 /**
  * listLifecycleOrphanDeleteMarkers - Return list of expired object delete marker in bucket
- * @param  {AuthInfo} authInfo - Instance of AuthInfo class with
- *                               requester's info
- * @param  {object} request    - http request object
- * @param  {function} log      - Werelogs request logger
- * @param  {function} callback - callback to respond to http request
- *                               with either error code or xml response body
+ * @param {AuthInfo} authInfo            - Instance of AuthInfo class with
+ *                                         requester's info
+ * @param {array} locationConstraints    - array of location contraint
+ * @param {object} request               - http request object
+ * @param {function} log                 - Werelogs request logger
+ * @param {function} callback            - callback to respond to http request
+ *                                          with either error code or xml response body
  * @return {undefined}
  */
-function listLifecycleOrphanDeleteMarkers(authInfo, request, log, callback) {
+function listLifecycleOrphanDeleteMarkers(authInfo, locationConstraints, request, log, callback) {
     const params = request.query;
     const bucketName = request.bucketName;
 
@@ -36,7 +37,7 @@ function listLifecycleOrphanDeleteMarkers(authInfo, request, log, callback) {
         Number.parseInt(params['max-keys'], 10) : 1000;
     if (Number.isNaN(requestMaxKeys) || requestMaxKeys < 0) {
         monitoring.promMetrics(
-            'GET', bucketName, 400, 'listBucket');
+            'GET', bucketName, 400, 'listLifecycleOrphanDeleteMarkers');
         return callback(errors.InvalidArgument);
     }
     const actualMaxKeys = Math.min(constants.listingHardLimit, requestMaxKeys);

--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -1110,7 +1110,7 @@ function listLifecycle(request, response, userInfo, log, cb) {
         return cb(errors.BadRequest.customizeDescription(errMessage));
     }
 
-    return call(userInfo, request, log, (err, data) => {
+    return call(userInfo, locationConstraints, request, log, (err, data) => {
         if (err) {
             log.error(`error during listing objects for lifecycle: ${listType}`, {
                 error: err,

--- a/tests/functional/backbeat/excludedDataStoreName.js
+++ b/tests/functional/backbeat/excludedDataStoreName.js
@@ -1,0 +1,283 @@
+const assert = require('assert');
+const async = require('async');
+const BucketUtility = require('../aws-node-sdk/lib/utility/bucket-util');
+const { removeAllVersions } = require('../aws-node-sdk/lib/utility/versioning-util');
+const { makeBackbeatRequest, runIfMongoV1, updateMetadata } = require('./utils');
+
+const testBucket = 'bucket-for-list-lifecycle-current-tests';
+const location1 = 'us-east-1';
+const location2 = 'us-east-2';
+
+const credentials = {
+    accessKey: 'accessKey1',
+    secretKey: 'verySecretKey1',
+};
+
+runIfMongoV1('excludedDataStoreName', () => {
+    let bucketUtil;
+    let s3;
+    const expectedVersions = [];
+
+    before(done => {
+        bucketUtil = new BucketUtility('account1', { signatureVersion: 'v4' });
+        s3 = bucketUtil.s3;
+
+        return async.series([
+            next => s3.createBucket({ Bucket: testBucket }, next),
+            next => s3.putBucketVersioning({
+                Bucket: testBucket,
+                VersioningConfiguration: { Status: 'Enabled' },
+            }, next),
+            next => s3.putObject({ Bucket: testBucket, Key: 'key0' }, (err, data) => {
+                expectedVersions.push(data.VersionId);
+                return next(err);
+            }),
+            next => s3.putObject({ Bucket: testBucket, Key: 'key0' }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                const versionId = data.VersionId;
+                return updateMetadata(
+                    { bucket: testBucket, objectKey: 'key0', versionId, authCredentials: credentials },
+                    { dataStoreName: location2 },
+                    next);
+            }),
+            next => s3.putObject({ Bucket: testBucket, Key: 'key0' }, (err, data) => {
+                expectedVersions.push(data.VersionId);
+                return next(err);
+            }),
+            next => s3.putObject({ Bucket: testBucket, Key: 'key0' }, next),
+            next => s3.putObject({ Bucket: testBucket, Key: 'key1' }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                const versionId = data.VersionId;
+                return updateMetadata(
+                    { bucket: testBucket, objectKey: 'key1', versionId, authCredentials: credentials },
+                    { dataStoreName: location2 },
+                    next);
+            }),
+            next => s3.putObject({ Bucket: testBucket, Key: 'key2' }, next),
+        ], done);
+    });
+
+    after(done => async.series([
+        next => removeAllVersions({ Bucket: testBucket }, next),
+        next => s3.deleteBucket({ Bucket: testBucket }, next),
+    ], done));
+
+    it('should return error when listing current versions if excluded-data-store-name is not in config', done => {
+        makeBackbeatRequest({
+            method: 'GET',
+            bucket: testBucket,
+            queryObj: { 'list-type': 'current', 'excluded-data-store-name': 'idonotexist' },
+            authCredentials: credentials,
+        }, err => {
+            assert(err, 'Expected error but found none');
+            assert.strictEqual(err.code, 'InvalidLocationConstraint');
+            assert.strictEqual(err.statusCode, 400);
+            assert.strictEqual(err.message, 'value of the location you are attempting to set' +
+            ' - idonotexist - is not listed in the locationConstraint config');
+            return done();
+        });
+    });
+
+    it('should return error when listing non-current versions if excluded-data-store-name is not in config', done => {
+        makeBackbeatRequest({
+            method: 'GET',
+            bucket: testBucket,
+            queryObj: { 'list-type': 'noncurrent', 'excluded-data-store-name': 'idonotexist' },
+            authCredentials: credentials,
+        }, err => {
+            assert(err, 'Expected error but found none');
+            assert.strictEqual(err.code, 'InvalidLocationConstraint');
+            assert.strictEqual(err.statusCode, 400);
+            assert.strictEqual(err.message, 'value of the location you are attempting to set' +
+            ' - idonotexist - is not listed in the locationConstraint config');
+            return done();
+        });
+    });
+
+    it('should exclude current versions stored in location2', done => {
+        makeBackbeatRequest({
+            method: 'GET',
+            bucket: testBucket,
+            queryObj: { 'list-type': 'current', 'excluded-data-store-name': location2 },
+            authCredentials: credentials,
+        }, (err, response) => {
+            assert.ifError(err);
+            assert.strictEqual(response.statusCode, 200);
+            const data = JSON.parse(response.body);
+
+            assert.strictEqual(data.IsTruncated, false);
+            assert(!data.NextMarker);
+            assert.strictEqual(data.MaxKeys, 1000);
+
+            const contents = data.Contents;
+            assert.strictEqual(contents.length, 2);
+
+            assert.strictEqual(contents[0].Key, 'key0');
+            assert.strictEqual(contents[0].DataStoreName, location1);
+            assert.strictEqual(contents[1].Key, 'key2');
+            assert.strictEqual(contents[1].DataStoreName, location1);
+            return done();
+        });
+    });
+
+    it('should return trucated listing that excludes current versions stored in location2', done => {
+        makeBackbeatRequest({
+            method: 'GET',
+            bucket: testBucket,
+            queryObj: { 'list-type': 'current', 'excluded-data-store-name': location2, 'max-keys': '1' },
+            authCredentials: credentials,
+        }, (err, response) => {
+            assert.ifError(err);
+            assert.strictEqual(response.statusCode, 200);
+            const data = JSON.parse(response.body);
+
+            assert.strictEqual(data.IsTruncated, true);
+            assert.strictEqual(data.NextMarker, 'key0');
+            assert.strictEqual(data.MaxKeys, 1);
+
+            const contents = data.Contents;
+            assert.strictEqual(contents.length, 1);
+
+            assert.strictEqual(contents[0].Key, 'key0');
+            assert.strictEqual(contents[0].DataStoreName, location1);
+
+            return  makeBackbeatRequest({
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: {
+                    'list-type': 'current',
+                    'excluded-data-store-name': location2,
+                    'max-keys': '1',
+                    'marker': 'key0',
+                },
+                authCredentials: credentials,
+            }, (err, response) => {
+                assert.ifError(err);
+                assert.strictEqual(response.statusCode, 200);
+                const data = JSON.parse(response.body);
+
+                assert.strictEqual(data.IsTruncated, false);
+                assert(!data.NextMarker);
+                assert.strictEqual(data.MaxKeys, 1);
+
+                const contents = data.Contents;
+                assert.strictEqual(contents.length, 1);
+
+                assert.strictEqual(contents[0].Key, 'key2');
+                assert.strictEqual(contents[0].DataStoreName, location1);
+                return done();
+            });
+        });
+    });
+
+    it('should exclude non-current versions stored in location2', done => {
+        makeBackbeatRequest({
+            method: 'GET',
+            bucket: testBucket,
+            queryObj: { 'list-type': 'noncurrent', 'excluded-data-store-name': location2 },
+            authCredentials: credentials,
+        }, (err, response) => {
+            assert.ifError(err);
+            assert.strictEqual(response.statusCode, 200);
+            const data = JSON.parse(response.body);
+
+            assert.strictEqual(data.IsTruncated, false);
+            assert(!data.NextKeyMarker);
+            assert(!data.NextVersionIdMarker);
+            assert.strictEqual(data.MaxKeys, 1000);
+
+            const contents = data.Contents;
+            assert.strictEqual(contents.length, 2);
+
+            assert.strictEqual(contents[0].Key, 'key0');
+            assert.strictEqual(contents[0].DataStoreName, location1);
+            assert.strictEqual(contents[0].VersionId, expectedVersions[1]);
+            assert.strictEqual(contents[1].Key, 'key0');
+            assert.strictEqual(contents[1].DataStoreName, location1);
+            assert.strictEqual(contents[1].VersionId, expectedVersions[0]);
+            return done();
+        });
+    });
+
+    it('should return trucated listing that excludes non-current versions stored in location2', done => {
+        makeBackbeatRequest({
+            method: 'GET',
+            bucket: testBucket,
+            queryObj: { 'list-type': 'noncurrent', 'excluded-data-store-name': location2, 'max-keys': '1' },
+            authCredentials: credentials,
+        }, (err, response) => {
+            assert.ifError(err);
+            assert.strictEqual(response.statusCode, 200);
+            const data = JSON.parse(response.body);
+
+            assert.strictEqual(data.IsTruncated, true);
+            assert.strictEqual(data.NextKeyMarker, 'key0');
+            assert.strictEqual(data.NextVersionIdMarker, expectedVersions[1]);
+            assert.strictEqual(data.MaxKeys, 1);
+
+            const contents = data.Contents;
+            assert.strictEqual(contents.length, 1);
+
+            assert.strictEqual(contents[0].Key, 'key0');
+            assert.strictEqual(contents[0].DataStoreName, location1);
+            assert.strictEqual(contents[0].VersionId, expectedVersions[1]);
+            return makeBackbeatRequest({
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: {
+                    'list-type': 'noncurrent',
+                    'excluded-data-store-name': location2,
+                    'key-marker': 'key0',
+                    'version-id-marker': expectedVersions[1],
+                    'max-keys': '1',
+                },
+                authCredentials: credentials,
+            }, (err, response) => {
+                assert.ifError(err);
+                assert.strictEqual(response.statusCode, 200);
+                const data = JSON.parse(response.body);
+
+                assert.strictEqual(data.IsTruncated, true);
+                assert.strictEqual(data.NextKeyMarker, 'key0');
+                assert.strictEqual(data.NextVersionIdMarker, expectedVersions[0]);
+                assert.strictEqual(data.MaxKeys, 1);
+
+                const contents = data.Contents;
+                assert.strictEqual(contents.length, 1);
+
+                assert.strictEqual(contents[0].Key, 'key0');
+                assert.strictEqual(contents[0].DataStoreName, location1);
+                assert.strictEqual(contents[0].VersionId, expectedVersions[0]);
+                return makeBackbeatRequest({
+                    method: 'GET',
+                    bucket: testBucket,
+                    queryObj: {
+                        'list-type': 'noncurrent',
+                        'excluded-data-store-name': location2,
+                        'key-marker': 'key0',
+                        'version-id-marker': expectedVersions[0],
+                        'max-keys': '1',
+                    },
+                    authCredentials: credentials,
+                }, (err, response) => {
+                    assert.ifError(err);
+                    assert.strictEqual(response.statusCode, 200);
+                    const data = JSON.parse(response.body);
+
+                    assert.strictEqual(data.IsTruncated, false);
+                    assert(!data.NextKeyMarker);
+                    assert(!data.NextVersionIdMarker);
+                    assert.strictEqual(data.MaxKeys, 1);
+
+                    const contents = data.Contents;
+                    assert.strictEqual(contents.length, 0);
+                    return done();
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
A new listing parameter called "excluded-data-store-name" is added to filter out keys that have already been transitioned. 

Note that orphan delete markers do not go through a transition workflow, so no filtering based on datastore name is applied to list orphan delete markers.

Note once https://github.com/scality/Arsenal/pull/2111 is merged, update the Arsenal package dependency.