### PR TITLE
CLDSRV-386: bump node version to 16.20 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=16.17.1-bullseye-slim
+ARG NODE_VERSION=16.20-bullseye-slim
 
 FROM node:${NODE_VERSION} as builder
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "8.7.18",
+  "version": "8.7.20",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Issue: CLDSRV-386