### PR TITLE
CLDSRV-488: fix website 404 with bucket policy

### DIFF
--- a/lib/api/apiUtils/authorization/permissionChecks.js
+++ b/lib/api/apiUtils/authorization/permissionChecks.js
@@ -281,6 +281,12 @@ function checkBucketPolicy(policy, requestType, canonicalID, arn, bucketOwner, l
     if (bucketOwner === canonicalID && actionImplicitDenies[requestType] === false) {
         permission = 'allow';
     }
+    // for website, requestType must be bucketGet to check bucket acl
+    // but objectGet to check bucket policy
+    if (request && request.websiteOverrideRequestTypeForBucketPolicy) {
+        // eslint-disable-next-line no-param-reassign
+        requestType = 'objectGet';
+    }
     let copiedStatement = JSON.parse(JSON.stringify(policy.Statement));
     while (copiedStatement.length > 0) {
         const s = copiedStatement[0];

--- a/lib/api/apiUtils/authorization/permissionChecks.js
+++ b/lib/api/apiUtils/authorization/permissionChecks.js
@@ -353,7 +353,7 @@ function isBucketAuthorized(bucket, requestTypesInput, canonicalID, authInfo, lo
         if (isWebsite && _requestType === 'bucketGet') {
             // eslint-disable-next-line no-param-reassign
             _requestType = 'objectGet';
-            actionImplicitDenies[_requestType] = actionImplicitDenies[_requestType] || false;
+            actionImplicitDenies['objectGet'] = actionImplicitDenies['objectGet'] || false;
         }
         return processBucketPolicy(_requestType, bucket, canonicalID, arn, bucket.getOwner(), log,
             request, aclPermission, results, actionImplicitDenies);

--- a/lib/api/apiUtils/authorization/permissionChecks.js
+++ b/lib/api/apiUtils/authorization/permissionChecks.js
@@ -353,7 +353,7 @@ function isBucketAuthorized(bucket, requestTypesInput, canonicalID, authInfo, lo
         if (isWebsite && _requestType === 'bucketGet') {
             // eslint-disable-next-line no-param-reassign
             _requestType = 'objectGet';
-            actionImplicitDenies['objectGet'] = actionImplicitDenies['objectGet'] || false;
+            actionImplicitDenies.objectGet = actionImplicitDenies.objectGet || false;
         }
         return processBucketPolicy(_requestType, bucket, canonicalID, arn, bucket.getOwner(), log,
             request, aclPermission, results, actionImplicitDenies);

--- a/lib/api/apiUtils/authorization/permissionChecks.js
+++ b/lib/api/apiUtils/authorization/permissionChecks.js
@@ -281,12 +281,6 @@ function checkBucketPolicy(policy, requestType, canonicalID, arn, bucketOwner, l
     if (bucketOwner === canonicalID && actionImplicitDenies[requestType] === false) {
         permission = 'allow';
     }
-    // for website, requestType must be bucketGet to check bucket acl
-    // but objectGet to check bucket policy
-    if (request && request.websiteOverrideRequestTypeForBucketPolicy) {
-        // eslint-disable-next-line no-param-reassign
-        requestType = 'objectGet';
-    }
     let copiedStatement = JSON.parse(JSON.stringify(policy.Statement));
     while (copiedStatement.length > 0) {
         const s = copiedStatement[0];
@@ -328,7 +322,7 @@ function processBucketPolicy(requestType, bucket, canonicalID, arn, bucketOwner,
 }
 
 function isBucketAuthorized(bucket, requestTypesInput, canonicalID, authInfo, log, request,
-    actionImplicitDeniesInput = {}) {
+    actionImplicitDeniesInput = {}, isWebsite = false) {
     const requestTypes = Array.isArray(requestTypesInput) ? requestTypesInput : [requestTypesInput];
     const actionImplicitDenies = !actionImplicitDeniesInput ? {} : actionImplicitDeniesInput;
     const mainApiCall = requestTypes[0];
@@ -352,6 +346,15 @@ function isBucketAuthorized(bucket, requestTypesInput, canonicalID, authInfo, lo
             return results[_requestType];
         }
         const aclPermission = checkBucketAcls(bucket, _requestType, canonicalID, mainApiCall);
+        // In case of error bucket access is checked with bucketGet
+        // For website, bucket policy only uses objectGet and ignores bucketGet
+        // https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteAccessPermissionsReqd.html
+        // bucketGet should be used to check acl but switched to objectGet for bucket policy
+        if (isWebsite && _requestType === 'bucketGet') {
+            // eslint-disable-next-line no-param-reassign
+            _requestType = 'objectGet';
+            actionImplicitDenies[_requestType] = actionImplicitDenies[_requestType] || false;
+        }
         return processBucketPolicy(_requestType, bucket, canonicalID, arn, bucket.getOwner(), log,
             request, aclPermission, results, actionImplicitDenies);
     });
@@ -376,7 +379,7 @@ function evaluateBucketPolicyWithIAM(bucket, requestTypesInput, canonicalID, aut
 }
 
 function isObjAuthorized(bucket, objectMD, requestTypesInput, canonicalID, authInfo, log, request,
-    actionImplicitDeniesInput = {}) {
+    actionImplicitDeniesInput = {}, isWebsite = false) {
     const requestTypes = Array.isArray(requestTypesInput) ? requestTypesInput : [requestTypesInput];
     const actionImplicitDenies = !actionImplicitDeniesInput ? {} : actionImplicitDeniesInput;
     const results = {};
@@ -398,7 +401,7 @@ function isObjAuthorized(bucket, objectMD, requestTypesInput, canonicalID, authI
             // check bucket has read access
             // 'bucketGet' covers listObjects and listMultipartUploads, bucket read actions
             results[_requestType] = isBucketAuthorized(bucket, 'bucketGet', canonicalID, authInfo, log, request,
-                actionImplicitDenies);
+                actionImplicitDenies, isWebsite);
             return results[_requestType];
         }
         let requesterIsNotUser = true;

--- a/lib/api/websiteGet.js
+++ b/lib/api/websiteGet.js
@@ -138,12 +138,8 @@ function websiteGet(request, log, callback) {
                     log.trace('error retrieving object metadata',
                     { error: err });
                     let returnErr = err;
-                    // requestType must be bucketGet to check bucket acl
-                    // but objectGet to check bucket policy
-                    // eslint-disable-next-line no-param-reassign
-                    request.websiteOverrideRequestTypeForBucketPolicy = true;
                     const bucketAuthorized = isBucketAuthorized(bucket, request.apiMethods || 'bucketGet',
-                    constants.publicId, null, log, request, request.actionImplicitDenies);
+                    constants.publicId, null, log, request, request.actionImplicitDenies, true);
                     // if index object does not exist and bucket is private AWS
                     // returns 403 - AccessDenied error.
                     if (err.is.NoSuchKey && !bucketAuthorized) {
@@ -155,7 +151,7 @@ function websiteGet(request, log, callback) {
                       callback);
                 }
                 if (!isObjAuthorized(bucket, objMD, request.apiMethods || 'objectGet',
-                    constants.publicId, null, log, request, request.actionImplicitDenies)) {
+                    constants.publicId, null, log, request, request.actionImplicitDenies, true)) {
                     const err = errors.AccessDenied;
                     log.trace('request not authorized', { error: err });
                     return _errorActions(err, websiteConfig.getErrorDocument(),

--- a/lib/api/websiteGet.js
+++ b/lib/api/websiteGet.js
@@ -138,6 +138,10 @@ function websiteGet(request, log, callback) {
                     log.trace('error retrieving object metadata',
                     { error: err });
                     let returnErr = err;
+                    // requestType must be bucketGet to check bucket acl
+                    // but objectGet to check bucket policy
+                    // eslint-disable-next-line no-param-reassign
+                    request.websiteOverrideRequestTypeForBucketPolicy = true;
                     const bucketAuthorized = isBucketAuthorized(bucket, request.apiMethods || 'bucketGet',
                     constants.publicId, null, log, request, request.actionImplicitDenies);
                     // if index object does not exist and bucket is private AWS

--- a/lib/api/websiteHead.js
+++ b/lib/api/websiteHead.js
@@ -96,12 +96,8 @@ function websiteHead(request, log, callback) {
                     log.trace('error retrieving object metadata',
                     { error: err });
                     let returnErr = err;
-                    // requestType must be bucketGet to check bucket acl
-                    // but objectGet to check bucket policy
-                    // eslint-disable-next-line no-param-reassign
-                    request.websiteOverrideRequestTypeForBucketPolicy = true;
                     const bucketAuthorized = isBucketAuthorized(bucket,
-                      'bucketGet', constants.publicId, null, log, request, request.actionImplicitDenies);
+                      'bucketGet', constants.publicId, null, log, request, request.actionImplicitDenies, true);
                     // if index object does not exist and bucket is private AWS
                     // returns 403 - AccessDenied error.
                     if (err.is.NoSuchKey && !bucketAuthorized) {
@@ -111,7 +107,7 @@ function websiteHead(request, log, callback) {
                         reqObjectKey, corsHeaders, log, callback);
                 }
                 if (!isObjAuthorized(bucket, objMD, 'objectGet',
-                    constants.publicId, null, log, request, request.actionImplicitDenies)) {
+                    constants.publicId, null, log, request, request.actionImplicitDenies, true)) {
                     const err = errors.AccessDenied;
                     log.trace('request not authorized', { error: err });
                     return _errorActions(err, routingRules, reqObjectKey,

--- a/lib/api/websiteHead.js
+++ b/lib/api/websiteHead.js
@@ -96,6 +96,10 @@ function websiteHead(request, log, callback) {
                     log.trace('error retrieving object metadata',
                     { error: err });
                     let returnErr = err;
+                    // requestType must be bucketGet to check bucket acl
+                    // but objectGet to check bucket policy
+                    // eslint-disable-next-line no-param-reassign
+                    request.websiteOverrideRequestTypeForBucketPolicy = true;
                     const bucketAuthorized = isBucketAuthorized(bucket,
                       'bucketGet', constants.publicId, null, log, request, request.actionImplicitDenies);
                     // if index object does not exist and bucket is private AWS

--- a/tests/functional/aws-node-sdk/test/object/websiteGet.js
+++ b/tests/functional/aws-node-sdk/test/object/websiteGet.js
@@ -625,6 +625,7 @@ describe('User visits bucket website endpoint', () => {
                                 Resource: [
                                     `arn:aws:s3:::${bucket}/index.html`,
                                     `arn:aws:s3:::${bucket}/error.html`,
+                                    `arn:aws:s3:::${bucket}/access.html`,
                                 ],
                             },
                             {
@@ -677,12 +678,21 @@ describe('User visits bucket website endpoint', () => {
                 }, done);
             });
 
-            it('should serve custom error with deny on unrelated object',
-            done => {
+            it('should serve custom error 403 with deny on unrelated object ' +
+            'and no access to key', done => {
                 WebsiteConfigTester.checkHTML({
                     method: 'GET',
                     url: `${endpoint}/non_existing.html`,
                     responseType: 'error-user',
+                }, done);
+            });
+
+            it('should serve custom error 404 with deny on unrelated object ' +
+            'and access to key', done => {
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: `${endpoint}/access.html`,
+                    responseType: 'error-user-404',
                 }, done);
             });
         });

--- a/tests/functional/aws-node-sdk/test/object/websiteHead.js
+++ b/tests/functional/aws-node-sdk/test/object/websiteHead.js
@@ -620,7 +620,10 @@ describe('Head request on bucket website endpoint', () => {
                                 Effect: 'Allow',
                                 Principal: '*',
                                 Action: ['s3:GetObject'],
-                                Resource: [`arn:aws:s3:::${bucket}/index.html`],
+                                Resource: [
+                                    `arn:aws:s3:::${bucket}/index.html`,
+                                    `arn:aws:s3:::${bucket}/access.html`,
+                                ],
                             }],
                         }
                     ) }, err => {
@@ -650,6 +653,26 @@ describe('Head request on bucket website endpoint', () => {
                 'requested', done => {
                 WebsiteConfigTester.makeHeadRequest(undefined, endpoint,
                     200, indexExpectedHeaders, done);
+            });
+
+            it('should serve error 403 with no access to key', done => {
+                const expectedHeaders = {
+                    'x-amz-error-code': 'AccessDenied',
+                    'x-amz-error-message': 'Access Denied',
+                };
+                WebsiteConfigTester.makeHeadRequest(undefined,
+                    `${endpoint}/non_existing.html`, 403, expectedHeaders,
+                    done);
+            });
+
+            it('should serve error 404 with access to key', done => {
+                const expectedHeaders = {
+                    'x-amz-error-code': 'NoSuchKey',
+                    'x-amz-error-message': 'The specified key does not exist.',
+                };
+                WebsiteConfigTester.makeHeadRequest(undefined,
+                    `${endpoint}/access.html`, 404, expectedHeaders,
+                    done);
             });
         });
     });


### PR DESCRIPTION
If object doesn’t exist but bucket policy allows access to the object, the response should be a 404 and not a 403.