### PR TITLE
CLDSRV-501 [7.70] PutMetadata should write metadata on top of a null version

### DIFF
--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -193,7 +193,7 @@ function processVersioningState(mst, vstat, nullVersionCompatMode) {
             // null keys are used, which is used as an optimization to
             // avoid having to check the versioned key since there can
             // be no more versioned key to clean up
-            if (mst.isNull && !mst.isNull2) {
+            if (mst.isNull && mst.versionId && !mst.isNull2) {
                 const delOptions = { versionId: mst.versionId };
                 return { options, delOptions };
             }
@@ -224,7 +224,7 @@ function processVersioningState(mst, vstat, nullVersionCompatMode) {
     if (masterIsNull) {
         // if master is a null version or a non-versioned key,
         // copy it to a new null key
-        const nullVersionId = mst.isNull ? mst.versionId : nonVersionedObjId;
+        const nullVersionId = (mst.isNull && mst.versionId) ? mst.versionId : nonVersionedObjId;
         if (nullVersionCompatMode) {
             options.extraMD = {
                 nullVersionId,

--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -49,6 +49,7 @@ const NAMESPACE = 'default';
 const CIPHER = null; // replication/lifecycle does not work on encrypted objects
 
 let { locationConstraints } = config;
+const { nullVersionCompatMode } = config;
 const { implName } = dataWrapper;
 let dataClient = dataWrapper.client;
 config.on('location-constraints-update', () => {
@@ -492,9 +493,7 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
         let isNull = false;
 
         if (versionId === 'null') {
-            if (!config.nullVersionCompatMode) {
-                isNull = true;
-            }
+            isNull = true;
             // Retrieve the null version id from the object metadata.
             versionId = objMd && objMd.versionId;
             if (!versionId) {
@@ -503,6 +502,11 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
                 // the flag is needed to allow cloudserver to know that the version
                 // is a null version and allow access to it using the "null" versionId.
                 omVal.isNull = true;
+                // If the new null keys logic (S3C-7352) is supported (not compatibility mode),
+                // create a null key with the isNull2 flag.
+                if (!nullVersionCompatMode) {
+                    omVal.isNull2 = true;
+                }
                 if (versioning) {
                     // If the null version does not have a version id, it is a current null version.
                     // To update the metadata of a current version, versioning is set to false.
@@ -514,6 +518,7 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
                     // If no new versioned objects are added for given object(s), they look like
                     // standalone master keys.
                     versioning = false;
+                    delete omVal.versionId;
                 } else {
                     const versioningConf = bucketInfo.getVersioningConfiguration();
                     // The purpose of this condition is to address situations in which
@@ -538,7 +543,6 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
 
         const options = {
             versionId,
-            isNull,
             overheadField: constants.overheadField,
         };
 
@@ -549,6 +553,11 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
         // Therefore, to avoid this confusion, we don't pass the versioning parameter at all if its value is false.
         if (versioning) {
             options.versioning = true;
+        }
+
+        // If the new null keys logic (S3C-7352) is not supported (compatibility mode), 'isNull' remains undefined.
+        if (!nullVersionCompatMode) {
+            options.isNull = isNull;
         }
 
         log.trace('putting object version', {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "git+https://github.com/scality/arsenal#7.70.22",
+    "arsenal": "git+https://github.com/scality/arsenal#bugfix/ARSN-392/null7.70",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,6 +61,11 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
+"@js-sdsl/ordered-set@^4.4.2":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-set/-/ordered-set-4.4.2.tgz#ab857eb63cf358b5a0f74fdd458b4601423779b7"
+  integrity sha512-ieYQ8WlBPKYzEo81H3q0DFbd8WtFRXXABb4+vRCF0AO3WWtJZFxYvRGdipUXGrd6tlSySmqhcPuO3J6SCodCxg==
+
 "@npmcli/fs@^1.0.0":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-1.1.1.tgz#72f719fe935e687c56a4faecf3c03d06ba593257"
@@ -494,10 +499,11 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#7.70.22":
-  version "7.70.22"
-  resolved "git+https://github.com/scality/arsenal#918c2c54735d5ccea7410e2f24f9fb2b8b33ba68"
+"arsenal@git+https://github.com/scality/arsenal#bugfix/ARSN-392/null7.70":
+  version "7.70.23"
+  resolved "git+https://github.com/scality/arsenal#dc2264325995cb186b51b6381ead9a160b6ca7bd"
   dependencies:
+    "@js-sdsl/ordered-set" "^4.4.2"
     "@types/async" "^3.2.12"
     "@types/utf8" "^3.0.1"
     JSONStream "^1.0.0"


### PR DESCRIPTION
- Handles isNull master version with no versionId
- Supports `nullVersionCompatMode` for using the old and new null keys logic ([S3C-7352])
- Test https://github.com/scality/Arsenal/pull/2216 once tests are forwardported.

[S3C-7352]: https://scality.atlassian.net/browse/S3C-7352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ