### PR TITLE
CLDSRV-646: MPU support for SUR

### DIFF
--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -300,6 +300,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                 replicationInfo: getReplicationInfo(objectKey, destBucket,
                     false, calculatedSize, REPLICATION_ACTION),
                 originOp: 's3:ObjectCreated:CompleteMultipartUpload',
+                overheadField: constants.overheadField,
                 log,
             };
             if (storedMetadata['x-amz-tagging']) {

--- a/lib/api/objectPutPart.js
+++ b/lib/api/objectPutPart.js
@@ -309,6 +309,7 @@ function objectPutPart(authInfo, request, streamingV4Params, log,
                 'last-modified': new Date().toJSON(),
                 'content-md5': hexDigest,
                 'content-length': size,
+                'owner-id': destinationBucket.getOwner(),
             };
             const mdParams = { overheadField: constants.overheadField };
             return metadata.putObjectMD(mpuBucketName, partKey, omVal, mdParams, log,

--- a/lib/services.js
+++ b/lib/services.js
@@ -884,7 +884,7 @@ const services = {
         // all at once in production implementation
         assert.strictEqual(typeof mpuBucketName, 'string');
         async.eachLimit(keysToDelete, 5, (key, callback) => {
-            metadata.deleteObjectMD(mpuBucketName, key, {}, log, callback);
+            metadata.deleteObjectMD(mpuBucketName, key, { overheadField: constants.overheadField }, log, callback);
         }, err => cb(err));
     },
 


### PR DESCRIPTION
2 small changes:
- pass overheadField during completeMPU and the delete of part MD 
- add the canonicalId of the destination bucket's owner as `owner-id` in the MPU part MD.