### PR TITLE
CLDSRV-479: fix error on index using bucket policy 

### DIFF
--- a/lib/api/apiUtils/object/websiteServing.js
+++ b/lib/api/apiUtils/object/websiteServing.js
@@ -101,8 +101,30 @@ function validateWebsiteHeader(header) {
     header.startsWith('http://') || header.startsWith('https://'));
 }
 
+/**
+ * appendWebsiteIndexDocument - append index to objectKey if necessary
+ * @param {object} request - normalized request object
+ * @param {string} indexDocumentSuffix - index document from website config
+ * @return {undefined}
+ */
+function appendWebsiteIndexDocument(request, indexDocumentSuffix) {
+    const reqObjectKey = request.objectKey ? request.objectKey : '';
+
+    // find index document if "directory" sent in request
+    if (reqObjectKey.endsWith('/')) {
+        // eslint-disable-next-line no-param-reassign
+        request.objectKey += indexDocumentSuffix;
+    }
+    // find index document if no key provided
+    if (reqObjectKey === '') {
+        // eslint-disable-next-line no-param-reassign
+        request.objectKey = indexDocumentSuffix;
+    }
+}
+
 module.exports = {
     findRoutingRule,
     extractRedirectInfo,
     validateWebsiteHeader,
+    appendWebsiteIndexDocument,
 };

--- a/lib/api/websiteGet.js
+++ b/lib/api/websiteGet.js
@@ -85,7 +85,6 @@ function websiteGet(request, log, callback) {
     log.debug('processing request', { method: 'websiteGet' });
     const bucketName = request.bucketName;
     const reqObjectKey = request.objectKey ? request.objectKey : '';
-    let objectKey = reqObjectKey;
 
     return metadata.getBucket(bucketName, log, (err, bucket) => {
         if (err) {
@@ -110,32 +109,34 @@ function websiteGet(request, log, callback) {
         // handle redirect all
         if (websiteConfig.getRedirectAllRequestsTo()) {
             return callback(null, false, null, corsHeaders,
-                websiteConfig.getRedirectAllRequestsTo(), objectKey);
+                websiteConfig.getRedirectAllRequestsTo(), reqObjectKey);
         }
 
         // check whether need to redirect based on key
         const routingRules = websiteConfig.getRoutingRules();
-        const keyRoutingRule = findRoutingRule(routingRules, objectKey);
+        const keyRoutingRule = findRoutingRule(routingRules, reqObjectKey);
 
         if (keyRoutingRule) {
             // TODO: optimize by not rerouting if only routing
             // rule is to change out key
             return callback(null, false, null, corsHeaders,
-                keyRoutingRule, objectKey);
+                keyRoutingRule, reqObjectKey);
         }
 
         // find index document if "directory" sent in request
         if (reqObjectKey.endsWith('/')) {
-            objectKey += websiteConfig.getIndexDocument();
+            // eslint-disable-next-line no-param-reassign
+            request.objectKey += websiteConfig.getIndexDocument();
         }
         // find index document if no key provided
         if (reqObjectKey === '') {
-            objectKey = websiteConfig.getIndexDocument();
+            // eslint-disable-next-line no-param-reassign
+            request.objectKey = websiteConfig.getIndexDocument();
         }
 
         // get object metadata and check authorization and header
         // validation
-        return metadata.getObjectMD(bucketName, objectKey, {}, log,
+        return metadata.getObjectMD(bucketName, request.objectKey, {}, log,
             (err, objMD) => {
                 // Note: In case of error, we intentionally send the original
                 // object key to _errorActions as in case of a redirect, we do

--- a/lib/api/websiteGet.js
+++ b/lib/api/websiteGet.js
@@ -5,7 +5,7 @@ const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const constants = require('../../constants');
 const metadata = require('../metadata/wrapper');
 const bucketShield = require('./apiUtils/bucket/bucketShield');
-const { findRoutingRule, extractRedirectInfo } =
+const { appendWebsiteIndexDocument, findRoutingRule, extractRedirectInfo } =
     require('./apiUtils/object/websiteServing');
 const { isObjAuthorized, isBucketAuthorized } =
     require('./apiUtils/authorization/permissionChecks');
@@ -123,16 +123,7 @@ function websiteGet(request, log, callback) {
                 keyRoutingRule, reqObjectKey);
         }
 
-        // find index document if "directory" sent in request
-        if (reqObjectKey.endsWith('/')) {
-            // eslint-disable-next-line no-param-reassign
-            request.objectKey += websiteConfig.getIndexDocument();
-        }
-        // find index document if no key provided
-        if (reqObjectKey === '') {
-            // eslint-disable-next-line no-param-reassign
-            request.objectKey = websiteConfig.getIndexDocument();
-        }
+        appendWebsiteIndexDocument(request, websiteConfig.getIndexDocument());
 
         // get object metadata and check authorization and header
         // validation

--- a/lib/api/websiteHead.js
+++ b/lib/api/websiteHead.js
@@ -46,7 +46,6 @@ function websiteHead(request, log, callback) {
     log.debug('processing request', { method: 'websiteHead' });
     const bucketName = request.bucketName;
     const reqObjectKey = request.objectKey ? request.objectKey : '';
-    let objectKey = reqObjectKey;
 
     return metadata.getBucket(bucketName, log, (err, bucket) => {
         if (err) {
@@ -72,21 +71,23 @@ function websiteHead(request, log, callback) {
         // handle redirect all
         if (websiteConfig.getRedirectAllRequestsTo()) {
             return callback(null, corsHeaders,
-                websiteConfig.getRedirectAllRequestsTo(), objectKey);
+                websiteConfig.getRedirectAllRequestsTo(), reqObjectKey);
         }
 
         // find index document if "directory" sent in request
         if (reqObjectKey.endsWith('/')) {
-            objectKey += websiteConfig.getIndexDocument();
+            // eslint-disable-next-line no-param-reassign
+            request.objectKey += websiteConfig.getIndexDocument();
         }
         // find index document if no key provided
         if (reqObjectKey === '') {
-            objectKey = websiteConfig.getIndexDocument();
+            // eslint-disable-next-line no-param-reassign
+            request.objectKey = websiteConfig.getIndexDocument();
         }
         // check whether need to redirect based on key
         const routingRules = websiteConfig.getRoutingRules();
 
-        const keyRoutingRule = findRoutingRule(routingRules, objectKey);
+        const keyRoutingRule = findRoutingRule(routingRules, request.objectKey);
 
         if (keyRoutingRule) {
             return callback(null, corsHeaders, keyRoutingRule, reqObjectKey);
@@ -94,7 +95,7 @@ function websiteHead(request, log, callback) {
 
         // get object metadata and check authorization and header
         // validation
-        return metadata.getObjectMD(bucketName, objectKey, {}, log,
+        return metadata.getObjectMD(bucketName, request.objectKey, {}, log,
             (err, objMD) => {
                 // Note: In case of error, we intentionally send the original
                 // object key to _errorActions as in case of a redirect, we do

--- a/lib/api/websiteHead.js
+++ b/lib/api/websiteHead.js
@@ -5,7 +5,7 @@ const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const constants = require('../../constants');
 const metadata = require('../metadata/wrapper');
 const bucketShield = require('./apiUtils/bucket/bucketShield');
-const { findRoutingRule, extractRedirectInfo } =
+const { appendWebsiteIndexDocument, findRoutingRule, extractRedirectInfo } =
     require('./apiUtils/object/websiteServing');
 const collectResponseHeaders = require('../utilities/collectResponseHeaders');
 const { pushMetric } = require('../utapi/utilities');
@@ -74,16 +74,8 @@ function websiteHead(request, log, callback) {
                 websiteConfig.getRedirectAllRequestsTo(), reqObjectKey);
         }
 
-        // find index document if "directory" sent in request
-        if (reqObjectKey.endsWith('/')) {
-            // eslint-disable-next-line no-param-reassign
-            request.objectKey += websiteConfig.getIndexDocument();
-        }
-        // find index document if no key provided
-        if (reqObjectKey === '') {
-            // eslint-disable-next-line no-param-reassign
-            request.objectKey = websiteConfig.getIndexDocument();
-        }
+        appendWebsiteIndexDocument(request, websiteConfig.getIndexDocument());
+
         // check whether need to redirect based on key
         const routingRules = websiteConfig.getRoutingRules();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.10.38",
+  "version": "7.10.39",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {

--- a/tests/functional/aws-node-sdk/test/object/websiteGet.js
+++ b/tests/functional/aws-node-sdk/test/object/websiteGet.js
@@ -565,5 +565,52 @@ describe('User visits bucket website endpoint', () => {
                 }, done);
             });
         });
+
+        describe('with bucket policy', () => {
+            beforeEach(done => {
+                const webConfig = new WebsiteConfigTester('index.html');
+                s3.putBucketWebsite({ Bucket: bucket,
+                    WebsiteConfiguration: webConfig }, err => {
+                    assert.strictEqual(err,
+                        null, `Found unexpected err ${err}`);
+                    s3.putBucketPolicy({ Bucket: bucket, Policy: JSON.stringify(
+                        {
+                            Version: '2012-10-17',
+                            Statement: [{
+                                Sid: 'PublicReadGetObject',
+                                Effect: 'Allow',
+                                Principal: '*',
+                                Action: ['s3:GetObject'],
+                                Resource: [`arn:aws:s3:::${bucket}/*`],
+                            }],
+                        }
+                    ) }, err => {
+                        assert.strictEqual(err,
+                            null, `Found unexpected err ${err}`);
+                        s3.putObject({ Bucket: bucket, Key: 'index.html',
+                            Body: fs.readFileSync(path.join(__dirname,
+                                '/websiteFiles/index.html')),
+                            ContentType: 'text/html' },
+                            err => {
+                                assert.strictEqual(err, null);
+                                done();
+                            });
+                    });
+                });
+            });
+
+            afterEach(done => {
+                s3.deleteObject({ Bucket: bucket, Key: 'index.html' },
+                err => done(err));
+            });
+
+            it('should serve indexDocument if no key requested', done => {
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: endpoint,
+                    responseType: 'index-user',
+                }, done);
+            });
+        });
     });
 });

--- a/tests/functional/aws-node-sdk/test/object/websiteGet.js
+++ b/tests/functional/aws-node-sdk/test/object/websiteGet.js
@@ -581,7 +581,7 @@ describe('User visits bucket website endpoint', () => {
                                 Effect: 'Allow',
                                 Principal: '*',
                                 Action: ['s3:GetObject'],
-                                Resource: [`arn:aws:s3:::${bucket}/*`],
+                                Resource: [`arn:aws:s3:::${bucket}/index.html`],
                             }],
                         }
                     ) }, err => {

--- a/tests/functional/aws-node-sdk/test/object/websiteHead.js
+++ b/tests/functional/aws-node-sdk/test/object/websiteHead.js
@@ -582,7 +582,7 @@ describe('Head request on bucket website endpoint', () => {
                                 Effect: 'Allow',
                                 Principal: '*',
                                 Action: ['s3:GetObject'],
-                                Resource: [`arn:aws:s3:::${bucket}/*`],
+                                Resource: [`arn:aws:s3:::${bucket}/index.html`],
                             }],
                         }
                     ) }, err => {


### PR DESCRIPTION
The variable holding the new objectKey with index suffix is not propagated to bucket policy function.

[_checkBucketPolicyResources](https://github.com/scality/cloudserver/blob/development/7.10/lib/api/apiUtils/authorization/permissionChecks.js#L228) function extract objectKey from request.
And for request on FQDN the objectKey is null in request
