### PR TITLE
CLDSRV-429: update get apis with impDeny logic

### DIFF
--- a/lib/api/bucketGet.js
+++ b/lib/api/bucketGet.js
@@ -3,7 +3,7 @@ const { errors, versioning, s3middleware } = require('arsenal');
 
 const constants = require('../../constants');
 const services = require('../services');
-const { metadataValidateBucket } = require('../metadata/metadataUtils');
+const { standardMetadataValidateBucket } = require('../metadata/metadataUtils');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const escapeForXml = s3middleware.escapeForXml;
 const { pushMetric } = require('../utapi/utilities');
@@ -345,7 +345,7 @@ function bucketGet(authInfo, request, log, callback) {
         listParams.marker = params.marker;
     }
 
-    metadataValidateBucket(metadataValParams, log, (err, bucket) => {
+    standardMetadataValidateBucket(metadataValParams, request.actionImplicitDenies, log, (err, bucket) => {
         const corsHeaders = collectCorsHeaders(request.headers.origin,
             request.method, bucket);
         if (err) {

--- a/lib/api/bucketGetACL.js
+++ b/lib/api/bucketGetACL.js
@@ -1,5 +1,5 @@
 const aclUtils = require('../utilities/aclUtils');
-const { metadataValidateBucket } = require('../metadata/metadataUtils');
+const { standardMetadataValidateBucket } = require('../metadata/metadataUtils');
 const vault = require('../auth/vault');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const { pushMetric } = require('../utapi/utilities');
@@ -54,7 +54,7 @@ function bucketGetACL(authInfo, request, log, callback) {
         },
     };
 
-    metadataValidateBucket(metadataValParams, log, (err, bucket) => {
+    standardMetadataValidateBucket(metadataValParams, request.actionImplicitDenies, log, (err, bucket) => {
         const corsHeaders = collectCorsHeaders(request.headers.origin,
             request.method, bucket);
         if (err) {

--- a/lib/api/bucketGetCors.js
+++ b/lib/api/bucketGetCors.js
@@ -34,7 +34,8 @@ function bucketGetCors(authInfo, request, log, callback) {
         const corsHeaders = collectCorsHeaders(request.headers.origin,
             request.method, bucket);
 
-        if (!isBucketAuthorized(bucket, requestType, canonicalID, authInfo, log, request)) {
+        if (!isBucketAuthorized(bucket, requestType, canonicalID, authInfo, log,
+            request, request.actionImplicitDenies)) {
             log.debug('access denied for user on bucket', {
                 requestType,
                 method: 'bucketGetCors',

--- a/lib/api/bucketGetEncryption.js
+++ b/lib/api/bucketGetEncryption.js
@@ -4,7 +4,7 @@ const async = require('async');
 const { pushMetric } = require('../utapi/utilities');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const { checkExpectedBucketOwner } = require('./apiUtils/authorization/bucketOwner');
-const { metadataValidateBucket } = require('../metadata/metadataUtils');
+const { standardMetadataValidateBucket } = require('../metadata/metadataUtils');
 const escapeForXml = s3middleware.escapeForXml;
 
 /**
@@ -27,7 +27,7 @@ function bucketGetEncryption(authInfo, request, log, callback) {
     };
 
     return async.waterfall([
-        next => metadataValidateBucket(metadataValParams, log, next),
+        next => standardMetadataValidateBucket(metadataValParams, request.actionImplicitDenies, log, next),
         (bucket, next) => checkExpectedBucketOwner(request.headers, bucket, log, err => next(err, bucket)),
         (bucket, next) => {
             // If sseInfo is present but the `mandatory` flag is not set

--- a/lib/api/bucketGetLifecycle.js
+++ b/lib/api/bucketGetLifecycle.js
@@ -2,7 +2,7 @@ const { errors } = require('arsenal');
 const LifecycleConfiguration =
     require('arsenal').models.LifecycleConfiguration;
 
-const { metadataValidateBucket } = require('../metadata/metadataUtils');
+const { standardMetadataValidateBucket } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 
@@ -23,7 +23,7 @@ function bucketGetLifecycle(authInfo, request, log, callback) {
         requestType: 'bucketGetLifecycle',
         request,
     };
-    return metadataValidateBucket(metadataValParams, log, (err, bucket) => {
+    return standardMetadataValidateBucket(metadataValParams, request.actionImplicitDenies, log, (err, bucket) => {
         const corsHeaders = collectCorsHeaders(headers.origin, method, bucket);
         if (err) {
             log.debug('error processing request', {

--- a/lib/api/bucketGetLocation.js
+++ b/lib/api/bucketGetLocation.js
@@ -36,7 +36,8 @@ function bucketGetLocation(authInfo, request, log, callback) {
         const corsHeaders = collectCorsHeaders(request.headers.origin,
             request.method, bucket);
 
-        if (!isBucketAuthorized(bucket, requestType, canonicalID, authInfo, log, request)) {
+        if (!isBucketAuthorized(bucket, requestType, canonicalID, authInfo, log, request,
+            request.actionImplicitDenies)) {
             log.debug('access denied for account on bucket', {
                 requestType,
                 method: 'bucketGetLocation',

--- a/lib/api/bucketGetNotification.js
+++ b/lib/api/bucketGetNotification.js
@@ -1,4 +1,4 @@
-const { metadataValidateBucket } = require('../metadata/metadataUtils');
+const { standardMetadataValidateBucket } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const { NotificationConfiguration } = require('arsenal').models;
@@ -41,7 +41,7 @@ function bucketGetNotification(authInfo, request, log, callback) {
         request,
     };
 
-    return metadataValidateBucket(metadataValParams, log, (err, bucket) => {
+    return standardMetadataValidateBucket(metadataValParams, request.actionImplicitDenies, log, (err, bucket) => {
         const corsHeaders = collectCorsHeaders(headers.origin, method, bucket);
         if (err) {
             log.debug('error processing request', {

--- a/lib/api/bucketGetObjectLock.js
+++ b/lib/api/bucketGetObjectLock.js
@@ -1,5 +1,5 @@
 const { errors } = require('arsenal');
-const { metadataValidateBucket } = require('../metadata/metadataUtils');
+const { standardMetadataValidateBucket } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const ObjectLockConfiguration =
@@ -36,7 +36,7 @@ function bucketGetObjectLock(authInfo, request, log, callback) {
         requestType: 'bucketGetObjectLock',
         request,
     };
-    return metadataValidateBucket(metadataValParams, log, (err, bucket) => {
+    return standardMetadataValidateBucket(metadataValParams, request.actionImplicitDenies, log, (err, bucket) => {
         const corsHeaders = collectCorsHeaders(headers.origin, method, bucket);
         if (err) {
             log.debug('error processing request', {

--- a/lib/api/bucketGetPolicy.js
+++ b/lib/api/bucketGetPolicy.js
@@ -1,6 +1,6 @@
 const { errors } = require('arsenal');
 
-const { metadataValidateBucket } = require('../metadata/metadataUtils');
+const { standardMetadataValidateBucket } = require('../metadata/metadataUtils');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 
 /**
@@ -21,7 +21,7 @@ function bucketGetPolicy(authInfo, request, log, callback) {
         request,
     };
 
-    return metadataValidateBucket(metadataValParams, log, (err, bucket) => {
+    return standardMetadataValidateBucket(metadataValParams, request.actionImplicitDenies, log, (err, bucket) => {
         const corsHeaders = collectCorsHeaders(headers.origin, method, bucket);
         if (err) {
             log.debug('error processing request', {

--- a/lib/api/bucketGetReplication.js
+++ b/lib/api/bucketGetReplication.js
@@ -1,6 +1,6 @@
 const { errors } = require('arsenal');
 
-const { metadataValidateBucket } = require('../metadata/metadataUtils');
+const { standardMetadataValidateBucket } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
 const { getReplicationConfigurationXML } =
     require('./apiUtils/bucket/getReplicationConfiguration');
@@ -23,7 +23,7 @@ function bucketGetReplication(authInfo, request, log, callback) {
         requestType: 'bucketGetReplication',
         request,
     };
-    return metadataValidateBucket(metadataValParams, log, (err, bucket) => {
+    return standardMetadataValidateBucket(metadataValParams, request.actionImplicitDenies, log, (err, bucket) => {
         const corsHeaders = collectCorsHeaders(headers.origin, method, bucket);
         if (err) {
             log.debug('error processing request', {

--- a/lib/api/bucketGetVersioning.js
+++ b/lib/api/bucketGetVersioning.js
@@ -1,4 +1,4 @@
-const { metadataValidateBucket } = require('../metadata/metadataUtils');
+const { standardMetadataValidateBucket } = require('../metadata/metadataUtils');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const { pushMetric } = require('../utapi/utilities');
 
@@ -57,7 +57,7 @@ function bucketGetVersioning(authInfo, request, log, callback) {
         request,
     };
 
-    metadataValidateBucket(metadataValParams, log, (err, bucket) => {
+    standardMetadataValidateBucket(metadataValParams, request.actionImplicitDenies, log, (err, bucket) => {
         const corsHeaders = collectCorsHeaders(request.headers.origin,
             request.method, bucket);
         if (err) {

--- a/lib/api/bucketGetWebsite.js
+++ b/lib/api/bucketGetWebsite.js
@@ -34,7 +34,8 @@ function bucketGetWebsite(authInfo, request, log, callback) {
 
         const corsHeaders = collectCorsHeaders(request.headers.origin,
             request.method, bucket);
-        if (!isBucketAuthorized(bucket, requestType, canonicalID, authInfo, log, request)) {
+        if (!isBucketAuthorized(bucket, requestType, canonicalID, authInfo, log,
+            request, request.actionImplicitDenies)) {
             log.debug('access denied for user on bucket', {
                 requestType,
                 method: 'bucketGetWebsite',

--- a/lib/api/objectGet.js
+++ b/lib/api/objectGet.js
@@ -9,7 +9,7 @@ const collectResponseHeaders = require('../utilities/collectResponseHeaders');
 const { pushMetric } = require('../utapi/utilities');
 const { getVersionIdResHeader } = require('./apiUtils/object/versioning');
 const setPartRanges = require('./apiUtils/object/setPartRanges');
-const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
+const { standardMetadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { getPartCountFromMd5 } = require('./apiUtils/object/partInfo');
 const { setExpirationHeaders } = require('./apiUtils/object/expirationHeaders');
 
@@ -48,7 +48,7 @@ function objectGet(authInfo, request, returnTagCount, log, callback) {
         request,
     };
 
-    return metadataValidateBucketAndObj(mdValParams, log,
+    return standardMetadataValidateBucketAndObj(mdValParams, request.actionImplicitDenies, log,
     (err, bucket, objMD) => {
         const corsHeaders = collectCorsHeaders(request.headers.origin,
             request.method, bucket);

--- a/lib/api/objectGetACL.js
+++ b/lib/api/objectGetACL.js
@@ -7,7 +7,7 @@ const { pushMetric } = require('../utapi/utilities');
 const { decodeVersionId, getVersionIdResHeader }
     = require('./apiUtils/object/versioning');
 const vault = require('../auth/vault');
-const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
+const { standardMetadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 
 //  Sample XML response:
 /*
@@ -71,7 +71,7 @@ function objectGetACL(authInfo, request, log, callback) {
 
     return async.waterfall([
         function validateBucketAndObj(next) {
-            return metadataValidateBucketAndObj(metadataValParams, log,
+            return standardMetadataValidateBucketAndObj(metadataValParams, request.actionImplicitDenies, log,
                 (err, bucket, objectMD) => {
                     if (err) {
                         log.trace('request authorization failed',

--- a/lib/api/objectGetLegalHold.js
+++ b/lib/api/objectGetLegalHold.js
@@ -4,7 +4,7 @@ const { errors, s3middleware } = require('arsenal');
 const { decodeVersionId, getVersionIdResHeader }
     = require('./apiUtils/object/versioning');
 
-const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
+const { standardMetadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 
@@ -43,7 +43,7 @@ function objectGetLegalHold(authInfo, request, log, callback) {
     };
 
     return async.waterfall([
-        next => metadataValidateBucketAndObj(metadataValParams, log,
+        next => standardMetadataValidateBucketAndObj(metadataValParams, request.actionImplicitDenies, log,
             (err, bucket, objectMD) => {
                 if (err) {
                     log.trace('request authorization failed',

--- a/lib/api/objectGetRetention.js
+++ b/lib/api/objectGetRetention.js
@@ -4,7 +4,7 @@ const { errors, s3middleware } = require('arsenal');
 const { decodeVersionId, getVersionIdResHeader }
     = require('./apiUtils/object/versioning');
 
-const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
+const { standardMetadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 
@@ -43,7 +43,7 @@ function objectGetRetention(authInfo, request, log, callback) {
     };
 
     return async.waterfall([
-        next => metadataValidateBucketAndObj(metadataValParams, log,
+        next => standardMetadataValidateBucketAndObj(metadataValParams, request.actionImplicitDenies, log,
             (err, bucket, objectMD) => {
                 if (err) {
                     log.trace('request authorization failed',

--- a/lib/api/objectGetTagging.js
+++ b/lib/api/objectGetTagging.js
@@ -4,7 +4,7 @@ const { errors, s3middleware } = require('arsenal');
 const { decodeVersionId, getVersionIdResHeader }
     = require('./apiUtils/object/versioning');
 
-const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
+const { standardMetadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const { convertToXml } = s3middleware.tagging;
@@ -43,7 +43,7 @@ function objectGetTagging(authInfo, request, log, callback) {
     };
 
     return async.waterfall([
-        next => metadataValidateBucketAndObj(metadataValParams, log,
+        next => standardMetadataValidateBucketAndObj(metadataValParams, request.actionImplicitDenies, log,
           (err, bucket, objectMD) => {
               if (err) {
                   log.trace('request authorization failed',

--- a/lib/api/websiteGet.js
+++ b/lib/api/websiteGet.js
@@ -21,12 +21,13 @@ const { pushMetric } = require('../utapi/utilities');
  * @param {string} objectKey - object key from request (or as translated in
  * websiteGet)
  * @param {object} corsHeaders - CORS-related response headers
+ * @param {object} request - normalized request object
  * @param {object} log - Werelogs instance
  * @param {function} callback - callback to function in route
  * @return {undefined}
  */
 function _errorActions(err, errorDocument, routingRules,
-    bucket, objectKey, corsHeaders, log, callback) {
+    bucket, objectKey, corsHeaders, request, log, callback) {
     const bucketName = bucket.getName();
     const errRoutingRule = findRoutingRule(routingRules,
         objectKey, err.code);
@@ -46,8 +47,8 @@ function _errorActions(err, errorDocument, routingRules,
                 }
                 // return the default error message if the object is private
                 // rather than sending a stored error file
-                if (!isObjAuthorized(bucket, errObjMD, 'objectGet',
-                    constants.publicId, null, log)) {
+                if (!isObjAuthorized(bucket, errObjMD, request.apiMethods || 'objectGet',
+                    constants.publicId, null, log, null, request.actionImplicitDenies)) {
                     log.trace('errorObj not authorized', { error: err });
                     return callback(err, true, null, corsHeaders);
                 }
@@ -143,8 +144,8 @@ function websiteGet(request, log, callback) {
                     log.trace('error retrieving object metadata',
                     { error: err });
                     let returnErr = err;
-                    const bucketAuthorized = isBucketAuthorized(bucket,
-                      'bucketGet', constants.publicId, null, log, request);
+                    const bucketAuthorized = isBucketAuthorized(bucket, request.apiMethods || 'bucketGet',
+                    constants.publicId, null, log, request, request.actionImplicitDenies);
                     // if index object does not exist and bucket is private AWS
                     // returns 403 - AccessDenied error.
                     if (err.is.NoSuchKey && !bucketAuthorized) {
@@ -152,16 +153,16 @@ function websiteGet(request, log, callback) {
                     }
                     return _errorActions(returnErr,
                       websiteConfig.getErrorDocument(), routingRules,
-                      bucket, reqObjectKey, corsHeaders, log,
+                      bucket, reqObjectKey, corsHeaders, request, log,
                       callback);
                 }
-                if (!isObjAuthorized(bucket, objMD, 'objectGet',
-                    constants.publicId, null, log, request)) {
+                if (!isObjAuthorized(bucket, objMD, request.apiMethods || 'objectGet',
+                    constants.publicId, null, log, request, request.actionImplicitDenies)) {
                     const err = errors.AccessDenied;
                     log.trace('request not authorized', { error: err });
                     return _errorActions(err, websiteConfig.getErrorDocument(),
                         routingRules, bucket,
-                        reqObjectKey, corsHeaders, log, callback);
+                        reqObjectKey, corsHeaders, request, log, callback);
                 }
 
                 const headerValResult = validateHeaders(request.headers,
@@ -171,7 +172,7 @@ function websiteGet(request, log, callback) {
                     log.trace('header validation error', { error: err });
                     return _errorActions(err, websiteConfig.getErrorDocument(),
                         routingRules, bucket, reqObjectKey,
-                        corsHeaders, log, callback);
+                        corsHeaders, request, log, callback);
                 }
                 // check if object to serve has website redirect header
                 // Note: AWS prioritizes website configuration rules over

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.10.35",
+  "version": "7.10.36",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {

--- a/tests/unit/api/bucketGet.js
+++ b/tests/unit/api/bucketGet.js
@@ -63,6 +63,7 @@ const baseGetRequest = {
     bucketName,
     namespace,
     headers: { host: '/' },
+    actionImplicitDenies: false,
 };
 const baseUrl = `/${bucketName}`;
 

--- a/tests/unit/api/bucketGetACL.js
+++ b/tests/unit/api/bucketGetACL.js
@@ -25,6 +25,7 @@ describe('bucketGetACL API', () => {
         namespace,
         headers: { host: `${bucketName}.s3.amazonaws.com` },
         url: '/',
+        actionImplicitDenies: false,
     };
     const testGetACLRequest = {
         bucketName,
@@ -32,6 +33,7 @@ describe('bucketGetACL API', () => {
         headers: { host: `${bucketName}.s3.amazonaws.com` },
         url: '/?acl',
         query: { acl: '' },
+        actionImplicitDenies: false,
     };
 
     it('should get a canned private ACL', done => {
@@ -44,6 +46,7 @@ describe('bucketGetACL API', () => {
             },
             url: '/?acl',
             query: { acl: '' },
+            actionImplicitDenies: false,
         };
 
         async.waterfall([
@@ -76,6 +79,7 @@ describe('bucketGetACL API', () => {
             },
             url: '/?acl',
             query: { acl: '' },
+            actionImplicitDenies: false,
         };
 
         async.waterfall([
@@ -119,6 +123,7 @@ describe('bucketGetACL API', () => {
             },
             url: '/?acl',
             query: { acl: '' },
+            actionImplicitDenies: false,
         };
 
         async.waterfall([
@@ -156,6 +161,7 @@ describe('bucketGetACL API', () => {
             },
             url: '/?acl',
             query: { acl: '' },
+            actionImplicitDenies: false,
         };
 
         async.waterfall([
@@ -194,6 +200,7 @@ describe('bucketGetACL API', () => {
             },
             url: '/?acl',
             query: { acl: '' },
+            actionImplicitDenies: false,
         };
 
         async.waterfall([
@@ -248,6 +255,7 @@ describe('bucketGetACL API', () => {
             },
             url: '/?acl',
             query: { acl: '' },
+            actionImplicitDenies: false,
         };
         const canonicalIDforSample1 =
             '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be';
@@ -338,6 +346,7 @@ describe('bucketGetACL API', () => {
                 },
                 url: '/?acl',
                 query: { acl: '' },
+                actionImplicitDenies: false,
             };
 
             async.waterfall([
@@ -377,6 +386,7 @@ describe('bucketGetACL API', () => {
             },
             url: '/?acl',
             query: { acl: '' },
+            actionImplicitDenies: false,
         };
 
         async.waterfall([

--- a/tests/unit/api/bucketGetCors.js
+++ b/tests/unit/api/bucketGetCors.js
@@ -16,6 +16,7 @@ const testBucketPutRequest = {
     bucketName,
     headers: { host: `${bucketName}.s3.amazonaws.com` },
     url: '/',
+    actionImplicitDenies: false,
 };
 
 function _makeCorsRequest(xml) {
@@ -26,6 +27,7 @@ function _makeCorsRequest(xml) {
         },
         url: '/?cors',
         query: { cors: '' },
+        actionImplicitDenies: false,
     };
 
     if (xml) {

--- a/tests/unit/api/bucketGetLifecycle.js
+++ b/tests/unit/api/bucketGetLifecycle.js
@@ -17,6 +17,7 @@ const testBucketPutRequest = {
     bucketName,
     headers: { host: `${bucketName}.s3.amazonaws.com` },
     url: '/',
+    actionImplicitDenies: false,
 };
 
 describe('getBucketLifecycle API', () => {

--- a/tests/unit/api/bucketGetLocation.js
+++ b/tests/unit/api/bucketGetLocation.js
@@ -16,6 +16,7 @@ const testBucketPutRequest = {
     bucketName,
     headers: { host: `${bucketName}.s3.amazonaws.com` },
     url: '/',
+    actionImplicitDenies: false,
 };
 
 const testGetLocationRequest = {
@@ -25,6 +26,7 @@ const testGetLocationRequest = {
     },
     url: '/?location',
     query: { location: '' },
+    actionImplicitDenies: false,
 };
 
 const locationConstraints = config.locationConstraints;

--- a/tests/unit/api/bucketGetNotification.js
+++ b/tests/unit/api/bucketGetNotification.js
@@ -15,6 +15,7 @@ const testBucketPutRequest = {
     bucketName,
     headers: { host: `${bucketName}.s3.amazonaws.com` },
     url: '/',
+    actionImplicitDenies: false,
 };
 
 function getNotificationRequest(bucketName, xml) {
@@ -23,6 +24,7 @@ function getNotificationRequest(bucketName, xml) {
         headers: {
             host: `${bucketName}.s3.amazonaws.com`,
         },
+        actionImplicitDenies: false,
     };
     if (xml) {
         request.post = xml;

--- a/tests/unit/api/bucketGetObjectLock.js
+++ b/tests/unit/api/bucketGetObjectLock.js
@@ -14,6 +14,7 @@ const bucketPutReq = {
         host: `${bucketName}.s3.amazonaws.com`,
     },
     url: '/',
+    actionImplicitDenies: false,
 };
 
 const testBucketPutReqWithObjLock = {
@@ -23,6 +24,7 @@ const testBucketPutReqWithObjLock = {
         'x-amz-bucket-object-lock-enabled': 'True',
     },
     url: '/',
+    actionImplicitDenies: false,
 };
 
 function getObjectLockConfigRequest(bucketName, xml) {
@@ -33,6 +35,7 @@ function getObjectLockConfigRequest(bucketName, xml) {
             'x-amz-bucket-object-lock-enabled': 'true',
         },
         url: '/?object-lock',
+        actionImplicitDenies: false,
     };
     if (xml) {
         request.post = xml;

--- a/tests/unit/api/bucketGetPolicy.js
+++ b/tests/unit/api/bucketGetPolicy.js
@@ -16,6 +16,7 @@ const testBasicRequest = {
     bucketName,
     headers: { host: `${bucketName}.s3.amazonaws.com` },
     url: '/',
+    actionImplicitDenies: false,
 };
 
 const expectedBucketPolicy = {
@@ -34,6 +35,7 @@ const testPutPolicyRequest = {
     bucketName,
     headers: { host: `${bucketName}.s3.amazonaws.com` },
     post: JSON.stringify(expectedBucketPolicy),
+    actionImplicitDenies: false,
 };
 
 describe('getBucketPolicy API', () => {

--- a/tests/unit/api/bucketGetWebsite.js
+++ b/tests/unit/api/bucketGetWebsite.js
@@ -15,6 +15,7 @@ const testBucketPutRequest = {
     bucketName,
     headers: { host: `${bucketName}.s3.amazonaws.com` },
     url: '/',
+    actionImplicitDenies: false,
 };
 
 function _makeWebsiteRequest(xml) {
@@ -25,6 +26,7 @@ function _makeWebsiteRequest(xml) {
         },
         url: '/?website',
         query: { website: '' },
+        actionImplicitDenies: false,
     };
 
     if (xml) {

--- a/tests/unit/api/objectGet.js
+++ b/tests/unit/api/objectGet.js
@@ -47,6 +47,7 @@ describe('objectGet API', () => {
         namespace,
         headers: {},
         url: `/${bucketName}`,
+        actionImplicitDenies: false,
     };
     const userMetadataKey = 'x-amz-meta-test';
     const userMetadataValue = 'some metadata';
@@ -56,6 +57,7 @@ describe('objectGet API', () => {
         objectKey: objectName,
         headers: {},
         url: `/${bucketName}/${objectName}`,
+        actionImplicitDenies: false,
     };
 
     it('should get the object metadata', done => {
@@ -84,6 +86,7 @@ describe('objectGet API', () => {
             'x-amz-bucket-object-lock-enabled': 'true',
         },
         url: `/${bucketName}`,
+        actionImplicitDenies: false,
     };
 
     const createPutDummyRetention = (date, mode) => new DummyRequest({
@@ -245,6 +248,7 @@ describe('objectGet API', () => {
                 objectKey: objectName,
                 headers: { host: `${bucketName}.s3.amazonaws.com` },
                 url: `/${objectName}?uploads`,
+                actionImplicitDenies: false,
             };
             async.waterfall([
                 next => bucketPut(authInfo, testPutBucketRequest, log, next),
@@ -321,6 +325,7 @@ describe('objectGet API', () => {
                         headers: { host: `${bucketName}.s3.amazonaws.com` },
                         query: { uploadId: testUploadId },
                         post: completeBody,
+                        actionImplicitDenies: false,
                     };
                     completeMultipartUpload(authInfo, completeRequest,
                                             log, err => {

--- a/tests/unit/api/objectGetACL.js
+++ b/tests/unit/api/objectGetACL.js
@@ -36,6 +36,7 @@ describe('objectGetACL API', () => {
             'x-amz-acl': 'public-read-write',
         },
         url: '/',
+        actionImplicitDenies: false,
     };
     const testGetACLRequest = {
         bucketName,
@@ -44,6 +45,7 @@ describe('objectGetACL API', () => {
         objectKey: objectName,
         url: `/${bucketName}/${objectName}?acl`,
         query: { acl: '' },
+        actionImplicitDenies: false,
     };
 
     it('should get a canned private ACL', done => {

--- a/tests/unit/api/objectGetLegalHold.js
+++ b/tests/unit/api/objectGetLegalHold.js
@@ -18,6 +18,7 @@ const bucketPutRequest = {
     bucketName,
     headers: { host: `${bucketName}.s3.amazonaws.com` },
     url: '/',
+    actionImplicitDenies: false,
 };
 
 const putObjectRequest = new DummyRequest({
@@ -37,12 +38,14 @@ const putObjectLegalHoldRequest = status => ({
     objectKey: objectName,
     headers: { host: `${bucketName}.s3.amazonaws.com` },
     post: objectLegalHoldXml(status),
+    actionImplicitDenies: false,
 });
 
 const getObjectLegalHoldRequest = {
     bucketName,
     objectKey: objectName,
     headers: { host: `${bucketName}.s3.amazonaws.com` },
+    actionImplicitDenies: false,
 };
 
 describe('getObjectLegalHold API', () => {

--- a/tests/unit/api/objectGetRetention.js
+++ b/tests/unit/api/objectGetRetention.js
@@ -21,6 +21,7 @@ const bucketPutRequest = {
     bucketName,
     headers: { host: `${bucketName}.s3.amazonaws.com` },
     url: '/',
+    actionImplicitDenies: false,
 };
 
 const putObjectRequest = new DummyRequest({
@@ -42,12 +43,14 @@ const putObjRetRequest = {
     objectKey: objectName,
     headers: { host: `${bucketName}.s3.amazonaws.com` },
     post: objectRetentionXml,
+    actionImplicitDenies: false,
 };
 
 const getObjRetRequest = {
     bucketName,
     objectKey: objectName,
     headers: { host: `${bucketName}.s3.amazonaws.com` },
+    actionImplicitDenies: false,
 };
 
 describe('getObjectRetention API', () => {

--- a/tests/unit/api/objectGetTagging.js
+++ b/tests/unit/api/objectGetTagging.js
@@ -21,6 +21,7 @@ const testBucketPutRequest = {
     bucketName,
     headers: { host: `${bucketName}.s3.amazonaws.com` },
     url: '/',
+    actionImplicitDenies: false,
 };
 
 const testPutObjectRequest = new DummyRequest({

--- a/tests/unit/api/serviceGet.js
+++ b/tests/unit/api/serviceGet.js
@@ -24,6 +24,7 @@ describe('serviceGet API', () => {
         parsedHost: 's3.amazonaws.com',
         headers: { host: 's3.amazonaws.com' },
         url: '/',
+        actionImplicitDenies: false,
     };
 
     it('should return the list of buckets owned by the user', done => {


### PR DESCRIPTION
Bucket policies are not correctly interpreted, this is part of the following epic to fix that: https://github.com/scality/Arsenal/pull/2181

This PR is aiming to update get apis since object and bucket authorisations are made at API level and need to support implicit denies, ticket linked to this issue here : https://scality.atlassian.net/browse/CLDSRV-429

PRs providing implicit Deny logic to CS for processing in this PR
https://github.com/scality/Arsenal/pull/2181
https://github.com/scality/Vault/pull/2135
https://github.com/scality/cloudserver/pull/5322
https://github.com/scality/cloudserver/pull/5420
https://github.com/scality/cloudserver/pull/5432
https://github.com/scality/cloudserver/pull/5456

Here CI links for zenko tests :
https://github.com/scality/Zenko/actions/runs/7084077460
https://github.com/scality/Zenko/actions/runs/7084088277
https://github.com/scality/Zenko/actions/runs/7084102967