### PR TITLE
Bump arsenal 8.1.137

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG NODE_VERSION=16.20-bullseye-slim
+ARG NODE_VERSION=16.20.2-bookworm-slim
 
-FROM node:${NODE_VERSION} as builder
+FROM node:${NODE_VERSION} AS builder
 
 WORKDIR /usr/src/app
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@azure/storage-blob": "^12.12.0",
     "@hapi/joi": "^17.1.0",
-    "arsenal": "git+https://github.com/scality/arsenal#8.1.135",
+    "arsenal": "git+https://github.com/scality/arsenal#8.1.137",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "bucketclient": "scality/bucketclient#8.1.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "8.8.32",
+  "version": "8.8.33",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1040,9 +1040,9 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#8.1.135":
-  version "8.1.135"
-  resolved "git+https://github.com/scality/arsenal#b5b126a3ce3defa235c3f1946fb60adb0cf4a1a0"
+"arsenal@git+https://github.com/scality/arsenal#8.1.137":
+  version "8.1.137"
+  resolved "git+https://github.com/scality/arsenal#eec5bc02f11e2351697b901a544d675d9c66ca81"
   dependencies:
     "@azure/identity" "^3.1.1"
     "@azure/storage-blob" "^12.12.0"


### PR DESCRIPTION
This fixes metrics report, which fails while trying to process
`system.views` as a regular "bucket" collection.

Issue: CLDSRV-562
