### PR TITLE
Add openssl platform dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,17 @@ WORKDIR /usr/src/app
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        build-essential \
-        ca-certificates \
-        curl \
-        git \
-        gnupg2 \
-        jq \
-        python3 \
-        ssh \
-        wget \
-        libffi-dev \
-        zlib1g-dev \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    gnupg2 \
+    jq \
+    python3 \
+    ssh \
+    wget \
+    libffi-dev \
+    zlib1g-dev \
     && apt-get clean \
     && mkdir -p /root/ssh \
     && ssh-keyscan -H github.com > /root/ssh/known_hosts
@@ -30,7 +30,7 @@ FROM node:${NODE_VERSION}
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        jq \
+    jq \
     && rm -rf /var/lib/apt/lists/*
 
 ENV NO_PROXY localhost,127.0.0.1
@@ -41,8 +41,9 @@ EXPOSE 8002
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        jq \
-        tini \
+    jq \
+    tini \
+    openssl \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/app


### PR DESCRIPTION

# Pull request template

## Description

Adds openssl to platform dependencies so the docker-entrypoint file can run without errors. 

### Motivation and context

The docker-entrypoint.sh file references openssl when generating certificates in cases where `SSL=true`. At the moment openssl isn't installed, so this crashes the container out.

### Related issues

#5561 

## Checklist

### Add tests to cover the changes

N/A

### Code conforms with the [style guide](https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#coding-style-guidelines)

N/A

### Sign your work

✅