### PR TITLE
CLDSRV-544: Add timestamp on stderr [S3C 7.10 & 9.4 LTS]

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 'use strict'; // eslint-disable-line strict
 
-/**
- * Catch uncaught exceptions and add timestamp to aid debugging
- */
-process.on('uncaughtException', err => {
-    process.stderr.write(`${new Date().toISOString()}: Uncaught exception: \n${err.stack}`);
-});
+require('werelogs').stderrUtils.catchAndTimestampStderr(
+    undefined,
+    // Do not exit as workers have their own listener that will exit
+    // But primary don't have another listener
+    require('cluster').isPrimary ? 1 : null,
+);
 
 require('./lib/server.js')();

--- a/lib/utapi/utapi.js
+++ b/lib/utapi/utapi.js
@@ -1,3 +1,4 @@
+require('werelogs').stderrUtils.catchAndTimestampStderr();
 const _config = require('../Config').config;
 const { utapiVersion, UtapiServer: utapiServer } = require('utapi');
 

--- a/lib/utapi/utapiReindex.js
+++ b/lib/utapi/utapiReindex.js
@@ -1,3 +1,4 @@
+require('werelogs').stderrUtils.catchAndTimestampStderr();
 const UtapiReindex = require('utapi').UtapiReindex;
 const { config } = require('../Config');
 

--- a/lib/utapi/utapiReplay.js
+++ b/lib/utapi/utapiReplay.js
@@ -1,3 +1,4 @@
+require('werelogs').stderrUtils.catchAndTimestampStderr();
 const UtapiReplay = require('utapi').UtapiReplay;
 const _config = require('../Config').config;
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "utf8": "~2.1.1",
     "uuid": "^3.0.1",
     "vaultclient": "scality/vaultclient#7.10.10",
-    "werelogs": "scality/werelogs#8.1.4",
+    "werelogs": "scality/werelogs#8.1.5",
     "xml2js": "~0.4.16"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.10.48",
+  "version": "7.10.49",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5481,6 +5481,13 @@ werelogs@scality/werelogs#8.1.4:
     fast-safe-stringify "^2.1.1"
     safe-json-stringify "^1.2.0"
 
+werelogs@scality/werelogs#8.1.5:
+  version "8.1.5"
+  resolved "https://codeload.github.com/scality/werelogs/tar.gz/4131abec824a336eeb68b531e6c91f2748a0644a"
+  dependencies:
+    fast-safe-stringify "^2.1.1"
+    safe-json-stringify "^1.2.0"
+
 werelogs@scality/werelogs#GA7.2.0.5:
   version "7.2.0"
   resolved "https://codeload.github.com/scality/werelogs/tar.gz/bc034589ebf7810d6e6d61932f94327976de6eef"


### PR DESCRIPTION
The previous version would not exit the master of the cluster
Now it exits as it should do

Also the error in cluster workers are printed in stdout as json and on stderr
___

> [!IMPORTANT]
> Cherry-picks:
> - https://github.com/scality/cloudserver/pull/5610
> - https://github.com/scality/cloudserver/pull/5611