### PR TITLE
CLDSRV-569 isAccountEncryptionEnabled removed after deleteBucketEncry…

### DIFF
--- a/lib/api/bucketDeleteEncryption.js
+++ b/lib/api/bucketDeleteEncryption.js
@@ -42,6 +42,11 @@ function bucketDeleteEncryption(authInfo, request, log, callback) {
                 configuredMasterKeyId: sseConfig.configuredMasterKeyId,
             };
 
+            const { isAccountEncryptionEnabled } = sseConfig;
+            if (isAccountEncryptionEnabled) {
+                updatedConfig.isAccountEncryptionEnabled = isAccountEncryptionEnabled;
+            }
+
             bucket.setServerSideEncryption(updatedConfig);
             return metadata.updateBucket(bucketName, bucket, log, err => next(err, bucket));
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.70.54",
+  "version": "7.70.55",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Context:
When a bucket is deleted, we don't remove the encryption information entirely; instead, we hide it using the mandatory property. This allows the default encryption master key to be reused.

Issue:
After calling S3.deleteBucketEncryption, the isAccountEncryptionEnabled flag is being removed. This flag is crucial, as it prevents the master encryption key from being deleted during a bucket deletion when the key is set at the account level.