### PR TITLE
keep storage class as cold for restored objects

### DIFF
--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -449,6 +449,7 @@ function overwritingVersioning(objMD, metadataStoreParams) {
     metadataStoreParams.creationTime = objMD['creation-time'];
     metadataStoreParams.lastModifiedDate = objMD['last-modified'];
     metadataStoreParams.updateMicroVersionId = true;
+    metadataStoreParams.amzStorageClass = objMD['x-amz-storage-class'];
 
     // set correct originOp
     metadataStoreParams.originOp = 's3:ObjectRestore:Completed';

--- a/lib/services.js
+++ b/lib/services.js
@@ -100,7 +100,7 @@ const services = {
             tagging, taggingCopy, replicationInfo, defaultRetention,
             dataStoreName, creationTime, retentionMode, retentionDate,
             legalHold, originOp, updateMicroVersionId, archive, oldReplayId,
-            deleteNullKey } = params;
+            deleteNullKey, amzStorageClass } = params;
         log.trace('storing object in metadata');
         assert.strictEqual(typeof bucketName, 'string');
         const md = new ObjectMD();
@@ -172,6 +172,7 @@ const services = {
         }
         // update restore
         if (archive) {
+            md.setAmzStorageClass(amzStorageClass);
             md.setArchive(new ObjectMDArchive(
                 archive.archiveInfo,
                 archive.restoreRequestedAt,

--- a/tests/functional/aws-node-sdk/test/object/objectCopy.js
+++ b/tests/functional/aws-node-sdk/test/object/objectCopy.js
@@ -144,6 +144,7 @@ describe('Object Copy', () => {
             s3.getObject({ Bucket: destBucketName,
                 Key: destObjName }, (err, res) => {
                 checkNoError(err);
+                assert.strictEqual(res.StorageClass, undefined);
                 assert.strictEqual(res.Body.toString(),
                     content);
                 assert.deepStrictEqual(res.Metadata,
@@ -1271,7 +1272,7 @@ describe('Object Copy', () => {
             });
         });
 
-        it('should copy restored object', done => {
+        it('should copy restored object and reset storage class', done => {
             const archiveCompleted = {
                 archiveInfo: {},
                 restoreRequestedAt: new Date(0),

--- a/tests/functional/aws-node-sdk/test/object/putVersion.js
+++ b/tests/functional/aws-node-sdk/test/object/putVersion.js
@@ -716,41 +716,80 @@ describe('PUT object with x-scal-s3-version-id header', () => {
             });
         });
 
-        it('should update restore metadata', done => {
-            const params = { Bucket: bucketName, Key: objectName };
-            let objMDBefore;
-            let objMDAfter;
+        [
+            'non versioned',
+            'versioned',
+            'suspended'
+        ].forEach(versioning => {
+            it(`should update restore metadata while keeping storage class (${versioning})`, done => {
+                const params = { Bucket: bucketName, Key: objectName };
+                let objMDBefore;
+                let objMDAfter;
 
-            async.series([
-                next => s3.putObject(params, next),
-                next => fakeMetadataArchive(bucketName, objectName, undefined, archive, next),
-                next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
-                    objMDBefore = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, next),
-                next => putObjectVersion(s3, params, '', next),
-                next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
-                    objMDAfter = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, next),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+                async.series([
+                    next => {
+                        if (versioning === 'versioned') {
+                            return s3.putBucketVersioning({
+                                Bucket: bucketName,
+                                VersioningConfiguration: { Status: 'Enabled' }
+                            }, next);
+                        } else if (versioning === 'suspended') {
+                            return s3.putBucketVersioning({
+                                Bucket: bucketName,
+                                VersioningConfiguration: { Status: 'Suspended' }
+                            }, next);
+                        }
+                        return next();
+                    },
+                    next => s3.putObject(params, next),
+                    next => fakeMetadataArchive(bucketName, objectName, undefined, archive, next),
+                    next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                        objMDBefore = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, next),
+                    next => putObjectVersion(s3, params, '', next),
+                    next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                        objMDAfter = objMD;
+                        return next(err);
+                    }),
+                    next => s3.listObjects({ Bucket: bucketName }, (err, res) => {
+                        assert.ifError(err);
+                        assert.strictEqual(res.Contents.length, 1);
+                        assert.strictEqual(res.Contents[0].StorageClass, 'location-dmf-v1');
+                        return next();
+                    }),
+                    next => s3.headObject(params, (err, res) => {
+                        assert.ifError(err);
+                        assert.strictEqual(res.StorageClass, 'location-dmf-v1');
+                        return next();
+                    }),
+                    next => s3.getObject(params, (err, res) => {
+                        assert.ifError(err);
+                        assert.strictEqual(res.StorageClass, 'location-dmf-v1');
+                        return next();
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
 
-                // Make sure object data location is set back to its bucket data location.
-                assert.deepStrictEqual(objMDAfter.dataStoreName, 'us-east-1');
+                    // storage class must stay as the cold location
+                    assert.deepStrictEqual(objMDAfter['x-amz-storage-class'], 'location-dmf-v1');
 
-                assert.deepStrictEqual(objMDAfter.archive.archiveInfo, objMDBefore.archive.archiveInfo);
-                assert.deepStrictEqual(objMDAfter.archive.restoreRequestedAt, objMDBefore.archive.restoreRequestedAt);
-                assert.deepStrictEqual(objMDAfter.archive.restoreRequestedDays,
-                    objMDBefore.archive.restoreRequestedDays);
-                assert.deepStrictEqual(objMDAfter['x-amz-restore']['ongoing-request'], false);
+                    /// Make sure object data location is set back to its bucket data location.
+                    assert.deepStrictEqual(objMDAfter.dataStoreName, 'us-east-1');
 
-                assert(objMDAfter.archive.restoreCompletedAt);
-                assert(objMDAfter.archive.restoreWillExpireAt);
-                assert(objMDAfter['x-amz-restore']['expiry-date']);
-                return done();
+                    assert.deepStrictEqual(objMDAfter.archive.archiveInfo, objMDBefore.archive.archiveInfo);
+                    assert.deepStrictEqual(objMDAfter.archive.restoreRequestedAt,
+                        objMDBefore.archive.restoreRequestedAt);
+                    assert.deepStrictEqual(objMDAfter.archive.restoreRequestedDays,
+                        objMDBefore.archive.restoreRequestedDays);
+                    assert.deepStrictEqual(objMDAfter['x-amz-restore']['ongoing-request'], false);
+
+                    assert(objMDAfter.archive.restoreCompletedAt);
+                    assert(objMDAfter.archive.restoreWillExpireAt);
+                    assert(objMDAfter['x-amz-restore']['expiry-date']);
+                    return done();
+                });
             });
         });
     });

--- a/tests/functional/aws-node-sdk/test/utils/init.js
+++ b/tests/functional/aws-node-sdk/test/utils/init.js
@@ -77,6 +77,7 @@ function fakeMetadataArchive(bucketName, objectName, versionId, archive, cb) {
 			return cb(err);
 		}
         /* eslint-disable no-param-reassign */
+        objMD['x-amz-storage-class'] = 'location-dmf-v1';
         objMD.dataStoreName = 'location-dmf-v1';
         objMD.archive = archive;
         /* eslint-enable no-param-reassign */


### PR DESCRIPTION
To be compliant with the AWS S3 standard, the storage class of restored objects should be left as cold location

Issue: CLDSRV-400
