### PR TITLE
[BACKPORT 7.10] CLDSRV-196: create new werelogs object over using global werelogs

### DIFF
--- a/lib/utilities/logger.js
+++ b/lib/utilities/logger.js
@@ -1,8 +1,8 @@
-const werelogs = require('werelogs');
+const { Werelogs } = require('werelogs');
 
 const _config = require('../Config.js').config;
 
-werelogs.configure({
+const werelogs = new Werelogs({
     level: _config.log.logLevel,
     dump: _config.log.dumpLevel,
 });


### PR DESCRIPTION
(cherry picked from commit 7fd547db243c5e39de8746719a1a1157cb6534a6)
