### PR TITLE
Bugfix/cldsrv 494/fix generate v4 headers for put with body requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "git+https://github.com/scality/arsenal#7.10.55",
+    "arsenal": "git+https://github.com/scality/arsenal#7.10.56",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "ft_management": "cd tests/functional/report && yarn test",
     "ft_node": "cd tests/functional/raw-node && yarn test",
     "ft_node_routes": "cd tests/functional/raw-node && yarn run test-routes",
+    "ft_node_route_backbeat": "cd tests/functional/raw-node && mocha --reporter mocha-multi-reporters --reporter-options configFile=$INIT_CWD/tests/reporter-config.json -t 40000 test/routes/routeBackbeat.js",
     "ft_gcp": "cd tests/functional/raw-node && yarn run test-gcp",
     "ft_healthchecks": "cd tests/functional/healthchecks && yarn test",
     "ft_s3cmd": "cd tests/functional/s3cmd && mocha --reporter mocha-multi-reporters --reporter-options configFile=$INIT_CWD/tests/reporter-config.json -t 40000 *.js",

--- a/tests/functional/raw-node/test/lifecycle.js
+++ b/tests/functional/raw-node/test/lifecycle.js
@@ -4,8 +4,8 @@ const { makeS3Request } = require('../utils/makeRequest');
 const { randomUUID } = require('crypto');
 
 const authCredentials = {
-    accessKey: process.env.AWS_ON_AIR ? 'awsAK' : 'accessKey1',
-    secretKey: process.env.AWS_ON_AIR ? 'awsSK' : 'verySecretKey1',
+    accessKey: process.env.AWS_ON_AIR ? process.env.AWS_ON_AIR_AK : 'accessKey1',
+    secretKey: process.env.AWS_ON_AIR ? process.env.AWS_ON_AIR_SK : 'verySecretKey1',
 };
 
 const bucket = `rawnodelifecyclebucket-${randomUUID()}`;

--- a/tests/functional/raw-node/test/routes/routeBackbeat.js
+++ b/tests/functional/raw-node/test/routes/routeBackbeat.js
@@ -1237,7 +1237,6 @@ describeSkipIfAWS('backbeat routes', () => {
                             queryObj,
                             headers: {
                                 'content-length': testData.length,
-                                'content-md5': testDataMd5,
                                 'x-scal-canonical-id': testArn,
                             },
                             authCredentials: backbeatAuthCredentials,
@@ -1294,7 +1293,6 @@ describeSkipIfAWS('backbeat routes', () => {
                     queryObj: { v2: '' },
                     headers: {
                         'content-length': testData.length,
-                        'content-md5': testDataMd5,
                         'x-scal-canonical-id': testArn,
                     },
                     authCredentials: backbeatAuthCredentials,
@@ -1354,7 +1352,6 @@ describeSkipIfAWS('backbeat routes', () => {
             queryObj: { v2: '' },
             headers: {
                 'content-length': testData.length,
-                'content-md5': testDataMd5,
                 'x-scal-canonical-id': testArn,
             },
             authCredentials: backbeatAuthCredentials,
@@ -1387,7 +1384,6 @@ describeSkipIfAWS('backbeat routes', () => {
                queryObj: { v2: '' },
                headers: {
                    'content-length': testData.length,
-                   'content-md5': testDataMd5,
                },
                authCredentials: backbeatAuthCredentials,
                requestBody: testData,
@@ -1396,23 +1392,6 @@ describeSkipIfAWS('backbeat routes', () => {
                assert.strictEqual(err.code, 'BadRequest');
                done();
            }));
-
-        it('should refuse PUT data if no content-md5 header is provided',
-        done => makeBackbeatRequest({
-            method: 'PUT', bucket: TEST_BUCKET,
-            objectKey: testKey, resourceType: 'data',
-            queryObj: { v2: '' },
-            headers: {
-                'content-length': testData.length,
-                'x-scal-canonical-id': testArn,
-            },
-            authCredentials: backbeatAuthCredentials,
-            requestBody: testData,
-        },
-        err => {
-            assert.strictEqual(err.code, 'BadRequest');
-            done();
-        }));
 
         it('should refuse PUT in metadata-only mode if object does not exist',
         done => {
@@ -1447,7 +1426,6 @@ describeSkipIfAWS('backbeat routes', () => {
                     resourceType: 'data',
                     headers: {
                         'content-length': testData.length,
-                        'content-md5': testDataMd5,
                         'x-scal-canonical-id': testArn,
                     },
                     authCredentials: backbeatAuthCredentials,
@@ -1492,7 +1470,6 @@ describeSkipIfAWS('backbeat routes', () => {
                     resourceType: 'data',
                     headers: {
                         'content-length': testData.length,
-                        'content-md5': testDataMd5,
                         'x-scal-canonical-id': testArn,
                     },
                     authCredentials: backbeatAuthCredentials,
@@ -1548,7 +1525,6 @@ describeSkipIfAWS('backbeat routes', () => {
                     resourceType: 'data',
                     headers: {
                         'content-length': testData.length,
-                        'content-md5': testDataMd5,
                         'x-scal-canonical-id': testArn,
                     },
                     authCredentials: backbeatAuthCredentials,
@@ -1634,7 +1610,6 @@ describeSkipIfAWS('backbeat routes', () => {
                     resourceType: 'data',
                     headers: {
                         'content-length': testData.length,
-                        'content-md5': testDataMd5,
                         'x-scal-canonical-id': testArn,
                     },
                     authCredentials: backbeatAuthCredentials,
@@ -1685,7 +1660,6 @@ describeSkipIfAWS('backbeat routes', () => {
                     resourceType: 'data',
                     headers: {
                         'content-length': testData.length,
-                        'content-md5': testDataMd5,
                         'x-scal-canonical-id': testArn,
                     },
                     authCredentials: backbeatAuthCredentials,
@@ -1716,7 +1690,6 @@ describeSkipIfAWS('backbeat routes', () => {
                     resourceType: 'data',
                     headers: {
                         'content-length': testData.length,
-                        'content-md5': testDataMd5,
                         'x-scal-canonical-id': testArn,
                     },
                     authCredentials: backbeatAuthCredentials,

--- a/tests/functional/raw-node/utils/makeRequest.js
+++ b/tests/functional/raw-node/utils/makeRequest.js
@@ -111,18 +111,14 @@ function makeRequest(params, callback) {
     // decode path because signing code re-encodes it
     req.path = _decodeURI(encodedPath);
     if (authCredentials && !params.GCP) {
-        if (queryObj) {
-            auth.client.generateV4Headers(req, queryObj,
-                authCredentials.accessKey, authCredentials.secretKey, 's3');
-        // may update later if request may contain POST body
-        } else {
-            auth.client.generateV4Headers(req, '', authCredentials.accessKey,
-                authCredentials.secretKey, 's3');
-        }
+        auth.client.generateV4Headers(req, queryObj || '',
+            authCredentials.accessKey, authCredentials.secretKey, 's3', undefined, undefined, requestBody);
     }
     // restore original URL-encoded path
     req.path = encodedPath;
-    req.path = queryObj ? `${options.path}?${qs}` : req.path;
+    if (queryObj) {
+        req.path = `${options.path}?${qs}`;
+    }
     if (requestBody) {
         req.write(requestBody);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -488,9 +488,9 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#7.10.55":
-  version "7.10.55"
-  resolved "git+https://github.com/scality/arsenal#4da59769d24ec0fa4590de1f826dd1dcab1872c6"
+"arsenal@git+https://github.com/scality/arsenal#7.10.56":
+  version "7.10.56"
+  resolved "git+https://github.com/scality/arsenal#29f39ab4806e0fd6471693cca58f0e6057e711d6"
   dependencies:
     "@types/async" "^3.2.12"
     "@types/utf8" "^3.0.1"


### PR DESCRIPTION
When attempting to send lifecycle configuration requests to AWS with this in-house client, I found that it did not include the necessary `content-md5` header. Unfortunately this header is also used when calling `backbeat`'s internal routes but the hash is expressed in hex form, not in base64.

Thus, I chose to go down the simplest path which is to add the header anyway but choose the encoding based on the route of the request. I am also adding the header all of the time, this does not have a negative impact on our tests in cloudserver (except for the one testing the behavior when the header is not present).

