### PR TITLE
Use rate interval in `Request time` panel

### DIFF
--- a/monitoring/dashboard.json
+++ b/monitoring/dashboard.json
@@ -1931,7 +1931,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum by(le) (increase(s3_cloudserver_http_request_duration_seconds_bucket{namespace=\"${namespace}\", job=~\"$job\"}[$__interval]))",
+          "expr": "sum by(le) (increase(s3_cloudserver_http_request_duration_seconds_bucket{namespace=\"${namespace}\", job=~\"$job\"}[$__rate_interval]))",
           "format": "heatmap",
           "hide": false,
           "instant": false,
@@ -1944,7 +1944,7 @@
           "target": ""
         }
       ],
-      "title": "Request time",
+      "title": "Request duration",
       "tooltip": {
         "show": true,
         "showHistogram": true
@@ -2038,7 +2038,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(http_request_duration_seconds_sum{namespace=\"${namespace}\", job=~\"$job\"}[$__rate_interval])) by (action)\n   /\nsum(rate(http_request_duration_seconds_count{namespace=\"${namespace}\", job=~\"$job\"}[$__rate_interval])) by (action)",
+          "expr": "sum(rate(s3_cloudserver_http_request_duration_seconds_sum{namespace=\"${namespace}\", job=~\"$job\"}[$__rate_interval])) by (action)\n   /\nsum(rate(s3_cloudserver_http_request_duration_seconds_count{namespace=\"${namespace}\", job=~\"$job\"}[$__rate_interval])) by (action)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2766,5 +2766,5 @@
   "timezone": "",
   "title": "S3 service",
   "uid": null,
-  "version": 30
+  "version": 31
 }

--- a/monitoring/dashboard.py
+++ b/monitoring/dashboard.py
@@ -401,7 +401,7 @@ latenciesByAction = TimeSeries(
 )
 
 requestTime = Heatmap(
-    title="Request time",
+    title="Request duration",
     dataSource="${DS_PROMETHEUS}",
     dataFormat="tsbuckets",
     maxDataPoints=25,
@@ -409,7 +409,7 @@ requestTime = Heatmap(
     yAxis=YAxis(format=UNITS.DURATION_SECONDS),
     color=HeatmapColor(mode="opacity"),
     targets=[Target(
-        expr='sum by(le) (increase(s3_cloudserver_http_request_duration_seconds_bucket{namespace="${namespace}", job=~"$job"}[$__interval]))',  # noqa: E501
+        expr='sum by(le) (increase(s3_cloudserver_http_request_duration_seconds_bucket{namespace="${namespace}", job=~"$job"}[$__rate_interval]))',  # noqa: E501
         format="heatmap",
         legendFormat="{{ le }}",
     )],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "8.6.23",
+  "version": "8.6.24",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
- Should use $__rate_interval, which handles small time range.
- Regenerating the dashboard also fixes the 'latency per s3 action'
  panel.

Issue: CLDSRV-500
