### PR TITLE
Fix handling of archived object replacement

### DIFF
--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -268,7 +268,8 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
             if (isPutVersion) {
                 const options = overwritingVersioning(objMD, metadataStoreParams);
                 return process.nextTick(() => next(null, options, infoArr));
-            } else if (!bucketMD.isVersioningEnabled() && objMD?.archive?.archiveInfo) {
+            }
+            if (!bucketMD.isVersioningEnabled() && objMD?.archive?.archiveInfo) {
                 // Ensure we trigger a "delete" event in the oplog for the previously archived object
                 metadataStoreParams.needOplogUpdate = 's3:ReplaceArchivedObject';
             }

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -382,6 +382,12 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     objMD, extraPartLocations, pseudoCipherBundle,
                     completeObjData, options));
             }
+
+            if (!destBucket.isVersioningEnabled() && objMD?.archive?.archiveInfo) {
+                // Ensure we trigger a "delete" event in the oplog for the previously archived object
+                metaStoreParams.needOplogUpdate = 's3:ReplaceArchivedObject';
+            }
+
             return versioningPreprocessing(bucketName,
                 destBucket, objectKey, objMD, log, (err, options) => {
                     if (err) {

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -479,6 +479,11 @@ function objectCopy(authInfo, request, sourceBucket,
         },
         function getVersioningInfo(storeMetadataParams, destDataGetInfoArr,
             destObjMD, serverSideEncryption, destBucketMD, next) {
+            if (!destBucketMD.isVersioningEnabled() && destObjMD?.archive?.archiveInfo) {
+                // Ensure we trigger a "delete" event in the oplog for the previously archived object
+                // eslint-disable-next-line
+                storeMetadataParams.needOplogUpdate = 's3:ReplaceArchivedObject';
+            }
             return versioningPreprocessing(destBucketName,
                 destBucketMD, destObjectKey, destObjMD, log,
                 (err, options) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "8.8.35",
+  "version": "8.8.36",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
When an objects overwrites an object in a non-versioned bucket, need
to add special handling to ensure an oplog entry is generated about the
"removal" of object: so that Backbeat can detect it, and notify cold
storage backend.

This was fixed already for putObject in CLDSRV-560, but the MPU and
copyObject cases were not handled.

Issue: CLDSRV-577
