### PR TITLE
CLDSRV-462 Expiration header is not compatible with legacy object md

### DIFF
--- a/lib/api/apiUtils/object/expirationHeaders.js
+++ b/lib/api/apiUtils/object/expirationHeaders.js
@@ -37,8 +37,10 @@ const AMZ_ABORT_ID_HEADER = 'x-amz-abort-rule-id';
 
 function _generateExpHeadersObjects(rules, params, datetime) {
     const tags = {
-        TagSet: Object.keys(params.tags)
-            .map(key => ({ Key: key, Value: params.tags[key] })),
+        TagSet: params.tags
+            ? Object.keys(params.tags)
+                .map(key => ({ Key: key, Value: params.tags[key] }))
+            : [],
     };
 
     const objectInfo = { Key: params.key };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.10.31",
+  "version": "7.10.32",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {

--- a/tests/unit/api/apiUtils/expirationHeaders.js
+++ b/tests/unit/api/apiUtils/expirationHeaders.js
@@ -104,6 +104,16 @@ describe('generateExpirationHeaders', () => {
             {},
         ],
         [
+            'should provide correct headers for compatibility with legacy objects missing the tags property',
+            {
+                lifecycleConfig: lifecycleExpirationDays,
+                objectParams: { key: 'object', date: objectDate },
+            },
+            {
+                'x-amz-expiration': `expiry-date="${expectedDaysExpiryDate}", rule-id="test-days"`,
+            },
+        ],
+        [
             'should return correct headers for object (days)',
             {
                 lifecycleConfig: lifecycleExpirationDays,


### PR DESCRIPTION
Before the Object Metadata refactor done around May 31, 2017 (https://github.com/scality/Cloudserver/commit/c22e44f63d571a6271af1f1a9c03266b9fd273ae), if no tags were set, the object tag was stored as undefined.

After the commit, if no tags are set, the object tag is stored as an empty object '{}'.

When the expiration response headers were implemented on https://github.com/scality/cloudserver/commit/812b09afeff5313ae3ec5e0adf99060b94c79b0d around Nov 22, 2021, the empty object was handled, but not the undefined tag logic, which made the expiration response headers not backward compatible.

We need to address both cases: the undefined property and the empty object '{}'.
