### PR TITLE
Forward system signals to the node process using tini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ EXPOSE 8002
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         jq \
+        tini \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/app
@@ -53,6 +54,6 @@ COPY --from=builder /usr/src/app/node_modules ./node_modules/
 
 VOLUME ["/usr/src/app/localData","/usr/src/app/localMetadata"]
 
-ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "/usr/src/app/docker-entrypoint.sh"]
 
 CMD [ "yarn", "start" ]


### PR DESCRIPTION
`npm run` doesn’t handle signal forwarding and crashes on the `SIGTERM` signal sent by Kubernetes.

We'll use `Tini`, which spawns a process at PID 1 that handles forwarding system signals to all it's child processes.
This is the recommended solution in the [NodeJS best practicing guide](https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#handling-kernel-signals).

Issue: CLDSRV-460

