### PR TITLE
CLDSRV-490: fix missing request for bucket policy

### DIFF
--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -119,6 +119,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                 // Required permissions for this action
                 // at the destinationBucket level are same as objectPut
                 requestType: 'objectPut',
+                request,
             };
             standardMetadataValidateBucketAndObj(metadataValParams, request.actionImplicitDenies, log, next);
         },

--- a/lib/api/objectPutACL.js
+++ b/lib/api/objectPutACL.js
@@ -83,6 +83,7 @@ function objectPutACL(authInfo, request, log, cb) {
         objectKey,
         requestType: request.apiMethods || 'objectPutACL',
         versionId: reqVersionId,
+        request,
     };
 
     const possibleGrants = ['FULL_CONTROL', 'WRITE_ACP', 'READ', 'READ_ACP'];

--- a/lib/api/websiteGet.js
+++ b/lib/api/websiteGet.js
@@ -47,8 +47,10 @@ function _errorActions(err, errorDocument, routingRules,
                 }
                 // return the default error message if the object is private
                 // rather than sending a stored error file
+                // eslint-disable-next-line no-param-reassign
+                request.objectKey = errorDocument;
                 if (!isObjAuthorized(bucket, errObjMD, request.apiMethods || 'objectGet',
-                    constants.publicId, null, log, null, request.actionImplicitDenies)) {
+                    constants.publicId, null, log, request, request.actionImplicitDenies)) {
                     log.trace('errorObj not authorized', { error: err });
                     return callback(err, true, null, corsHeaders);
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.10.41",
+  "version": "7.10.42",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {

--- a/tests/functional/aws-node-sdk/test/object/websiteGet.js
+++ b/tests/functional/aws-node-sdk/test/object/websiteGet.js
@@ -573,7 +573,7 @@ describe('User visits bucket website endpoint', () => {
                 'error.html');
 
                 async.waterfall([
-                    (next) => s3.putBucketWebsite({ Bucket: bucket,
+                    next => s3.putBucketWebsite({ Bucket: bucket,
                         WebsiteConfiguration: webConfig }, next),
                     (data, next) => s3.putBucketPolicy({ Bucket: bucket,
                         Policy: JSON.stringify({
@@ -612,7 +612,7 @@ describe('User visits bucket website endpoint', () => {
                         ContentType: 'text/html',
                     }, next),
 
-                ], (err) => {
+                ], err => {
                     assert.ifError(err);
                     done();
                 });
@@ -620,11 +620,11 @@ describe('User visits bucket website endpoint', () => {
 
             afterEach(done => {
                 async.waterfall([
-                    (next) => s3.deleteObject({ Bucket: bucket,
+                    next => s3.deleteObject({ Bucket: bucket,
                         Key: 'index.html' }, next),
                     (data, next) => s3.deleteObject({ Bucket: bucket,
                             Key: 'error.html' }, next),
-                ], (err) => {
+                ], err => {
                     assert.ifError(err);
                     done();
                 });

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -2262,7 +2262,7 @@ describe('complete mpu with bucket policy', () => {
         const authNotRoot = makeAuthInfo(canonicalID, 'not-root');
 
         async.waterfall([
-            (next) => bucketPutPolicy(authInfo,
+            next => bucketPutPolicy(authInfo,
                 bucketPutPolicyRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authNotRoot,
                 initiateReqFixed, log, next),
@@ -2283,7 +2283,7 @@ describe('complete mpu with bucket policy', () => {
                     calculatedHash,
                 }, requestFix), partBody);
                 objectPutPart(authNotRoot, partRequest,
-                    undefined, log, (err) => next(err, testUploadId));
+                    undefined, log, err => next(err, testUploadId));
             },
             (testUploadId, next) => {
                 const completeRequest = new DummyRequest(Object.assign({
@@ -2301,7 +2301,7 @@ describe('complete mpu with bucket policy', () => {
                     log, next);
             },
         ],
-        (err) => {
+        err => {
             assert.ifError(err);
             done();
         });

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -7,6 +7,7 @@ const moment = require('moment');
 const { parseString } = require('xml2js');
 
 const { bucketPut } = require('../../../lib/api/bucketPut');
+const bucketPutPolicy = require('../../../lib/api/bucketPutPolicy');
 const bucketPutVersioning = require('../../../lib/api/bucketPutVersioning');
 const objectPut = require('../../../lib/api/objectPut');
 const completeMultipartUpload
@@ -2209,6 +2210,100 @@ describe('multipart upload with object lock', () => {
             assert.deepStrictEqual(json.LegalHold, expectedLegalHold);
             changeObjectLock(
                 [{ bucket: lockedBucket, key: objectKey, versionId }], '', done);
+        });
+    });
+});
+
+describe('complete mpu with bucket policy', () => {
+    function getPolicyRequest(policy) {
+        return {
+            bucketName,
+            headers: {
+                host: `${bucketName}.s3.amazonaws.com`,
+            },
+            post: JSON.stringify(policy),
+            actionImplicitDenies: false,
+        };
+    }
+    /** Additional fields are required on existing request mocks */
+    const requestFix = {
+        connection: { encrypted: false },
+        destroy: () => {},
+    };
+    const initiateReqFixed = Object.assign({}, initiateRequest, requestFix);
+    const partBody = Buffer.from('I am a part\n', 'utf8');
+    const md5Hash = crypto.createHash('md5').update(partBody);
+    const calculatedHash = md5Hash.digest('hex');
+    const completeBody = '<CompleteMultipartUpload>' +
+    '<Part>' +
+    '<PartNumber>1</PartNumber>' +
+    `<ETag>"${calculatedHash}"</ETag>` +
+    '</Part>' +
+    '</CompleteMultipartUpload>';
+
+    beforeEach(done => {
+        cleanup();
+        bucketPut(authInfo, bucketPutRequest, log, done);
+    });
+
+    it('should complete with a deny on unrelated object as non root', done => {
+        const bucketPutPolicyRequest = getPolicyRequest({
+            Version: '2012-10-17',
+            Statement: [
+                {
+                    Effect: 'Deny',
+                    Principal: '*',
+                    Action: ['s3:PutObject'],
+                    Resource: `arn:aws:s3:::${bucketName}/unrelated_obj`,
+                },
+            ],
+        });
+        /** root user doesn't check bucket policy */
+        const authNotRoot = makeAuthInfo(canonicalID, 'not-root');
+
+        async.waterfall([
+            (next) => bucketPutPolicy(authInfo,
+                bucketPutPolicyRequest, log, next),
+            (corsHeaders, next) => initiateMultipartUpload(authNotRoot,
+                initiateReqFixed, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
+            (json, next) => {
+                const testUploadId =
+                json.InitiateMultipartUploadResult.UploadId[0];
+                const partRequest = new DummyRequest(Object.assign({
+                    bucketName,
+                    namespace,
+                    objectKey,
+                    headers: { host: `${bucketName}.s3.amazonaws.com` },
+                    url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                    query: {
+                        partNumber: '1',
+                        uploadId: testUploadId,
+                    },
+                    calculatedHash,
+                }, requestFix), partBody);
+                objectPutPart(authNotRoot, partRequest,
+                    undefined, log, (err) => next(err, testUploadId));
+            },
+            (testUploadId, next) => {
+                const completeRequest = new DummyRequest(Object.assign({
+                    bucketName,
+                    namespace,
+                    objectKey,
+                    parsedHost: 's3.amazonaws.com',
+                    url: `/${objectKey}?uploadId=${testUploadId}`,
+                    headers: { host: `${bucketName}.s3.amazonaws.com` },
+                    query: { uploadId: testUploadId },
+                    post: completeBody,
+                    actionImplicitDenies: false,
+                }, requestFix));
+                completeMultipartUpload(authNotRoot, completeRequest,
+                    log, next);
+            },
+        ],
+        (err) => {
+            assert.ifError(err);
+            done();
         });
     });
 });

--- a/tests/unit/api/objectPutACL.js
+++ b/tests/unit/api/objectPutACL.js
@@ -501,10 +501,10 @@ describe('putObjectACL API', () => {
 
         beforeEach(done => {
             async.waterfall([
-                (next) => bucketPut(authInfo, testPutBucketRequest, log, next),
+                next => bucketPut(authInfo, testPutBucketRequest, log, next),
                 (cors, next) => objectPut(authInfo,
                     testPutObjectRequest, undefined, log, next),
-            ], (err) => {
+            ], err => {
                 assert.ifError(err);
                 done();
             });
@@ -535,7 +535,7 @@ describe('putObjectACL API', () => {
             /** root user doesn't check bucket policy */
             const authNotRoot = makeAuthInfo(canonicalID, 'not-root');
             async.waterfall([
-                (next) => bucketPutPolicy(authInfo,
+                next => bucketPutPolicy(authInfo,
                     bucketPutPolicyRequest, log, next),
                 (cors, next) => objectPutACL(authNotRoot,
                     testObjACLRequest, log, next),
@@ -574,11 +574,11 @@ describe('putObjectACL API', () => {
                 canonicalID: constants.publicId,
             });
             async.waterfall([
-                (next) => bucketPutPolicy(authInfo,
+                next => bucketPutPolicy(authInfo,
                     bucketPutPolicyRequest, log, next),
                 (cors, next) => objectPutACL(publicAuth,
                     testObjACLRequest, log, next),
-            ], (err) => {
+            ], err => {
                 assert(err instanceof Error);
                 assert.strictEqual(err.code, errors.AccessDenied.code);
                 done();


### PR DESCRIPTION
The function that checks resources in bucket policy returns true if the request is omitted (https://github.com/scality/cloudserver/blob/042120b17e186e3a3f2212e1d87ece92ddbcac97/lib/api/apiUtils/authorization/permissionChecks.js#L239-L240) which means the bucket policy might return an invalid DENY of ALLOW if request is missing.

There are 3 endpoints that are affected (they don’t pass the request to isObjAuthorized or standardMetadataValidateBucketAndObj):

- GET website error handling (_errorActions)
- completeMultipartUpload
- objectPutACL