### PR TITLE
CLDSRV-438: update AWS backend bucket and keys for the CI

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -39,8 +39,8 @@ models:
         %(secret:b2backend_b2_storage_access_key)s
       GOOGLE_SERVICE_EMAIL: "%(secret:gcp_service_email)s"
       GOOGLE_SERVICE_KEY: "%(secret:gcp_service_key)s"
-      AWS_S3_BACKEND_ACCESS_KEY: "%(secret:aws_s3_backend_access_key)s"
-      AWS_S3_BACKEND_SECRET_KEY: "%(secret:aws_s3_backend_secret_key)s"
+      AWS_S3_BACKEND_ACCESS_KEY: "%(secret:aws_s3_backend_access_key_3)s"
+      AWS_S3_BACKEND_SECRET_KEY: "%(secret:aws_s3_backend_secret_key_3)s"
       AWS_S3_BACKEND_ACCESS_KEY_2: "%(secret:aws_s3_backend_access_key_2)s"
       AWS_S3_BACKEND_SECRET_KEY_2: "%(secret:aws_s3_backend_secret_key_2)s"
       AWS_GCP_BACKEND_ACCESS_KEY: "%(secret:aws_gcp_backend_access_key)s"

--- a/tests/locationConfig/locationConfigLegacy.json
+++ b/tests/locationConfig/locationConfigLegacy.json
@@ -35,7 +35,7 @@
         "legacyAwsBehavior": true,
         "details": {
             "awsEndpoint": "s3.amazonaws.com",
-            "bucketName": "multitester555",
+            "bucketName": "cloudserver-ci-aws-backend-test-bucket",
             "bucketMatch": true,
             "credentialsProfile": "default",
             "serverSideEncryption": true
@@ -46,7 +46,7 @@
         "legacyAwsBehavior": true,
         "details": {
             "awsEndpoint": "s3.amazonaws.com",
-            "bucketName": "multitester555",
+            "bucketName": "cloudserver-ci-aws-backend-test-bucket",
             "bucketMatch": true,
             "credentialsProfile": "default"
         }
@@ -56,7 +56,7 @@
         "legacyAwsBehavior": true,
         "details": {
             "awsEndpoint": "s3.amazonaws.com",
-            "bucketName": "multitester555",
+            "bucketName": "cloudserver-ci-aws-backend-test-bucket",
             "bucketMatch": false,
             "credentialsProfile": "default"
         }

--- a/tests/locationConfig/locationConfigTests.json
+++ b/tests/locationConfig/locationConfigTests.json
@@ -29,7 +29,7 @@
         "legacyAwsBehavior": true,
         "details": {
             "awsEndpoint": "s3.amazonaws.com",
-            "bucketName": "multitester555",
+            "bucketName": "cloudserver-ci-aws-backend-test-bucket",
             "bucketMatch": true,
             "credentialsProfile": "default",
             "serverSideEncryption": true
@@ -40,7 +40,7 @@
         "legacyAwsBehavior": true,
         "details": {
             "awsEndpoint": "s3.amazonaws.com",
-            "bucketName": "multitester555",
+            "bucketName": "cloudserver-ci-aws-backend-test-bucket",
             "bucketMatch": true,
             "credentialsProfile": "default"
         }
@@ -50,7 +50,7 @@
         "legacyAwsBehavior": true,
         "details": {
             "awsEndpoint": "s3.amazonaws.com",
-            "bucketName": "multitester555",
+            "bucketName": "cloudserver-ci-aws-backend-test-bucket",
             "bucketMatch": false,
             "credentialsProfile": "default"
         }

--- a/tests/multipleBackend/objectPutCopyPart.js
+++ b/tests/multipleBackend/objectPutCopyPart.js
@@ -29,7 +29,7 @@ const body = Buffer.from('I am a body', 'utf8');
 
 const memLocation = 'scality-internal-mem';
 const fileLocation = 'scality-internal-file';
-const awsBucket = 'multitester555';
+const awsBucket = 'cloudserver-ci-aws-backend-test-bucket';
 const awsLocation = 'awsbackend';
 const awsLocation2 = 'awsbackend2';
 const awsLocationMismatch = 'awsbackendmismatch';


### PR DESCRIPTION
## Description
Changes AWS keys and bucket name for AWS backend 1 to use the same account as the second AWS backend.

### Motivation and context
Platform Engineering team is trying to limit IAM accounts in AWS. This change moved AWS backend one to the same account as used by the 2nd aws backend specified in the CI

### Related issues
https://scality.atlassian.net/browse/S3C-8001
https://scality.atlassian.net/browse/CLDSRV-438


### Note to reviewers
1. If we specifically need two different AWS account then this change should not be made.
2. As the build is not starting on development/7.4, we will probably bypass ci checks on 7.4, so please help review: https://github.com/scality/cloudserver/pull/5299/files