### PR TITLE
improvement/CLDSRV-451-specific-7.70-apis-update

### DIFF
--- a/lib/api/backbeat/listLifecycleCurrents.js
+++ b/lib/api/backbeat/listLifecycleCurrents.js
@@ -1,7 +1,7 @@
 const { errors } = require('arsenal');
 const constants = require('../../../constants');
 const services = require('../../services');
-const { metadataValidateBucket } = require('../../metadata/metadataUtils');
+const { standardMetadataValidateBucket } = require('../../metadata/metadataUtils');
 const { pushMetric } = require('../../utapi/utilities');
 const monitoring = require('../../utilities/metrics');
 const { getLocationConstraintErrorMessage, processCurrents,
@@ -77,7 +77,7 @@ function listLifecycleCurrents(authInfo, locationConstraints, request, log, call
         maxScannedLifecycleListingEntries,
     };
 
-    return metadataValidateBucket(metadataValParams, log, (err, bucket) => {
+    return standardMetadataValidateBucket(metadataValParams, request.actionImplicitDenies, log, (err, bucket) => {
         if (err) {
             log.debug('error processing request', { method: 'metadataValidateBucket', error: err });
             monitoring.promMetrics(

--- a/lib/api/backbeat/listLifecycleNonCurrents.js
+++ b/lib/api/backbeat/listLifecycleNonCurrents.js
@@ -1,7 +1,7 @@
 const { errors, versioning } = require('arsenal');
 const constants = require('../../../constants');
 const services = require('../../services');
-const { metadataValidateBucket } = require('../../metadata/metadataUtils');
+const { standardMetadataValidateBucket } = require('../../metadata/metadataUtils');
 const { pushMetric } = require('../../utapi/utilities');
 const versionIdUtils = versioning.VersionID;
 const monitoring = require('../../utilities/metrics');
@@ -83,7 +83,7 @@ function listLifecycleNonCurrents(authInfo, locationConstraints, request, log, c
     listParams.versionIdMarker = params['version-id-marker'] ?
         versionIdUtils.decode(params['version-id-marker']) : undefined;
 
-    return metadataValidateBucket(metadataValParams, log, (err, bucket) => {
+    return standardMetadataValidateBucket(metadataValParams, request.actionImplicitDenies, log, (err, bucket) => {
         if (err) {
             log.debug('error processing request', { method: 'metadataValidateBucket', error: err });
             monitoring.promMetrics(

--- a/lib/api/backbeat/listLifecycleOrphanDeleteMarkers.js
+++ b/lib/api/backbeat/listLifecycleOrphanDeleteMarkers.js
@@ -1,7 +1,7 @@
 const { errors } = require('arsenal');
 const constants = require('../../../constants');
 const services = require('../../services');
-const { metadataValidateBucket } = require('../../metadata/metadataUtils');
+const { standardMetadataValidateBucket } = require('../../metadata/metadataUtils');
 const { pushMetric } = require('../../utapi/utilities');
 const monitoring = require('../../utilities/metrics');
 const { processOrphans, validateMaxScannedEntries } = require('../apiUtils/object/lifecycle');
@@ -68,7 +68,7 @@ function listLifecycleOrphanDeleteMarkers(authInfo, locationConstraints, request
         maxScannedLifecycleListingEntries,
     };
 
-    return metadataValidateBucket(metadataValParams, log, (err, bucket) => {
+    return standardMetadataValidateBucket(metadataValParams, request.actionImplicitDenies, log, (err, bucket) => {
         if (err) {
             log.debug('error processing request', { method: 'metadataValidateBucket', error: err });
             monitoring.promMetrics(

--- a/lib/api/bucketDeleteTagging.js
+++ b/lib/api/bucketDeleteTagging.js
@@ -1,5 +1,5 @@
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
-const { metadataValidateBucket } = require('../metadata/metadataUtils');
+const { standardMetadataValidateBucket } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
 const metadata = require('../metadata/wrapper');
 const util = require('node:util');
@@ -19,18 +19,18 @@ async function bucketDeleteTagging(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'bucketDeleteTagging', bucketName });
 
     let bucket;
-    const metadataValidateBucketPromise = util.promisify(metadataValidateBucket);
+    const metadataValidateBucketPromise = util.promisify(standardMetadataValidateBucket);
     let updateBucketPromise = util.promisify(metadata.updateBucket);
     // necessary to bind metadata as updateBucket calls 'this', causing undefined otherwise
     updateBucketPromise = updateBucketPromise.bind(metadata);
     const metadataValParams = {
         authInfo,
         bucketName,
-        requestType: 'bucketDeleteTagging',
+        requestType: request.apiMethods || 'bucketDeleteTagging',
     };
 
     try {
-        bucket = await metadataValidateBucketPromise(metadataValParams, log);
+        bucket = await metadataValidateBucketPromise(metadataValParams, request.actionImplicitDenies, log);
         bucket.setTags([]);
         // eslint-disable-next-line no-unused-expressions
         await updateBucketPromise(bucket.getName(), bucket, log);

--- a/lib/api/bucketGetTagging.js
+++ b/lib/api/bucketGetTagging.js
@@ -1,4 +1,4 @@
-const { metadataValidateBucket } = require('../metadata/metadataUtils');
+const { standardMetadataValidateBucket } = require('../metadata/metadataUtils');
 const util = require('node:util');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const { checkExpectedBucketOwner } = require('./apiUtils/authorization/bucketOwner');
@@ -64,13 +64,13 @@ async function bucketGetTagging(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'bucketGetTagging' });
 
     const { bucketName, headers } = request;
-    const metadataValidateBucketPromise = util.promisify(metadataValidateBucket);
+    const metadataValidateBucketPromise = util.promisify(standardMetadataValidateBucket);
     const checkExpectedBucketOwnerPromise = util.promisify(checkExpectedBucketOwner);
 
     const metadataValParams = {
         authInfo,
         bucketName,
-        requestType: 'bucketGetTagging',
+        requestType: request.apiMethods || 'bucketGetTagging',
         request,
     };
 
@@ -78,7 +78,7 @@ async function bucketGetTagging(authInfo, request, log, callback) {
     let xml = null;
 
     try {
-        bucket = await metadataValidateBucketPromise(metadataValParams, log);
+        bucket = await metadataValidateBucketPromise(metadataValParams, request.actionImplicitDenies, log);
         // eslint-disable-next-line no-unused-expressions
         await checkExpectedBucketOwnerPromise(headers, bucket, log);
         const tags = bucket.getTags();

--- a/lib/api/bucketPutTagging.js
+++ b/lib/api/bucketPutTagging.js
@@ -3,7 +3,7 @@ const { s3middleware } = require('arsenal');
 
 
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
-const { metadataValidateBucket } = require('../metadata/metadataUtils');
+const { standardMetadataValidateBucket } = require('../metadata/metadataUtils');
 const metadata = require('../metadata/wrapper');
 const { pushMetric } = require('../utapi/utilities');
 const { checkExpectedBucketOwner } = require('./apiUtils/authorization/bucketOwner');
@@ -38,11 +38,11 @@ function bucketPutTagging(authInfo, request, log, callback) {
     const metadataValParams = {
         authInfo,
         bucketName,
-        requestType: 'bucketPutTagging',
+        requestType: request.apiMethods || 'bucketPutTagging',
     };
     let bucket = null;
     return waterfall([
-        next => metadataValidateBucket(metadataValParams, log,
+        next => standardMetadataValidateBucket(metadataValParams, request.actionImplicitDenies, log,
             (err, b) => {
                 bucket = b;
                 return next(err);

--- a/lib/metadata/metadataUtils.js
+++ b/lib/metadata/metadataUtils.js
@@ -169,70 +169,6 @@ function validateBucket(bucket, params, log, actionImplicitDenies = {}) {
     }
     return null;
 }
-
-/** metadataValidateBucketAndObj - retrieve bucket and object md from metadata
- * and check if user is authorized to access them.
- * @param {object} params - function parameters
- * @param {AuthInfo} params.authInfo - AuthInfo class instance, requester's info
- * @param {string} params.bucketName - name of bucket
- * @param {string} params.objectKey - name of object
- * @param {string} [params.versionId] - version id if getting specific version
- * @param {string} params.requestType - type of request
- * @param {object} params.request - http request object
- * @param {RequestLogger} log - request logger
- * @param {function} callback - callback
- * @return {undefined} - and call callback with params err, bucket md
- */
-function metadataValidateBucketAndObj(params, log, callback) {
-    const { authInfo, bucketName, objectKey, versionId, getDeleteMarker,
-            requestType, request } = params;
-    async.waterfall([
-        next => {
-            // versionId may be 'null', which asks metadata to fetch the null key specifically
-            const getOptions = { versionId };
-            if (getDeleteMarker) {
-                getOptions.getDeleteMarker = true;
-            }
-            return metadata.getBucketAndObjectMD(bucketName, objectKey, getOptions, log, next);
-        },
-        (getResult, next) => {
-            const bucket = getResult.bucket ?
-                  BucketInfo.deSerialize(getResult.bucket) : undefined;
-            if (!bucket) {
-                log.debug('bucketAttrs is undefined', {
-                    bucket: bucketName,
-                    method: 'metadataValidateBucketAndObj',
-                });
-                return next(errors.NoSuchBucket);
-            }
-            const validationError = validateBucket(bucket, params, log);
-            if (validationError) {
-                return next(validationError, bucket);
-            }
-            const objMD = getResult.obj ? JSON.parse(getResult.obj) : undefined;
-            if (!objMD && versionId === 'null') {
-                return getNullVersionFromMaster(bucketName, objectKey, log,
-                     (err, nullVer) => next(err, bucket, nullVer));
-            }
-            return next(null, bucket, objMD);
-        },
-        (bucket, objMD, next) => {
-            const canonicalID = authInfo.getCanonicalID();
-            if (!isObjAuthorized(bucket, objMD, requestType, canonicalID, authInfo, log, request)) {
-                log.debug('access denied for user on object', { requestType });
-                return next(errors.AccessDenied, bucket);
-            }
-            return next(null, bucket, objMD);
-        },
-    ], (err, bucket, objMD) => {
-        if (err) {
-            // still return bucket for cors headers
-            return callback(err, bucket);
-        }
-        return callback(null, bucket, objMD);
-    });
-}
-
 /** standardMetadataValidateBucketAndObj - retrieve bucket and object md from metadata
  * and check if user is authorized to access them.
  * @param {object} params - function parameters
@@ -310,30 +246,6 @@ function standardMetadataValidateBucketAndObj(params, actionImplicitDenies, log,
         return callback(null, bucket, objMD);
     });
 }
-
-/** metadataValidateBucket - retrieve bucket from metadata and check if user
- * is authorized to access it
- * @param {object} params - function parameters
- * @param {AuthInfo} params.authInfo - AuthInfo class instance, requester's info
- * @param {string} params.bucketName - name of bucket
- * @param {string} params.requestType - type of request
- * @param {string} params.request - http request object
- * @param {RequestLogger} log - request logger
- * @param {function} callback - callback
- * @return {undefined} - and call callback with params err, bucket md
- */
-function metadataValidateBucket(params, log, callback) {
-    const { bucketName } = params;
-    return metadata.getBucket(bucketName, log, (err, bucket) => {
-        if (err) {
-            log.debug('metadata getbucket failed', { error: err });
-            return callback(err);
-        }
-        const validationError = validateBucket(bucket, params, log);
-        return callback(validationError, bucket);
-    });
-}
-
 /** standardMetadataValidateBucket - retrieve bucket from metadata and check if user
  * is authorized to access it
  * @param {object} params - function parameters
@@ -367,8 +279,6 @@ module.exports = {
     validateBucket,
     metadataGetObject,
     metadataGetObjects,
-    metadataValidateBucketAndObj,
-    metadataValidateBucket,
     standardMetadataValidateBucketAndObj,
     standardMetadataValidateBucket,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.70.35",
+  "version": "7.70.36",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Bucket policies are not correctly interpreted, this is part of the following epic to fix that: https://github.com/scality/Arsenal/pull/2181

This PR is aiming to update get apis since object and bucket authorisations are made at API level and need to support implicit denies, ticket linked to this issue here : https://scality.atlassian.net/browse/CLDSRV-451

PRs providing implicit Deny logic to CS for processing in this PR
https://github.com/scality/Arsenal/pull/2181 and https://github.com/scality/Arsenal/pull/2193
https://github.com/scality/Vault/pull/2135
https://github.com/scality/cloudserver/pull/5322
https://github.com/scality/cloudserver/pull/5420
https://github.com/scality/cloudserver/pull/5432
https://github.com/scality/cloudserver/pull/5456
https://github.com/scality/cloudserver/pull/5462
https://github.com/scality/cloudserver/pull/5470
https://github.com/scality/cloudserver/pull/5479

Here CI links for zenko tests :


**As there are differences on the 8.x branches reviews are highly appreciated**
