### PR TITLE
bf: CLDSRV-513 fix request logger for batchDelete

### DIFF
--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -5,7 +5,6 @@ const getMetaHeaders = s3middleware.userMetadata.getMetaHeaders;
 const constants = require('../../../../constants');
 const { data } = require('../../../data/wrapper');
 const services = require('../../../services');
-const logger = require('../../../utilities/logger');
 const { dataStore } = require('./storeObject');
 const locationConstraintCheck = require('./locationConstraintCheck');
 const { versioningPreprocessing } = require('./versioning');
@@ -47,7 +46,7 @@ function _checkAndApplyZenkoMD(metaHeaders, request, isDeleteMarker) {
 }
 
 function _storeInMDandDeleteData(bucketName, dataGetInfo, cipherBundle,
-    metadataStoreParams, dataToDelete, deleteLog, requestMethod, callback) {
+    metadataStoreParams, dataToDelete, log, requestMethod, callback) {
     services.metadataStoreObject(bucketName, dataGetInfo,
         cipherBundle, metadataStoreParams, (err, result) => {
             if (err) {
@@ -57,7 +56,7 @@ function _storeInMDandDeleteData(bucketName, dataGetInfo, cipherBundle,
                 const newDataStoreName = Array.isArray(dataGetInfo) ?
                     dataGetInfo[0].dataStoreName : null;
                 return data.batchDelete(dataToDelete, requestMethod,
-                    newDataStoreName, deleteLog, err => callback(err, result));
+                    newDataStoreName, log, err => callback(err, result));
             }
             return callback(null, result);
         });
@@ -203,8 +202,6 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
     const dontSkipBackend = externalBackends;
     /* eslint-enable camelcase */
 
-    const requestLogger =
-        logger.newRequestLoggerFromSerializedUids(log.getSerializedUids());
     return async.waterfall([
         function storeData(next) {
             if (size === 0 && !dontSkipBackend[locationType]) {
@@ -261,7 +258,7 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
             metadataStoreParams.nullUploadId = options.nullUploadId;
             return _storeInMDandDeleteData(bucketName, infoArr,
                 cipherBundle, metadataStoreParams,
-                options.dataToDelete, requestLogger, requestMethod, next);
+                options.dataToDelete, log, requestMethod, next);
         },
     ], callback);
 }

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -23,8 +23,6 @@ const locationKeysHaveChanged
     = require('./apiUtils/object/locationKeysHaveChanged');
 const { setExpirationHeaders } = require('./apiUtils/object/expirationHeaders');
 
-const logger = require('../utilities/logger');
-
 const versionIdUtils = versioning.VersionID;
 
 let splitter = constants.splitter;
@@ -419,12 +417,9 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                         const newDataStoreName =
                             Array.isArray(dataLocations) && dataLocations[0] ?
                             dataLocations[0].dataStoreName : null;
-                        const delLog =
-                            logger.newRequestLoggerFromSerializedUids(log
-                            .getSerializedUids());
                         return data.batchDelete(dataToDelete,
                             request.method,
-                            newDataStoreName, delLog, err => {
+                            newDataStoreName, log, err => {
                                 if (err) {
                                     return next(err);
                                 }
@@ -447,10 +442,8 @@ function completeMultipartUpload(authInfo, request, log, callback) {
         function batchDeleteExtraParts(extraPartLocations, destinationBucket,
             aggregateETag, generatedVersionId, next) {
             if (extraPartLocations && extraPartLocations.length > 0) {
-                const delLog = logger.newRequestLoggerFromSerializedUids(
-                    log.getSerializedUids());
                 return data.batchDelete(extraPartLocations, request.method,
-                    null, delLog, err => {
+                    null, log, err => {
                         if (err) {
                             return next(err);
                         }

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -12,7 +12,6 @@ const { checkQueryVersionId, versioningPreprocessing }
     = require('./apiUtils/object/versioning');
 const getReplicationInfo = require('./apiUtils/object/getReplicationInfo');
 const { data } = require('../data/wrapper');
-const logger = require('../utilities/logger');
 const services = require('../services');
 const { pushMetric } = require('../utapi/utilities');
 const removeAWSChunked = require('./apiUtils/object/removeAWSChunked');
@@ -492,10 +491,8 @@ function objectCopy(authInfo, request, sourceBucket,
             // the same as the destination
             if (!sourceIsDestination && dataToDelete) {
                 const newDataStoreName = storeMetadataParams.dataStoreName;
-                const delLog = logger.newRequestLoggerFromSerializedUids(
-                    log.getSerializedUids());
                 return data.batchDelete(dataToDelete, request.method,
-                    newDataStoreName, delLog, err => {
+                    newDataStoreName, log, err => {
                         if (err) {
                             // if error, log the error and move on as it is not
                             // relevant to the client as the client's

--- a/lib/api/objectPutCopyPart.js
+++ b/lib/api/objectPutCopyPart.js
@@ -9,7 +9,6 @@ const locationConstraintCheck =
     require('./apiUtils/object/locationConstraintCheck');
 const metadata = require('../metadata/wrapper');
 const { pushMetric } = require('../utapi/utilities');
-const logger = require('../utilities/logger');
 const services = require('../services');
 const setUpCopyLocator = require('./apiUtils/object/setUpCopyLocator');
 const { standardMetadataValidateBucketAndObj } = require('../metadata/metadataUtils');
@@ -374,10 +373,8 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
             // Clean up the old data now that new metadata (with new
             // data locations) has been stored
             if (oldLocationsToDelete) {
-                const delLog = logger.newRequestLoggerFromSerializedUids(
-                    log.getSerializedUids());
                 return data.batchDelete(oldLocationsToDelete, request.method, null,
-                    delLog, err => {
+                    log, err => {
                         if (err) {
                             // if error, log the error and move on as it is not
                             // relevant to the client as the client's

--- a/lib/api/objectPutPart.js
+++ b/lib/api/objectPutPart.js
@@ -12,7 +12,6 @@ const { isBucketAuthorized } =
 const kms = require('../kms/wrapper');
 const metadata = require('../metadata/wrapper');
 const { pushMetric } = require('../utapi/utilities');
-const logger = require('../utilities/logger');
 const services = require('../services');
 const locationConstraintCheck
     = require('./apiUtils/object/locationConstraintCheck');
@@ -368,10 +367,8 @@ function objectPutPart(authInfo, request, streamingV4Params, log,
             prevObjectSize, next) => {
             if (oldLocationsToDelete) {
                 log.trace('overwriting mpu part, deleting data');
-                const delLog = logger.newRequestLoggerFromSerializedUids(
-                    log.getSerializedUids());
                 return data.batchDelete(oldLocationsToDelete, request.method,
-                    objectLocationConstraint, delLog, err => {
+                    objectLocationConstraint, log, err => {
                         if (err) {
                             // if error, log the error and move on as it is not
                             // relevant to the client as the client's

--- a/lib/services.js
+++ b/lib/services.js
@@ -9,7 +9,6 @@ const acl = require('./metadata/acl');
 const constants = require('../constants');
 const { data } = require('./data/wrapper');
 const metadata = require('./metadata/wrapper');
-const logger = require('./utilities/logger');
 const { setObjectLockInformation }
     = require('./api/apiUtils/object/objectLockHelpers');
 const removeAWSChunked = require('./api/apiUtils/object/removeAWSChunked');
@@ -305,17 +304,14 @@ const services = {
                         return cb(err, res);
                     }
                     log.trace('deleteObject: metadata delete OK');
-                    const deleteLog =
-                        logger.newRequestLoggerFromSerializedUids(
-                            log.getSerializedUids());
                     if (objectMD.location === null) {
                         return cb(null, res);
                     } else if (!Array.isArray(objectMD.location)) {
-                        data.delete(objectMD.location, deleteLog);
+                        data.delete(objectMD.location, log);
                         return cb(null, res);
                     }
                     return data.batchDelete(objectMD.location, null, null,
-                    deleteLog, err => {
+                    log, err => {
                         if (err) {
                             return cb(err);
                         }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "utf8": "~2.1.1",
     "uuid": "^3.0.1",
     "vaultclient": "scality/vaultclient#7.10.10",
-    "werelogs": "scality/werelogs#8.1.0",
+    "werelogs": "scality/werelogs#8.1.4",
     "xml2js": "~0.4.16"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.10.45",
+  "version": "7.10.46",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "git+https://github.com/scality/arsenal#7.10.61",
+    "arsenal": "git+https://github.com/scality/arsenal#7.10.62",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -488,9 +488,9 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#7.10.61":
-  version "7.10.61"
-  resolved "git+https://github.com/scality/arsenal#9ee40f343bd438d20bd02a91148b2ee07662153c"
+"arsenal@git+https://github.com/scality/arsenal#7.10.62":
+  version "7.10.62"
+  resolved "git+https://github.com/scality/arsenal#e9d815cc9d212932924a5388173548ff804edc6b"
   dependencies:
     "@types/async" "^3.2.12"
     "@types/utf8" "^3.0.1"
@@ -523,7 +523,7 @@ arraybuffer.slice@~0.0.7:
     sproxydclient "github:scality/sproxydclient#8.0.4"
     utf8 "2.1.2"
     uuid "^3.0.1"
-    werelogs scality/werelogs#8.1.0
+    werelogs scality/werelogs#8.1.4
     xml2js "~0.4.23"
   optionalDependencies:
     ioctl "^2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1918,6 +1918,11 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
+fast-safe-stringify@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
+  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
+
 "fcntl@github:scality/node-fcntl#0.2.0":
   version "0.2.0"
   resolved "https://codeload.github.com/scality/node-fcntl/tar.gz/ae7493da46fb353eff0c4cb79e2cce838197c066"
@@ -4537,7 +4542,7 @@ safe-json-stringify@1.0.3:
   resolved "https://registry.yarnpkg.com/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz#3cb6717660a086d07cb5bd9b7a6875bcf67bd05e"
   integrity sha512-FspOTGvddR3ZE2k+NqHsywbCrnD7xow+r156P04MEMURbRF65Pdccpl2f4XU3KjXKsK5zdF03ScdKoL7Ti4Gpg==
 
-safe-json-stringify@^1.0.3:
+safe-json-stringify@^1.0.3, safe-json-stringify@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz#356e44bc98f1f93ce45df14bcd7c01cda86e0afd"
   integrity sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==
@@ -5468,6 +5473,13 @@ werelogs@scality/werelogs#8.1.0:
   resolved "https://codeload.github.com/scality/werelogs/tar.gz/e8f828725642c54c511cdbe580b18f43d3589313"
   dependencies:
     safe-json-stringify "1.0.3"
+
+werelogs@scality/werelogs#8.1.4:
+  version "8.1.4"
+  resolved "https://codeload.github.com/scality/werelogs/tar.gz/d6bec11df034c88a12959791eb7dd60913eb5f47"
+  dependencies:
+    fast-safe-stringify "^2.1.1"
+    safe-json-stringify "^1.2.0"
 
 werelogs@scality/werelogs#GA7.2.0.5:
   version "7.2.0"


### PR DESCRIPTION
Arsenal's `DataWrapper.batchDelete()` now already creates a request logger on which it calls `end()` to get the elapsed time. So as there's no need to create one before the call, remove the corresponding code.

Note that the main fix is the arsenal version bump which, by creating a request logger, fixes naturally the forgotten case in `checkHashMatchMD5`.

Also bump werelogs dependency.
