### PR TITLE
CLDSRV-549 restore 'git.commit-sha' and 'git.repository' labels

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -145,6 +145,9 @@ jobs:
           provenance: false
           tags: |
             ghcr.io/${{ github.repository }}:${{ github.sha }}
+          labels: |
+            git.repository=${{ github.repository }}
+            git.commit-sha=${{ github.sha }}
           cache-from: type=gha,scope=cloudserver
           cache-to: type=gha,mode=max,scope=cloudserver
       - name: Build and push pykmip image
@@ -154,6 +157,9 @@ jobs:
           context: .github/pykmip
           tags: |
             ghcr.io/${{ github.repository }}/pykmip:${{ github.sha }}
+          labels: |
+            git.repository=${{ github.repository }}
+            git.commit-sha=${{ github.sha }}
           cache-from: type=gha,scope=pykmip
           cache-to: type=gha,mode=max,scope=pykmip
 
@@ -178,6 +184,9 @@ jobs:
           file: images/svc-base/Dockerfile
           tags: |
             ghcr.io/${{ github.repository }}:${{ github.sha }}-svc-base
+          labels: |
+            git.repository=${{ github.repository }}
+            git.commit-sha=${{ github.sha }}
           cache-from: type=gha,scope=federation
           cache-to: type=gha,mode=max,scope=federation
 


### PR DESCRIPTION
Add back the 'git.commit-sha' and 'git.repository' labels to pushed images, which were not attached anymore after the change of registry.
