### PR TITLE
CLDSRV-452: Id and principal on policy hotfixbranch

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "git+https://github.com/scality/arsenal#7.10.47",
+    "arsenal": "git+https://github.com/scality/arsenal#7.10.47-1",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.10.30",
+  "version": "7.10.30-1",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {

--- a/tests/functional/aws-node-sdk/test/bucket/putBucketPolicy.js
+++ b/tests/functional/aws-node-sdk/test/bucket/putBucketPolicy.js
@@ -30,6 +30,33 @@ function getPolicyParams(paramToChange) {
     };
 }
 
+function getPolicyParamsWithId(paramToChange, policyId) {
+    const newParam = {};
+    const bucketPolicy = {
+        Version: '2012-10-17',
+        Id: policyId,
+        Statement: [basicStatement],
+    };
+    if (paramToChange) {
+        newParam[paramToChange.key] = paramToChange.value;
+        bucketPolicy.Statement[0] = Object.assign({}, basicStatement, newParam);
+    }
+    return {
+        Bucket: bucket,
+        Policy: JSON.stringify(bucketPolicy),
+    };
+}
+
+function generateRandomString(length) {
+    // All allowed characters matching the regex in arsenal
+    const allowedCharacters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+=,.@ -/';
+    const allowedCharactersLength = allowedCharacters.length;
+
+    return [...Array(length)]
+      .map(() => allowedCharacters[~~(Math.random() * allowedCharactersLength)])
+      .join('');
+}
+
 // Check for the expected error response code and status code.
 function assertError(err, expectedErr, cb) {
     if (expectedErr === null) {
@@ -43,6 +70,7 @@ function assertError(err, expectedErr, cb) {
     }
     cb();
 }
+
 
 describe('aws-sdk test put bucket policy', () => {
     let s3;
@@ -99,6 +127,32 @@ describe('aws-sdk test put bucket policy', () => {
         it('should not allow bucket policy with no Principal',
         done => {
             const params = getPolicyParams({ key: 'Principal', value: '' });
+            s3.putBucketPolicy(params, err =>
+                assertError(err, 'MalformedPolicy', done));
+        });
+
+        it('should return MalformedPolicy because Id is not a string',
+        done => {
+            const params = getPolicyParamsWithId(null, 59);
+            s3.putBucketPolicy(params, err =>
+                assertError(err, 'MalformedPolicy', done));
+        });
+
+        it('should put a bucket policy on bucket since Id is a string',
+        done => {
+            const params = getPolicyParamsWithId(null, 'cd3ad3d9-2776-4ef1-a904-4c229d1642e');
+            s3.putBucketPolicy(params, err =>
+                assertError(err, null, done));
+        });
+
+        it('should allow bucket policy with pincipal arn less than 2048 characters', done => {
+            const params = getPolicyParams({ key: 'Principal', value: { AWS: `arn:aws:iam::767707094035:user/${generateRandomString(150)}` } }); // eslint-disable-line max-len
+            s3.putBucketPolicy(params, err =>
+                assertError(err, null, done));
+        });
+
+        it('should not allow bucket policy with pincipal arn more than 2048 characters', done => {
+            const params = getPolicyParams({ key: 'Principal', value: { AWS: `arn:aws:iam::767707094035:user/${generateRandomString(2020)}` } }); // eslint-disable-line max-len
             s3.putBucketPolicy(params, err =>
                 assertError(err, 'MalformedPolicy', done));
         });

--- a/tests/functional/aws-node-sdk/test/bucket/putBucketPolicy.js
+++ b/tests/functional/aws-node-sdk/test/bucket/putBucketPolicy.js
@@ -71,7 +71,6 @@ function assertError(err, expectedErr, cb) {
     cb();
 }
 
-
 describe('aws-sdk test put bucket policy', () => {
     let s3;
     let otherAccountS3;

--- a/yarn.lock
+++ b/yarn.lock
@@ -488,9 +488,9 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#7.10.47":
-  version "7.10.47"
-  resolved "git+https://github.com/scality/arsenal#3f24336b83581d121f52146b8003e0a68d9ce876"
+"arsenal@git+https://github.com/scality/arsenal#7.10.47-1":
+  version "7.10.47-1"
+  resolved "git+https://github.com/scality/arsenal#7f4192a727a3f01fbffa8b7edc062f933f9ef1b1"
   dependencies:
     "@types/async" "^3.2.12"
     "@types/utf8" "^3.0.1"


### PR DESCRIPTION
# Pull request template

## Description

### Motivation and context

This PR adds the arsenal version that support of the Id definition on resource policy document and principal length restriction on both resource and user policy

Ticket link : https://scality.atlassian.net/browse/CLDSRV-452
ARSN PR link : https://github.com/scality/Arsenal/pull/2178

**I am aiming for the hotfix/7.10.8 branch on Federation , here's the link showing the cldsrv version used in there: https://github.com/scality/Federation/blob/54ef0fdca84a8f5a64ffe28eaef816daf5f42d53/group_vars/all#L141**

Tests were added as well