### PR TITLE
CLDSRV-455 orphan delete marker list interruption skips processed key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.70.26",
+  "version": "7.70.27",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "git+https://github.com/scality/arsenal#7.70.11",
+    "arsenal": "git+https://github.com/scality/arsenal#7.70.12",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/tests/functional/backbeat/listLifecycleOrphanDeleteMarkers.js
+++ b/tests/functional/backbeat/listLifecycleOrphanDeleteMarkers.js
@@ -279,13 +279,13 @@ describe('listLifecycleOrphanDeleteMarkers', () => {
             if (process.env.DEFAULT_BUCKET_KEY_FORMAT === 'v1') {
                 // With v1 metadata bucket key format, master key is automaticaly deleted
                 // when the last version of an object is a delete marker
-                assert.strictEqual(nextMarker, 'key1old');
+                assert.strictEqual(nextMarker, 'key1');
                 assert.strictEqual(contents.length, 3);
                 assert.strictEqual(contents[0].Key, 'key0');
                 assert.strictEqual(contents[1].Key, 'key0old');
                 assert.strictEqual(contents[2].Key, 'key1');
             } else {
-                assert.strictEqual(nextMarker, 'key0old');
+                assert.strictEqual(nextMarker, 'key0');
                 assert.strictEqual(contents.length, 1);
                 assert.strictEqual(contents[0].Key, 'key0');
             }
@@ -319,12 +319,12 @@ describe('listLifecycleOrphanDeleteMarkers', () => {
             if (process.env.DEFAULT_BUCKET_KEY_FORMAT === 'v1') {
                 // With v1 metadata bucket key format, master key is automaticaly deleted
                 // when the last version of an object is a delete marker
-                assert.strictEqual(nextMarker, 'key1');
+                assert.strictEqual(nextMarker, 'key0old');
                 assert.strictEqual(contents.length, 2);
                 assert.strictEqual(contents[0].Key, 'key0');
                 assert.strictEqual(contents[1].Key, 'key0old');
             } else {
-                assert.strictEqual(nextMarker, 'key0old');
+                assert.strictEqual(nextMarker, 'key0');
                 assert.strictEqual(contents.length, 1);
                 assert.strictEqual(contents[0].Key, 'key0');
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -494,9 +494,9 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#7.70.11":
-  version "7.70.11"
-  resolved "git+https://github.com/scality/arsenal#d84cc974d38e6a2fe8582bcf28902cbd302709b9"
+"arsenal@git+https://github.com/scality/arsenal#7.70.12":
+  version "7.70.12"
+  resolved "git+https://github.com/scality/arsenal#79b83a90678e0b9eea521f08b3a7ec9eb158d748"
   dependencies:
     "@types/async" "^3.2.12"
     "@types/utf8" "^3.0.1"


### PR DESCRIPTION
The key marker in the orphan delete marker listing response should match the last key in the response's key array. 
This ensures that the next listing begins after the key that has already been returned.