### PR TITLE
CLDSRC-370: Release dev docker image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,18 @@ jobs:
       file: images/svc-base/Dockerfile
       tag: ${{ github.event.inputs.tag }}-svc-base
 
+  build-dev-image:
+    uses: scality/workflows/.github/workflows/docker-build.yaml@v1
+    secrets: inherit
+    with:
+      push: true
+      registry: registry.scality.com
+      namespace: ${{ github.event.repository.name }}-dev
+      name: ${{ github.event.repository.name }}
+      context: .
+      file: Dockerfile
+      tag: ${{ github.event.inputs.tag }}
+
   github-release:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,13 +21,13 @@ jobs:
       file: images/svc-base/Dockerfile
       tag: ${{ github.event.inputs.tag }}-svc-base
 
-  build-dev-image:
+  build-image:
     uses: scality/workflows/.github/workflows/docker-build.yaml@v1
     secrets: inherit
     with:
       push: true
       registry: registry.scality.com
-      namespace: ${{ github.event.repository.name }}-dev
+      namespace: ${{ github.event.repository.name }}
       name: ${{ github.event.repository.name }}
       context: .
       file: Dockerfile

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -225,7 +225,7 @@ jobs:
     - name: Setup python2 test environment
       run: |
         sudo apt-get install -y libdigest-hmac-perl
-        pip install virtualenv
+        pip install virtualenv==20.21.0
         virtualenv -p $(which python2) ~/.virtualenv/py2
         source ~/.virtualenv/py2/bin/activate
         pip install 's3cmd==1.6.1'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -117,6 +117,10 @@ if [[ -n "$BUCKET_DENY_FILTER" ]]; then
     JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .utapi.filter.deny.bucket=[\"$BUCKET_DENY_FILTER\"]"
 fi
 
+if [[ "$BUCKETD_BOOTSTRAP" ]]; then
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .bucketd.bootstrap=[\"$BUCKETD_BOOTSTRAP\""]
+fi
+
 if [[ $JQ_FILTERS_CONFIG != "." ]]; then
     jq "$JQ_FILTERS_CONFIG" config.json > config.json.tmp
     mv config.json.tmp config.json


### PR DESCRIPTION
In Scuba we need: 
- To use the cloudserver's "dev" docker image for pre-merge tests. This adds the publishing of this image in the release workflow so that we can use it with a release tag. 
- To specify the `bucketd.bootstrap` config parameter when using the dev docker image

Also contains a fix for a failure to setup virtualenv in the CI ( see: https://github.com/scality/cloudserver/actions/runs/4873146866/jobs/8692634059 )
The fix is to pin virtualenv to the last version that worked.

Note: please review the integration branches. I have added a commit for the virtualenv issue ( https://github.com/scality/cloudserver/commit/6952b915391aa7d89afa3d36afca22a216e13968 )