### PR TITLE
Use scaledMsPerDay when restore-adjust

### DIFF
--- a/lib/api/apiUtils/object/coldStorage.js
+++ b/lib/api/apiUtils/object/coldStorage.js
@@ -7,6 +7,8 @@ const errors = require('arsenal').errors;
 const { config } = require('../../../Config');
 const { locationConstraints } = config;
 
+const { scaledMsPerDay } = config.getTimeOptions();
+
 /**
  * Get response header "x-amz-restore"
  * Be called by objectHead.js
@@ -145,7 +147,7 @@ function _updateObjectExpirationDate(objectMD, log) {
     });
     if (isObjectAlreadyRestored) {
         const expiryDate = new Date(objectMD.archive.restoreRequestedAt);
-        expiryDate.setDate(expiryDate.getDate() + objectMD.archive.restoreRequestedDays);
+        expiryDate.setTime(expiryDate.getTime() + (objectMD.archive.restoreRequestedDays * scaledMsPerDay));
 
         /* eslint-disable no-param-reassign */
         objectMD.archive.restoreWillExpireAt = expiryDate;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "8.7.46",
+  "version": "8.7.47",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {

--- a/tests/unit/api/apiUtils/coldStorage.js
+++ b/tests/unit/api/apiUtils/coldStorage.js
@@ -8,6 +8,8 @@ const {
 } = require('../../../../lib/api/apiUtils/object/coldStorage');
 const { DummyRequestLogger } = require('../../helpers');
 const { ObjectMD, ObjectMDArchive } = require('arsenal/build/lib/models');
+const { config } = require('../../../../lib/Config');
+const { scaledMsPerDay } = config.getTimeOptions();
 const log = new DummyRequestLogger();
 const oneDay = 24 * 60 * 60 * 1000;
 
@@ -227,8 +229,7 @@ describe('cold storage', () => {
 
                 assert.strictEqual(objectMd.archive.restoreCompletedAt, restoreCompletedAt);
                 assert.strictEqual(objectMd.archive.restoreWillExpireAt.getTime(),
-                    objectMd.archive.restoreRequestedAt.getTime() + 5 * oneDay
-                );
+                    objectMd.archive.restoreRequestedAt.getTime() + (5 * scaledMsPerDay));
                 assert.deepEqual(objectMd['x-amz-restore'], {
                     'ongoing-request': false,
                     'expiry-date': objectMd.archive.restoreWillExpireAt,


### PR DESCRIPTION
Use scaledMsPerday when restoring an object that has already been restored to be able to make the time go faster for testing purpose

Issue: CLDSRV-512
