### PR TITLE
Improvement/cldsrv 548 flag update oplog

### DIFF
--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -193,6 +193,11 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
         metadataStoreParams.oldReplayId = objMD.uploadId;
     }
 
+    if (objMD && !bucketMD.isVersioningEnabled() && objMD?.archive?.archiveInfo) {
+        metadataStoreParams.needOplogUpdate = true;
+        metadataStoreParams.originOp = 's3:ReplaceArchivedObject';
+    }
+
     /* eslint-disable camelcase */
     const dontSkipBackend = externalBackends;
     /* eslint-enable camelcase */

--- a/lib/services.js
+++ b/lib/services.js
@@ -109,7 +109,7 @@ const services = {
             tagging, taggingCopy, replicationInfo, defaultRetention,
             dataStoreName, creationTime, retentionMode, retentionDate,
             legalHold, originOp, updateMicroVersionId, archive, oldReplayId,
-            deleteNullKey, amzStorageClass, overheadField } = params;
+            deleteNullKey, amzStorageClass, overheadField, needOplogUpdate } = params;
         log.trace('storing object in metadata');
         assert.strictEqual(typeof bucketName, 'string');
         const md = new ObjectMD();
@@ -175,6 +175,10 @@ const services = {
         }
         if (versionId || versionId === '') {
             options.versionId = versionId;
+        }
+        if (needOplogUpdate) {
+            options.needOplogUpdate = true;
+            options.originOp = originOp;
         }
         if (uploadId) {
             md.setUploadId(uploadId);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "8.8.27",
+  "version": "8.8.28",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@azure/storage-blob": "^12.12.0",
     "@hapi/joi": "^17.1.0",
-    "arsenal": "git+https://github.com/scality/arsenal#8.1.130",
+    "arsenal": "git+https://github.com/scality/arsenal#8.1.133",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "bucketclient": "scality/bucketclient#8.1.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1040,9 +1040,9 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#8.1.130":
-  version "8.1.130"
-  resolved "git+https://github.com/scality/arsenal#30eaaf15eb0d6e304c710b0a275410ae7c99d34d"
+"arsenal@git+https://github.com/scality/arsenal#8.1.133":
+  version "8.1.133"
+  resolved "git+https://github.com/scality/arsenal#817bb836ec0e04fbf083b4c57e42e3986dcdc9bc"
   dependencies:
     "@azure/identity" "^3.1.1"
     "@azure/storage-blob" "^12.12.0"


### PR DESCRIPTION
This PR aims to introduce a flag that will be used by Arsenal to introduce a hack to write the MD twice in the oplog: one "deleted: true" copy of the previous MD, followed by the expected update with the new metadata. 

Issue: CLDSRV-548