### PR TITLE
CLDSRV-486: fix object redirect to root /

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.10.39",
+  "version": "7.10.42",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "git+https://github.com/scality/arsenal#7.10.51",
+    "arsenal": "git+https://github.com/scality/arsenal#f2974cb",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "git+https://github.com/scality/arsenal#f2974cb",
+    "arsenal": "git+https://github.com/scality/arsenal#7.10.53",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/tests/functional/aws-node-sdk/test/object/websiteGet.js
+++ b/tests/functional/aws-node-sdk/test/object/websiteGet.js
@@ -566,6 +566,45 @@ describe('User visits bucket website endpoint', () => {
             });
         });
 
+        describe('object redirect to /', () => {
+            beforeEach(done => {
+                const webConfig = new WebsiteConfigTester('index.html');
+                s3.putBucketWebsite({ Bucket: bucket,
+                    WebsiteConfiguration: webConfig }, err => {
+                    assert.strictEqual(err,
+                        null, `Found unexpected err ${err}`);
+                    s3.putObject({ Bucket: bucket, Key: 'index.html',
+                        ACL: 'public-read',
+                        Body: fs.readFileSync(path.join(__dirname,
+                            '/websiteFiles/index.html')),
+                        ContentType: 'text/html',
+                        Metadata: {
+                            test: 'value',
+                        },
+                        WebsiteRedirectLocation: '/',
+                    },
+                        err => {
+                            assert.strictEqual(err, null);
+                            done();
+                        });
+                });
+            });
+
+            afterEach(done => {
+                s3.deleteObject({ Bucket: bucket, Key: 'index.html' },
+                err => done(err));
+            });
+
+            it('should redirect to /', done => {
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: `${endpoint}/index.html`,
+                    responseType: 'redirect',
+                    redirectUrl: '/',
+                }, done);
+            });
+        });
+
         describe('with bucket policy', () => {
             beforeEach(done => {
                 const webConfig = new WebsiteConfigTester('index.html');

--- a/yarn.lock
+++ b/yarn.lock
@@ -488,9 +488,9 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#7.10.51":
-  version "7.10.51"
-  resolved "git+https://github.com/scality/arsenal#477a574500318b183e5805e6d15ef2aef8f74d02"
+"arsenal@git+https://github.com/scality/arsenal#f2974cb":
+  version "7.10.53"
+  resolved "git+https://github.com/scality/arsenal#f2974cbd07e33e0866d122b463416f6b6045b2cc"
   dependencies:
     "@types/async" "^3.2.12"
     "@types/utf8" "^3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -488,9 +488,9 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#f2974cb":
+"arsenal@git+https://github.com/scality/arsenal#7.10.53":
   version "7.10.53"
-  resolved "git+https://github.com/scality/arsenal#f2974cbd07e33e0866d122b463416f6b6045b2cc"
+  resolved "git+https://github.com/scality/arsenal#b5487e3c9453de05594122265465d96744b32535"
   dependencies:
     "@types/async" "^3.2.12"
     "@types/utf8" "^3.0.1"


### PR DESCRIPTION
A single `/` in an object header `x-amz-website-redirect-location` results in an empty `Location` header in a redirect response because arsenal removed the trailing `/`.

This PR bumps arsenal and tests this PR https://github.com/scality/Arsenal/pull/2203
