### PR TITLE
Fix originOp when deleting a version

### DIFF
--- a/lib/api/objectDelete.js
+++ b/lib/api/objectDelete.js
@@ -179,8 +179,8 @@ function objectDeleteInternal(authInfo, request, log, isExpiration, cb) {
                         }
                         return services.deleteObject(bucketName, objectMD,
                             objectKey, delOptions, log, isExpiration ?
-                                's3:LifecycleExpiration:DeleteMarkerCreated' :
-                                's3:ObjectRemoved:DeleteMarkerCreated',
+                                's3:LifecycleExpiration:Delete' :
+                                's3:ObjectRemoved:Delete',
                             (err, delResult) =>
                                 next(err, bucketMD, objectMD, delResult,  deleteInfo));
                     });
@@ -199,8 +199,8 @@ function objectDeleteInternal(authInfo, request, log, isExpiration, cb) {
 
                 return services.deleteObject(bucketName, objectMD, objectKey,
                     delOptions, log, isExpiration ?
-                        's3:LifecycleExpiration:DeleteMarkerCreated' :
-                        's3:ObjectRemoved:DeleteMarkerCreated',
+                        's3:LifecycleExpiration:Delete' :
+                        's3:ObjectRemoved:Delete',
                     (err, delResult) => next(err, bucketMD,
                         objectMD, delResult, deleteInfo));
             }
@@ -209,8 +209,9 @@ function objectDeleteInternal(authInfo, request, log, isExpiration, cb) {
             return createAndStoreObject(bucketName, bucketMD,
                 objectKey, objectMD, authInfo, canonicalID, null, request,
                 deleteInfo.newDeleteMarker, null, log, isExpiration ?
-                's3:LifecycleExpiration:DeleteMarkerCreated' :
-                's3:ObjectRemoved:DeleteMarkerCreated', (err, newDelMarkerRes) => {
+                    's3:LifecycleExpiration:DeleteMarkerCreated' :
+                    's3:ObjectRemoved:DeleteMarkerCreated',
+                (err, newDelMarkerRes) => {
                     next(err, bucketMD, objectMD, newDelMarkerRes, deleteInfo);
                 });
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "8.7.16",
+  "version": "8.7.18",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
DeleteMarkerCreated was sent instead of the expect Delete, which breaks
bucket notifications.

Issue: CLDSRV-383
