### PR TITLE
Fix handling of archived object replacement

### DIFF
--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -193,11 +193,6 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
         metadataStoreParams.oldReplayId = objMD.uploadId;
     }
 
-    if (objMD && !bucketMD.isVersioningEnabled() && objMD?.archive?.archiveInfo) {
-        metadataStoreParams.needOplogUpdate = true;
-        metadataStoreParams.originOp = 's3:ReplaceArchivedObject';
-    }
-
     /* eslint-disable camelcase */
     const dontSkipBackend = externalBackends;
     /* eslint-enable camelcase */
@@ -273,6 +268,9 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
             if (isPutVersion) {
                 const options = overwritingVersioning(objMD, metadataStoreParams);
                 return process.nextTick(() => next(null, options, infoArr));
+            } else if (!bucketMD.isVersioningEnabled() && objMD?.archive?.archiveInfo) {
+                // Ensure we trigger a "delete" event in the oplog for the previously archived object
+                metadataStoreParams.needOplogUpdate = 's3:ReplaceArchivedObject';
             }
             return versioningPreprocessing(bucketName, bucketMD,
                 metadataStoreParams.objectKey, objMD, log, (err, options) => {

--- a/lib/services.js
+++ b/lib/services.js
@@ -178,7 +178,7 @@ const services = {
         }
         if (needOplogUpdate) {
             options.needOplogUpdate = true;
-            options.originOp = originOp;
+            options.originOp = needOplogUpdate;
         }
         if (uploadId) {
             md.setUploadId(uploadId);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "8.8.31",
+  "version": "8.8.32",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
- The `delete` oplog entry must not be generated when putObject is used
to restore the object: otherwise a GC request will be sent to cold
backend, and the object will never be expired.
- The `originOp` of the (new) metadata should not be affected:
"s3:ReplaceArchivedObject" should only be set on the extra `delete` op
in the oplog.

Issue: CLDSRV-560
