### PR TITLE
CLDSRV-501 PutMetadata should write metadata on top of a null version

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -476,10 +476,8 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
 
         let versionId = decodeVersionId(request.query);
         let versioning = bucketInfo.isVersioningEnabled();
-        let isNull = false;
 
         if (versionId === 'null') {
-            isNull = true;
             // Retrieve the null version id from the object metadata.
             versionId = objMd && objMd.versionId;
             if (!versionId) {
@@ -521,9 +519,7 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
             omVal.replicationInfo.isNFS = !isReplica;
         }
 
-        const options = {
-            isNull,
-        };
+        const options = {};
 
         // NOTE: When 'versioning' is set to true and no 'versionId' is specified,
         // it results in the creation of a "new" version, which also updates the master.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "git+https://github.com/scality/arsenal#7.10.59",
+    "arsenal": "git+https://github.com/scality/arsenal#7.10.61",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "git+https://github.com/scality/arsenal#7.10.58",
+    "arsenal": "git+https://github.com/scality/arsenal#7.10.59",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/tests/functional/raw-node/test/routes/routeBackbeat.js
+++ b/tests/functional/raw-node/test/routes/routeBackbeat.js
@@ -327,6 +327,132 @@ describeSkipIfAWS('backbeat routes', () => {
             });
         });
 
+        it('should update metadata of a suspended null version', done => {
+            let objMD;
+            return async.series({
+                suspendVersioning: next => s3.putBucketVersioning(
+                    { Bucket: bucket, VersioningConfiguration: { Status: 'Suspended' } }, next),
+                putObject: next => s3.putObject(
+                    { Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, next),
+                enableVersioning: next => s3.putBucketVersioning(
+                    { Bucket: bucket, VersioningConfiguration: { Status: 'Enabled' } }, next),
+                getMetadata: next => makeBackbeatRequest({
+                    method: 'GET',
+                    resourceType: 'metadata',
+                    bucket,
+                    objectKey: keyName,
+                    queryObj: {
+                        versionId: 'null',
+                    },
+                    authCredentials: backbeatAuthCredentials,
+                }, (err, data) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    const { error, result } = updateStorageClass(data, storageClass);
+                    if (error) {
+                        return next(error);
+                    }
+                    objMD = result;
+                    return next();
+                }),
+                putUpdatedMetadata: next => makeBackbeatRequest({
+                    method: 'PUT',
+                    resourceType: 'metadata',
+                    bucket,
+                    objectKey: keyName,
+                    queryObj: {
+                        versionId: 'null',
+                    },
+                    authCredentials: backbeatAuthCredentials,
+                    requestBody: objMD.getSerialized(),
+                }, next),
+                headObject: next => s3.headObject({ Bucket: bucket, Key: keyName, VersionId: 'null' }, next),
+                listObjectVersions: next => s3.listObjectVersions({ Bucket: bucket }, next),
+            }, (err, results) => {
+                if (err) {
+                    return done(err);
+                }
+                const headObjectRes = results.headObject;
+                assert.strictEqual(headObjectRes.VersionId, 'null');
+                assert.strictEqual(headObjectRes.StorageClass, storageClass);
+
+                const listObjectVersionsRes = results.listObjectVersions;
+                const { Versions } = listObjectVersionsRes;
+
+                assert.strictEqual(Versions.length, 1);
+
+                const [currentVersion] = Versions;
+                assertVersionIsNullAndUpdated(currentVersion);
+                return done();
+            });
+        });
+
+        it('should update metadata of a suspended null version with internal version id', done => {
+            let objMD;
+            return async.series({
+                suspendVersioning: next => s3.putBucketVersioning(
+                    { Bucket: bucket, VersioningConfiguration: { Status: 'Suspended' } }, next),
+                putObject: next => s3.putObject(
+                    { Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, next),
+                enableVersioning: next => s3.putBucketVersioning(
+                    { Bucket: bucket, VersioningConfiguration: { Status: 'Enabled' } }, next),
+                putObjectTagging: next => s3.putObjectTagging({
+                    Bucket: bucket, Key: keyName, VersionId: 'null',
+                    Tagging: { TagSet: [{ Key: 'key1', Value: 'value1' }] },
+                }, next),
+                getMetadata: next => makeBackbeatRequest({
+                    method: 'GET',
+                    resourceType: 'metadata',
+                    bucket,
+                    objectKey: keyName,
+                    queryObj: {
+                        versionId: 'null',
+                    },
+                    authCredentials: backbeatAuthCredentials,
+                }, (err, data) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    const { error, result } = updateStorageClass(data, storageClass);
+                    if (error) {
+                        return next(error);
+                    }
+                    objMD = result;
+                    return next();
+                }),
+                putUpdatedMetadata: next => makeBackbeatRequest({
+                    method: 'PUT',
+                    resourceType: 'metadata',
+                    bucket,
+                    objectKey: keyName,
+                    queryObj: {
+                        versionId: 'null',
+                    },
+                    authCredentials: backbeatAuthCredentials,
+                    requestBody: objMD.getSerialized(),
+                }, next),
+                headObject: next => s3.headObject({ Bucket: bucket, Key: keyName, VersionId: 'null' }, next),
+                listObjectVersions: next => s3.listObjectVersions({ Bucket: bucket }, next),
+            }, (err, results) => {
+                if (err) {
+                    return done(err);
+                }
+                const headObjectRes = results.headObject;
+                assert.strictEqual(headObjectRes.VersionId, 'null');
+                assert.strictEqual(headObjectRes.StorageClass, storageClass);
+
+                const listObjectVersionsRes = results.listObjectVersions;
+                const { Versions } = listObjectVersionsRes;
+
+                assert.strictEqual(Versions.length, 1);
+
+                const [currentVersion] = Versions;
+                assertVersionIsNullAndUpdated(currentVersion);
+                return done();
+            });
+        });
+
         // Skipping is necessary because non-versioned buckets are not supported by S3C backbeat routes.
         it.skip('should update metadata of a non-version object', done => {
             let objMD;

--- a/tests/functional/raw-node/test/routes/routeBackbeatForReplication.js
+++ b/tests/functional/raw-node/test/routes/routeBackbeatForReplication.js
@@ -247,4 +247,861 @@ describeSkipIfAWS('backbeat routes for replication', () => {
             return done();
         });
     });
+
+    it('should replicate/put metadata to a destination that has a version', done => {
+        let objMD;
+        let firstVersionId;
+        let secondVersionId;
+
+        async.series({
+            enableVersioningDestination: next => s3.putBucketVersioning(
+                { Bucket: bucketDestination, VersioningConfiguration: { Status: 'Enabled' } }, next),
+            putObjectDestination: next => s3.putObject(
+            { Bucket: bucketDestination, Key: keyName, Body: Buffer.from(testData) }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                firstVersionId = data.VersionId;
+                return next();
+            }),
+            enableVersioningSource: next => s3.putBucketVersioning(
+                { Bucket: bucketSource, VersioningConfiguration: { Status: 'Enabled' } }, next),
+            putObjectSource: next => s3.putObject(
+            { Bucket: bucketSource, Key: keyName, Body: Buffer.from(testData) }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                secondVersionId = data.VersionId;
+                return next();
+            }),
+            getMetadata: next => makeBackbeatRequest({
+                method: 'GET',
+                resourceType: 'metadata',
+                bucket: bucketSource,
+                objectKey: keyName,
+                queryObj: {
+                    versionId: secondVersionId,
+                },
+                authCredentials: backbeatAuthCredentials,
+            }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                objMD = JSON.parse(data.body).Body;
+                return next();
+            }),
+            replicateMetadata: next => makeBackbeatRequest({
+                method: 'PUT',
+                resourceType: 'metadata',
+                bucket: bucketDestination,
+                objectKey: keyName,
+                queryObj: {
+                    versionId: secondVersionId,
+                },
+                authCredentials: backbeatAuthCredentials,
+                requestBody: objMD,
+            }, next),
+            headObjectFirstVersion: next => s3.headObject(
+                { Bucket: bucketDestination, Key: keyName, VersionId: firstVersionId }, next),
+            headObjectSecondVersion: next => s3.headObject(
+                { Bucket: bucketDestination, Key: keyName, VersionId: secondVersionId }, next),
+            listObjectVersions: next => s3.listObjectVersions({ Bucket: bucketDestination }, next),
+        }, (err, results) => {
+            if (err) {
+                return done(err);
+            }
+
+            const firstHeadObjectRes = results.headObjectFirstVersion;
+            assert.strictEqual(firstHeadObjectRes.VersionId, firstVersionId);
+
+            const secondHeadObjectRes = results.headObjectSecondVersion;
+            assert.strictEqual(secondHeadObjectRes.VersionId, secondVersionId);
+
+            const listObjectVersionsRes = results.listObjectVersions;
+            const { Versions } = listObjectVersionsRes;
+
+            assert.strictEqual(Versions.length, 2);
+            const [currentVersion, nonCurrentVersion] = Versions;
+
+            assert.strictEqual(currentVersion.VersionId, secondVersionId);
+            assert.strictEqual(currentVersion.IsLatest, true);
+
+            assert.strictEqual(nonCurrentVersion.VersionId, firstVersionId);
+            assert.strictEqual(nonCurrentVersion.IsLatest, false);
+
+            return done();
+        });
+    });
+
+    it('should replicate/put metadata to a destination that has a null version', done => {
+        let objMD;
+        let versionId;
+
+        async.series({
+            putObjectDestinationInitial: next => s3.putObject(
+                { Bucket: bucketDestination, Key: keyName, Body: Buffer.from(testData) }, next),
+            enableVersioningDestination: next => s3.putBucketVersioning(
+                { Bucket: bucketDestination, VersioningConfiguration: { Status: 'Enabled' } }, next),
+            enableVersioningSource: next => s3.putBucketVersioning(
+                { Bucket: bucketSource, VersioningConfiguration: { Status: 'Enabled' } }, next),
+            putObjectSource: next => s3.putObject(
+            { Bucket: bucketSource, Key: keyName, Body: Buffer.from(testData) }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                versionId = data.VersionId;
+                return next();
+            }),
+            getMetadata: next => makeBackbeatRequest({
+                method: 'GET',
+                resourceType: 'metadata',
+                bucket: bucketSource,
+                objectKey: keyName,
+                queryObj: {
+                    versionId,
+                },
+                authCredentials: backbeatAuthCredentials,
+            }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                objMD = JSON.parse(data.body).Body;
+                return next();
+            }),
+            replicateMetadata: next => makeBackbeatRequest({
+                method: 'PUT',
+                resourceType: 'metadata',
+                bucket: bucketDestination,
+                objectKey: keyName,
+                queryObj: {
+                    versionId,
+                },
+                authCredentials: backbeatAuthCredentials,
+                requestBody: objMD,
+            }, next),
+            headObjectNullVersion: next => s3.headObject(
+                { Bucket: bucketDestination, Key: keyName, VersionId: 'null' }, next),
+            listObjectVersions: next => s3.listObjectVersions(
+                { Bucket: bucketDestination }, next),
+        }, (err, results) => {
+            if (err) {
+                return done(err);
+            }
+
+            const headObjectRes = results.headObjectNullVersion;
+            assert.strictEqual(headObjectRes.VersionId, 'null');
+
+            const listObjectVersionsRes = results.listObjectVersions;
+            const { Versions } = listObjectVersionsRes;
+
+            assert.strictEqual(Versions.length, 2);
+            const [currentVersion, nonCurrentVersion] = Versions;
+
+            assert.strictEqual(currentVersion.VersionId, versionId);
+            assert.strictEqual(currentVersion.IsLatest, true);
+
+            assert.strictEqual(nonCurrentVersion.VersionId, 'null');
+            assert.strictEqual(nonCurrentVersion.IsLatest, false);
+
+            return done();
+        });
+    });
+
+    it('should replicate/put metadata to a destination that has a suspended null version', done => {
+        let objMD;
+        let versionId;
+
+        async.series({
+            suspendVersioningDestination: next => s3.putBucketVersioning(
+                { Bucket: bucketDestination, VersioningConfiguration: { Status: 'Suspended' } }, next),
+            putObjectDestinationInitial: next => s3.putObject(
+                { Bucket: bucketDestination, Key: keyName, Body: Buffer.from(testData) }, next),
+            enableVersioningDestination: next => s3.putBucketVersioning(
+                { Bucket: bucketDestination, VersioningConfiguration: { Status: 'Enabled' } }, next),
+            enableVersioningSource: next => s3.putBucketVersioning(
+                { Bucket: bucketSource, VersioningConfiguration: { Status: 'Enabled' } }, next),
+            putObjectSource: next => s3.putObject(
+            { Bucket: bucketSource, Key: keyName, Body: Buffer.from(testData) }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                versionId = data.VersionId;
+                return next();
+            }),
+            getMetadata: next => makeBackbeatRequest({
+                method: 'GET',
+                resourceType: 'metadata',
+                bucket: bucketSource,
+                objectKey: keyName,
+                queryObj: {
+                    versionId,
+                },
+                authCredentials: backbeatAuthCredentials,
+            }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                objMD = JSON.parse(data.body).Body;
+                return next();
+            }),
+            replicateMetadata: next => makeBackbeatRequest({
+                method: 'PUT',
+                resourceType: 'metadata',
+                bucket: bucketDestination,
+                objectKey: keyName,
+                queryObj: {
+                    versionId,
+                },
+                authCredentials: backbeatAuthCredentials,
+                requestBody: objMD,
+            }, next),
+            headObjectNullVersion: next => s3.headObject(
+                { Bucket: bucketDestination, Key: keyName, VersionId: 'null' }, next),
+            listObjectVersions: next => s3.listObjectVersions({ Bucket: bucketDestination }, next),
+        }, (err, results) => {
+            if (err) {
+                return done(err);
+            }
+
+            const headObjectRes = results.headObjectNullVersion;
+            assert.strictEqual(headObjectRes.VersionId, 'null');
+
+            const listObjectVersionsRes = results.listObjectVersions;
+            const { Versions } = listObjectVersionsRes;
+
+            assert.strictEqual(Versions.length, 2);
+            const [currentVersion, nonCurrentVersion] = Versions;
+
+            assert.strictEqual(currentVersion.VersionId, versionId);
+            assert.strictEqual(currentVersion.IsLatest, true);
+
+            assert.strictEqual(nonCurrentVersion.VersionId, 'null');
+            assert.strictEqual(nonCurrentVersion.IsLatest, false);
+
+            return done();
+        });
+    });
+
+    it('should replicate/put metadata to a destination that has a previously updated null version', done => {
+        let objMD;
+        let objMDNull;
+        let versionId;
+
+        async.series({
+            putObjectDestinationInitial: next => s3.putObject(
+                { Bucket: bucketDestination, Key: keyName, Body: Buffer.from(testData) }, next),
+            enableVersioningDestination: next => s3.putBucketVersioning(
+                { Bucket: bucketDestination, VersioningConfiguration: { Status: 'Enabled' } }, next),
+            getMetadataNullVersion: next => makeBackbeatRequest({
+                method: 'GET',
+                resourceType: 'metadata',
+                bucket: bucketDestination,
+                objectKey: keyName,
+                queryObj: {
+                    versionId: 'null',
+                },
+                authCredentials: backbeatAuthCredentials,
+            }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                objMDNull = JSON.parse(data.body).Body;
+                return next();
+            }),
+            updateMetadataNullVersion: next => makeBackbeatRequest({
+                method: 'PUT',
+                resourceType: 'metadata',
+                bucket: bucketDestination,
+                objectKey: keyName,
+                queryObj: {
+                    versionId: 'null',
+                },
+                authCredentials: backbeatAuthCredentials,
+                requestBody: objMDNull,
+            }, next),
+            enableVersioningSource: next => s3.putBucketVersioning(
+                { Bucket: bucketSource, VersioningConfiguration: { Status: 'Enabled' } }, next),
+            putObjectSource: next => s3.putObject(
+            { Bucket: bucketSource, Key: keyName, Body: Buffer.from(testData) }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                versionId = data.VersionId;
+                return next();
+            }),
+            getMetadata: next => makeBackbeatRequest({
+                method: 'GET',
+                resourceType: 'metadata',
+                bucket: bucketSource,
+                objectKey: keyName,
+                queryObj: {
+                    versionId,
+                },
+                authCredentials: backbeatAuthCredentials,
+            }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                objMD = JSON.parse(data.body).Body;
+                return next();
+            }),
+            replicateMetadata: next => makeBackbeatRequest({
+                method: 'PUT',
+                resourceType: 'metadata',
+                bucket: bucketDestination,
+                objectKey: keyName,
+                queryObj: {
+                    versionId,
+                },
+                authCredentials: backbeatAuthCredentials,
+                requestBody: objMD,
+            }, next),
+            headObjectNullVersion: next => s3.headObject(
+                { Bucket: bucketDestination, Key: keyName, VersionId: 'null' }, next),
+            listObjectVersions: next => s3.listObjectVersions({ Bucket: bucketDestination }, next),
+        }, (err, results) => {
+            if (err) {
+                return done(err);
+            }
+
+            const headObjectRes = results.headObjectNullVersion;
+            assert.strictEqual(headObjectRes.VersionId, 'null');
+
+            const listObjectVersionsRes = results.listObjectVersions;
+            const { Versions } = listObjectVersionsRes;
+
+            assert.strictEqual(Versions.length, 2);
+            const [currentVersion, nonCurrentVersion] = Versions;
+
+            assert.strictEqual(currentVersion.VersionId, versionId);
+            assert.strictEqual(currentVersion.IsLatest, true);
+
+            assert.strictEqual(nonCurrentVersion.VersionId, 'null');
+            assert.strictEqual(nonCurrentVersion.IsLatest, false);
+
+            return done();
+        });
+    });
+
+    it('should replicate/put metadata to a destination that has a suspended null version with internal version',
+    done => {
+        const tagSet = [
+            {
+                Key: 'key1',
+                Value: 'value1',
+            },
+        ];
+        let objMD;
+        let versionId;
+
+        async.series({
+            suspendVersioningDestination: next => s3.putBucketVersioning(
+                { Bucket: bucketDestination, VersioningConfiguration: { Status: 'Suspended' } }, next),
+            putObjectDestinationInitial: next => s3.putObject(
+                { Bucket: bucketDestination, Key: keyName, Body: Buffer.from(testData) }, next),
+            putObjectTagging: next => s3.putObjectTagging(
+                { Bucket: bucketDestination, Key: keyName, Tagging: { TagSet: tagSet } }, next),
+            enableVersioningDestination: next => s3.putBucketVersioning(
+                { Bucket: bucketDestination, VersioningConfiguration: { Status: 'Enabled' } }, next),
+            enableVersioningSource: next => s3.putBucketVersioning(
+                { Bucket: bucketSource, VersioningConfiguration: { Status: 'Enabled' } }, next),
+            putObjectSource: next => s3.putObject(
+            { Bucket: bucketSource, Key: keyName, Body: Buffer.from(testData) }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                versionId = data.VersionId;
+                return next();
+            }),
+            getMetadata: next => makeBackbeatRequest({
+                method: 'GET',
+                resourceType: 'metadata',
+                bucket: bucketSource,
+                objectKey: keyName,
+                queryObj: {
+                    versionId,
+                },
+                authCredentials: backbeatAuthCredentials,
+            }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                objMD = JSON.parse(data.body).Body;
+                return next();
+            }),
+            replicateMetadata: next => makeBackbeatRequest({
+                method: 'PUT',
+                resourceType: 'metadata',
+                bucket: bucketDestination,
+                objectKey: keyName,
+                queryObj: {
+                    versionId,
+                },
+                authCredentials: backbeatAuthCredentials,
+                requestBody: objMD,
+            }, next),
+            headObjectNullVersion: next => s3.headObject(
+                { Bucket: bucketDestination, Key: keyName, VersionId: 'null' }, next),
+            getObjectTaggingNullVersion: next => s3.getObjectTagging(
+                { Bucket: bucketDestination, Key: keyName, VersionId: 'null' }, next),
+            listObjectVersions: next => s3.listObjectVersions({ Bucket: bucketDestination }, next),
+        }, (err, results) => {
+            if (err) {
+                return done(err);
+            }
+
+            const headObjectRes = results.headObjectNullVersion;
+            assert.strictEqual(headObjectRes.VersionId, 'null');
+
+            const getObjectTaggingRes = results.getObjectTaggingNullVersion;
+            assert.deepStrictEqual(getObjectTaggingRes.TagSet, tagSet);
+
+            const listObjectVersionsRes = results.listObjectVersions;
+            const { Versions } = listObjectVersionsRes;
+
+            assert.strictEqual(Versions.length, 2);
+            const [currentVersion, nonCurrentVersion] = Versions;
+
+            assert.strictEqual(currentVersion.VersionId, versionId);
+            assert.strictEqual(currentVersion.IsLatest, true);
+
+            assert.strictEqual(nonCurrentVersion.VersionId, 'null');
+            assert.strictEqual(nonCurrentVersion.IsLatest, false);
+
+            return done();
+        });
+    });
+
+    it('should mimic null version replication by crrExistingObjects, then replicate version', done => {
+        let objMDNull;
+        let objMDNullReplicated;
+        let objMDVersion;
+        let versionId;
+
+        async.series({
+            createNullSoloMasterKey: next => s3.putObject(
+                { Bucket: bucketSource, Key: keyName, Body: Buffer.from(testData) }, next),
+            enableVersioningSource: next => s3.putBucketVersioning(
+                { Bucket: bucketSource, VersioningConfiguration: { Status: 'Enabled' } }, next),
+            simulateCrrExistingObjectsGetMetadata: next => makeBackbeatRequest({
+                method: 'GET',
+                resourceType: 'metadata',
+                bucket: bucketSource,
+                objectKey: keyName,
+                queryObj: {
+                    versionId: 'null',
+                },
+                authCredentials: backbeatAuthCredentials,
+            }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                objMDNull = JSON.parse(data.body).Body;
+                assert.strictEqual(JSON.parse(objMDNull).versionId, undefined);
+                return next();
+            }),
+            simulateCrrExistingObjectsPutMetadata: next => makeBackbeatRequest({
+                method: 'PUT',
+                resourceType: 'metadata',
+                bucket: bucketSource,
+                objectKey: keyName,
+                queryObj: {
+                    versionId: 'null',
+                },
+                authCredentials: backbeatAuthCredentials,
+                requestBody: objMDNull,
+            }, next),
+            enableVersioningDestination: next => s3.putBucketVersioning(
+                { Bucket: bucketDestination, VersioningConfiguration: { Status: 'Enabled' } }, next),
+            replicateNullVersion: next => makeBackbeatRequest({
+                method: 'GET',
+                resourceType: 'metadata',
+                bucket: bucketSource,
+                objectKey: keyName,
+                queryObj: {
+                    versionId: 'null',
+                },
+                authCredentials: backbeatAuthCredentials,
+            }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                objMDNullReplicated = JSON.parse(data.body).Body;
+                return next();
+            }),
+            putReplicatedNullVersion: next => makeBackbeatRequest({
+                method: 'PUT',
+                resourceType: 'metadata',
+                bucket: bucketDestination,
+                objectKey: keyName,
+                queryObj: {
+                    versionId: 'null',
+                },
+                authCredentials: backbeatAuthCredentials,
+                requestBody: objMDNullReplicated,
+            }, next),
+            putNewVersionSource: next => s3.putObject(
+            { Bucket: bucketSource, Key: keyName, Body: Buffer.from(testData) }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                versionId = data.VersionId;
+                return next();
+            }),
+            simulateMetadataReplicationVersion: next => makeBackbeatRequest({
+                method: 'GET',
+                resourceType: 'metadata',
+                bucket: bucketSource,
+                objectKey: keyName,
+                queryObj: {
+                    versionId,
+                },
+                authCredentials: backbeatAuthCredentials,
+            }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                objMDVersion = JSON.parse(data.body).Body;
+                return next();
+            }),
+            listObjectVersionsBeforeReplicate: next => s3.listObjectVersions({ Bucket: bucketDestination }, next),
+            putReplicatedVersion: next => makeBackbeatRequest({
+                method: 'PUT',
+                resourceType: 'metadata',
+                bucket: bucketDestination,
+                objectKey: keyName,
+                queryObj: {
+                    versionId,
+                },
+                authCredentials: backbeatAuthCredentials,
+                requestBody: objMDVersion,
+            }, next),
+            checkReplicatedNullVersion: next => s3.headObject(
+                { Bucket: bucketDestination, Key: keyName, VersionId: 'null' }, next),
+            checkReplicatedVersion: next => s3.headObject(
+                { Bucket: bucketDestination, Key: keyName, VersionId: versionId }, next),
+            listObjectVersionsAfterReplicate: next => s3.listObjectVersions({ Bucket: bucketDestination }, next),
+        }, (err, results) => {
+            if (err) {
+                return done(err);
+            }
+
+            const headObjectNullVersionRes = results.checkReplicatedNullVersion;
+            assert.strictEqual(headObjectNullVersionRes.VersionId, 'null');
+
+            const headObjectVersionRes = results.checkReplicatedVersion;
+            assert.strictEqual(headObjectVersionRes.VersionId, versionId);
+
+            const listObjectVersionsRes = results.listObjectVersionsAfterReplicate;
+            const { Versions } = listObjectVersionsRes;
+
+            assert.strictEqual(Versions.length, 2);
+
+            const [currentVersion, nonCurrentVersion] = Versions;
+
+            assert.strictEqual(currentVersion.VersionId, versionId);
+            assert.strictEqual(currentVersion.IsLatest, true);
+
+            assert.strictEqual(nonCurrentVersion.VersionId, 'null');
+            assert.strictEqual(nonCurrentVersion.IsLatest, false);
+
+            return done();
+        });
+    });
+
+    it('should replicate/put NULL metadata to a destination that has a version', done => {
+        let objMD;
+        let versionId;
+
+        async.series({
+            enableVersioningDestination: next => s3.putBucketVersioning({
+                Bucket: bucketDestination,
+                VersioningConfiguration: { Status: 'Enabled' },
+            }, next),
+            putObjectDestination: next => s3.putObject({
+                Bucket: bucketDestination,
+                Key: keyName,
+                Body: Buffer.from(testData),
+            }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                versionId = data.VersionId;
+                return next();
+            }),
+            putObjectSource: next => s3.putObject({
+                Bucket: bucketSource,
+                Key: keyName,
+                Body: Buffer.from(testData),
+            }, next),
+            enableVersioningSource: next => s3.putBucketVersioning({
+                Bucket: bucketSource,
+                VersioningConfiguration: { Status: 'Enabled' },
+            }, next),
+            getMetadata: next => makeBackbeatRequest({
+                method: 'GET',
+                resourceType: 'metadata',
+                bucket: bucketSource,
+                objectKey: keyName,
+                queryObj: { versionId: 'null' },
+                authCredentials: backbeatAuthCredentials,
+            }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                objMD = JSON.parse(data.body).Body;
+                return next();
+            }),
+            replicateMetadata: next => makeBackbeatRequest({
+                method: 'PUT',
+                resourceType: 'metadata',
+                bucket: bucketDestination,
+                objectKey: keyName,
+                queryObj: { versionId: 'null' },
+                authCredentials: backbeatAuthCredentials,
+                requestBody: objMD,
+            }, next),
+            headObjectByVersionId: next => s3.headObject({
+                Bucket: bucketDestination,
+                Key: keyName,
+                VersionId: versionId,
+            }, next),
+            headObjectByNullVersionId: next => s3.headObject({
+                Bucket: bucketDestination,
+                Key: keyName,
+                VersionId: 'null',
+            }, next),
+            listObjectVersions: next => s3.listObjectVersions({
+                Bucket: bucketDestination,
+            }, next),
+        }, (err, results) => {
+            if (err) {
+                return done(err);
+            }
+
+            const firstHeadObjectRes = results.headObjectByVersionId;
+            assert.strictEqual(firstHeadObjectRes.VersionId, versionId);
+
+            const secondHeadObjectRes = results.headObjectByNullVersionId;
+            assert.strictEqual(secondHeadObjectRes.VersionId, 'null');
+
+            const listObjectVersionsRes = results.listObjectVersions;
+            const { Versions } = listObjectVersionsRes;
+
+            assert.strictEqual(Versions.length, 2);
+            const [currentVersion, nonCurrentVersion] = Versions;
+
+            assert.strictEqual(currentVersion.VersionId, 'null');
+            assert.strictEqual(currentVersion.IsLatest, true);
+
+            assert.strictEqual(nonCurrentVersion.VersionId, versionId);
+            assert.strictEqual(nonCurrentVersion.IsLatest, false);
+
+            return done();
+        });
+    });
+
+    it('should replicate/put NULL metadata to a destination that has a null version', done => {
+        let objMD;
+
+        async.series({
+            putObjectDestinationInitial: next => s3.putObject({
+                Bucket: bucketDestination,
+                Key: keyName,
+                Body: Buffer.from(testData),
+            }, next),
+            enableVersioningDestination: next => s3.putBucketVersioning({
+                Bucket: bucketDestination,
+                VersioningConfiguration: { Status: 'Enabled' },
+            }, next),
+            putObjectSource: next => s3.putObject({
+                Bucket: bucketSource,
+                Key: keyName,
+                Body: Buffer.from(testData),
+            }, next),
+            enableVersioningSource: next => s3.putBucketVersioning({
+                Bucket: bucketSource,
+                VersioningConfiguration: { Status: 'Enabled' },
+            }, next),
+            putObjectTaggingSource: next => s3.putObjectTagging({
+                Bucket: bucketSource,
+                Key: keyName,
+                VersionId: 'null',
+                Tagging: { TagSet: [{ Key: 'key1', Value: 'value1' }] },
+            }, next),
+            getMetadata: next => makeBackbeatRequest({
+                method: 'GET',
+                resourceType: 'metadata',
+                bucket: bucketSource,
+                objectKey: keyName,
+                queryObj: { versionId: 'null' },
+                authCredentials: backbeatAuthCredentials,
+            }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                objMD = JSON.parse(data.body).Body;
+                return next();
+            }),
+            replicateMetadata: next => makeBackbeatRequest({
+                method: 'PUT',
+                resourceType: 'metadata',
+                bucket: bucketDestination,
+                objectKey: keyName,
+                queryObj: { versionId: 'null' },
+                authCredentials: backbeatAuthCredentials,
+                requestBody: objMD,
+            }, next),
+            headObjectNullVersion: next => s3.headObject({
+                Bucket: bucketDestination,
+                Key: keyName,
+                VersionId: 'null',
+            }, next),
+            getObjectTaggingNullVersion: next => s3.getObjectTagging({
+                Bucket: bucketDestination,
+                Key: keyName,
+                VersionId: 'null',
+            }, next),
+            listObjectVersions: next => s3.listObjectVersions({
+                Bucket: bucketDestination,
+            }, next),
+        }, (err, results) => {
+            if (err) {
+                return done(err);
+            }
+
+            const headObjectRes = results.headObjectNullVersion;
+            assert.strictEqual(headObjectRes.VersionId, 'null');
+
+            const getObjectTaggingRes = results.getObjectTaggingNullVersion;
+            assert.deepStrictEqual(getObjectTaggingRes.TagSet, [{ Key: 'key1', Value: 'value1' }]);
+
+            const listObjectVersionsRes = results.listObjectVersions;
+            const { Versions } = listObjectVersionsRes;
+
+            assert.strictEqual(Versions.length, 1);
+            const [currentVersion] = Versions;
+
+            assert.strictEqual(currentVersion.VersionId, 'null');
+            assert.strictEqual(currentVersion.IsLatest, true);
+
+            return done();
+        });
+    });
+
+    it('should replicate/put a lifecycled NULL metadata to a destination that has a version', done => {
+        let objMDUpdated;
+        let objMDReplicated;
+        let versionId;
+
+        async.series({
+            enableVersioningDestination: next => s3.putBucketVersioning({
+                Bucket: bucketDestination,
+                VersioningConfiguration: { Status: 'Enabled' },
+            }, next),
+            putObjectDestination: next => s3.putObject({
+                Bucket: bucketDestination,
+                Key: keyName,
+                Body: Buffer.from(testData),
+            }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                versionId = data.VersionId;
+                return next();
+            }),
+            putObjectSource: next => s3.putObject({
+                Bucket: bucketSource,
+                Key: keyName,
+                Body: Buffer.from(testData),
+            }, next),
+            enableVersioningSource: next => s3.putBucketVersioning({
+                Bucket: bucketSource,
+                VersioningConfiguration: { Status: 'Enabled' },
+            }, next),
+            simulateLifecycleNullVersion: next => makeBackbeatRequest({
+                method: 'GET',
+                resourceType: 'metadata',
+                bucket: bucketSource,
+                objectKey: keyName,
+                queryObj: { versionId: 'null' },
+                authCredentials: backbeatAuthCredentials,
+            }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                objMDUpdated = JSON.parse(data.body).Body;
+                return next();
+            }),
+            updateMetadataSource: next => makeBackbeatRequest({
+                method: 'PUT',
+                resourceType: 'metadata',
+                bucket: bucketSource,
+                objectKey: keyName,
+                queryObj: { versionId: 'null' },
+                authCredentials: backbeatAuthCredentials,
+                requestBody: objMDUpdated,
+            }, next),
+            getReplicatedNullVersion: next => makeBackbeatRequest({
+                method: 'GET',
+                resourceType: 'metadata',
+                bucket: bucketSource,
+                objectKey: keyName,
+                queryObj: { versionId: 'null' },
+                authCredentials: backbeatAuthCredentials,
+            }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                objMDReplicated = JSON.parse(data.body).Body;
+                return next();
+            }),
+            putReplicatedNullVersion: next => makeBackbeatRequest({
+                method: 'PUT',
+                resourceType: 'metadata',
+                bucket: bucketDestination,
+                objectKey: keyName,
+                queryObj: { versionId: 'null' },
+                authCredentials: backbeatAuthCredentials,
+                requestBody: objMDReplicated,
+            }, next),
+            headObjectByVersionId: next => s3.headObject({
+                Bucket: bucketDestination,
+                Key: keyName,
+                VersionId: versionId,
+            }, next),
+            headObjectByNullVersion: next => s3.headObject({
+                Bucket: bucketDestination,
+                Key: keyName,
+                VersionId: 'null',
+            }, next),
+            listObjectVersionsDestination: next => s3.listObjectVersions({
+                Bucket: bucketDestination,
+            }, next),
+        }, (err, results) => {
+            if (err) {
+                return done(err);
+            }
+
+            const firstHeadObjectRes = results.headObjectByVersionId;
+            assert.strictEqual(firstHeadObjectRes.VersionId, versionId);
+
+            const secondHeadObjectRes = results.headObjectByNullVersion;
+            assert.strictEqual(secondHeadObjectRes.VersionId, 'null');
+
+            const listObjectVersionsRes = results.listObjectVersionsDestination;
+            const { Versions } = listObjectVersionsRes;
+
+            assert.strictEqual(Versions.length, 2);
+            const [currentVersion, nonCurrentVersion] = Versions;
+
+            assert.strictEqual(currentVersion.VersionId, 'null');
+            assert.strictEqual(currentVersion.IsLatest, true);
+
+            assert.strictEqual(nonCurrentVersion.VersionId, versionId);
+            assert.strictEqual(nonCurrentVersion.IsLatest, false);
+
+            return done();
+        });
+    });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -488,9 +488,9 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#7.10.58":
-  version "7.10.58"
-  resolved "git+https://github.com/scality/arsenal#9c5bc2bfe076a8db290c4fcba41e1c10307a709c"
+"arsenal@git+https://github.com/scality/arsenal#7.10.59":
+  version "7.10.59"
+  resolved "git+https://github.com/scality/arsenal#f1891851b394f64a6be95c414767d314791884c9"
   dependencies:
     "@types/async" "^3.2.12"
     "@types/utf8" "^3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -488,9 +488,9 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#7.10.59":
-  version "7.10.59"
-  resolved "git+https://github.com/scality/arsenal#f1891851b394f64a6be95c414767d314791884c9"
+"arsenal@git+https://github.com/scality/arsenal#7.10.61":
+  version "7.10.61"
+  resolved "git+https://github.com/scality/arsenal#9ee40f343bd438d20bd02a91148b2ee07662153c"
   dependencies:
     "@types/async" "^3.2.12"
     "@types/utf8" "^3.0.1"


### PR DESCRIPTION
NOTE: only the tests will be forwarded to `development/7.70` because the null key behavior has changed in `development/7.70`.

The `options.isNull` parameter indicates support for the new null keys logic (S3C-7352). 
However, in `development/7.10`,  the new null keys logic is not available.

This PR functionally tests: https://github.com/scality/Arsenal/pull/2215