### PR TITLE
CLDSRV-424: api call updated with implicit deny logic

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -107,6 +107,7 @@ const api = {
         // no need to check auth on website or cors preflight requests
         if (apiMethod === 'websiteGet' || apiMethod === 'websiteHead' ||
         apiMethod === 'corsPreflight') {
+            request.actionImplicitDenies = false;
             return this[apiMethod](request, log, callback);
         }
 
@@ -129,15 +130,25 @@ const api = {
 
         const requestContexts = prepareRequestContexts(apiMethod, request,
             sourceBucket, sourceObject, sourceVersionId);
+        // Extract all the _apiMethods and store them in an array
+        const apiMethods = requestContexts ? requestContexts.map(context => context._apiMethod) : [];
+        // Attach the names to the current request
+        // eslint-disable-next-line no-param-reassign
+        request.apiMethods = apiMethods;
 
         function checkAuthResults(authResults) {
             let returnTagCount = true;
+            const isImplicitDeny = {};
+            let isOnlyImplicitDeny = true;
             if (apiMethod === 'objectGet') {
                 // first item checks s3:GetObject(Version) action
-                if (!authResults[0].isAllowed) {
+                if (!authResults[0].isAllowed && !authResults[0].isImplicit) {
                     log.trace('get object authorization denial from Vault');
                     return errors.AccessDenied;
                 }
+                // TODO add support for returnTagCount in the bucket policy
+                // checks
+                isImplicitDeny[authResults[0].action] = authResults[0].isImplicit;
                 // second item checks s3:GetObject(Version)Tagging action
                 if (!authResults[1].isAllowed) {
                     log.trace('get tagging authorization denial ' +
@@ -146,13 +157,25 @@ const api = {
                 }
             } else {
                 for (let i = 0; i < authResults.length; i++) {
-                    if (!authResults[i].isAllowed) {
+                    isImplicitDeny[authResults[i].action] = true;
+                    if (!authResults[i].isAllowed && !authResults[i].isImplicit) {
+                        // Any explicit deny rejects the current API call
                         log.trace('authorization denial from Vault');
                         return errors.AccessDenied;
+                    } else if (authResults[i].isAllowed) {
+                        // If the action is allowed, the result is not implicit
+                        // Deny.
+                        isImplicitDeny[authResults[i].action] = false;
+                        isOnlyImplicitDeny = false;
                     }
                 }
             }
-            return returnTagCount;
+            // These two APIs cannot use ACLs or Bucket Policies, hence, any
+            // implicit deny from vault must be treated as an explicit deny.
+            if ((apiMethod === 'bucketPut' || apiMethod === 'serviceGet') && isOnlyImplicitDeny) {
+                return errors.AccessDenied;
+            }
+            return { returnTagCount, isImplicitDeny };
         }
 
         return async.waterfall([
@@ -230,7 +253,16 @@ const api = {
                 if (checkedResults instanceof Error) {
                     return callback(checkedResults);
                 }
-                returnTagCount = checkedResults;
+                returnTagCount = checkedResults.returnTagCount;
+                request.actionImplicitDenies = checkedResults.isImplicitDeny;
+            } else {
+                // create an object of keys apiMethods with all values to false:
+                // for backward compatibility, all apiMethods are allowed by default
+                // thus it is explicitly allowed, so implicit deny is false
+                request.actionImplicitDenies = apiMethods.reduce((acc, curr) => {
+                    acc[curr] = false;
+                    return acc;
+                }, {});
             }
             if (apiMethod === 'objectPut' || apiMethod === 'objectPutPart') {
                 request._response = response;

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -162,7 +162,8 @@ const api = {
                         // Any explicit deny rejects the current API call
                         log.trace('authorization denial from Vault');
                         return errors.AccessDenied;
-                    } else if (authResults[i].isAllowed) {
+                    }
+                    if (authResults[i].isAllowed) {
                         // If the action is allowed, the result is not implicit
                         // Deny.
                         isImplicitDeny[authResults[i].action] = false;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "git+https://github.com/scality/arsenal#df5ff0f4006ee0a21269e139567fd5c425a4225f",
+    "arsenal": "git+https://github.com/scality/arsenal#7.10.49",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.10.31",
+  "version": "7.10.32",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "git+https://github.com/scality/arsenal#7.10.48",
+    "arsenal": "git+https://github.com/scality/arsenal#df5ff0f4006ee0a21269e139567fd5c425a4225f",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -488,9 +488,9 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#df5ff0f4006ee0a21269e139567fd5c425a4225f":
-  version "7.10.48"
-  resolved "git+https://github.com/scality/arsenal#df5ff0f4006ee0a21269e139567fd5c425a4225f"
+"arsenal@git+https://github.com/scality/arsenal#7.10.49":
+  version "7.10.49"
+  resolved "git+https://github.com/scality/arsenal#fbf5562a1180055249745881c1a324562d7cdc8a"
   dependencies:
     "@types/async" "^3.2.12"
     "@types/utf8" "^3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -488,9 +488,9 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#7.10.48":
+"arsenal@git+https://github.com/scality/arsenal#df5ff0f4006ee0a21269e139567fd5c425a4225f":
   version "7.10.48"
-  resolved "git+https://github.com/scality/arsenal#f49cea3914390880008e3d41cedb1a02f9d99f39"
+  resolved "git+https://github.com/scality/arsenal#df5ff0f4006ee0a21269e139567fd5c425a4225f"
   dependencies:
     "@types/async" "^3.2.12"
     "@types/utf8" "^3.0.1"


### PR DESCRIPTION
In this PR we are updating ApiCall method Auth checks to handle Implicit denies from Vault it's part of the following epic : https://github.com/scality/Arsenal/pull/2181

The ticket for this issue : https://scality.atlassian.net/browse/CLDSRV-424

Related issues
PRs providing implicit Deny logic to CS for processing in this PR
https://github.com/scality/Arsenal/pull/2181
https://github.com/scality/Vault/pull/2135
