### PR TITLE
Keep original MPU object etag after restore

### DIFF
--- a/.github/actions/setup-ci/action.yaml
+++ b/.github/actions/setup-ci/action.yaml
@@ -20,6 +20,9 @@ runs:
       with:
         node-version: '16'
         cache: 'yarn'
+    - name: install typescript
+      shell: bash
+      run: yarn global add typescript@4.9.5
     - name: install dependencies
       shell: bash
       run: yarn install --ignore-engines --frozen-lockfile --network-concurrency 1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -79,6 +79,9 @@ jobs:
       with:
         node-version: '16'
         cache: yarn
+    - name: install typescript
+      shell: bash
+      run: yarn global add typescript@4.9.5
     - name: install dependencies
       run: yarn install --frozen-lockfile --network-concurrency 1
     - uses: actions/setup-python@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update \
 
 ENV PYTHON=python3
 COPY package.json yarn.lock /usr/src/app/
-RUN npm install typescript -g
+RUN npm install typescript@4.9.5 -g
 RUN yarn install --production --ignore-optional --frozen-lockfile --ignore-engines --network-concurrency 1
 
 ################################################################################

--- a/images/svc-base/Dockerfile
+++ b/images/svc-base/Dockerfile
@@ -14,7 +14,7 @@ RUN rm -f ~/.gitconfig && \
     git config --global --add safe.directory . && \
     git lfs install && \
     GIT_LFS_SKIP_SMUDGE=1 && \
-    yarn global add typescript && \
+    yarn global add typescript@4.9.5 && \
     yarn install --frozen-lockfile --production --network-concurrency 1 && \
     yarn cache clean --all && \
     yarn global remove typescript

--- a/lib/api/apiUtils/object/coldStorage.js
+++ b/lib/api/apiUtils/object/coldStorage.js
@@ -58,6 +58,7 @@ function setArchiveInfoHeaders(objMD) {
         if (objMD.archive.restoreCompletedAt) {
             headers['x-amz-scal-restore-completed-at'] = new Date(objMD.archive.restoreCompletedAt).toUTCString();
             headers['x-amz-scal-restore-will-expire-at'] = new Date(objMD.archive.restoreWillExpireAt).toUTCString();
+            headers['x-amz-scal-restore-etag'] = objMD['x-amz-restore']?.['content-md5'];
         }
     }
 
@@ -190,6 +191,7 @@ function _updateObjectExpirationDate(objectMD, log) {
         objectMD['x-amz-restore'] = {
             'ongoing-request': false,
             'expiry-date': expiryDate,
+            'content-md5': objectMD['x-amz-restore']?.['content-md5'],
         };
         /* eslint-enable no-param-reassign */
     }

--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -518,6 +518,14 @@ function overwritingVersioning(objMD, metadataStoreParams) {
     // set correct originOp
     metadataStoreParams.originOp = 's3:ObjectRestore:Completed';
 
+    // When restoring an MPU with different number of parts the etag changes
+    // as it's calculated based on the etags of the parts. We keep the original
+    // etag to allow proper expiration of the restored object.
+    if (metadataStoreParams.contentMD5 !== objMD['content-md5']) {
+        metadataStoreParams.restoredEtag = metadataStoreParams.contentMD5;
+        metadataStoreParams.contentMD5 = objMD['content-md5'];
+    }
+
     // update restore
     const days = objMD.archive?.restoreRequestedDays;
     const now = Date.now();

--- a/lib/services.js
+++ b/lib/services.js
@@ -109,7 +109,8 @@ const services = {
             tagging, taggingCopy, replicationInfo, defaultRetention,
             dataStoreName, creationTime, retentionMode, retentionDate,
             legalHold, originOp, updateMicroVersionId, archive, oldReplayId,
-            deleteNullKey, amzStorageClass, overheadField, needOplogUpdate } = params;
+            deleteNullKey, amzStorageClass, overheadField, needOplogUpdate,
+            restoredEtag } = params;
         log.trace('storing object in metadata');
         assert.strictEqual(typeof bucketName, 'string');
         const md = new ObjectMD();
@@ -200,6 +201,7 @@ const services = {
             md.setAmzRestore({
                 'ongoing-request': false,
                 'expiry-date': archive.restoreWillExpireAt,
+                'content-md5': restoredEtag,
             });
         }
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "npm-run-all": "~4.1.5",
     "prom-client": "14.2.0",
     "request": "^2.81.0",
-    "scubaclient": "git+https://github.com/scality/scubaclient.git",
+    "scubaclient": "git+https://github.com/scality/scubaclient.git#fb7375a9298bda7df0e9f9ed81d7fc5b363590a9",
     "sql-where-parser": "~2.2.1",
     "utapi": "github:scality/utapi#8.1.15",
     "utf-8-validate": "^5.0.8",

--- a/tests/functional/aws-node-sdk/test/object/mpuVersion.js
+++ b/tests/functional/aws-node-sdk/test/object/mpuVersion.js
@@ -81,10 +81,9 @@ function putMPU(s3, bucketName, objectName, cb) {
 function checkVersionsAndUpdate(versionsBefore, versionsAfter, indexes) {
     indexes.forEach(i => {
         assert.notStrictEqual(versionsAfter[i].value.Size, versionsBefore[i].value.Size);
-        assert.notStrictEqual(versionsAfter[i].value.ETag, versionsBefore[i].value.ETag);
+        assert.strictEqual(versionsAfter[i].value.ETag, versionsBefore[i].value.ETag);
         /* eslint-disable no-param-reassign */
         versionsBefore[i].value.Size = versionsAfter[i].value.Size;
-        versionsBefore[i].value.ETag = versionsAfter[i].value.ETag;
         /* eslint-enable no-param-reassign */
     });
 }
@@ -199,7 +198,7 @@ describe('MPU with x-scal-s3-version-id header', () => {
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
                 checkObjMdAndUpdate(objMDBefore, objMDAfter,
-                    ['location', 'content-length', 'content-md5', 'originOp', 'uploadId', 'microVersionId',
+                    ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
                     'x-amz-restore', 'archive', 'dataStoreName']);
 
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
@@ -252,7 +251,7 @@ describe('MPU with x-scal-s3-version-id header', () => {
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
                 checkObjMdAndUpdate(objMDBefore, objMDAfter,
-                    ['location', 'content-length', 'content-md5', 'originOp', 'uploadId', 'microVersionId',
+                    ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
                     'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
@@ -304,7 +303,7 @@ describe('MPU with x-scal-s3-version-id header', () => {
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
                 checkObjMdAndUpdate(objMDBefore, objMDAfter,
-                    ['location', 'content-length', 'content-md5', 'originOp', 'uploadId', 'microVersionId',
+                    ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
                     'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
@@ -411,7 +410,7 @@ describe('MPU with x-scal-s3-version-id header', () => {
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
                 checkObjMdAndUpdate(objMDBefore, objMDAfter,
-                    ['location', 'content-length', 'content-md5', 'originOp', 'uploadId', 'microVersionId',
+                    ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
                     'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
@@ -464,7 +463,7 @@ describe('MPU with x-scal-s3-version-id header', () => {
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
                 checkObjMdAndUpdate(objMDBefore, objMDAfter,
-                    ['location', 'content-length', 'content-md5', 'originOp', 'uploadId', 'microVersionId',
+                    ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
                     'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
@@ -520,7 +519,7 @@ describe('MPU with x-scal-s3-version-id header', () => {
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
                 checkObjMdAndUpdate(objMDBefore, objMDAfter,
-                    ['location', 'content-length', 'content-md5', 'originOp', 'uploadId', 'microVersionId',
+                    ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
                     'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
@@ -574,7 +573,7 @@ describe('MPU with x-scal-s3-version-id header', () => {
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
                 checkObjMdAndUpdate(objMDBefore, objMDAfter,
-                    ['location', 'content-length', 'content-md5', 'originOp', 'uploadId', 'microVersionId',
+                    ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
                     'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
@@ -627,7 +626,7 @@ describe('MPU with x-scal-s3-version-id header', () => {
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
                 checkObjMdAndUpdate(objMDBefore, objMDAfter,
-                    ['location', 'content-length', 'content-md5', 'originOp', 'uploadId', 'microVersionId',
+                    ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
                     'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
@@ -687,7 +686,7 @@ describe('MPU with x-scal-s3-version-id header', () => {
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
                 checkObjMdAndUpdate(objMDBefore, objMDAfter,
-                    ['location', 'content-length', 'content-md5', 'originOp', 'uploadId', 'microVersionId',
+                    ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
                     'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
@@ -735,7 +734,7 @@ describe('MPU with x-scal-s3-version-id header', () => {
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
                 checkObjMdAndUpdate(objMDBefore, objMDAfter,
-                    ['location', 'content-length', 'content-md5', 'originOp', 'uploadId', 'microVersionId',
+                    ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
                     'x-amz-restore', 'archive', 'dataStoreName']);
 
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
@@ -964,7 +963,7 @@ describe('MPU with x-scal-s3-version-id header', () => {
                     // data related
                     objMD['content-length'] = 99;
                     objMD['content-type'] = 'testtype';
-                    objMD['content-md5'] = 'testmd 5';
+                    objMD['content-md5'] = 'testmd5';
                     objMD['content-encoding'] = 'testencoding';
                     objMD['x-amz-server-side-encryption'] = 'aws:kms';
                     /* eslint-enable no-param-reassign */
@@ -984,9 +983,12 @@ describe('MPU with x-scal-s3-version-id header', () => {
                     // make sure data related metadatas ar not the same before and after
                     assert.notStrictEqual(objMD['x-amz-server-side-encryption'], 'aws:kms');
                     assert.notStrictEqual(objMD['content-length'], 99);
-                    assert.notStrictEqual(objMD['content-md5'], 'testmd5');
                     assert.notStrictEqual(objMD['content-encoding'], 'testencoding');
                     assert.notStrictEqual(objMD['content-type'], 'testtype');
+                    // make sure we keep the same etag and add the new restored
+                    // data's etag inside x-amz-restore
+                    assert.strictEqual(objMD['content-md5'], 'testmd5');
+                    assert.strictEqual(typeof objMD['x-amz-restore']['content-md5'], 'string');
                     return next();
                 }),
                 // removing legal hold to be able to clean the bucket after the test

--- a/tests/functional/aws-node-sdk/test/object/putVersion.js
+++ b/tests/functional/aws-node-sdk/test/object/putVersion.js
@@ -32,10 +32,9 @@ function putObjectVersion(s3, params, vid, next) {
 function checkVersionsAndUpdate(versionsBefore, versionsAfter, indexes) {
     indexes.forEach(i => {
         assert.notStrictEqual(versionsAfter[i].value.Size, versionsBefore[i].value.Size);
-        assert.notStrictEqual(versionsAfter[i].value.ETag, versionsBefore[i].value.ETag);
+        assert.strictEqual(versionsAfter[i].value.ETag, versionsBefore[i].value.ETag);
         /* eslint-disable no-param-reassign */
         versionsBefore[i].value.Size = versionsAfter[i].value.Size;
-        versionsBefore[i].value.ETag = versionsAfter[i].value.ETag;
         /* eslint-enable no-param-reassign */
     });
 }
@@ -109,7 +108,7 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'content-md5',
+                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length',
                 'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName', 'originOp']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
@@ -161,7 +160,7 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
                 checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
-                'content-md5', 'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
+                'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
             });
@@ -212,7 +211,7 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
                 checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
-                'content-md5', 'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
+                'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
             });
@@ -325,7 +324,7 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
                 checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
-                'content-md5', 'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
+                'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
             });
@@ -377,7 +376,7 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
                 checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
-                'content-md5', 'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
+                'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
             });
@@ -432,7 +431,7 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
                 checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
-                'content-md5', 'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
+                'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
             });
@@ -485,7 +484,7 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
                 checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
-                'content-md5', 'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
+                'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
             });
@@ -537,7 +536,7 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
                 checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
-                'content-md5', 'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
+                'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
             });
@@ -596,7 +595,7 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
                 checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
-                'content-md5', 'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
+                'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
             });
@@ -643,7 +642,7 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                 assert.deepStrictEqual(versionsAfter, versionsBefore);
 
                 checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
-                'content-md5', 'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
+                'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
                 return done();
             });
@@ -873,7 +872,7 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                     // data related
                     objMD['content-length'] = 99;
                     objMD['content-type'] = 'testtype';
-                    objMD['content-md5'] = 'testmd 5';
+                    objMD['content-md5'] = 'testmd5';
                     objMD['content-encoding'] = 'testencoding';
                     objMD['x-amz-server-side-encryption'] = 'aws:kms';
                     /* eslint-enable no-param-reassign */
@@ -893,9 +892,12 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                     // make sure data related metadatas ar not the same before and after
                     assert.notStrictEqual(objMD['x-amz-server-side-encryption'], 'aws:kms');
                     assert.notStrictEqual(objMD['content-length'], 99);
-                    assert.notStrictEqual(objMD['content-md5'], 'testmd5');
                     assert.notStrictEqual(objMD['content-encoding'], 'testencoding');
                     assert.notStrictEqual(objMD['content-type'], 'testtype');
+                    // make sure we keep the same etag and add the new restored
+                    // data's etag inside x-amz-restore
+                    assert.strictEqual(objMD['content-md5'], 'testmd5');
+                    assert.strictEqual(typeof objMD['x-amz-restore']['content-md5'], 'string');
                     return next();
                 }),
                 // removing legal hold to be able to clean the bucket after the test

--- a/tests/unit/api/apiUtils/coldStorage.js
+++ b/tests/unit/api/apiUtils/coldStorage.js
@@ -214,7 +214,11 @@ describe('cold storage', () => {
                 /*restoreRequestedDays*/ 2,
                 /*restoreCompletedAt*/  new Date(Date.now() - 1 * oneDay),
                 /*restoreWillExpireAt*/ new Date(Date.now() + 1 * oneDay),
-            )).getValue();
+            )).setAmzRestore({
+                'ongoing-request': false,
+                'expiry-date': new Date(Date.now() + 1 * oneDay),
+                'content-md5': '12345'
+            }).getValue();
 
             const restoreCompletedAt = objectMd.archive.restoreCompletedAt;
             const t = new Date();
@@ -233,6 +237,7 @@ describe('cold storage', () => {
                 assert.deepEqual(objectMd['x-amz-restore'], {
                     'ongoing-request': false,
                     'expiry-date': objectMd.archive.restoreWillExpireAt,
+                    'content-md5': '12345'
                 });
 
                 done();

--- a/tests/unit/api/apiUtils/versioning.js
+++ b/tests/unit/api/apiUtils/versioning.js
@@ -985,13 +985,54 @@ describe('versioning helpers', () => {
                         'restoreCompletedAt': new Date(now),
                         'restoreWillExpireAt': new Date(now + (days * scaledMsPerDay)),
                     }
-                }
+                },
+            },
+                {
+                    description: 'Should keep contentMD5 of the original object',
+                    objMD: {
+                    'versionId': '2345678',
+                    'creation-time': now,
+                    'last-modified': now,
+                    'originOp': 's3:PutObject',
+                    'x-amz-storage-class': 'cold-location',
+                    'content-md5': '123456789-5',
+                    'acl': {},
+                    'archive': {
+                        'restoreRequestedDays': days,
+                        'restoreRequestedAt': now,
+                        archiveInfo
+                        }
+                    },
+                    metadataStoreParams: {
+                        'contentMD5': '987654321-3',
+                    },
+                    expectedRes: {
+                        'creationTime': now,
+                        'lastModifiedDate': now,
+                        'updateMicroVersionId': true,
+                        'originOp': 's3:ObjectRestore:Completed',
+                        'contentMD5': '123456789-5',
+                        'restoredEtag': '987654321-3',
+                        'acl': {},
+                        'taggingCopy': undefined,
+                        'amzStorageClass': 'cold-location',
+                        'archive': {
+                            archiveInfo,
+                            'restoreRequestedDays': 3,
+                            'restoreRequestedAt': now,
+                            'restoreCompletedAt': new Date(now),
+                            'restoreWillExpireAt': new Date(now + (days * scaledMsPerDay)),
+                        }
+                    }
             },
         ].forEach(testCase => {
             it(testCase.description, () => {
                 const metadataStoreParams = {};
                 if (testCase.hasUserMD) {
                     metadataStoreParams.metaHeaders = {};
+                }
+                if (testCase.metadataStoreParams) {
+                    Object.assign(metadataStoreParams, testCase.metadataStoreParams);
                 }
                 const options = overwritingVersioning(testCase.objMD, metadataStoreParams);
                 assert.deepStrictEqual(options.versionId, testCase.objMD.versionId);

--- a/tests/unit/api/objectHead.js
+++ b/tests/unit/api/objectHead.js
@@ -552,6 +552,7 @@ describe('objectHead API', () => {
                         new Date(objectCustomMDFields.archive.restoreCompletedAt).toUTCString());
                     assert.strictEqual(res['x-amz-scal-restore-will-expire-at'],
                         new Date(objectCustomMDFields.archive.restoreWillExpireAt).toUTCString());
+                    assert.strictEqual(res['x-amz-scal-restore-etag'], mdColdHelper.restoredEtag);
                     assert.strictEqual(res['x-amz-storage-class'], mdColdHelper.defaultLocation);
                     assert.strictEqual(res['x-amz-scal-owner-id'], mdColdHelper.defaultOwnerId);
                     done(err);

--- a/tests/unit/api/utils/metadataMockColdStorage.js
+++ b/tests/unit/api/utils/metadataMockColdStorage.js
@@ -8,6 +8,7 @@ const BucketInfo = require('arsenal').models.BucketInfo;
 
 const defaultLocation = 'location-dmf-v1';
 const defaultOwnerId = '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be';
+const restoredEtag = '1234567890abcdef';
 
 const baseMd = {
     'owner-display-name': 'accessKey1displayName',
@@ -149,7 +150,11 @@ function getArchiveRestoredMD() {
             5,
             new Date(Date.now() - 10000),
             new Date(Date.now() + 60000 * 60 * 24)).getValue(),
-        'x-amz-restore': new ObjectMDAmzRestore(false, new Date(Date.now() + 60 * 60 * 24)),
+        'x-amz-restore': {
+            'ongoing-request': false,
+            'expiry-date': new Date(Date.now() + 60 * 60 * 24),
+            'content-md5': restoredEtag,
+        },
     };
 }
 
@@ -180,4 +185,5 @@ module.exports = {
     putBucketMock,
     defaultLocation,
     defaultOwnerId,
+    restoredEtag,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5302,7 +5302,7 @@ sax@>=0.6.0, sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-"scubaclient@git+https://github.com/scality/scubaclient.git":
+"scubaclient@git+https://github.com/scality/scubaclient.git#fb7375a9298bda7df0e9f9ed81d7fc5b363590a9":
   version "1.0.0"
   resolved "git+https://github.com/scality/scubaclient.git#fb7375a9298bda7df0e9f9ed81d7fc5b363590a9"
   dependencies:


### PR DESCRIPTION
When restoring an MPU, the object data might be PUT with a different number of parts, which in turn changes the etag of the object as it is calculated based on the etag of each uploaded part.

We now keep the same etag in case of a restore to avoid breaking the expiration of the restored object as it checks the etag of the object before expiting.

The new etag is kept in the metadata of the object and can be viewed with a head-object operation when passing the `x-amz-scal-archive-info` header.

The new etag field is added to the `x-amz-restore` section of the metadata, so it will be removed when the object expires.

Issue: CLDSRV-564