### PR TITLE
Bugfix/cldsrv 493/fully align with aws on lifecycle configuration dates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.10.43",
+  "version": "7.10.44",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "git+https://github.com/scality/arsenal#7.10.54",
+    "arsenal": "git+https://github.com/scality/arsenal#7.10.55",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/tests/functional/raw-node/test/lifecycle.js
+++ b/tests/functional/raw-node/test/lifecycle.js
@@ -1,0 +1,133 @@
+const assert = require('assert');
+
+const { makeS3Request } = require('../utils/makeRequest');
+const { randomUUID } = require('crypto');
+
+const authCredentials = {
+    accessKey: process.env.AWS_ON_AIR ? 'awsAK' : 'accessKey1',
+    secretKey: process.env.AWS_ON_AIR ? 'awsSK' : 'verySecretKey1',
+};
+
+const bucket = `rawnodelifecyclebucket-${randomUUID()}`;
+
+function makeLifeCycleXML(date) {
+    return `<LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+    <Rule>
+        <Expiration>
+            <Date>${date}</Date>
+        </Expiration>
+        <ID>my-id</ID>
+        <Filter />
+        <Status>Enabled</Status>
+    </Rule>
+</LifecycleConfiguration>`;
+}
+
+describe('api tests', () => {
+    before(done => {
+        makeS3Request({
+            method: 'PUT',
+            authCredentials,
+            bucket,
+        }, err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+
+    after(done => {
+        makeS3Request({
+            method: 'DELETE',
+            authCredentials,
+            bucket,
+        }, err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+
+    it('should accept a lifecycle policy with a date at midnight', done => {
+        makeS3Request({
+            method: 'PUT',
+            authCredentials,
+            bucket,
+            queryObj: { lifecycle: '' },
+            requestBody: makeLifeCycleXML('2024-01-08T00:00:00Z'),
+        }, (err, res) => {
+            assert.ifError(err);
+            assert.strictEqual(res.statusCode, 200);
+            return done();
+        });
+    });
+
+    it('should accept a lifecycle policy with a date at midnight', done => {
+        makeS3Request({
+            method: 'PUT',
+            authCredentials,
+            bucket,
+            queryObj: { lifecycle: '' },
+            requestBody: makeLifeCycleXML('2024-01-08T00:00:00'),
+        }, (err, res) => {
+            assert.ifError(err);
+            assert.strictEqual(res.statusCode, 200);
+            return done();
+        });
+    });
+
+    it('should accept a lifecycle policy with a date at midnight', done => {
+        makeS3Request({
+            method: 'PUT',
+            authCredentials,
+            bucket,
+            queryObj: { lifecycle: '' },
+            requestBody: makeLifeCycleXML('2024-01-08T06:00:00+06:00'),
+        }, (err, res) => {
+            assert.ifError(err);
+            assert.strictEqual(res.statusCode, 200);
+            return done();
+        });
+    });
+
+    it('should reject a lifecycle policy with a date not at midnight', done => {
+        makeS3Request({
+            method: 'PUT',
+            authCredentials,
+            bucket,
+            queryObj: { lifecycle: '' },
+            requestBody: makeLifeCycleXML('2024-01-08T12:34:56Z'),
+        }, err => {
+            assert.strictEqual(err.code, 'InvalidArgument');
+            assert.strictEqual(err.statusCode, 400);
+            return done();
+        });
+    });
+
+    it('should reject a lifecycle policy with an illegal date', done => {
+        makeS3Request({
+            method: 'PUT',
+            authCredentials,
+            bucket,
+            queryObj: { lifecycle: '' },
+            requestBody: makeLifeCycleXML('2024-01-08T00:00:00+34:00'),
+        }, err => {
+            // This value is catched by AWS during XML parsing
+            assert(err.code === 'InvalidArgument' || err.code === 'MalformedXML');
+            assert.strictEqual(err.statusCode, 400);
+            return done();
+        });
+    });
+
+    it('should reject a lifecycle policy with a date not at midnight', done => {
+        makeS3Request({
+            method: 'PUT',
+            authCredentials,
+            bucket,
+            queryObj: { lifecycle: '' },
+            requestBody: makeLifeCycleXML('2024-01-08T00:00:00.123Z'),
+        }, err => {
+            assert.strictEqual(err.code, 'InvalidArgument');
+            assert.strictEqual(err.statusCode, 400);
+            return done();
+        });
+    });
+});

--- a/tests/functional/raw-node/utils/makeRequest.js
+++ b/tests/functional/raw-node/utils/makeRequest.js
@@ -143,7 +143,7 @@ function makeRequest(params, callback) {
  * @return {undefined} - and call callback
  */
 function makeS3Request(params, callback) {
-    const { method, queryObj, headers, bucket, objectKey, authCredentials }
+    const { method, queryObj, headers, bucket, objectKey, authCredentials, requestBody }
         = params;
     const options = {
         authCredentials,
@@ -153,6 +153,7 @@ function makeS3Request(params, callback) {
         queryObj,
         headers: headers || {},
         path: bucket ? `/${bucket}/` : '/',
+        requestBody,
     };
     if (objectKey) {
         options.path = `${options.path}${objectKey}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -488,9 +488,9 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#7.10.54":
-  version "7.10.54"
-  resolved "git+https://github.com/scality/arsenal#63bf2cb5b1e3ccf4725dd6be1d02496913f396f4"
+"arsenal@git+https://github.com/scality/arsenal#7.10.55":
+  version "7.10.55"
+  resolved "git+https://github.com/scality/arsenal#4da59769d24ec0fa4590de1f826dd1dcab1872c6"
   dependencies:
     "@types/async" "^3.2.12"
     "@types/utf8" "^3.0.1"


### PR DESCRIPTION
Originally we had an issue where cloudserver is too permissive with the dates accepted in lifecycle configurations. We moved to accepting only dates at midnight but some other formats are also allowed by AWS S3 and not by cloudserver. This PR aims to align their behavior, and add tests around this. The tests can be run against both cloudserver and AWS. 

This PR is best viewed as commits. 