### PR TITLE
Add expiration backbeat route

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -35,6 +35,7 @@ const kms = require('../kms/wrapper');
 const { listLifecycleCurrents } = require('../api/backbeat/listLifecycleCurrents');
 const { listLifecycleNonCurrents } = require('../api/backbeat/listLifecycleNonCurrents');
 const { listLifecycleOrphanDeleteMarkers } = require('../api/backbeat/listLifecycleOrphanDeleteMarkers');
+const objectDelete = require('../api/objectDelete');
 const { CURRENT_TYPE, NON_CURRENT_TYPE, ORPHAN_DM_TYPE } = constants.lifecycleListing;
 
 const lifecycleTypeCalls = {
@@ -694,6 +695,23 @@ function putObject(request, response, log, callback) {
         });
 }
 
+// This method was added to avoid having two different paths in Backbeat when
+// expiring an object. In Zenko this function sets the proper originOp to trigger
+// an expiration notification. Not supported in S3C as it may add significant load
+// with the added metadata update operations.
+function deleteObjectFromExpiration(request, response, userInfo, log, callback) {
+    return objectDelete(userInfo, request, log, err => {
+        if (err) {
+            log.error('error deleting object from expiration', {
+                error: err,
+                method: 'deleteObjectFromExpiration',
+            });
+            return callback(err);
+        }
+        return _respond(response, {}, log, callback);
+    });
+}
+
 function deleteObject(request, response, log, callback) {
     const err = _checkMultipleBackendRequest(request, log);
     if (err) {
@@ -1199,6 +1217,7 @@ const backbeatRoutes = {
         batchdelete: batchDelete,
     },
     DELETE: {
+        expiration: deleteObjectFromExpiration,
         multiplebackenddata: {
             deleteobject: deleteObject,
             deleteobjecttagging: deleteObjectTagging,


### PR DESCRIPTION
Implement the `deleteObjectFromExpiration` API in backbeat routes in 7.x that routes to the standard delete API to avoid having two different deletion paths in the unified backbeat when expiring an object.

Issue: CLDSRV-572