### PR TITLE
Allow reading transition-in-progress objects

### DIFF
--- a/lib/api/apiUtils/object/coldStorage.js
+++ b/lib/api/apiUtils/object/coldStorage.js
@@ -207,16 +207,10 @@ function verifyColdObjectAvailable(objMD) {
     if (objMD.archive &&
         // Object is in cold backend
         (!objMD.archive.restoreRequestedAt ||
-        // Object is being restored
-        (objMD.archive.restoreRequestedAt && !objMD.archive.restoreCompletedAt))) {
+            // Object is being restored
+            (objMD.archive.restoreRequestedAt && !objMD.archive.restoreCompletedAt))) {
         const err = errors.InvalidObjectState
             .customizeDescription('The operation is not valid for the object\'s storage class');
-        return err;
-    }
-    // return error when object is transitioning to a second location
-    if (objMD['x-amz-scal-transition-in-progress']) {
-        const err = errors.InvalidObjectState
-            .customizeDescription('The operation is not valid on a transitioning object');
         return err;
     }
     return null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "8.7.14",
+  "version": "8.7.15",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {

--- a/tests/functional/aws-node-sdk/test/object/copyPart.js
+++ b/tests/functional/aws-node-sdk/test/object/copyPart.js
@@ -734,7 +734,7 @@ describe('Object Part Copy', () => {
             });
         });
 
-        it('should not copy a part of an object when it\'s transitioning to cold', done => {
+        it('should copy a part of an object when it\'s transitioning to cold', done => {
             fakeMetadataTransition(sourceBucketName, sourceObjName, undefined, err => {
                 assert.ifError(err);
                 s3.uploadPartCopy({
@@ -743,11 +743,12 @@ describe('Object Part Copy', () => {
                     CopySource: `${sourceBucketName}/${sourceObjName}`,
                     PartNumber: 1,
                     UploadId: uploadId,
-                }, err => {
-                        assert.strictEqual(err.code, 'InvalidObjectState');
-                        assert.strictEqual(err.statusCode, 403);
-                        done();
-                    });
+                }, (err, res) => {
+                    checkNoError(err);
+                    assert.strictEqual(res.ETag, etag);
+                    assert(res.LastModified);
+                    done();
+                });
             });
         });
 

--- a/tests/functional/aws-node-sdk/test/object/objectCopy.js
+++ b/tests/functional/aws-node-sdk/test/object/objectCopy.js
@@ -1257,18 +1257,17 @@ describe('Object Copy', () => {
             });
         });
 
-        it('should not copy an object when it\'s transitioning to cold', done => {
+        it('should copy an object when it\'s transitioning to cold', done => {
             fakeMetadataTransition(sourceBucketName, sourceObjName, undefined, err => {
                 assert.ifError(err);
                 s3.copyObject({
                     Bucket: destBucketName,
                     Key: destObjName,
                     CopySource: `${sourceBucketName}/${sourceObjName}`,
-                }, err => {
-                        assert.strictEqual(err.code, 'InvalidObjectState');
-                        assert.strictEqual(err.statusCode, 403);
-                        done();
-                    });
+                }, (err, res) => {
+                    successCopyCheck(err, res, originalMetadata,
+                        destBucketName, destObjName, done);
+                });
             });
         });
 
@@ -1289,7 +1288,7 @@ describe('Object Copy', () => {
                 }, (err, res) => {
                     successCopyCheck(err, res, originalMetadata,
                         destBucketName, destObjName, done);
-                    });
+                });
             });
         });
     });

--- a/tests/unit/api/apiUtils/coldStorage.js
+++ b/tests/unit/api/apiUtils/coldStorage.js
@@ -85,12 +85,8 @@ describe('cold storage', () => {
                 objectMd: new ObjectMD()
                     .setArchive(new ObjectMDArchive({
                         archiveId: '97a71dfe-49c1-4cca-840a-69199e0b0322',
-                        archiveVersion: 5577006791947779
+                        archiveVersion: 5577006791947779,
                     }, Date.now()))
-            },
-            {
-                description: 'should return error if object is transitioning to a cold location',
-                objectMd: new ObjectMD().setTransitionInProgress(true)
             },
         ].forEach(params => {
             it(`${params.description}`, () => {
@@ -101,6 +97,25 @@ describe('cold storage', () => {
 
         it('should return null if object data is not in cold', () => {
             const objectMd = new ObjectMD();
+            const err = verifyColdObjectAvailable(objectMd.getValue());
+            assert.ifError(err);
+        });
+
+        it('should return null if object is transitioning to cold', () => {
+            const objectMd = new ObjectMD().setTransitionInProgress(true);
+            const err = verifyColdObjectAvailable(objectMd.getValue());
+            assert.ifError(err);
+        });
+
+        it('should return null if object is restored', () => {
+            const objectMd = new ObjectMD().setArchive(new ObjectMDArchive({
+                archiveId: '97a71dfe-49c1-4cca-840a-69199e0b0322',
+                archiveVersion: 5577006791947779,
+                restoreRequestedAt: new Date(0),
+                restoreRequestedDays: 5,
+                restoreCompletedAt: new Date(1000),
+                restoreWillExpireAt: new Date(1000 + 5 * oneDay),
+            }));
             const err = verifyColdObjectAvailable(objectMd.getValue());
             assert.ifError(err);
         });


### PR DESCRIPTION
This “transition in progress” state does not exist in AWS S3 (so we have no reference), and we need to access the data for cold storage framework.

When the transition has been performed, the archive id and storage class will be updated first (as well as clearing the ‘transitioning’ flag) before triggering the “GC” to remove the (local) data.

So we are sure that data is available in this state, and that simply checking that the object is in cold storage is enough.

Issue: CLDSRV-380
