### PR TITLE
Remove userMD counting restore retries and add tests

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -182,6 +182,9 @@ const services = {
                 'ongoing-request': false,
                 'expiry-date': archive.restoreWillExpireAt,
             });
+            md.setUserMetadata({
+                'x-amz-meta-scal-s3-restore-attempt': undefined,
+            });
         }
 
         if (oldReplayId) {

--- a/tests/functional/aws-node-sdk/test/object/copyPart.js
+++ b/tests/functional/aws-node-sdk/test/object/copyPart.js
@@ -718,7 +718,7 @@ describe('Object Part Copy', () => {
                     archiveVersion: 5577006791947779
                 },
             };
-            fakeMetadataArchive(sourceBucketName, sourceObjName, undefined, archive, err => {
+            fakeMetadataArchive(sourceBucketName, sourceObjName, undefined, archive, undefined, err => {
                 assert.ifError(err);
                 s3.uploadPartCopy({
                     Bucket: destBucketName,
@@ -760,7 +760,7 @@ describe('Object Part Copy', () => {
                 restoreCompletedAt: new Date(10),
                 restoreWillExpireAt: new Date(10 + (5 * 24 * 60 * 60 * 1000)),
             };
-            fakeMetadataArchive(sourceBucketName, sourceObjName, undefined, archiveCompleted, err => {
+            fakeMetadataArchive(sourceBucketName, sourceObjName, undefined, archiveCompleted, undefined, err => {
                 assert.ifError(err);
                 s3.uploadPartCopy({
                     Bucket: destBucketName,

--- a/tests/functional/aws-node-sdk/test/object/objectCopy.js
+++ b/tests/functional/aws-node-sdk/test/object/objectCopy.js
@@ -1243,7 +1243,7 @@ describe('Object Copy', () => {
                     archiveVersion: 5577006791947779
                 },
             };
-            fakeMetadataArchive(sourceBucketName, sourceObjName, undefined, archive, err => {
+            fakeMetadataArchive(sourceBucketName, sourceObjName, undefined, archive, undefined, err => {
                 assert.ifError(err);
                 s3.copyObject({
                     Bucket: destBucketName,
@@ -1279,7 +1279,7 @@ describe('Object Copy', () => {
                 restoreCompletedAt: new Date(10),
                 restoreWillExpireAt: new Date(10 + (5 * 24 * 60 * 60 * 1000)),
             };
-            fakeMetadataArchive(sourceBucketName, sourceObjName, undefined, archiveCompleted, err => {
+            fakeMetadataArchive(sourceBucketName, sourceObjName, undefined, archiveCompleted, undefined, err => {
                 assert.ifError(err);
                 s3.copyObject({
                     Bucket: destBucketName,

--- a/tests/functional/aws-node-sdk/test/utils/init.js
+++ b/tests/functional/aws-node-sdk/test/utils/init.js
@@ -68,10 +68,11 @@ function fakeMetadataTransition(bucketName, objectName, versionId, cb) {
  * @param {string} objectName obejct name
  * @param {string} versionId encoded object version id
  * @param {Object} archive archive info object
+ * @param {Object} userMD user metadata
  * @param {Function} cb callback
  * @returns {undefined}
  */
-function fakeMetadataArchive(bucketName, objectName, versionId, archive, cb) {
+function fakeMetadataArchive(bucketName, objectName, versionId, archive, userMD, cb) {
     return getMetadata(bucketName, objectName, versionId, (err, objMD) => {
         if (err) {
 			return cb(err);
@@ -79,6 +80,7 @@ function fakeMetadataArchive(bucketName, objectName, versionId, archive, cb) {
         /* eslint-disable no-param-reassign */
         objMD.dataStoreName = 'location-dmf-v1';
         objMD.archive = archive;
+        Object.assign(objMD, userMD);
         /* eslint-enable no-param-reassign */
         return metadata.putObjectMD(bucketName, objectName, objMD, { versionId: decodeVersionId(versionId) },
             log, err => cb(err));


### PR DESCRIPTION
Remove 'x-amz-meta-scal-s3-restore-attempt' user metadata that is used to count the time we try a restore

Issue: CLDSRV-403
