### PR TITLE
CLDSRV-411: Add mechanism for imposing `last-modified` in object-put in tests

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -110,6 +110,7 @@ const constants = {
 
     // user metadata header to set object locationConstraint
     objectLocationConstraintHeader: 'x-amz-meta-scal-location-constraint',
+    lastModifiedHeader: 'x-amz-meta-x-scal-last-modified',
     legacyLocations: ['sproxyd', 'legacy'],
     /* eslint-disable camelcase */
     externalBackends: { aws_s3: true, azure: true, gcp: true },

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -121,6 +121,10 @@ if [[ "$BUCKETD_BOOTSTRAP" ]]; then
     JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .bucketd.bootstrap=[\"$BUCKETD_BOOTSTRAP\""]
 fi
 
+if [[ "$TESTING_MODE" ]]; then
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .testingMode=true"
+fi
+
 if [[ $JQ_FILTERS_CONFIG != "." ]]; then
     jq "$JQ_FILTERS_CONFIG" config.json > config.json.tmp
     mv config.json.tmp config.json

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1299,6 +1299,8 @@ class Config extends EventEmitter {
         }
 
         this.lifecycleRoleName = config.lifecycleRoleName || null;
+
+        this.testingMode = config.testingMode || false;
     }
 
     _configureBackends() {

--- a/lib/services.js
+++ b/lib/services.js
@@ -14,9 +14,20 @@ const { setObjectLockInformation }
     = require('./api/apiUtils/object/objectLockHelpers');
 const removeAWSChunked = require('./api/apiUtils/object/removeAWSChunked');
 const { parseTagFromQuery } = s3middleware.tagging;
+const { config } = require('./Config');
 
 const usersBucket = constants.usersBucket;
 const oldUsersBucket = constants.oldUsersBucket;
+
+function setLastModifiedFromHeader(md, metaHeaders) {
+    const forcedLastModifiedTs = Date.parse(metaHeaders[constants.lastModifiedHeader]);
+
+    // eslint-disable-next-line no-param-reassign
+    md._data['last-modified'] = new Date(forcedLastModifiedTs).toJSON();
+
+    // eslint-disable-next-line no-param-reassign
+    delete metaHeaders[constants.lastModifiedHeader];
+}
 
 const services = {
     getService(authInfo, request, log, splitter, cb, overrideUserbucket) {
@@ -101,6 +112,11 @@ const services = {
         log.trace('storing object in metadata');
         assert.strictEqual(typeof bucketName, 'string');
         const md = new ObjectMD();
+
+        if (config.testingMode && metaHeaders && metaHeaders[constants.lastModifiedHeader]) {
+            setLastModifiedFromHeader(md, metaHeaders);
+        }
+
         // This should be object creator's canonical ID.
         md.setOwnerId(authInfo.getCanonicalID())
             .setCacheControl(cacheControl)

--- a/lib/services.js
+++ b/lib/services.js
@@ -23,7 +23,7 @@ function setLastModifiedFromHeader(md, metaHeaders) {
     const forcedLastModifiedTs = Date.parse(metaHeaders[constants.lastModifiedHeader]);
 
     // eslint-disable-next-line no-param-reassign
-    md._data['last-modified'] = new Date(forcedLastModifiedTs).toJSON();
+    md.setLastModified(new Date(forcedLastModifiedTs).toJSON());
 
     // eslint-disable-next-line no-param-reassign
     delete metaHeaders[constants.lastModifiedHeader];

--- a/tests/unit/api/objectPut.js
+++ b/tests/unit/api/objectPut.js
@@ -17,6 +17,7 @@ const objectPut = require('../../../lib/api/objectPut');
 const { objectLockTestUtils } = require('../helpers');
 const DummyRequest = require('../DummyRequest');
 const mpuUtils = require('../utils/mpuUtils');
+const { lastModifiedHeader } = require('../../../constants');
 
 const any = sinon.match.any;
 
@@ -369,6 +370,80 @@ describe('objectPut API', () => {
                                         'some more metadata');
                             assert.strictEqual(md['x-amz-meta-test3'],
                                         'even more metadata');
+                            done();
+                        });
+                });
+        });
+    });
+
+    it('If testingMode=true and the last-modified header is given, should set last-modified accordingly', done => {
+        const imposedLastModified = '2024-07-19';
+        const testPutObjectRequest = new DummyRequest({
+            bucketName,
+            namespace,
+            objectKey: objectName,
+            headers: {
+                [lastModifiedHeader]: imposedLastModified,
+            },
+            url: `/${bucketName}/${objectName}`,
+            calculatedHash: 'vnR+tLdVF79rPPfF+7YvOg==',
+        }, postBody);
+
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            const config = require('../../../lib/Config');
+            config.config.testingMode = true;
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                (err, resHeaders) => {
+                    assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
+                    metadata.getObjectMD(bucketName, objectName, {}, log,
+                        (err, md) => {
+                            assert(md);
+
+                            const lastModified = md['last-modified'];
+                            const lastModifiedDate = lastModified.split('T')[0];
+                            // last-modified date should be the one set by the last-modified header
+                            assert.strictEqual(lastModifiedDate, imposedLastModified);
+
+                            // The header should be removed after being treated.
+                            assert(md[lastModifiedHeader] === undefined);
+
+                            config.config.testingMode = false;
+                            done();
+                        });
+                });
+        });
+    });
+
+    it('should not take into acccount the last-modified header when testingMode=false', done => {
+        const imposedLastModified = '2024-07-19';
+
+        const testPutObjectRequest = new DummyRequest({
+            bucketName,
+            namespace,
+            objectKey: objectName,
+            headers: {
+                'x-amz-meta-x-scal-last-modified': imposedLastModified,
+            },
+            url: `/${bucketName}/${objectName}`,
+            calculatedHash: 'vnR+tLdVF79rPPfF+7YvOg==',
+        }, postBody);
+
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            const config = require('../../../lib/Config');
+            config.config.testingMode = false;
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                (err, resHeaders) => {
+                    assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
+                    metadata.getObjectMD(bucketName, objectName, {}, log,
+                        (err, md) => {
+                            assert(md);
+                            assert.strictEqual(md['x-amz-meta-x-scal-last-modified'],
+                                        imposedLastModified);
+                            const lastModified = md['last-modified'];
+                            const lastModifiedDate = lastModified.split('T')[0];
+                            const currentTs = new Date().toJSON();
+                            const currentDate = currentTs.split('T')[0];
+                            assert.strictEqual(lastModifiedDate, currentDate);
                             done();
                         });
                 });


### PR DESCRIPTION
A put operation can specify a custom `last-modified` date using the header `x-amz-meta-x-scal-last-modified`
- This is intended to be used in tests only.
- It is only possible when the configuration parameter `testingMode` is set to true

Issue: CLDSRV-411