### PR TITLE
CLDSRV-492: fix monitoring for website head for 7.70

### DIFF
--- a/lib/api/website.js
+++ b/lib/api/website.js
@@ -34,8 +34,10 @@ function _errorActions(err, errorDocument, routingRules,
         objectKey, err.code);
     if (errRoutingRule) {
         // route will redirect
-        monitoring.promMetrics(
-            'GET', bucketName, err.code, 'getObject');
+        if (request.method === 'GET') {
+            monitoring.promMetrics(
+                'GET', bucketName, err.code, 'getObject');
+        }
         return callback(err, false, null, corsHeaders, errRoutingRule,
             objectKey);
     }
@@ -136,6 +138,7 @@ function website(request, log, callback) {
         callback = callbackGetToHead(callback);
     }
     const methodCapitalized = capitalize(request.method);
+    const action = `${request.method.toLowerCase()}Object`;
     log.debug('processing request', { method: `website${methodCapitalized}` });
     const bucketName = request.bucketName;
     const reqObjectKey = request.objectKey ? request.objectKey : '';
@@ -144,13 +147,13 @@ function website(request, log, callback) {
         if (err) {
             log.trace('error retrieving bucket metadata', { error: err });
             monitoring.promMetrics(
-                'GET', bucketName, err.code, 'getObject');
+                request.method, bucketName, err.code, action);
             return callback(err, false);
         }
         if (bucketShield(bucket, `object${methodCapitalized}`)) {
             log.trace('bucket in transient/deleted state so shielding');
             monitoring.promMetrics(
-                'GET', bucketName, 404, 'getObject');
+                request.method, bucketName, 404, action);
             return callback(errors.NoSuchBucket, false);
         }
         const corsHeaders = collectCorsHeaders(request.headers.origin,
@@ -160,7 +163,7 @@ function website(request, log, callback) {
         const websiteConfig = bucket.getWebsiteConfiguration();
         if (!websiteConfig) {
             monitoring.promMetrics(
-                'GET', bucketName, 404, 'getObject');
+                request.method, bucketName, 404, action);
             return callback(errors.NoSuchWebsiteConfiguration, false, null,
             corsHeaders);
         }
@@ -197,8 +200,10 @@ function website(request, log, callback) {
                 if (err) {
                     log.trace('error retrieving object metadata',
                     { error: err });
-                    monitoring.promMetrics(
-                        'GET', bucketName, err.code, 'getObject');
+                    if (request.method === 'GET') {
+                        monitoring.promMetrics(
+                            'GET', bucketName, err.code, 'getObject');
+                    }
                     let returnErr = err;
                     const bucketAuthorized = isBucketAuthorized(bucket, request.apiMethods || 'bucketGet',
                     constants.publicId, null, log, request, request.actionImplicitDenies, true);
@@ -251,6 +256,8 @@ function website(request, log, callback) {
 
                 if (request.method === 'HEAD') {
                     pushMetric('headObject', log, { bucket: bucketName });
+                    monitoring.promMetrics('HEAD',
+                        bucketName, '200', 'headObject');
                     return callback(null, false, null, responseMetaHeaders);
                 }
 

--- a/lib/api/website.js
+++ b/lib/api/website.js
@@ -34,14 +34,15 @@ function _errorActions(err, errorDocument, routingRules,
         objectKey, err.code);
     if (errRoutingRule) {
         // route will redirect
-        if (request.method === 'GET') {
-            monitoring.promMetrics(
-                'GET', bucketName, err.code, 'getObject');
-        }
+        const action = request.method === 'HEAD' ? 'headObject' : 'getObject';
+        monitoring.promMetrics(
+            request.method, bucketName, err.code, action);
         return callback(err, false, null, corsHeaders, errRoutingRule,
             objectKey);
     }
     if (request.method === 'HEAD') {
+        monitoring.promMetrics(
+            'HEAD', bucketName, err.code, 'headObject');
         return callback(err, false, null, corsHeaders);
     }
     if (errorDocument) {
@@ -138,7 +139,7 @@ function website(request, log, callback) {
         callback = callbackGetToHead(callback);
     }
     const methodCapitalized = capitalize(request.method);
-    const action = `${request.method.toLowerCase()}Object`;
+    const action = request.method === 'HEAD' ? 'headObject' : 'getObject';
     log.debug('processing request', { method: `website${methodCapitalized}` });
     const bucketName = request.bucketName;
     const reqObjectKey = request.objectKey ? request.objectKey : '';
@@ -210,10 +211,8 @@ function website(request, log, callback) {
                     if (err) {
                         log.trace('error retrieving object metadata',
                         { error: err });
-                        if (request.method === 'GET') {
-                            monitoring.promMetrics(
-                                'GET', bucketName, err.code, 'getObject');
-                        }
+                        monitoring.promMetrics(
+                            request.method, bucketName, err.code, action);
                         let returnErr = err;
                         const bucketAuthorized = isBucketAuthorized(bucket, request.apiMethods || 'bucketGet',
                         constants.publicId, null, log, request, request.actionImplicitDenies, true);

--- a/lib/api/website.js
+++ b/lib/api/website.js
@@ -211,8 +211,6 @@ function website(request, log, callback) {
                     if (err) {
                         log.trace('error retrieving object metadata',
                         { error: err });
-                        monitoring.promMetrics(
-                            request.method, bucketName, err.code, action);
                         let returnErr = err;
                         const bucketAuthorized = isBucketAuthorized(bucket, request.apiMethods || 'bucketGet',
                         constants.publicId, null, log, request, request.actionImplicitDenies, true);


### PR DESCRIPTION
Some monitoring is present in 7.70 but not 7.10, so I didn't see it in integration branches in https://github.com/scality/cloudserver/pull/5510 when merging GET and HEAD files.

I matched version of websiteHead before the merge: https://github.com/scality/cloudserver/blob/b52f2356baf8709fceecff3dff2e72757375513a/lib/api/websiteHead.js