### PR TITLE
CLDSRV-498 Handling isNull master version with no versionId

### DIFF
--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -170,7 +170,7 @@ function processVersioningState(mst, vstat) {
         options.versioning = true;
         if (mst.exists) {
             // store master version in a new key
-            const versionId = mst.isNull ? mst.versionId : nonVersionedObjId;
+            const versionId = (mst.isNull && mst.versionId) ? mst.versionId : nonVersionedObjId;
             storeOptions.versionId = versionId;
             storeOptions.isNull = true;
             options.nullVersionId = versionId;


### PR DESCRIPTION
In certain cases, a master version may not have a versionId and be set as null (isNull:true). For instance, this occurs when a customer:

- Create a bucket.
- Put an object to it.
- Put bucket versioning.
- Put metadata (BackbeatClient.putMetadata), which results in the master version being set to null (isNull:true) with no versionId.

Currently, if an object is put after these steps, CloudServer fails to appropriately generate a null version. This is because CloudServer doesn't handle situations where the master version is set to isNull:true with no versionId.

The correct approach when an object is put should be to:
- Create the new version key.
- Create a new null version key, assigning it a “default non-version version id”.
- Update this “default non-version version id” to the `nullVersionId` field of the master key.