### PR TITLE
CLDSRV-489: redirect 302 on folder with index without trailing /

### DIFF
--- a/lib/api/apiUtils/object/websiteServing.js
+++ b/lib/api/apiUtils/object/websiteServing.js
@@ -105,21 +105,24 @@ function validateWebsiteHeader(header) {
  * appendWebsiteIndexDocument - append index to objectKey if necessary
  * @param {object} request - normalized request object
  * @param {string} indexDocumentSuffix - index document from website config
+ * @param {boolean} force - flag to force append index
  * @return {undefined}
  */
-function appendWebsiteIndexDocument(request, indexDocumentSuffix) {
+function appendWebsiteIndexDocument(request, indexDocumentSuffix, force = false) {
     const reqObjectKey = request.objectKey ? request.objectKey : '';
+    /* eslint-disable no-param-reassign */
 
     // find index document if "directory" sent in request
     if (reqObjectKey.endsWith('/')) {
-        // eslint-disable-next-line no-param-reassign
         request.objectKey += indexDocumentSuffix;
-    }
     // find index document if no key provided
-    if (reqObjectKey === '') {
-        // eslint-disable-next-line no-param-reassign
+    } else if (reqObjectKey === '') {
         request.objectKey = indexDocumentSuffix;
+    // force for redirect 302 on folder without trailing / that has an index
+    } else if (force) {
+        request.objectKey += `/${indexDocumentSuffix}`;
     }
+    /* eslint-enable no-param-reassign */
 }
 
 module.exports = {

--- a/lib/api/website.js
+++ b/lib/api/website.js
@@ -53,7 +53,7 @@ function _errorActions(err, errorDocument, routingRules,
                 // eslint-disable-next-line no-param-reassign
                 request.objectKey = errorDocument;
                 if (!isObjAuthorized(bucket, errObjMD, request.apiMethods || 'objectGet',
-                    constants.publicId, null, log, request, request.actionImplicitDenies)) {
+                    constants.publicId, null, log, request, request.actionImplicitDenies, true)) {
                     log.trace('errorObj not authorized', { error: err });
                     return callback(err, true, null, corsHeaders);
                 }
@@ -170,87 +170,119 @@ function website(request, log, callback) {
 
         appendWebsiteIndexDocument(request, websiteConfig.getIndexDocument());
 
-        // get object metadata and check authorization and header
-        // validation
-        return metadata.getObjectMD(bucketName, request.objectKey, {}, log,
-            (err, objMD) => {
-                // Note: In case of error, we intentionally send the original
-                // object key to _errorActions as in case of a redirect, we do
-                // not want to append index key to redirect location
-                if (err) {
-                    log.trace('error retrieving object metadata',
-                    { error: err });
-                    let returnErr = err;
-                    const bucketAuthorized = isBucketAuthorized(bucket, request.apiMethods || 'bucketGet',
-                    constants.publicId, null, log, request, request.actionImplicitDenies, true);
-                    // if index object does not exist and bucket is private AWS
-                    // returns 403 - AccessDenied error.
-                    if (err.is.NoSuchKey && !bucketAuthorized) {
-                        returnErr = errors.AccessDenied;
+        /**
+         * Recursive function with 1 recursive call to look for index
+         * in case of error for potential redirect to folder notation
+         * if there is not already an index appended
+         * @param {Error} [originalError] - presence of this argument
+         * differentiates original user request from recursive call to /index.
+         * This error is returned if /index is not found
+         * @returns {undefined}
+         */
+        function runWebsite(originalError) {
+            // get object metadata and check authorization and header
+            // validation
+            return metadata.getObjectMD(bucketName, request.objectKey, {}, log,
+                (err, objMD) => {
+                    // Note: In case of error, we intentionally send the original
+                    // object key to _errorActions as in case of a redirect, we do
+                    // not want to append index key to redirect location
+                    if (err) {
+                        log.trace('error retrieving object metadata',
+                        { error: err });
+
+                        let returnErr = err;
+                        const bucketAuthorized = isBucketAuthorized(bucket, request.apiMethods || 'bucketGet',
+                        constants.publicId, null, log, request, request.actionImplicitDenies, true);
+                        // if index object does not exist and bucket is private AWS
+                        // returns 403 - AccessDenied error.
+                        if (err.is.NoSuchKey && !bucketAuthorized) {
+                            returnErr = errors.AccessDenied;
+                        }
+
+                        // Check if key is a folder containing index for redirect 302
+                        // https://docs.aws.amazon.com/AmazonS3/latest/userguide/IndexDocumentSupport.html
+                        if (!originalError && reqObjectKey && !reqObjectKey.endsWith('/')) {
+                            appendWebsiteIndexDocument(request, websiteConfig.getIndexDocument(), true);
+                            // propagate returnErr as originalError to be used if index is not found
+                            return runWebsite(returnErr);
+                        }
+
+                        return _errorActions(originalError || returnErr,
+                        websiteConfig.getErrorDocument(), routingRules,
+                        bucket, reqObjectKey, corsHeaders, request, log,
+                        callback);
                     }
-                    return _errorActions(returnErr,
-                      websiteConfig.getErrorDocument(), routingRules,
-                      bucket, reqObjectKey, corsHeaders, request, log,
-                      callback);
-                }
-                if (!isObjAuthorized(bucket, objMD, request.apiMethods || 'objectGet',
-                    constants.publicId, null, log, request, request.actionImplicitDenies, true)) {
-                    const err = errors.AccessDenied;
-                    log.trace('request not authorized', { error: err });
-                    return _errorActions(err, websiteConfig.getErrorDocument(),
-                        routingRules, bucket,
-                        reqObjectKey, corsHeaders, request, log, callback);
-                }
-
-                const headerValResult = validateHeaders(request.headers,
-                    objMD['last-modified'], objMD['content-md5']);
-                if (headerValResult.error) {
-                    const err = headerValResult.error;
-                    log.trace('header validation error', { error: err });
-                    return _errorActions(err, websiteConfig.getErrorDocument(),
-                        routingRules, bucket, reqObjectKey,
-                        corsHeaders, request, log, callback);
-                }
-                // check if object to serve has website redirect header
-                // Note: AWS prioritizes website configuration rules over
-                // object key's website redirect header, so we make the
-                // check at the end.
-                if (objMD['x-amz-website-redirect-location']) {
-                    const redirectLocation =
-                        objMD['x-amz-website-redirect-location'];
-                    const redirectInfo =
-                        extractRedirectInfo(redirectLocation);
-                    log.trace('redirecting to x-amz-website-redirect-location',
-                        { location: redirectLocation });
-                    return callback(null, false, null, corsHeaders,
-                        redirectInfo, '');
-                }
-                // got obj metadata, authorized and headers validated,
-                // good to go
-                const responseMetaHeaders = collectResponseHeaders(objMD,
-                    corsHeaders);
-
-                if (request.method === 'HEAD') {
-                    pushMetric('headObject', log, { bucket: bucketName });
-                    return callback(null, false, null, responseMetaHeaders);
-                }
-
-                const dataLocator = objMD.location;
-                if (objMD['x-amz-server-side-encryption']) {
-                    for (let i = 0; i < dataLocator.length; i++) {
-                        dataLocator[i].masterKeyId =
-                            objMD['x-amz-server-side-encryption-aws-' +
-                                'kms-key-id'];
-                        dataLocator[i].algorithm =
-                            objMD['x-amz-server-side-encryption'];
+                    if (!isObjAuthorized(bucket, objMD, request.apiMethods || 'objectGet',
+                        constants.publicId, null, log, request, request.actionImplicitDenies, true)) {
+                        const err = errors.AccessDenied;
+                        log.trace('request not authorized', { error: err });
+                        return _errorActions(err, websiteConfig.getErrorDocument(),
+                            routingRules, bucket,
+                            reqObjectKey, corsHeaders, request, log, callback);
                     }
-                }
-                pushMetric('getObject', log, {
-                    bucket: bucketName,
-                    newByteLength: responseMetaHeaders['Content-Length'],
+
+                    // access granted to index document, needs a redirect 302
+                    // to the original key with trailing /
+                    if (originalError) {
+                        const redirectInfo = { withError: true,
+                            location: `/${reqObjectKey}/` };
+                        return callback(errors.Found, false, null, corsHeaders,
+                            redirectInfo, '');
+                    }
+
+                    const headerValResult = validateHeaders(request.headers,
+                        objMD['last-modified'], objMD['content-md5']);
+                    if (headerValResult.error) {
+                        const err = headerValResult.error;
+                        log.trace('header validation error', { error: err });
+                        return _errorActions(err, websiteConfig.getErrorDocument(),
+                            routingRules, bucket, reqObjectKey,
+                            corsHeaders, request, log, callback);
+                    }
+                    // check if object to serve has website redirect header
+                    // Note: AWS prioritizes website configuration rules over
+                    // object key's website redirect header, so we make the
+                    // check at the end.
+                    if (objMD['x-amz-website-redirect-location']) {
+                        const redirectLocation =
+                            objMD['x-amz-website-redirect-location'];
+                        const redirectInfo =
+                            extractRedirectInfo(redirectLocation);
+                        log.trace('redirecting to x-amz-website-redirect-location',
+                            { location: redirectLocation });
+                        return callback(null, false, null, corsHeaders,
+                            redirectInfo, '');
+                    }
+                    // got obj metadata, authorized and headers validated,
+                    // good to go
+                    const responseMetaHeaders = collectResponseHeaders(objMD,
+                        corsHeaders);
+
+                    if (request.method === 'HEAD') {
+                        pushMetric('headObject', log, { bucket: bucketName });
+                        return callback(null, false, null, responseMetaHeaders);
+                    }
+
+                    const dataLocator = objMD.location;
+                    if (objMD['x-amz-server-side-encryption']) {
+                        for (let i = 0; i < dataLocator.length; i++) {
+                            dataLocator[i].masterKeyId =
+                                objMD['x-amz-server-side-encryption-aws-' +
+                                    'kms-key-id'];
+                            dataLocator[i].algorithm =
+                                objMD['x-amz-server-side-encryption'];
+                        }
+                    }
+                    pushMetric('getObject', log, {
+                        bucket: bucketName,
+                        newByteLength: responseMetaHeaders['Content-Length'],
+                    });
+                    return callback(null, false, dataLocator, responseMetaHeaders);
                 });
-                return callback(null, false, dataLocator, responseMetaHeaders);
-            });
+        }
+
+        return runWebsite();
     });
 }
 

--- a/tests/functional/aws-node-sdk/lib/utility/website-util.js
+++ b/tests/functional/aws-node-sdk/lib/utility/website-util.js
@@ -230,8 +230,8 @@ function _assertResponseHtmlRedirect(response, type, redirectUrl, method,
             assert.strictEqual(response.headers['x-amz-error-message'],
             'Resource Found');
             _assertContainsHtml(response.body);
-            _assertResponseHtml(response.body, 'title', '302 Moved Temporarily');
-            _assertResponseHtml(response.body, 'h1', '302 Moved Temporarily');
+            _assertResponseHtml(response.body, 'title', '302 Found');
+            _assertResponseHtml(response.body, 'h1', '302 Found');
             _assertResponseHtml(response.body, 'ul', [
                 'Code: Found',
                 'Message: Resource Found',

--- a/tests/functional/aws-node-sdk/test/object/websiteGet.js
+++ b/tests/functional/aws-node-sdk/test/object/websiteGet.js
@@ -849,8 +849,9 @@ describe('User visits bucket website endpoint', () => {
                         it: 'on no access with index',
                         key: 'no_access_file',
                     },
-                ].forEach(test => it(test.it, done => {
-                    WebsiteConfigTester.checkHTML({
+                ].forEach(test =>
+                    it(test.it, done => {
+                        WebsiteConfigTester.checkHTML({
                         method: 'GET',
                         url: `${endpoint}/${test.key}`,
                         responseType: '403-access-denied',

--- a/tests/functional/aws-node-sdk/test/object/websiteGet.js
+++ b/tests/functional/aws-node-sdk/test/object/websiteGet.js
@@ -852,11 +852,11 @@ describe('User visits bucket website endpoint', () => {
                 ].forEach(test =>
                     it(test.it, done => {
                         WebsiteConfigTester.checkHTML({
-                        method: 'GET',
-                        url: `${endpoint}/${test.key}`,
-                        responseType: '403-access-denied',
-                    }, done);
-                }));
+                            method: 'GET',
+                            url: `${endpoint}/${test.key}`,
+                            responseType: '403-access-denied',
+                        }, done);
+                    }));
             });
         });
     });

--- a/tests/functional/aws-node-sdk/test/object/websiteGet.js
+++ b/tests/functional/aws-node-sdk/test/object/websiteGet.js
@@ -761,5 +761,102 @@ describe('User visits bucket website endpoint', () => {
                 }, done);
             });
         });
+
+        describe('without trailing / for recursive index check', () => {
+            beforeEach(done => {
+                const webConfig = new WebsiteConfigTester('index.html');
+                const object = {
+                    Bucket: bucket,
+                    Body: fs.readFileSync(path.join(__dirname,
+                    '/websiteFiles/index.html')),
+                    ContentType: 'text/html',
+                };
+                async.waterfall([
+                    next => s3.putBucketWebsite({ Bucket: bucket,
+                        WebsiteConfiguration: webConfig }, next),
+                    (data, next) => s3.putBucketPolicy({ Bucket: bucket,
+                        Policy: JSON.stringify({
+                            Version: '2012-10-17',
+                            Statement: [{
+                                Sid: 'PublicReadGetObject',
+                                Effect: 'Allow',
+                                Principal: '*',
+                                Action: ['s3:GetObject'],
+                                Resource: [
+                                    `arn:aws:s3:::${bucket}/original_key_file`,
+                                    `arn:aws:s3:::${bucket}/original_key_nofile`,
+                                    `arn:aws:s3:::${bucket}/file/*`,
+                                    `arn:aws:s3:::${bucket}/nofile/*`,
+                                ],
+                            }],
+                        }),
+                    }, next),
+                    (data, next) => s3.putObject(Object.assign({}, object,
+                        { Key: 'original_key_file/index.html' }), next),
+                    (data, next) => s3.putObject(Object.assign({}, object,
+                        { Key: 'file/index.html' }), next), // the redirect 302
+                    (data, next) => s3.putObject(Object.assign({}, object,
+                        { Key: 'no_access_file/index.html' }), next),
+                ], err => {
+                    assert.ifError(err);
+                    done();
+                });
+            });
+
+            afterEach(done => {
+                async.waterfall([
+                    next => s3.deleteObject({ Bucket: bucket,
+                        Key: 'original_key_file/index.html' }, next),
+                    (data, next) => s3.deleteObject({ Bucket: bucket,
+                            Key: 'file/index.html' }, next),
+                    (data, next) => s3.deleteObject({ Bucket: bucket,
+                        Key: 'no_access_file/index.html' }, next),
+                ], err => {
+                    assert.ifError(err);
+                    done();
+                });
+            });
+
+            it('should redirect 302 with trailing / on folder with index', done => {
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: `${endpoint}/file`,
+                    responseType: 'redirect-error-found',
+                    redirectUrl: '/file/',
+                }, done);
+            });
+
+            it('should return 404 on original key access without index',
+            done => {
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: `${endpoint}/original_key_nofile`,
+                    responseType: '404-not-found',
+                }, done);
+            });
+
+            describe('should return 403', () => {
+                [
+                    {
+                        it: 'on original key access with index no access',
+                        key: 'original_key_file',
+                    },
+                    {
+                        it: 'on folder access without index',
+                        key: 'nofile',
+                    },
+                    {
+                        it: 'on no access with index',
+                        key: 'no_access_file',
+                    },
+                ].forEach(test => it(test.it, done => {
+                    WebsiteConfigTester.checkHTML({
+                        method: 'GET',
+                        url: `${endpoint}/${test.key}`,
+                        responseType: '403-access-denied',
+                    }, done);
+                }));
+            });
+        });
     });
 });

--- a/tests/functional/aws-node-sdk/test/object/websiteHead.js
+++ b/tests/functional/aws-node-sdk/test/object/websiteHead.js
@@ -808,7 +808,8 @@ describe('Head request on bucket website endpoint', () => {
                         it: 'on no access with index',
                         key: 'no_access_file',
                     },
-                ].forEach(test => it(test.it, done => {
+                ].forEach(test =>
+                    it(test.it, done => {
                     const expectedHeaders = {
                         'x-amz-error-code': 'AccessDenied',
                         'x-amz-error-message': 'Access Denied',

--- a/tests/functional/aws-node-sdk/test/object/websiteHead.js
+++ b/tests/functional/aws-node-sdk/test/object/websiteHead.js
@@ -810,14 +810,14 @@ describe('Head request on bucket website endpoint', () => {
                     },
                 ].forEach(test =>
                     it(test.it, done => {
-                    const expectedHeaders = {
-                        'x-amz-error-code': 'AccessDenied',
-                        'x-amz-error-message': 'Access Denied',
-                    };
-                    WebsiteConfigTester.makeHeadRequest(undefined,
-                        `${endpoint}/${test.key}`, 403,
-                        expectedHeaders, done);
-                }));
+                        const expectedHeaders = {
+                            'x-amz-error-code': 'AccessDenied',
+                            'x-amz-error-message': 'Access Denied',
+                        };
+                        WebsiteConfigTester.makeHeadRequest(undefined,
+                            `${endpoint}/${test.key}`, 403,
+                            expectedHeaders, done);
+                    }));
             });
         });
     });

--- a/tests/functional/aws-node-sdk/test/object/websiteHead.js
+++ b/tests/functional/aws-node-sdk/test/object/websiteHead.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const async = require('async');
 const fs = require('fs');
 const path = require('path');
 
@@ -714,6 +715,108 @@ describe('Head request on bucket website endpoint', () => {
             it('should not redirect if index key is not explicit', done => {
                 WebsiteConfigTester.makeHeadRequest(undefined, endpoint,
                     200, indexExpectedHeaders, done);
+            });
+        });
+
+        describe('without trailing / for recursive index check', () => {
+            beforeEach(done => {
+                const webConfig = new WebsiteConfigTester('index.html');
+                const object = {
+                    Bucket: bucket,
+                    Body: fs.readFileSync(path.join(__dirname,
+                    '/websiteFiles/index.html')),
+                    ContentType: 'text/html',
+                };
+                async.waterfall([
+                    next => s3.putBucketWebsite({ Bucket: bucket,
+                        WebsiteConfiguration: webConfig }, next),
+                    (data, next) => s3.putBucketPolicy({ Bucket: bucket,
+                        Policy: JSON.stringify({
+                            Version: '2012-10-17',
+                            Statement: [{
+                                Sid: 'PublicReadGetObject',
+                                Effect: 'Allow',
+                                Principal: '*',
+                                Action: ['s3:GetObject'],
+                                Resource: [
+                                    `arn:aws:s3:::${bucket}/original_key_file`,
+                                    `arn:aws:s3:::${bucket}/original_key_nofile`,
+                                    `arn:aws:s3:::${bucket}/file/*`,
+                                    `arn:aws:s3:::${bucket}/nofile/*`,
+                                ],
+                            }],
+                        }),
+                    }, next),
+                    (data, next) => s3.putObject(Object.assign({}, object,
+                        { Key: 'original_key_file/index.html' }), next),
+                    (data, next) => s3.putObject(Object.assign({}, object,
+                        { Key: 'file/index.html' }), next), // the redirect 302
+                    (data, next) => s3.putObject(Object.assign({}, object,
+                        { Key: 'no_access_file/index.html' }), next),
+                ], err => {
+                    assert.ifError(err);
+                    done();
+                });
+            });
+
+            afterEach(done => {
+                async.waterfall([
+                    next => s3.deleteObject({ Bucket: bucket,
+                        Key: 'original_key_file/index.html' }, next),
+                    (data, next) => s3.deleteObject({ Bucket: bucket,
+                            Key: 'file/index.html' }, next),
+                    (data, next) => s3.deleteObject({ Bucket: bucket,
+                        Key: 'no_access_file/index.html' }, next),
+                ], err => {
+                    assert.ifError(err);
+                    done();
+                });
+            });
+
+            it('should redirect 302 with trailing / on folder with index', done => {
+                const expectedHeaders = {
+                    'location': '/file/',
+                    'x-amz-error-code': 'Found',
+                    'x-amz-error-message': 'Resource Found',
+                };
+                WebsiteConfigTester.makeHeadRequest(undefined,
+                    `${endpoint}/file`, 302, expectedHeaders, done);
+            });
+
+            it('should return 404 on original key access without index',
+            done => {
+                const expectedHeaders = {
+                    'x-amz-error-code': 'NoSuchKey',
+                    'x-amz-error-message': 'The specified key does not exist.',
+                };
+                WebsiteConfigTester.makeHeadRequest(undefined,
+                    `${endpoint}/original_key_nofile`, 404,
+                    expectedHeaders, done);
+            });
+
+            describe('should return 403', () => {
+                [
+                    {
+                        it: 'on original key access with index no access',
+                        key: 'original_key_file',
+                    },
+                    {
+                        it: 'on folder access without index',
+                        key: 'nofile',
+                    },
+                    {
+                        it: 'on no access with index',
+                        key: 'no_access_file',
+                    },
+                ].forEach(test => it(test.it, done => {
+                    const expectedHeaders = {
+                        'x-amz-error-code': 'AccessDenied',
+                        'x-amz-error-message': 'Access Denied',
+                    };
+                    WebsiteConfigTester.makeHeadRequest(undefined,
+                        `${endpoint}/${test.key}`, 403,
+                        expectedHeaders, done);
+                }));
             });
         });
     });


### PR DESCRIPTION
If a folder has an accessible index document and the request is made to the folder without a trailing / instead of returning an error there should be a redirect 302 to append the trailing /.

See: https://docs.aws.amazon.com/AmazonS3/latest/userguide/IndexDocumentSupport.html#IndexDocumentsandFolders

> However, if you exclude the trailing slash from the preceding URL, Amazon S3 first looks for an object photos in the bucket. If the photos object is not found, it searches for an index document, photos/index.html. If that document is found, Amazon S3 returns a 302 Found message and points to the photos/ key. For subsequent requests to photos/, Amazon S3 returns photos/index.html. If the index document is not found, Amazon S3 returns an error.
