### PR TITLE
Fix complete MPU with missing parts

### DIFF
--- a/lib/api/apiUtils/object/abortMultipartUpload.js
+++ b/lib/api/apiUtils/object/abortMultipartUpload.js
@@ -18,6 +18,8 @@ function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
         preciseRequestType: request.apiMethods || 'multipartDelete',
         request,
     };
+
+    log.debug('processing request', { method: 'abortMultipartUpload' });
     // For validating the request at the destinationBucket level
     // params are the same as validating at the MPU level
     // but the requestType is the more general 'objectDelete'
@@ -30,6 +32,7 @@ function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
             standardMetadataValidateBucketAndObj(metadataValParams, authzIdentityResult, log,
                 (err, destinationBucket, objectMD) => {
                     if (err) {
+                        log.error('error validating request', { error: err });
                         return next(err, destinationBucket);
                     }
                     if (destinationBucket.policies) {
@@ -50,6 +53,7 @@ function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
             services.metadataValidateMultipart(metadataValParams,
                 (err, mpuBucket, mpuOverviewObj) => {
                     if (err) {
+                        log.error('error validating multipart', { error: err });
                         return next(err, destBucket);
                     }
                     return next(err, mpuBucket, mpuOverviewObj, destBucket, objectMD);
@@ -67,6 +71,7 @@ function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
                 // eslint-disable-next-line no-param-reassign
                 request.actionImplicitDenies = originalIdentityAuthzResults;
                 if (err) {
+                    log.error('error aborting MPU', { error: err });
                     return next(err, destBucket);
                 }
                 // for Azure and GCP we do not need to delete data
@@ -79,6 +84,7 @@ function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
             services.getMPUparts(mpuBucket.getName(), uploadId, log,
                 (err, result) => {
                     if (err) {
+                        log.error('error getting parts', { error: err });
                         return next(err, destBucket);
                     }
                     const storedParts = result.Contents;
@@ -115,7 +121,11 @@ function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
             // In case there has been an error during cleanup after a complete MPU
             // (e.g. failure to delete MPU MD in shadow bucket),
             // we need to ensure that the MPU metadata is deleted.
-
+            log.info('Object has existing metadata, deleting them', {
+                method: 'abortMultipartUpload',
+                bucketName,
+                objectKey,
+            });
             return metadata.deleteObjectMD(bucketName, objectKey, undefined, log, err => {
                 if (err) {
                     log.error('error deleting object metadata', { error: err });

--- a/lib/api/apiUtils/object/abortMultipartUpload.js
+++ b/lib/api/apiUtils/object/abortMultipartUpload.js
@@ -104,7 +104,7 @@ function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
                 bucketName,
                 objectKey,
                 uploadId,
-                versionId: objectMD.versionId
+                versionId: objectMD.versionId,
             });
             return metadata.deleteObjectMD(bucketName, objectKey, { versionId: objectMD.versionId }, log, err => {
                 if (err) {
@@ -120,16 +120,15 @@ function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
             }
             // The locations were sent to metadata as an array
             // under partLocations.  Pull the partLocations.
-            let locations = storedParts.flatMap(item => item.value.partLocations);
+            const locations = storedParts.flatMap(item => item.value.partLocations);
             if (locations.length === 0) {
                 return next(null, mpuBucket, storedParts, destBucket);
             }
 
-            const existingLocations = new Set(locations.map(loc => loc.key));
-
             if (objectMD?.location) {
+                const existingLocations = new Set(locations.map(loc => loc.key));
                 const remainingObjectLocations = objectMD.location.filter(loc => !existingLocations.has(loc.key));
-                locations = [...locations, ...remainingObjectLocations];
+                locations.push(...remainingObjectLocations);
             }
 
             return async.eachLimit(locations, 5, (loc, cb) => {

--- a/lib/api/apiUtils/object/abortMultipartUpload.js
+++ b/lib/api/apiUtils/object/abortMultipartUpload.js
@@ -128,7 +128,7 @@ function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
                 uploadId,
                 versionId: objectMD.versionId
             });
-            return metadata.deleteObjectMD(bucketName, objectKey, {versionId: objectMD.versionId}, log, err => {
+            return metadata.deleteObjectMD(bucketName, objectKey, { versionId: objectMD.versionId }, log, err => {
                 if (err) {
                     log.error('error deleting object metadata', { error: err });
                 }

--- a/lib/api/apiUtils/object/abortMultipartUpload.js
+++ b/lib/api/apiUtils/object/abortMultipartUpload.js
@@ -120,17 +120,16 @@ function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
             }
             // The locations were sent to metadata as an array
             // under partLocations.  Pull the partLocations.
-            let locations = storedParts.map(item => item.value.partLocations);
+            let locations = storedParts.flatMap(item => item.value.partLocations);
             if (locations.length === 0) {
                 return next(null, mpuBucket, storedParts, destBucket);
             }
-            // flatten the array
-            locations = [].concat(...locations);
+
+            const existingLocations = new Set(locations.map(loc => loc.key));
 
             if (objectMD?.location) {
-                const objectLocationLeft = objectMD.location.filter(loc =>
-                    !locations.some(existingLoc => existingLoc.key === loc.key));
-                locations = locations.concat(objectLocationLeft);
+                const remainingObjectLocations = objectMD.location.filter(loc => !existingLocations.has(loc.key));
+                locations = [...locations, ...remainingObjectLocations];
             }
 
             return async.eachLimit(locations, 5, (loc, cb) => {

--- a/lib/api/apiUtils/object/abortMultipartUpload.js
+++ b/lib/api/apiUtils/object/abortMultipartUpload.js
@@ -125,8 +125,10 @@ function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
                 method: 'abortMultipartUpload',
                 bucketName,
                 objectKey,
+                uploadId,
+                versionId: objectMD.versionId
             });
-            return metadata.deleteObjectMD(bucketName, objectKey, undefined, log, err => {
+            return metadata.deleteObjectMD(bucketName, objectKey, {versionId: objectMD.versionId}, log, err => {
                 if (err) {
                     log.error('error deleting object metadata', { error: err });
                 }
@@ -138,9 +140,9 @@ function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
                 return next(null, mpuBucket, storedParts, destBucket);
             }
             // Filtering parts that has already been delete by the previous step
-            let partLocations = storedParts.map(item => item.value.partLocations);
-            partLocations = [].concat(...partLocations);
-            partLocations = new Set(partLocations.map(loc => loc.key));
+            const partLocations = new Set(
+                storedParts.flatMap(item => item.value.partLocations.map(loc => loc.key))
+            );
             const objectLocationLeft = objectMD.location.filter(loc => !partLocations.has(loc.key));
 
             return async.eachLimit(objectLocationLeft, 5, (loc, cb) => {

--- a/lib/api/apiUtils/object/abortMultipartUpload.js
+++ b/lib/api/apiUtils/object/abortMultipartUpload.js
@@ -109,14 +109,14 @@ function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
             }, () => next(null, mpuBucket, storedParts, destBucket, objectMD));
         },
         function deleteObjectMetadata(mpuBucket, storedParts, destBucket, objectMD, next) {
-            if (objectMD && metadataValMPUparams.uploadId !== objectMD.uploadId) {
+            if (!objectMD || metadataValMPUparams.uploadId !== objectMD.uploadId) {
                 return next(null, mpuBucket, storedParts, destBucket, objectMD);
             }
             // In case there has been an error during cleanup after a complete MPU
             // (e.g. failure to delete MPU MD in shadow bucket),
             // we need to ensure that the MPU metadata is deleted.
 
-            metadata.deleteObjectMD(bucketName, objectKey, undefined, log, err => {
+            return metadata.deleteObjectMD(bucketName, objectKey, undefined, log, err => {
                 if (err) {
                     log.error('error deleting object metadata', { error: err });
                 }

--- a/lib/api/apiUtils/object/abortMultipartUpload.js
+++ b/lib/api/apiUtils/object/abortMultipartUpload.js
@@ -6,6 +6,7 @@ const locationConstraintCheck = require('../object/locationConstraintCheck');
 const { standardMetadataValidateBucketAndObj } =
     require('../../../metadata/metadataUtils');
 const services = require('../../../services');
+const metadata = require('../../../metadata/wrapper');
 
 function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
     callback, request) {
@@ -27,7 +28,7 @@ function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
     async.waterfall([
         function checkDestBucketVal(next) {
             standardMetadataValidateBucketAndObj(metadataValParams, authzIdentityResult, log,
-                (err, destinationBucket) => {
+                (err, destinationBucket, objectMD) => {
                     if (err) {
                         return next(err, destinationBucket);
                     }
@@ -41,20 +42,20 @@ function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
                         metadataValMPUparams.requestType =
                             'bucketPolicyGoAhead';
                     }
-                    return next(null, destinationBucket);
+                    return next(null, destinationBucket, objectMD);
                 });
         },
-        function checkMPUval(destBucket, next) {
+        function checkMPUval(destBucket, objectMD, next) {
             metadataValParams.log = log;
             services.metadataValidateMultipart(metadataValParams,
                 (err, mpuBucket, mpuOverviewObj) => {
                     if (err) {
                         return next(err, destBucket);
                     }
-                    return next(err, mpuBucket, mpuOverviewObj, destBucket);
+                    return next(err, mpuBucket, mpuOverviewObj, destBucket, objectMD);
                 });
         },
-        function abortExternalMpu(mpuBucket, mpuOverviewObj, destBucket,
+        function abortExternalMpu(mpuBucket, mpuOverviewObj, destBucket, objectMD,
         next) {
             const location = mpuOverviewObj.controllingLocationConstraint;
             const originalIdentityAuthzResults = request.actionImplicitDenies;
@@ -70,10 +71,10 @@ function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
                 }
                 // for Azure and GCP we do not need to delete data
                 // for all other backends, skipDataDelete will be set to false
-                return next(null, mpuBucket, destBucket, skipDataDelete);
+                return next(null, mpuBucket, destBucket, objectMD, skipDataDelete);
             });
         },
-        function getPartLocations(mpuBucket, destBucket, skipDataDelete,
+        function getPartLocations(mpuBucket, destBucket, objectMD, skipDataDelete,
         next) {
             services.getMPUparts(mpuBucket.getName(), uploadId, log,
                 (err, result) => {
@@ -81,20 +82,20 @@ function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
                         return next(err, destBucket);
                     }
                     const storedParts = result.Contents;
-                    return next(null, mpuBucket, storedParts, destBucket,
+                    return next(null, mpuBucket, storedParts, destBucket, objectMD,
                     skipDataDelete);
                 });
         },
-        function deleteData(mpuBucket, storedParts, destBucket,
+        function deleteData(mpuBucket, storedParts, destBucket, objectMD,
         skipDataDelete, next) {
             if (skipDataDelete) {
-                return next(null, mpuBucket, storedParts, destBucket);
+                return next(null, mpuBucket, storedParts, destBucket, objectMD);
             }
             // The locations were sent to metadata as an array
             // under partLocations.  Pull the partLocations.
             let locations = storedParts.map(item => item.value.partLocations);
             if (locations.length === 0) {
-                return next(null, mpuBucket, storedParts, destBucket);
+                return next(null, mpuBucket, storedParts, destBucket, objectMD);
             }
             // flatten the array
             locations = [].concat(...locations);
@@ -105,9 +106,39 @@ function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
                     }
                     cb();
                 });
-            }, () => next(null, mpuBucket, storedParts, destBucket));
+            }, () => next(null, mpuBucket, storedParts, destBucket, objectMD));
         },
-        function deleteMetadata(mpuBucket, storedParts, destBucket, next) {
+        function deleteObjectData(mpuBucket, storedParts, destBucket, objectMD, next) {
+            // Filtering parts that has already been delete by the previous step
+            let partLocations = storedParts.map(item => item.value.partLocations);
+            partLocations = [].concat(...partLocations);
+            partLocations = new Set(partLocations.map(loc => loc.key));
+            const objectLocationLeft = objectMD.location.filter(loc => !partLocations.has(loc.key));
+
+            return async.eachLimit(objectLocationLeft, 5, (loc, cb) => {
+                data.delete(loc, log, err => {
+                    if (err) {
+                        log.fatal('delete object data failed', { err });
+                    }
+                    cb();
+                });
+            }, () => next(null, mpuBucket, storedParts, destBucket, objectMD));
+        },
+        function deleteObjectMetadata(mpuBucket, storedParts, destBucket, objectMD, next) {
+            if (metadataValMPUparams.uploadId === objectMD.uploadId) {
+                // In case there has been an error during cleanup after a complete MPU
+                // (e.g. failure to delete MPU MD in shadow bucket),
+                // we need to ensure that the MPU metadata is deleted.
+
+                metadata.deleteObjectMD(bucketName, objectKey, undefined, log, err => {
+                    if (err) {
+                        log.error('error deleting object metadata', { error: err });
+                    }
+                    return next(err, mpuBucket, storedParts, destBucket);
+                });
+            }
+        },
+        function deleteShadowObjectMetadata(mpuBucket, storedParts, destBucket, next) {
             let splitter = constants.splitter;
             // BACKWARD: Remove to remove the old splitter
             if (mpuBucket.getMdBucketModelVersion() < 2) {

--- a/lib/api/apiUtils/object/abortMultipartUpload.js
+++ b/lib/api/apiUtils/object/abortMultipartUpload.js
@@ -92,31 +92,9 @@ function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
                     skipDataDelete);
                 });
         },
-        function deleteData(mpuBucket, storedParts, destBucket, objectMD,
-        skipDataDelete, next) {
-            if (skipDataDelete) {
-                return next(null, mpuBucket, storedParts, destBucket, objectMD);
-            }
-            // The locations were sent to metadata as an array
-            // under partLocations.  Pull the partLocations.
-            let locations = storedParts.map(item => item.value.partLocations);
-            if (locations.length === 0) {
-                return next(null, mpuBucket, storedParts, destBucket, objectMD);
-            }
-            // flatten the array
-            locations = [].concat(...locations);
-            return async.eachLimit(locations, 5, (loc, cb) => {
-                data.delete(loc, log, err => {
-                    if (err) {
-                        log.fatal('delete ObjectPart failed', { err });
-                    }
-                    cb();
-                });
-            }, () => next(null, mpuBucket, storedParts, destBucket, objectMD));
-        },
-        function deleteObjectMetadata(mpuBucket, storedParts, destBucket, objectMD, next) {
+        function deleteObjectMetadata(mpuBucket, storedParts, destBucket, objectMD, skipDataDelete, next) {
             if (!objectMD || metadataValMPUparams.uploadId !== objectMD.uploadId) {
-                return next(null, mpuBucket, storedParts, destBucket, objectMD);
+                return next(null, mpuBucket, storedParts, destBucket, objectMD, skipDataDelete);
             }
             // In case there has been an error during cleanup after a complete MPU
             // (e.g. failure to delete MPU MD in shadow bucket),
@@ -132,23 +110,33 @@ function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
                 if (err) {
                     log.error('error deleting object metadata', { error: err });
                 }
-                return next(err, mpuBucket, storedParts, destBucket, objectMD);
+                return next(err, mpuBucket, storedParts, destBucket, objectMD, skipDataDelete);
             });
         },
-        function deleteObjectData(mpuBucket, storedParts, destBucket, objectMD, next) {
-            if (!objectMD?.location) {
+        function deleteData(mpuBucket, storedParts, destBucket, objectMD,
+        skipDataDelete, next) {
+            if (skipDataDelete) {
                 return next(null, mpuBucket, storedParts, destBucket);
             }
-            // Filtering parts that has already been delete by the previous step
-            const partLocations = new Set(
-                storedParts.flatMap(item => item.value.partLocations.map(loc => loc.key))
-            );
-            const objectLocationLeft = objectMD.location.filter(loc => !partLocations.has(loc.key));
+            // The locations were sent to metadata as an array
+            // under partLocations.  Pull the partLocations.
+            let locations = storedParts.map(item => item.value.partLocations);
+            if (locations.length === 0) {
+                return next(null, mpuBucket, storedParts, destBucket);
+            }
+            // flatten the array
+            locations = [].concat(...locations);
 
-            return async.eachLimit(objectLocationLeft, 5, (loc, cb) => {
+            if (objectMD?.location) {
+                const objectLocationLeft = objectMD.location.filter(loc =>
+                    !locations.some(existingLoc => existingLoc.key === loc.key));
+                locations = locations.concat(objectLocationLeft);
+            }
+
+            return async.eachLimit(locations, 5, (loc, cb) => {
                 data.delete(loc, log, err => {
                     if (err) {
-                        log.fatal('delete object data failed', { err });
+                        log.fatal('delete ObjectPart failed', { err });
                     }
                     cb();
                 });

--- a/lib/api/apiUtils/object/abortMultipartUpload.js
+++ b/lib/api/apiUtils/object/abortMultipartUpload.js
@@ -108,7 +108,25 @@ function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
                 });
             }, () => next(null, mpuBucket, storedParts, destBucket, objectMD));
         },
+        function deleteObjectMetadata(mpuBucket, storedParts, destBucket, objectMD, next) {
+            if (objectMD && metadataValMPUparams.uploadId !== objectMD.uploadId) {
+                return next(null, mpuBucket, storedParts, destBucket, objectMD);
+            }
+            // In case there has been an error during cleanup after a complete MPU
+            // (e.g. failure to delete MPU MD in shadow bucket),
+            // we need to ensure that the MPU metadata is deleted.
+
+            metadata.deleteObjectMD(bucketName, objectKey, undefined, log, err => {
+                if (err) {
+                    log.error('error deleting object metadata', { error: err });
+                }
+                return next(err, mpuBucket, storedParts, destBucket, objectMD);
+            });
+        },
         function deleteObjectData(mpuBucket, storedParts, destBucket, objectMD, next) {
+            if (!objectMD?.location) {
+                return next(null, mpuBucket, storedParts, destBucket);
+            }
             // Filtering parts that has already been delete by the previous step
             let partLocations = storedParts.map(item => item.value.partLocations);
             partLocations = [].concat(...partLocations);
@@ -122,21 +140,7 @@ function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
                     }
                     cb();
                 });
-            }, () => next(null, mpuBucket, storedParts, destBucket, objectMD));
-        },
-        function deleteObjectMetadata(mpuBucket, storedParts, destBucket, objectMD, next) {
-            if (metadataValMPUparams.uploadId === objectMD.uploadId) {
-                // In case there has been an error during cleanup after a complete MPU
-                // (e.g. failure to delete MPU MD in shadow bucket),
-                // we need to ensure that the MPU metadata is deleted.
-
-                metadata.deleteObjectMD(bucketName, objectKey, undefined, log, err => {
-                    if (err) {
-                        log.error('error deleting object metadata', { error: err });
-                    }
-                    return next(err, mpuBucket, storedParts, destBucket);
-                });
-            }
+            }, () => next(null, mpuBucket, storedParts, destBucket));
         },
         function deleteShadowObjectMetadata(mpuBucket, storedParts, destBucket, next) {
             let splitter = constants.splitter;

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -152,6 +152,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
             return services.metadataValidateMultipart(metadataValParams,
                 (err, mpuBucket, mpuOverview, storedMetadata) => {
                     if (err) {
+                        log.error('error validating request', { error: err });
                         return next(err, destBucket);
                     }
                     return next(null, destBucket, objMD, mpuBucket,
@@ -172,6 +173,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
             if (request.post) {
                 return parseXml(request.post, (err, jsonList) => {
                     if (err) {
+                        log.error('error parsing XML', { error: err });
                         return next(err, destBucket);
                     }
                     return next(null, destBucket, objMD, mpuBucket,
@@ -190,6 +192,12 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                 storedMetadata,
             }, log, err => {
                 if (err) {
+                    log.error('error marking MPU object for completion', {
+                        bucketName: mpuBucket.getName(),
+                        objectKey,
+                        uploadId,
+                        error: err,
+                    });
                     return next(err);
                 }
                 return next(null, destBucket, objMD, mpuBucket,
@@ -201,6 +209,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
             return services.getMPUparts(mpuBucket.getName(), uploadId, log,
                 (err, result) => {
                     if (err) {
+                        log.error('error getting parts', { error: err });
                         return next(err, destBucket);
                     }
                     const storedParts = result.Contents;
@@ -222,6 +231,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                 // eslint-disable-next-line no-param-reassign
                 request.actionImplicitDenies = originalIdentityImpDenies;
                 if (err) {
+                    log.error('error completing MPU externally', { error: err });
                     return next(err, destBucket);
                 }
                 // if mpu not handled externally, completeObjData will be null
@@ -452,6 +462,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                 dataLocations, pseudoCipherBundle, metaStoreParams,
                 (err, res) => {
                     if (err) {
+                        log.error('error storing object metadata', { error: err });
                         return next(err, destinationBucket);
                     }
 

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -30,7 +30,6 @@ const metadataswitch = require('../metadataswitch');
 const { metadata } = storage.metadata.inMemory.metadata;
 const metadataBackend = storage.metadata.inMemory.metastore;
 const { ds } = storage.data.inMemory.datastore;
-const ms = storage.metadata.inMemory.metastore;
 
 const log = new DummyRequestLogger();
 
@@ -1919,8 +1918,8 @@ describe('Multipart Upload API', () => {
     });
 
     it('should abort an MPU and delete its MD if it has been created by a failed complete before', done => {
-        const delMeta = ms.deleteObject;
-        ms.deleteObject = (bucketName, objName, params, log, cb) => cb(errors.InternalError);
+        const delMeta = metadataBackend.deleteObject;
+        metadataBackend.deleteObject = (bucketName, objName, params, log, cb) => cb(errors.InternalError);
         const partBody = Buffer.from('I am a part\n', 'utf8');
         initiateRequest.headers['x-amz-meta-stuff'] =
             'I am some user metadata';
@@ -1976,7 +1975,7 @@ describe('Multipart Upload API', () => {
                             'I am some user metadata');
                         assert.strictEqual(MD.uploadId, testUploadId);
 
-                        ms.deleteObject = delMeta;
+                        metadataBackend.deleteObject = delMeta;
                         const deleteRequest = {
                             bucketName,
                             namespace,
@@ -1998,8 +1997,8 @@ describe('Multipart Upload API', () => {
     });
 
     it('should complete an MPU and promote its MD if it has been created by a failed complete before', done => {
-        const delMeta = ms.deleteObject;
-        ms.deleteObject = (bucketName, objName, params, log, cb) => cb(errors.InternalError);
+        const delMeta = metadataBackend.deleteObject;
+        metadataBackend.deleteObject = (bucketName, objName, params, log, cb) => cb(errors.InternalError);
         const partBody = Buffer.from('I am a part\n', 'utf8');
         initiateRequest.headers['x-amz-meta-stuff'] =
             'I am some user metadata';
@@ -2053,7 +2052,7 @@ describe('Multipart Upload API', () => {
                         assert.strictEqual(MD['x-amz-meta-stuff'],
                             'I am some user metadata');
                         assert.strictEqual(MD.uploadId, testUploadId);
-                        ms.deleteObject = delMeta;
+                        metadataBackend.deleteObject = delMeta;
                         assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 2);
                         completeMultipartUpload(authInfo,
                             completeRequest, log, err => {
@@ -2306,8 +2305,8 @@ describe('complete mpu with versioning', () => {
 
     it('should complete an MPU and promote its MD if it has been created by a failed complete before' +
         'without creating a new version', done => {
-        const delMeta = ms.deleteObject;
-        ms.deleteObject = (bucketName, objName, params, log, cb) => cb(errors.InternalError);
+        const delMeta = metadataBackend.deleteObject;
+        metadataBackend.deleteObject = (bucketName, objName, params, log, cb) => cb(errors.InternalError);
         const partBody = Buffer.from('I am a part\n', 'utf8');
         initiateRequest.headers['x-amz-meta-stuff'] =
             'I am some user metadata';
@@ -2364,7 +2363,7 @@ describe('complete mpu with versioning', () => {
                         assert.strictEqual(MD['x-amz-meta-stuff'],
                             'I am some user metadata');
                         assert.strictEqual(MD.uploadId, testUploadId);
-                        ms.deleteObject = delMeta;
+                        metadataBackend.deleteObject = delMeta;
                         assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 2);
                         completeMultipartUpload(authInfo,
                             completeRequest, log, err => {

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -2048,8 +2048,7 @@ describe('Multipart Upload API', () => {
                 completeMultipartUpload(authInfo,
                     completeRequest, log, err => {
                         assert(err.is.InternalError);
-                        const MD = metadata.keyMaps.get(bucketName)
-                                                    .get(objectKey);
+                        const MD = metadata.keyMaps.get(bucketName).get(objectKey);
                         assert(MD);
                         assert.strictEqual(MD['x-amz-meta-stuff'],
                             'I am some user metadata');


### PR DESCRIPTION
In case of a complete MPU error after the storage of the object MD, the abort must delete object MDs and object Data, some part may have been deleted already in the MPU metadata, hence we need to verify in the object MD for the parts it's linked to, to avoid creating orphans

Issue: CLDSRV-570