### PR TITLE
Support reading archive details

### DIFF
--- a/lib/api/apiUtils/authorization/prepareRequestContexts.js
+++ b/lib/api/apiUtils/authorization/prepareRequestContexts.js
@@ -140,6 +140,11 @@ function prepareRequestContexts(apiMethod, request, sourceBucket,
                 generateRequestContext(objectHeadVersionAction);
             requestContexts.push(headObjectVersion);
         }
+        if (request.headers['x-amz-scal-archive-info']) {
+            const coldStatus =
+                generateRequestContext('objectGetArchiveInfo');
+            requestContexts.push(coldStatus);
+        }
     } else if (apiMethodAfterVersionCheck === 'objectPutTagging') {
         const putObjectTaggingRequestContext =
             generateRequestContext('objectPutTagging');

--- a/lib/api/apiUtils/object/coldStorage.js
+++ b/lib/api/apiUtils/object/coldStorage.js
@@ -35,6 +35,39 @@ function getAmzRestoreResHeader(objMD) {
 }
 
 /**
+ * set archiveInfo headers to target header object
+ * @param {object} objMD - object metadata
+ * @returns {object} headers - target header object
+ */
+function setArchiveInfoHeaders(objMD) {
+    const headers = {};
+
+    if (objMD['x-amz-scal-transition-in-progress']) {
+        headers['x-amz-scal-transition-in-progress'] = true;
+        headers['x-amz-scal-transition-time'] = new Date(objMD['x-amz-scal-transition-time']).toUTCString();
+    }
+
+    if (objMD.archive) {
+        headers['x-amz-scal-archive-info'] = JSON.stringify(objMD.archive.archiveInfo);
+
+        if (objMD.archive.restoreRequestedAt) {
+            headers['x-amz-scal-restore-requested-at'] = new Date(objMD.archive.restoreRequestedAt).toUTCString();
+            headers['x-amz-scal-restore-requested-days'] = objMD.archive.restoreRequestedDays;
+        }
+
+        if (objMD.archive.restoreCompletedAt) {
+            headers['x-amz-scal-restore-completed-at'] = new Date(objMD.archive.restoreCompletedAt).toUTCString();
+            headers['x-amz-scal-restore-will-expire-at'] = new Date(objMD.archive.restoreWillExpireAt).toUTCString();
+        }
+    }
+
+    // Always get the "real" storage class (even when STANDARD) in this case
+    headers['x-amz-storage-class'] = objMD['x-amz-storage-class'] || objMD.dataStoreName;
+
+    return headers;
+}
+
+/**
  * Check if restore can be done.
  *
  * @param {ObjectMD} objectMD - object metadata
@@ -244,4 +277,5 @@ module.exports = {
     getAmzRestoreResHeader,
     validatePutVersionId,
     verifyColdObjectAvailable,
+    setArchiveInfoHeaders,
 };

--- a/lib/api/apiUtils/object/coldStorage.js
+++ b/lib/api/apiUtils/object/coldStorage.js
@@ -64,6 +64,9 @@ function setArchiveInfoHeaders(objMD) {
     // Always get the "real" storage class (even when STANDARD) in this case
     headers['x-amz-storage-class'] = objMD['x-amz-storage-class'] || objMD.dataStoreName;
 
+    // Get the owner-id
+    headers['x-amz-scal-owner-id'] = objMD['owner-id'];
+
     return headers;
 }
 

--- a/lib/api/objectHead.js
+++ b/lib/api/objectHead.js
@@ -16,6 +16,7 @@ const { locationConstraints } = config;
 const { standardMetadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { maximumAllowedPartCount } = require('../../constants');
 const { setExpirationHeaders } = require('./apiUtils/object/expirationHeaders');
+const { setArchiveInfoHeaders } = require('./apiUtils/object/coldStorage');
 
 /**
  * HEAD Object - Same as Get Object but only respond with headers
@@ -109,6 +110,10 @@ function objectHead(authInfo, request, log, callback) {
                 },
                 isVersionedReq: !!versionId,
             });
+
+            if (request.headers['x-amz-scal-archive-info']) {
+                Object.assign(responseHeaders, setArchiveInfoHeaders(objMD));
+            }
 
             const objLength = (objMD.location === null ?
                 0 : parseInt(objMD['content-length'], 10));

--- a/lib/utilities/collectResponseHeaders.js
+++ b/lib/utilities/collectResponseHeaders.js
@@ -52,6 +52,10 @@ function collectResponseHeaders(objectMD, corsHeaders, versioningCfg,
         responseMetaHeaders['x-amz-restore'] = restoreHeader;
     }
 
+    if (objectMD['x-amz-scal-transition-in-progress']) {
+        responseMetaHeaders['x-amz-meta-scal-s3-transition-in-progress'] = true;
+    }
+
     responseMetaHeaders['Accept-Ranges'] = 'bytes';
 
     if (objectMD['cache-control']) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "8.8.28",
+  "version": "8.8.29",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {

--- a/tests/unit/api/apiUtils/authorization/prepareRequestContexts.js
+++ b/tests/unit/api/apiUtils/authorization/prepareRequestContexts.js
@@ -96,6 +96,60 @@ describe('prepareRequestContexts', () => {
         assert.strictEqual(results[1].getAction(), expectedAction2);
     });
 
+    it('should return s3:GetObject for headObject', () => {
+        const apiMethod = 'objectHead';
+        const request = makeRequest({
+        });
+        const results = prepareRequestContexts(apiMethod, request, sourceBucket,
+            sourceObject, sourceVersionId);
+
+        assert.strictEqual(results.length, 1);
+        assert.strictEqual(results[0].getAction(), 's3:GetObject');
+    });
+
+    it('should return s3:GetObject and s3:GetObjectVersion for headObject', () => {
+        const apiMethod = 'objectHead';
+        const request = makeRequest({
+            'x-amz-version-id': '0987654323456789',
+        });
+        const results = prepareRequestContexts(apiMethod, request, sourceBucket,
+            sourceObject, sourceVersionId);
+
+        assert.strictEqual(results.length, 2);
+        assert.strictEqual(results[0].getAction(), 's3:GetObject');
+        assert.strictEqual(results[1].getAction(), 's3:GetObjectVersion');
+    });
+
+    it('should return s3:GetObject and scality:GetObjectArchiveInfo for headObject ' +
+    'with x-amz-scal-archive-info header', () => {
+        const apiMethod = 'objectHead';
+        const request = makeRequest({
+            'x-amz-scal-archive-info': 'true',
+        });
+        const results = prepareRequestContexts(apiMethod, request, sourceBucket,
+            sourceObject, sourceVersionId);
+
+        assert.strictEqual(results.length, 2);
+        assert.strictEqual(results[0].getAction(), 's3:GetObject');
+        assert.strictEqual(results[1].getAction(), 'scality:GetObjectArchiveInfo');
+    });
+
+    it('should return s3:GetObject, s3:GetObjectVersion and scality:GetObjectArchiveInfo ' +
+    ' for headObject with x-amz-scal-archive-info header', () => {
+        const apiMethod = 'objectHead';
+        const request = makeRequest({
+            'x-amz-version-id': '0987654323456789',
+            'x-amz-scal-archive-info': 'true',
+        });
+        const results = prepareRequestContexts(apiMethod, request, sourceBucket,
+            sourceObject, sourceVersionId);
+
+        assert.strictEqual(results.length, 3);
+        assert.strictEqual(results[0].getAction(), 's3:GetObject');
+        assert.strictEqual(results[1].getAction(), 's3:GetObjectVersion');
+        assert.strictEqual(results[2].getAction(), 'scality:GetObjectArchiveInfo');
+    });
+
     ['initiateMultipartUpload', 'objectPutPart', 'completeMultipartUpload'].forEach(apiMethod => {
         it(`should return s3:PutObjectVersion request context action for ${apiMethod} method ` +
         'with x-scal-s3-version-id header', () => {

--- a/tests/unit/api/objectHead.js
+++ b/tests/unit/api/objectHead.js
@@ -386,6 +386,7 @@ describe('objectHead API', () => {
                     assert.strictEqual(res['x-amz-scal-archive-info'], undefined);
                     assert.strictEqual(res['x-amz-scal-restore-requested-at'], undefined);
                     assert.strictEqual(res['x-amz-scal-restore-requested-days'], undefined);
+                    assert.strictEqual(res['x-amz-scal-owner-id'], undefined);
                     done();
                 });
             });
@@ -416,13 +417,13 @@ describe('objectHead API', () => {
                     assert.strictEqual(res['x-amz-scal-restore-requested-at'], undefined);
                     assert.strictEqual(res['x-amz-scal-restore-completed-at'], undefined);
                     assert.strictEqual(res['x-amz-scal-restore-will-expire-at'], undefined);
+                    assert.strictEqual(res['x-amz-scal-owner-id'], undefined);
                     done();
                 });
             });
         });
     });
 
-    // add GetRequest with flag for different kind of objects
     it('should report when transition in progress', done => {
         const testGetRequest = {
             bucketName,
@@ -439,6 +440,7 @@ describe('objectHead API', () => {
                     assert.strictEqual(res['x-amz-scal-transition-in-progress'], undefined);
                     assert.strictEqual(res['x-amz-scal-transition-time'], undefined);
                     assert.strictEqual(res['x-amz-scal-archive-info'], undefined);
+                    assert.strictEqual(res['x-amz-scal-owner-id'], undefined);
                     done(err);
                 });
             });
@@ -464,6 +466,7 @@ describe('objectHead API', () => {
                     assert.strictEqual(res['x-amz-scal-transition-time'],
                         new Date(objectCustomMDFields['x-amz-scal-transition-time']).toUTCString());
                     assert.strictEqual(res['x-amz-scal-archive-info'], undefined);
+                    assert.strictEqual(res['x-amz-scal-owner-id'], mdColdHelper.defaultOwnerId);
                     done(err);
                 });
             });
@@ -488,6 +491,7 @@ describe('objectHead API', () => {
                     assert.strictEqual(res['x-amz-scal-transition-in-progress'], undefined);
                     assert.strictEqual(res['x-amz-scal-archive-info'], '{"foo":0,"bar":"stuff"}');
                     assert.strictEqual(res['x-amz-storage-class'], mdColdHelper.defaultLocation);
+                    assert.strictEqual(res['x-amz-scal-owner-id'], mdColdHelper.defaultOwnerId);
                     done(err);
                 });
             });
@@ -516,6 +520,7 @@ describe('objectHead API', () => {
                     assert.strictEqual(res['x-amz-scal-restore-requested-days'],
                         objectCustomMDFields.archive.restoreRequestedDays);
                     assert.strictEqual(res['x-amz-storage-class'], mdColdHelper.defaultLocation);
+                    assert.strictEqual(res['x-amz-scal-owner-id'], mdColdHelper.defaultOwnerId);
                     done(err);
                 });
             });
@@ -548,6 +553,7 @@ describe('objectHead API', () => {
                     assert.strictEqual(res['x-amz-scal-restore-will-expire-at'],
                         new Date(objectCustomMDFields.archive.restoreWillExpireAt).toUTCString());
                     assert.strictEqual(res['x-amz-storage-class'], mdColdHelper.defaultLocation);
+                    assert.strictEqual(res['x-amz-scal-owner-id'], mdColdHelper.defaultOwnerId);
                     done(err);
                 });
             });

--- a/tests/unit/api/utils/metadataMockColdStorage.js
+++ b/tests/unit/api/utils/metadataMockColdStorage.js
@@ -7,10 +7,11 @@ const ObjectMDArchive = require('arsenal').models.ObjectMDArchive;
 const BucketInfo = require('arsenal').models.BucketInfo;
 
 const defaultLocation = 'location-dmf-v1';
+const defaultOwnerId = '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be';
 
 const baseMd = {
     'owner-display-name': 'accessKey1displayName',
-    'owner-id': '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be',
+    'owner-id': defaultOwnerId,
     'content-length': 11,
     'content-md5': 'be747eb4b75517bf6b3cf7c5fbb62f3a',
     'content-language': '',
@@ -178,4 +179,5 @@ module.exports = {
     getTransitionInProgressMD,
     putBucketMock,
     defaultLocation,
+    defaultOwnerId,
 };

--- a/tests/unit/api/utils/metadataMockColdStorage.js
+++ b/tests/unit/api/utils/metadataMockColdStorage.js
@@ -105,7 +105,9 @@ function putObjectMock(bucketName, objectName, fields, cb) {
  */
 function getArchiveArchivedMD() {
     return {
-        archive: new ObjectMDArchive({}).getValue(),
+        archive: new ObjectMDArchive(
+            { foo: 0, bar: 'stuff' }, // opaque, can be anything...
+        ).getValue(),
     };
 }
 
@@ -115,7 +117,11 @@ function getArchiveArchivedMD() {
  */
 function getArchiveOngoingRequestMD() {
     return {
-        archive: new ObjectMDArchive({}, new Date(Date.now() - 60), 5).getValue(),
+        archive: new ObjectMDArchive(
+            { foo: 0, bar: 'stuff' }, // opaque, can be anything...
+            new Date(Date.now() - 60),
+            5).getValue(),
+        'x-amz-restore': new ObjectMDAmzRestore(true, new Date(Date.now() + 60 * 60 * 24)),
     };
 }
 
@@ -126,6 +132,7 @@ function getArchiveOngoingRequestMD() {
 function getTransitionInProgressMD() {
     return {
         'x-amz-scal-transition-in-progress': true,
+        'x-amz-scal-transition-time': new Date(Date.now() - 60),
     };
 }
 
@@ -136,7 +143,7 @@ function getTransitionInProgressMD() {
 function getArchiveRestoredMD() {
     return {
         archive: new ObjectMDArchive(
-            {},
+            { foo: 0, bar: 'stuff' }, // opaque, can be anything...
             new Date(Date.now() - 60000),
             5,
             new Date(Date.now() - 10000),
@@ -152,7 +159,7 @@ function getArchiveRestoredMD() {
 function getArchiveExpiredMD() {
     return {
         archive: new ObjectMDArchive(
-            {},
+            { foo: 0, bar: 'stuff' }, // opaque, can be anything...
             new Date(Date.now() - 30000),
             5,
             new Date(Date.now() - 20000),

--- a/tests/unit/utils/collectResponseHeaders.js
+++ b/tests/unit/utils/collectResponseHeaders.js
@@ -39,4 +39,18 @@ describe('Middleware: Collect Response Headers', () => {
         assert.strictEqual(headers['x-amz-website-redirect-location'],
             'google.com');
     });
+
+    it('should not set flag when transition not in progress', () => {
+        const obj = {};
+        const headers = collectResponseHeaders(obj);
+        assert.strictEqual(headers['x-amz-scal-transition-in-progress'], undefined);
+        assert.strictEqual(headers['x-amz-meta-scal-s3-transition-in-progress'], undefined);
+    });
+
+    it('should set flag when transition in progress', () => {
+        const obj = { 'x-amz-scal-transition-in-progress': 'true' };
+        const headers = collectResponseHeaders(obj);
+        assert.strictEqual(headers['x-amz-scal-transition-in-progress'], undefined);
+        assert.strictEqual(headers['x-amz-meta-scal-s3-transition-in-progress'], true);
+    });
 });


### PR DESCRIPTION
- Expose transition-in-progress flag in user metadata: x-amz-meta-scal-s3-transition-in-progress
- HeadObject: expose archive info and other "internal" metadata, which may be used for testing or troubleshooting. This is protected by an extra permission `scality:GetObjectArchiveInfo`.

Issue: CLDSRV-545
