### PR TITLE
Bugfix/cldsrv 413/crr existing null version

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -482,6 +482,11 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
             // Retrieve the null version id from the object metadata.
             versionId = objMd && objMd.versionId;
             if (!versionId) {
+                // Set isNull in the object metadata to be written.
+                // Since metadata will generate a versionId for the null version,
+                // the flag is needed to allow cloudserver to know that the version
+                // is a null version and allow access to it using the "null" versionId.
+                omVal.isNull = true;
                 if (versioning) {
                     // If the null version does not have a version id, it is a current null version.
                     // To update the metadata of a current version, versioning is set to false.
@@ -501,7 +506,6 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
                     // In such scenarios, we generate a new null version and designate it as the master version.
                     if (versioningConf && versioningConf.Status === 'Suspended') {
                         versionId = '';
-                        omVal.isNull = true;
                     }
                 }
             }

--- a/tests/functional/aws-node-sdk/lib/utility/bucket-util.js
+++ b/tests/functional/aws-node-sdk/lib/utility/bucket-util.js
@@ -14,6 +14,18 @@ class BucketUtility {
         });
     }
 
+    bucketExists(bucketName) {
+        return this.s3
+            .headBucket({ Bucket: bucketName }).promise()
+            .then(() => true)
+            .catch(err => {
+                if (err.code === 'NotFound') {
+                    return false;
+                }
+                throw err;
+            });
+    }
+
     createOne(bucketName) {
         return this.s3
             .createBucket({ Bucket: bucketName }).promise()
@@ -116,6 +128,24 @@ class BucketUtility {
     emptyMany(bucketNames) {
         const promises = bucketNames.map(
             bucketName => this.empty(bucketName)
+        );
+
+        return Promise.all(promises);
+    }
+
+    emptyIfExists(bucketName) {
+        return this.bucketExists(bucketName)
+            .then(exists => {
+                if (exists) {
+                    return this.empty(bucketName);
+                }
+                return undefined;
+            });
+    }
+
+    emptyManyIfExists(bucketNames) {
+        const promises = bucketNames.map(
+            bucketName => this.emptyIfExists(bucketName)
         );
 
         return Promise.all(promises);

--- a/tests/functional/raw-node/test/routes/routeBackbeat.js
+++ b/tests/functional/raw-node/test/routes/routeBackbeat.js
@@ -156,7 +156,8 @@ describeSkipIfAWS('backbeat routes', () => {
         bucketUtil = new BucketUtility(
             'default', { signatureVersion: 'v4' });
         s3 = bucketUtil.s3;
-        s3.createBucket({ Bucket: TEST_BUCKET }).promise()
+        bucketUtil.emptyManyIfExists([TEST_BUCKET, TEST_ENCRYPTED_BUCKET, NONVERSIONED_BUCKET])
+            .then(() => s3.createBucket({ Bucket: TEST_BUCKET }).promise())
             .then(() => s3.putBucketVersioning(
                 {
                     Bucket: TEST_BUCKET,
@@ -190,15 +191,16 @@ describeSkipIfAWS('backbeat routes', () => {
                 throw err;
             });
     });
-    after(done => {
+
+    after(done =>
         bucketUtil.empty(TEST_BUCKET)
             .then(() => s3.deleteBucket({ Bucket: TEST_BUCKET }).promise())
             .then(() => bucketUtil.empty(TEST_ENCRYPTED_BUCKET))
             .then(() => s3.deleteBucket({ Bucket: TEST_ENCRYPTED_BUCKET }).promise())
             .then(() =>
                 s3.deleteBucket({ Bucket: NONVERSIONED_BUCKET }).promise())
-            .then(() => done());
-    });
+            .then(() => done(), err => done(err))
+    );
 
     describe('null version', () => {
         const bucket = BUCKET_FOR_NULL_VERSION;
@@ -219,12 +221,17 @@ describeSkipIfAWS('backbeat routes', () => {
             assert.strictEqual(StorageClass, 'STANDARD');
         }
 
-        beforeEach(done => s3.createBucket({ Bucket: BUCKET_FOR_NULL_VERSION }, done));
-        afterEach(done => {
+        beforeEach(done =>
+            bucketUtil.emptyIfExists(BUCKET_FOR_NULL_VERSION)
+                .then(() => s3.createBucket({ Bucket: BUCKET_FOR_NULL_VERSION }).promise())
+                .then(() => done(), err => done(err))
+        );
+
+        afterEach(done =>
             bucketUtil.empty(BUCKET_FOR_NULL_VERSION)
                 .then(() => s3.deleteBucket({ Bucket: BUCKET_FOR_NULL_VERSION }).promise())
-                .then(() => done());
-        });
+                .then(() => done(), err => done(err))
+        );
 
         it('should update metadata of a current null version', done => {
             let objMD;


### PR DESCRIPTION
~This uses preProcessVersioning to handle `null` versions in backbeat putMetadata route.
It handles converting pre-versioning objects to have a versionId so that they can be dealt with as normal versioned objects.~

Much simplified fix by setting `isNull` in the incoming object metadata to be put.