### PR TITLE
Add config to set buckets default SSE config

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1296,6 +1296,22 @@ class Config extends EventEmitter {
                 'bad config: maxScannedLifecycleListingEntries must be greater than 2');
             this.maxScannedLifecycleListingEntries = config.maxScannedLifecycleListingEntries;
         }
+
+        this.defaultBucketSseConfig = {};
+        if (config.defaultBucketSseConfig) {
+            const algorithm = config.defaultBucketSseConfig.algorithm;
+            if (algorithm !== undefined) {
+                assert(algorithm === 'AES256',
+                    'bad config: defaultBucketSseConfig.algorithm must be AES256');
+                this.defaultBucketSseConfig.algorithm = algorithm;
+            }
+            const mandatory = config.defaultBucketSseConfig.mandatory;
+            if (mandatory !== undefined) {
+                assert(typeof mandatory === 'boolean',
+                    'bad config: defaultBucketSseConfig.mandatory must be a boolean');
+                this.defaultBucketSseConfig.mandatory = mandatory;
+            }
+        }
     }
 
     _configureBackends() {

--- a/lib/api/apiUtils/bucket/bucketCreation.js
+++ b/lib/api/apiUtils/bucket/bucketCreation.js
@@ -10,6 +10,7 @@ const { parseBucketEncryptionHeaders } = require('./bucketEncryption');
 const metadata = require('../../../metadata/wrapper');
 const kms = require('../../../kms/wrapper');
 const isLegacyAWSBehavior = require('../../../utilities/legacyAWSBehavior');
+const { config } = require('../../../Config');
 
 const usersBucket = constants.usersBucket;
 const oldUsersBucket = constants.oldUsersBucket;
@@ -230,6 +231,8 @@ function createBucket(authInfo, bucketName, headers,
         const newBucketMD = results.prepareNewBucketMD;
         if (existingBucketMD === 'NoBucketYet') {
             const sseConfig = parseBucketEncryptionHeaders(headers);
+            sseConfig.algorithm = sseConfig.algorithm ?? config.defaultBucketSseConfig.algorithm ?? null;
+            sseConfig.mandatory = sseConfig.mandatory ?? config.defaultBucketSseConfig.mandatory ?? false;
             return bucketLevelServerSideEncryption(
                 bucketName, sseConfig, log,
                 (err, sseInfo) => {


### PR DESCRIPTION
This config allows enabling encryption by default. It currently only allows AES256.
If the user provide the x-amz-scal-server-side-encryption header on bucket creation, the header's value takes precedence.

