### PR TITLE
Improvement/cldsrv-426-ACL-Implicit-Deny

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -174,6 +174,11 @@ const constants = {
         'user',
         'bucket',
     ],
+    arrayOfAllowed: [
+        'objectPutTagging',
+        'objectPutLegalHold',
+        'objectPutRetention',
+    ],
     allowedUtapiEventFilterStates: ['allow', 'deny'],
     // The AWS assumed Role resource type
     assumedRoleArnResourceType: 'assumed-role',

--- a/lib/api/apiUtils/authorization/permissionChecks.js
+++ b/lib/api/apiUtils/authorization/permissionChecks.js
@@ -2,19 +2,43 @@ const { evaluators, actionMaps, RequestContext } = require('arsenal').policies;
 const constants = require('../../../../constants');
 
 const { allAuthedUsersId, bucketOwnerActions, logId, publicId,
-    assumedRoleArnResourceType, backbeatLifecycleSessionName } = constants;
+    assumedRoleArnResourceType, backbeatLifecycleSessionName, arrayOfAllowed } = constants;
 
 // whitelist buckets to allow public read on objects
 const publicReadBuckets = process.env.ALLOW_PUBLIC_READ_BUCKETS ?
     process.env.ALLOW_PUBLIC_READ_BUCKETS.split(',') : [];
 
-function checkBucketAcls(bucket, requestType, canonicalID) {
+/**
+ * Checks the access control for a given bucket based on the request type and user's canonical ID.
+ *
+ * @param {Bucket} bucket - The bucket to check access control for.
+ * @param {string} requestType - The list of s3 actions to check within the API call.
+ * @param {string} canonicalID - The canonical ID of the user making the request.
+ * @param {string} mainApiCall - The main API call (first item of the requestType).
+ *
+ * @returns {boolean} - Returns true if the user has the necessary access rights, otherwise false.
+ */
+
+function checkBucketAcls(bucket, requestType, canonicalID, mainApiCall) {
+    // Same logic applies on the Versioned APIs, so let's simplify it.
+    const requestTypeParsed = requestType.endsWith('Version') ?
+        requestType.slice(0, 'Version'.length * -1) : requestType;
     if (bucket.getOwner() === canonicalID) {
         return true;
     }
+    if (mainApiCall === 'objectGet') {
+        if (requestTypeParsed === 'objectGetTagging') {
+            return true;
+        }
+    }
+    if (mainApiCall === 'objectPut') {
+        if (arrayOfAllowed.includes(requestTypeParsed)) {
+            return true;
+        }
+    }
 
     const bucketAcl = bucket.getAcl();
-    if (requestType === 'bucketGet' || requestType === 'bucketHead') {
+    if (requestTypeParsed === 'bucketGet' || requestTypeParsed === 'bucketHead') {
         if (bucketAcl.Canned === 'public-read'
             || bucketAcl.Canned === 'public-read-write'
             || (bucketAcl.Canned === 'authenticated-read'
@@ -32,7 +56,7 @@ function checkBucketAcls(bucket, requestType, canonicalID) {
             return true;
         }
     }
-    if (requestType === 'bucketGetACL') {
+    if (requestTypeParsed === 'bucketGetACL') {
         if ((bucketAcl.Canned === 'log-delivery-write'
             && canonicalID === logId)
             || bucketAcl.FULL_CONTROL.indexOf(canonicalID) > -1
@@ -48,7 +72,7 @@ function checkBucketAcls(bucket, requestType, canonicalID) {
         }
     }
 
-    if (requestType === 'bucketPutACL') {
+    if (requestTypeParsed === 'bucketPutACL') {
         if (bucketAcl.FULL_CONTROL.indexOf(canonicalID) > -1
             || bucketAcl.WRITE_ACP.indexOf(canonicalID) > -1) {
             return true;
@@ -62,11 +86,7 @@ function checkBucketAcls(bucket, requestType, canonicalID) {
         }
     }
 
-    if (requestType === 'bucketDelete' && bucket.getOwner() === canonicalID) {
-        return true;
-    }
-
-    if (requestType === 'objectDelete' || requestType === 'objectPut') {
+    if (requestTypeParsed === 'objectDelete' || requestTypeParsed === 'objectPut') {
         if (bucketAcl.Canned === 'public-read-write'
             || bucketAcl.FULL_CONTROL.indexOf(canonicalID) > -1
             || bucketAcl.WRITE.indexOf(canonicalID) > -1) {
@@ -86,11 +106,12 @@ function checkBucketAcls(bucket, requestType, canonicalID) {
     // objectPutACL, objectGetACL, objectHead or objectGet, the bucket
     // authorization check should just return true so can move on to check
     // rights at the object level.
-    return (requestType === 'objectPutACL' || requestType === 'objectGetACL' ||
-        requestType === 'objectGet' || requestType === 'objectHead');
+    return (requestTypeParsed === 'objectPutACL' || requestTypeParsed === 'objectGetACL' ||
+    requestTypeParsed === 'objectGet' || requestTypeParsed === 'objectHead');
 }
 
-function checkObjectAcls(bucket, objectMD, requestType, canonicalID) {
+function checkObjectAcls(bucket, objectMD, requestType, canonicalID, requesterIsNotUser,
+    isUserUnauthenticated, mainApiCall) {
     const bucketOwner = bucket.getOwner();
     // acls don't distinguish between users and accounts, so both should be allowed
     if (bucketOwnerActions.includes(requestType)
@@ -100,6 +121,15 @@ function checkObjectAcls(bucket, objectMD, requestType, canonicalID) {
     if (objectMD['owner-id'] === canonicalID) {
         return true;
     }
+
+    // Backward compatibility
+    if (mainApiCall === 'objectGet') {
+        if ((isUserUnauthenticated || (requesterIsNotUser && bucketOwner === objectMD['owner-id']))
+            && requestType === 'objectGetTagging') {
+            return true;
+        }
+    }
+
     if (!objectMD.acl) {
         return false;
     }

--- a/tests/unit/auth/permissionChecks.js
+++ b/tests/unit/auth/permissionChecks.js
@@ -1,0 +1,317 @@
+const assert = require('assert');
+const { checkBucketAcls, checkObjectAcls } = require('../../../lib/api/apiUtils/authorization/permissionChecks');
+const constants = require('../../../constants');
+
+const { bucketOwnerActions, logId } = constants;
+
+describe('checkBucketAcls', () => {
+    const mockBucket = {
+        getOwner: () => 'ownerId',
+        getAcl: () => ({
+            Canned: '',
+            FULL_CONTROL: [],
+            READ: [],
+            READ_ACP: [],
+            WRITE: [],
+            WRITE_ACP: [],
+        }),
+    };
+
+    const testScenarios = [
+        {
+            description: 'should return true if bucket owner matches canonicalID',
+            input: {
+                bucketAcl: {}, requestType: 'anyType', canonicalID: 'ownerId', mainApiCall: 'anyApiCall',
+            },
+            expected: true,
+        },
+        {
+            description: 'should return true for objectGetTagging when mainApiCall is objectGet',
+            input: {
+                bucketAcl: {}, requestType: 'objectGetTagging', canonicalID: 'anyId', mainApiCall: 'objectGet',
+            },
+            expected: true,
+        },
+        {
+            description: 'should return true for objectPutTagging when mainApiCall is objectPut',
+            input: {
+                bucketAcl: {}, requestType: 'objectPutTagging', canonicalID: 'anyId', mainApiCall: 'objectPut',
+            },
+            expected: true,
+        },
+        {
+            description: 'should return true for objectPutLegalHold when mainApiCall is objectPut',
+            input: {
+                bucketAcl: {}, requestType: 'objectPutLegalHold', canonicalID: 'anyId', mainApiCall: 'objectPut',
+            },
+            expected: true,
+        },
+        {
+            description: 'should return true for objectPutRetention when mainApiCall is objectPut',
+            input: {
+                bucketAcl: {}, requestType: 'objectPutRetention', canonicalID: 'anyId', mainApiCall: 'objectPut',
+            },
+            expected: true,
+        },
+        {
+            description: 'should return true for bucketGet if canned acl is public-read-write',
+            input: {
+                bucketAcl: { Canned: 'public-read-write' },
+                requestType: 'bucketGet',
+                canonicalID: 'anyId',
+                mainApiCall: 'anyApiCall',
+            },
+            expected: true,
+        },
+        {
+            description: 'should return true for bucketGet if canned acl is authenticated-read and id is not publicId',
+            input: {
+                bucketAcl: { Canned: 'authenticated-read' },
+                requestType: 'bucketGet',
+                canonicalID: 'anyIdNotPublic',
+                mainApiCall: 'anyApiCall',
+            },
+            expected: true,
+        },
+        {
+            description: 'should return true for bucketHead if canned acl is public-read',
+            input: {
+                bucketAcl: { Canned: 'public-read' },
+                requestType: 'bucketHead',
+                canonicalID: 'anyId',
+                mainApiCall: 'anyApiCall',
+            },
+            expected: true,
+        },
+        {
+            description: 'should return false for bucketPut even if canonicalID has FULL_CONTROL and write access ',
+            input: {
+                bucketAcl: {
+                    FULL_CONTROL: ['anyId'],
+                    WRITE: ['anyId'],
+                },
+                requestType: 'bucketPut',
+                canonicalID: 'anyId',
+                mainApiCall: 'anyApiCall',
+            },
+            expected: false,
+        },
+        {
+            description: 'should return true for log-delivery-write ACL when canonicalID matches logId',
+            input: {
+                bucketAcl: { Canned: 'log-delivery-write' },
+                requestType: 'bucketGetACL',
+                canonicalID: logId,
+                mainApiCall: 'anyApiCall',
+            },
+            expected: true,
+        },
+        {
+            description: 'should return false when the canonicalID is not the owner and has no ACL permissions',
+            input: {
+                bucketAcl: {
+                    FULL_CONTROL: ['someOtherId'],
+                    WRITE: ['someOtherId'],
+                },
+                requestType: 'objectPut',
+                canonicalID: 'anyId',
+                mainApiCall: 'anyApiCall',
+            },
+            expected: false,
+        },
+        {
+            description: 'should return false for bucketPutACL if canonicalID does not have ACL permissions',
+            input: {
+                bucketAcl: {
+                    FULL_CONTROL: ['someOtherId'],
+                    WRITE_ACP: ['someOtherId'],
+                },
+                requestType: 'bucketPutACL',
+                canonicalID: 'anyId',
+                mainApiCall: 'anyApiCall',
+            },
+            expected: false,
+        },
+        {
+            description: 'should return true for bucketGet if canonicalID has FULL_CONTROL access',
+            input: {
+                bucketAcl: { FULL_CONTROL: ['anyId'], READ: [] },
+                requestType: 'bucketGet',
+                canonicalID: 'anyId',
+                mainApiCall: 'anyApiCall',
+            },
+            expected: true,
+        },
+        {
+            description: 'should return true for bucketGetACL if canonicalID has FULL_CONTROL',
+            input: {
+                bucketAcl: { FULL_CONTROL: ['anyId'], READ_ACP: [] },
+                requestType: 'bucketGetACL',
+                canonicalID: 'anyId',
+                mainApiCall: 'anyApiCall',
+            },
+            expected: true,
+        },
+        {
+            description: 'should return true for objectDelete if bucketAcl.Canned is public-read-write',
+            input: {
+                bucketAcl: { Canned: 'public-read-write' },
+                requestType: 'objectDelete',
+                canonicalID: 'anyId',
+                mainApiCall: 'anyApiCall',
+            },
+            expected: true,
+        },
+        {
+            description: 'should return true for requestType ending with "Version"',
+            input: {
+                bucketAcl: {},
+                requestType: 'objectGetVersion',
+                canonicalID: 'anyId',
+                mainApiCall: 'objectGet',
+            },
+            expected: true,
+        },
+        {
+            description: 'should return true for objectPutACL',
+            input: {
+                bucketAcl: {},
+                requestType: 'objectPutACL',
+                canonicalID: 'anyId',
+                mainApiCall: 'anyApiCall',
+            },
+            expected: true,
+        },
+        {
+            description: 'should return true for objectGetACL',
+            input: {
+                bucketAcl: {},
+                requestType: 'objectGetACL',
+                canonicalID: 'anyId',
+                mainApiCall: 'anyApiCall',
+            },
+            expected: true,
+        },
+        {
+            description: 'should return false for unmatched scenarios',
+            input: {
+                bucketAcl: {},
+                requestType: 'unmatchedRequest',
+                canonicalID: 'anyId',
+                mainApiCall: 'anyApiCall',
+            },
+            expected: false,
+        },
+    ];
+
+    testScenarios.forEach(scenario => {
+        it(scenario.description, () => {
+            // Mock the bucket based on the test scenario's input
+            mockBucket.getAcl = () => scenario.input.bucketAcl;
+
+            const result = checkBucketAcls(mockBucket,
+                scenario.input.requestType, scenario.input.canonicalID, scenario.input.mainApiCall);
+            assert.strictEqual(result, scenario.expected);
+        });
+    });
+});
+
+describe('checkObjectAcls', () => {
+    const mockBucket = {
+        getOwner: () => 'bucketOwnerId',
+        getName: () => 'bucketName',
+        getAcl: () => ({ Canned: '' }),
+    };
+    const mockObjectMD = {
+        'owner-id': 'objectOwnerId',
+        'acl': {
+            Canned: '',
+            FULL_CONTROL: [],
+            READ: [],
+            READ_ACP: [],
+            WRITE: [],
+            WRITE_ACP: [],
+        },
+    };
+
+    it('should return true if request type is in bucketOwnerActions and bucket owner matches canonicalID', () => {
+        assert.strictEqual(checkObjectAcls(mockBucket, mockObjectMD, bucketOwnerActions[0],
+            'bucketOwnerId', false, false, 'anyApiCall'), true);
+    });
+
+    it('should return true if objectMD owner matches canonicalID', () => {
+        assert.strictEqual(checkObjectAcls(mockBucket, mockObjectMD, 'anyType',
+            'objectOwnerId', false, false, 'anyApiCall'), true);
+    });
+
+    it('should return true for objectGetTagging when mainApiCall is objectGet and conditions met', () => {
+        assert.strictEqual(checkObjectAcls(mockBucket, mockObjectMD, 'objectGetTagging',
+            'anyIdNotPublic', true, true, 'objectGet'), true);
+    });
+
+    it('should return false if no acl provided in objectMD', () => {
+        const objMDWithoutAcl = Object.assign({}, mockObjectMD);
+        delete objMDWithoutAcl.acl;
+        assert.strictEqual(checkObjectAcls(mockBucket, objMDWithoutAcl, 'anyType',
+            'anyId', false, false, 'anyApiCall'), false);
+    });
+
+    const tests = [
+        {
+            acl: 'public-read', reqType: 'objectGet', id: 'anyIdNotPublic', expected: true,
+        },
+        {
+            acl: 'public-read-write', reqType: 'objectGet', id: 'anyIdNotPublic', expected: true,
+        },
+        {
+            acl: 'authenticated-read', reqType: 'objectGet', id: 'anyIdNotPublic', expected: true,
+        },
+        {
+            acl: 'bucket-owner-read', reqType: 'objectGet', id: 'bucketOwnerId', expected: true,
+        },
+        {
+            acl: 'bucket-owner-full-control', reqType: 'objectGet', id: 'bucketOwnerId', expected: true,
+        },
+        {
+            aclList: ['someId', 'anyIdNotPublic'],
+            aclField: 'FULL_CONTROL',
+            reqType: 'objectGet',
+            id: 'anyIdNotPublic',
+            expected: true,
+        },
+        {
+            aclList: ['someId', 'anyIdNotPublic'],
+            aclField: 'READ',
+            reqType: 'objectGet',
+            id: 'anyIdNotPublic',
+            expected: true,
+        },
+        { reqType: 'objectPut', id: 'anyId', expected: true },
+        { reqType: 'objectDelete', id: 'anyId', expected: true },
+        {
+            aclList: ['anyId'], aclField: 'FULL_CONTROL', reqType: 'objectPutACL', id: 'anyId', expected: true,
+        },
+        {
+            aclList: ['anyId'], aclField: 'FULL_CONTROL', reqType: 'objectGetACL', id: 'anyId', expected: true,
+        },
+        {
+            acl: '', reqType: 'objectGet', id: 'randomId', expected: false,
+        },
+    ];
+
+    tests.forEach(test => {
+        it(`should return ${test.expected} for ${test.reqType} with ACL as ${test.acl
+            || (`${test.aclField}:${JSON.stringify(test.aclList)}`)}`, () => {
+            if (test.acl) {
+                mockObjectMD.acl.Canned = test.acl;
+            } else if (test.aclList && test.aclField) {
+                mockObjectMD.acl[test.aclField] = test.aclList;
+            }
+
+            assert.strictEqual(
+                checkObjectAcls(mockBucket, mockObjectMD, test.reqType, test.id, false, false, 'anyApiCall'),
+                test.expected,
+            );
+        });
+    });
+});


### PR DESCRIPTION
PR opened after closing : https://github.com/scality/cloudserver/pull/5323

Bucket policies are not correctly interpreted, this is part of the following epic to fix that: https://github.com/scality/Arsenal/pull/2181

This PR is aiming to update ACL checks for APIs with multiple permission , ticket linked to this issue here : https://scality.atlassian.net/browse/CLDSRV-426

PRs providing implicit Deny logic to CS for processing in this PR
https://github.com/scality/Arsenal/pull/2181
https://github.com/scality/Vault/pull/2135
https://github.com/scality/cloudserver/pull/5322

Tests have also been added.

**I'm not bumping a new CLDSRV version since a new version has been created in this merged PR : https://github.com/scality/cloudserver/pull/5322 , Please let me know if it needs to be done anyways.**