### PR TITLE
CLDSRV-573: Fix crash because of prom-client timeout

### DIFF
--- a/lib/utilities/monitoringHandler.js
+++ b/lib/utilities/monitoringHandler.js
@@ -24,7 +24,15 @@ async function routeHandler(req, res, cb) {
     if (req.method !== 'GET') {
         return cb(errors.BadRequest, []);
     }
-    const metrics = await aggregatorRegistry.clusterMetrics();
+    let metrics;
+    try {
+        // Catch timeout on IPC between worker and primary
+        // prom-client has a 5s hardcoded timeout
+        metrics = await aggregatorRegistry.clusterMetrics();
+    } catch (err) {
+        return cb(err, { message: err.toString() });
+    }
+
     const contentLen = Buffer.byteLength(metrics, 'utf8');
     res.writeHead(200, {
         'Content-Length': contentLen,
@@ -48,7 +56,11 @@ function monitoringHandler(clientIP, req, res, log) {
     function monitoringEndHandler(err, results) {
         writeResponse(res, err, results, error => {
             if (error) {
-                return log.end().warn('monitoring error', { err: error });
+                return log.end().warn('monitoring error', { err: {
+                    ...error,
+                    // For ArsenalError message is in description
+                    message: error.description || error.message,
+                } });
             }
             return log.end();
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.70.55",
+  "version": "7.70.56",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Instead of crashing it will now stay alive, return a 500 with body `{"message":"Error: Operation timed out."}` and log

```json
{"name":"S3","clientIP":"::1","clientPort":53518,"httpMethod":"GET","httpURL":"/metrics","err":{"message":"Operation timed out."},"time":1730901149499,"req_id":"31b0c58cb14cad5c9583","elapsed_ms":5002.625237,"level":"warn","message":"monitoring error","hostname":"MDM-RING-46789-store-1","pid":115}
```

For other arsenal error  we will have the message field: `"err":{"MethodNotAllowed":true,"message":"The specified method is not allowed against this resource."}`

This changes will not go into ZENKO as they don't use the cluster module with prom-client

> [!IMPORTANT]
>
> This problem happens often in low resource platform (like CI).
> This will fix many flaky CI on Federation that fails because the step `Check if s3 Prometheus exporter is active` retry 3 times ith small delay, crashing s3 multiple time