### PR TITLE
CLDSRV-446 Limiting entries scanned during the lifecycle listing

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -184,6 +184,7 @@ const constants = {
         NON_CURRENT_TYPE: 'noncurrent',
         ORPHAN_DM_TYPE: 'orphan',
     },
+    maxScannedLifecycleListingEntries: 10000,
 };
 
 module.exports = constants;

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1333,6 +1333,17 @@ class Config extends EventEmitter {
         }
 
         this.testingMode = config.testingMode || false;
+
+        this.maxScannedLifecycleListingEntries = constants.maxScannedLifecycleListingEntries;
+        if (config.maxScannedLifecycleListingEntries !== undefined) {
+            // maxScannedLifecycleListingEntries > 2 is required as a minimum because we must
+            // scan at least three entries to determine version eligibility.
+            // Two entries representing the master key and the following one representing the non-current version.
+            assert(Number.isInteger(config.maxScannedLifecycleListingEntries) &&
+                config.maxScannedLifecycleListingEntries > 2,
+                'bad config: maxScannedLifecycleListingEntries must be greater than 2');
+            this.maxScannedLifecycleListingEntries = config.maxScannedLifecycleListingEntries;
+        }
     }
 
     _configureBackends() {

--- a/lib/api/apiUtils/object/lifecycle.js
+++ b/lib/api/apiUtils/object/lifecycle.js
@@ -21,6 +21,7 @@ function processCurrents(bucketName, listParams, isBucketVersioned, list) {
         Name: bucketName,
         Prefix: listParams.prefix,
         MaxKeys: listParams.maxKeys,
+        MaxScannedLifecycleListingEntries: listParams.maxScannedLifecycleListingEntries,
         IsTruncated: !!list.IsTruncated,
         Marker: listParams.marker,
         BeforeDate: listParams.beforeDate,
@@ -77,6 +78,7 @@ function processNonCurrents(bucketName, listParams, list) {
         Name: bucketName,
         Prefix: listParams.prefix,
         MaxKeys: listParams.maxKeys,
+        MaxScannedLifecycleListingEntries: listParams.maxScannedLifecycleListingEntries,
         IsTruncated: !!list.IsTruncated,
         KeyMarker: listParams.keyMarker,
         VersionIdMarker: versionIdMarker,
@@ -119,6 +121,7 @@ function processOrphans(bucketName, listParams, list) {
         Name: bucketName,
         Prefix: listParams.prefix,
         MaxKeys: listParams.maxKeys,
+        MaxScannedLifecycleListingEntries: listParams.maxScannedLifecycleListingEntries,
         IsTruncated: !!list.IsTruncated,
         Marker: listParams.marker,
         BeforeDate: listParams.beforeDate,
@@ -151,9 +154,37 @@ function getLocationConstraintErrorMessage(locationName) {
         `- ${locationName} - is not listed in the locationConstraint config`;
 }
 
+/**
+ * validateMaxScannedEntries - Validates and returns the maximum scanned entries value.
+ *
+ * @param {object} params - Query parameters
+ * @param {object} config - CloudServer configuration
+ * @param {number} min - Minimum number of entries to be scanned
+ * @returns {Object} - An object indicating the validation result:
+ *   - isValid (boolean): Whether the validation is successful.
+ *   - maxScannedLifecycleListingEntries (number): The validated maximum scanned entries value if isValid is true.
+ */
+function validateMaxScannedEntries(params, config, min) {
+    let maxScannedLifecycleListingEntries = config.maxScannedLifecycleListingEntries;
+
+    if (params['max-scanned-lifecycle-listing-entries']) {
+        const maxEntriesParams = Number.parseInt(params['max-scanned-lifecycle-listing-entries'], 10);
+
+        if (Number.isNaN(maxEntriesParams) || maxEntriesParams < min ||
+            maxEntriesParams > maxScannedLifecycleListingEntries) {
+            return { isValid: false };
+        }
+
+        maxScannedLifecycleListingEntries = maxEntriesParams;
+    }
+
+    return { isValid: true, maxScannedLifecycleListingEntries };
+}
+
 module.exports = {
     processCurrents,
     processNonCurrents,
     processOrphans,
     getLocationConstraintErrorMessage,
+    validateMaxScannedEntries,
 };

--- a/lib/api/backbeat/listLifecycleCurrents.js
+++ b/lib/api/backbeat/listLifecycleCurrents.js
@@ -4,8 +4,9 @@ const services = require('../../services');
 const { metadataValidateBucket } = require('../../metadata/metadataUtils');
 const { pushMetric } = require('../../utapi/utilities');
 const monitoring = require('../../utilities/metrics');
-const { getLocationConstraintErrorMessage, processCurrents } = require('../apiUtils/object/lifecycle');
-
+const { getLocationConstraintErrorMessage, processCurrents,
+    validateMaxScannedEntries } = require('../apiUtils/object/lifecycle');
+const { config } = require('../../Config');
 
 function handleResult(listParams, requestMaxKeys, authInfo,
     bucketName, list, isBucketVersioned, log, callback) {
@@ -43,6 +44,14 @@ function listLifecycleCurrents(authInfo, locationConstraints, request, log, call
     }
     const actualMaxKeys = Math.min(constants.listingHardLimit, requestMaxKeys);
 
+    const minEntriesToBeScanned = 1;
+    const { isValid, maxScannedLifecycleListingEntries } =
+        validateMaxScannedEntries(params, config, minEntriesToBeScanned);
+    if (!isValid) {
+        monitoring.promMetrics('GET', bucketName, 400, 'listLifecycleCurrents');
+        return callback(errors.InvalidArgument);
+    }
+
     const excludedDataStoreName = params['excluded-data-store-name'];
     if (excludedDataStoreName && !locationConstraints[excludedDataStoreName]) {
         const errMsg = getLocationConstraintErrorMessage(excludedDataStoreName);
@@ -65,6 +74,7 @@ function listLifecycleCurrents(authInfo, locationConstraints, request, log, call
         beforeDate: params['before-date'],
         marker: params.marker,
         excludedDataStoreName,
+        maxScannedLifecycleListingEntries,
     };
 
     return metadataValidateBucket(metadataValParams, log, (err, bucket) => {

--- a/lib/api/backbeat/listLifecycleNonCurrents.js
+++ b/lib/api/backbeat/listLifecycleNonCurrents.js
@@ -5,7 +5,9 @@ const { metadataValidateBucket } = require('../../metadata/metadataUtils');
 const { pushMetric } = require('../../utapi/utilities');
 const versionIdUtils = versioning.VersionID;
 const monitoring = require('../../utilities/metrics');
-const { getLocationConstraintErrorMessage, processNonCurrents } = require('../apiUtils/object/lifecycle');
+const { getLocationConstraintErrorMessage, processNonCurrents,
+    validateMaxScannedEntries } = require('../apiUtils/object/lifecycle');
+const { config } = require('../../Config');
 
 function handleResult(listParams, requestMaxKeys, authInfo,
     bucketName, list, log, callback) {
@@ -43,6 +45,16 @@ function listLifecycleNonCurrents(authInfo, locationConstraints, request, log, c
     }
     const actualMaxKeys = Math.min(constants.listingHardLimit, requestMaxKeys);
 
+    // 3 is required as a minimum because we must scan at least three entries to determine version eligibility.
+    // Two entries representing the master key and the following one representing the non-current version.
+    const minEntriesToBeScanned = 3;
+    const { isValid, maxScannedLifecycleListingEntries } =
+        validateMaxScannedEntries(params, config, minEntriesToBeScanned);
+    if (!isValid) {
+        monitoring.promMetrics('GET', bucketName, 400, 'listLifecycleNonCurrents');
+        return callback(errors.InvalidArgument);
+    }
+
     const excludedDataStoreName = params['excluded-data-store-name'];
     if (excludedDataStoreName && !locationConstraints[excludedDataStoreName]) {
         const errMsg = getLocationConstraintErrorMessage(excludedDataStoreName);
@@ -65,6 +77,7 @@ function listLifecycleNonCurrents(authInfo, locationConstraints, request, log, c
         beforeDate: params['before-date'],
         keyMarker: params['key-marker'],
         excludedDataStoreName,
+        maxScannedLifecycleListingEntries,
     };
 
     listParams.versionIdMarker = params['version-id-marker'] ?

--- a/lib/api/backbeat/listLifecycleOrphanDeleteMarkers.js
+++ b/lib/api/backbeat/listLifecycleOrphanDeleteMarkers.js
@@ -4,7 +4,8 @@ const services = require('../../services');
 const { metadataValidateBucket } = require('../../metadata/metadataUtils');
 const { pushMetric } = require('../../utapi/utilities');
 const monitoring = require('../../utilities/metrics');
-const { processOrphans } = require('../apiUtils/object/lifecycle');
+const { processOrphans, validateMaxScannedEntries } = require('../apiUtils/object/lifecycle');
+const { config } = require('../../Config');
 
 function handleResult(listParams, requestMaxKeys, authInfo,
     bucketName, list, log, callback) {
@@ -42,6 +43,16 @@ function listLifecycleOrphanDeleteMarkers(authInfo, locationConstraints, request
     }
     const actualMaxKeys = Math.min(constants.listingHardLimit, requestMaxKeys);
 
+    // 3 is required as a minimum because we must scan at least three entries to determine version eligibility.
+    // Two entries representing the master key and the following one representing the non-current version.
+    const minEntriesToBeScanned = 3;
+    const { isValid, maxScannedLifecycleListingEntries } =
+        validateMaxScannedEntries(params, config, minEntriesToBeScanned);
+    if (!isValid) {
+        monitoring.promMetrics('GET', bucketName, 400, 'listLifecycleOrphanDeleteMarkers');
+        return callback(errors.InvalidArgument);
+    }
+
     const metadataValParams = {
         authInfo,
         bucketName,
@@ -54,6 +65,7 @@ function listLifecycleOrphanDeleteMarkers(authInfo, locationConstraints, request
         prefix: params.prefix,
         beforeDate: params['before-date'],
         marker: params.marker,
+        maxScannedLifecycleListingEntries,
     };
 
     return metadataValidateBucket(metadataValParams, log, (err, bucket) => {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "git+https://github.com/scality/arsenal#7.70.10",
+    "arsenal": "git+https://github.com/scality/arsenal#7.70.11",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/tests/functional/backbeat/listLifecycleCurrents.js
+++ b/tests/functional/backbeat/listLifecycleCurrents.js
@@ -3,6 +3,7 @@ const async = require('async');
 const BucketUtility = require('../aws-node-sdk/lib/utility/bucket-util');
 const { removeAllVersions } = require('../aws-node-sdk/lib/utility/versioning-util');
 const { makeBackbeatRequest } = require('./utils');
+const { config } = require('../../../lib/Config');
 
 const credentials = {
     accessKey: 'accessKey1',
@@ -118,6 +119,7 @@ function checkContents(contents, expectedKeyVersions) {
                 assert.strictEqual(data.IsTruncated, false);
                 assert(!data.NextMarker);
                 assert.strictEqual(data.MaxKeys, 1000);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
                 assert.strictEqual(data.Contents.length, 0);
                 return done();
             });
@@ -137,6 +139,7 @@ function checkContents(contents, expectedKeyVersions) {
                 assert.strictEqual(data.IsTruncated, false);
                 assert(!data.NextMarker);
                 assert.strictEqual(data.MaxKeys, 1000);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
                 assert.strictEqual(data.Contents.length, 0);
                 return done();
             });
@@ -156,6 +159,7 @@ function checkContents(contents, expectedKeyVersions) {
                 assert.strictEqual(data.IsTruncated, false);
                 assert(!data.NextMarker);
                 assert.strictEqual(data.MaxKeys, 0);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
                 assert.strictEqual(data.Contents.length, 0);
 
                 return done();
@@ -186,6 +190,43 @@ function checkContents(contents, expectedKeyVersions) {
             });
         });
 
+        it('should return InvalidArgument error if max-scanned-lifecycle-listing-entries is invalid', done => {
+            makeBackbeatRequest({
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: { 'list-type': 'current', 'max-scanned-lifecycle-listing-entries': 'a' },
+                authCredentials: credentials,
+            }, err => {
+                assert.strictEqual(err.code, 'InvalidArgument');
+                return done();
+            });
+        });
+
+        it('should return InvalidArgument error if max-scanned-lifecycle-listing-entries is set to 0', done => {
+            makeBackbeatRequest({
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: { 'list-type': 'current', 'max-scanned-lifecycle-listing-entries': '0' },
+                authCredentials: credentials,
+            }, err => {
+                assert.strictEqual(err.code, 'InvalidArgument');
+                return done();
+            });
+        });
+
+        it('should return InvalidArgument if max-scanned-lifecycle-listing-entries exceeds the default value', done => {
+            makeBackbeatRequest({
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: { 'list-type': 'current', 'max-scanned-lifecycle-listing-entries':
+                    (config.maxScannedLifecycleListingEntries + 1).toString() },
+                authCredentials: credentials,
+            }, err => {
+                assert.strictEqual(err.code, 'InvalidArgument');
+                return done();
+            });
+        });
+
         it('should return all the current versions', done => {
             makeBackbeatRequest({
                 method: 'GET',
@@ -200,9 +241,34 @@ function checkContents(contents, expectedKeyVersions) {
                 assert.strictEqual(data.IsTruncated, false);
                 assert(!data.NextMarker);
                 assert.strictEqual(data.MaxKeys, 1000);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
 
                 const contents = data.Contents;
                 assert.strictEqual(contents.length, 8);
+                checkContents(contents, expectedKeyVersions);
+
+                return done();
+            });
+        });
+
+        it('should return all the current versions before max scanned entries value is reached', done => {
+            makeBackbeatRequest({
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: { 'list-type': 'current', 'max-scanned-lifecycle-listing-entries': '5' },
+                authCredentials: credentials,
+            }, (err, response) => {
+                assert.ifError(err);
+                assert.strictEqual(response.statusCode, 200);
+                const data = JSON.parse(response.body);
+
+                assert.strictEqual(data.IsTruncated, true);
+                assert.strictEqual(data.NextMarker, 'key4');
+                assert.strictEqual(data.MaxKeys, 1000);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, 5);
+
+                const contents = data.Contents;
+                assert.strictEqual(contents.length, 5);
                 checkContents(contents, expectedKeyVersions);
 
                 return done();
@@ -225,6 +291,7 @@ function checkContents(contents, expectedKeyVersions) {
                 assert.strictEqual(data.IsTruncated, false);
                 assert(!data.NextMarker);
                 assert.strictEqual(data.MaxKeys, 1000);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
                 assert.strictEqual(data.Prefix, prefix);
 
                 const contents = data.Contents;
@@ -249,6 +316,7 @@ function checkContents(contents, expectedKeyVersions) {
                 assert.strictEqual(data.IsTruncated, false);
                 assert(!data.NextMarker);
                 assert.strictEqual(data.MaxKeys, 1000);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
                 assert.strictEqual(data.Contents.length, 3);
                 assert.strictEqual(data.BeforeDate, date);
 
@@ -275,6 +343,7 @@ function checkContents(contents, expectedKeyVersions) {
                 assert.strictEqual(data.IsTruncated, true);
                 assert.strictEqual(data.NextMarker, 'oldkey0');
                 assert.strictEqual(data.MaxKeys, 1);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
                 assert.strictEqual(data.BeforeDate, date);
                 assert.strictEqual(data.Contents.length, 1);
 
@@ -300,6 +369,7 @@ function checkContents(contents, expectedKeyVersions) {
                 assert.strictEqual(data.Marker, 'oldkey0');
                 assert.strictEqual(data.NextMarker, 'oldkey1');
                 assert.strictEqual(data.MaxKeys, 1);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
                 assert.strictEqual(data.Contents.length, 1);
 
                 const contents = data.Contents;
@@ -323,6 +393,7 @@ function checkContents(contents, expectedKeyVersions) {
 
                 assert.strictEqual(data.IsTruncated, false);
                 assert.strictEqual(data.MaxKeys, 1);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
                 assert.strictEqual(data.Marker, 'oldkey1');
                 assert.strictEqual(data.BeforeDate, date);
 
@@ -408,6 +479,7 @@ describe('listLifecycleCurrents with bucket versioning enabled and maxKeys', () 
             assert.strictEqual(data.IsTruncated, true);
             assert.strictEqual(data.NextMarker, 'key0');
             assert.strictEqual(data.MaxKeys, 1);
+            assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
             assert.strictEqual(data.Contents.length, 1);
 
             const contents = data.Contents;
@@ -437,6 +509,7 @@ describe('listLifecycleCurrents with bucket versioning enabled and maxKeys', () 
             assert.strictEqual(data.IsTruncated, true);
             assert.strictEqual(data.NextMarker, 'key1');
             assert.strictEqual(data.MaxKeys, 1);
+            assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
             assert.strictEqual(data.Contents.length, 1);
 
             const contents = data.Contents;
@@ -466,6 +539,7 @@ describe('listLifecycleCurrents with bucket versioning enabled and maxKeys', () 
             assert.strictEqual(data.IsTruncated, false);
             assert.strictEqual(data.Marker, 'key1');
             assert.strictEqual(data.MaxKeys, 1);
+            assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
             assert.strictEqual(data.Contents.length, 1);
 
             const contents = data.Contents;
@@ -546,6 +620,7 @@ describe('listLifecycleCurrents with bucket versioning enabled and delete object
             assert.strictEqual(data.IsTruncated, true);
             assert.strictEqual(data.NextMarker, keyName0);
             assert.strictEqual(data.MaxKeys, 1);
+            assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
             assert.strictEqual(data.Contents.length, 1);
 
             const contents = data.Contents;
@@ -575,6 +650,7 @@ describe('listLifecycleCurrents with bucket versioning enabled and delete object
             assert.strictEqual(data.IsTruncated, false);
             assert.strictEqual(data.Marker, keyName0);
             assert.strictEqual(data.MaxKeys, 1);
+            assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
             assert.strictEqual(data.Contents.length, 1);
 
             const contents = data.Contents;

--- a/tests/unit/api/apiUtils/lifecycle.js
+++ b/tests/unit/api/apiUtils/lifecycle.js
@@ -1,0 +1,50 @@
+const assert = require('assert');
+const { validateMaxScannedEntries } =
+      require('../../../../lib/api/apiUtils/object/lifecycle');
+
+const tests = [
+    {
+        it: 'should return config value if no query params set',
+        config: { maxScannedLifecycleListingEntries: 10000 },
+        params: {},
+        minEntriesToBeScanned: 3,
+        expected: { isValid: true, maxScannedLifecycleListingEntries: 10000 },
+    },
+    {
+        it: 'should validate when query param is within the allowed range',
+        config: { maxScannedLifecycleListingEntries: 10000 },
+        params: { 'max-scanned-lifecycle-listing-entries': '5000' },
+        minEntriesToBeScanned: 3,
+        expected: { isValid: true, maxScannedLifecycleListingEntries: 5000 },
+    },
+    {
+        it: 'should return invalid when query param is not a number',
+        config: { maxScannedLifecycleListingEntries: 10000 },
+        params: { 'max-scanned-lifecycle-listing-entries': 'invalid' },
+        minEntriesToBeScanned: 3,
+        expected: { isValid: false },
+    },
+    {
+        it: 'should return invalid when query param is less than min',
+        config: { maxScannedLifecycleListingEntries: 10000 },
+        params: { 'max-scanned-lifecycle-listing-entries': '1' },
+        minEntriesToBeScanned: 3,
+        expected: { isValid: false },
+    },
+    {
+        it: 'should return invalid when query param exceeds config value',
+        config: { maxScannedLifecycleListingEntries: 10000 },
+        params: { 'max-scanned-lifecycle-listing-entries': '15000' },
+        minEntriesToBeScanned: 3,
+        expected: { isValid: false },
+    },
+];
+
+describe('getReplicationInfo helper', () => {
+    tests.forEach(t => {
+        it(t.it, () => {
+            const result = validateMaxScannedEntries(t.params, t.config, t.minEntriesToBeScanned);
+            assert.deepStrictEqual(result, t.expected);
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -494,9 +494,9 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#7.70.10":
-  version "7.70.10"
-  resolved "git+https://github.com/scality/arsenal#0177fbe98fc277eb9fb985fb9db56e460065331d"
+"arsenal@git+https://github.com/scality/arsenal#7.70.11":
+  version "7.70.11"
+  resolved "git+https://github.com/scality/arsenal#d84cc974d38e6a2fe8582bcf28902cbd302709b9"
   dependencies:
     "@types/async" "^3.2.12"
     "@types/utf8" "^3.0.1"


### PR DESCRIPTION
Implement the "New Limit on Scanned Entries Approach" for metadata filtering to improve response time and resource management.

**Description:**
Metadata filtering process might experience delays, impacting response times and server resources. To address this issue, we propose implementing the "New Limit on Scanned Entries Approach". 
It was currently implemented as an "Internal Timeout Approach": cf https://scality.atlassian.net/browse/S3C-7928

**Approach:**
The "New Limit on Scanned Entries Approach" involves setting a maximum number of entries to scan and filter before responding with up to 1000 entries. This approach aims to provide more predictable resource usage while potentially delivering more comprehensive results.

**Benefits:**
- Predictable resource usage.
- Potential for more comprehensive results.