### PR TITLE
CLDSRV-580 Custom KMS key id persisted after deleting bucket encrypti…

### DIFF
--- a/lib/api/bucketDeleteEncryption.js
+++ b/lib/api/bucketDeleteEncryption.js
@@ -30,24 +30,33 @@ function bucketDeleteEncryption(authInfo, request, log, callback) {
         (bucket, next) => checkExpectedBucketOwner(request.headers, bucket, log, err => next(err, bucket)),
         (bucket, next) => {
             const sseConfig = bucket.getServerSideEncryption();
+
             if (sseConfig === null) {
                 return next(null, bucket);
             }
 
-            const updatedConfig = {
-                mandatory: false,
-                algorithm: sseConfig.algorithm,
-                cryptoScheme: sseConfig.cryptoScheme,
-                masterKeyId: sseConfig.masterKeyId,
-                configuredMasterKeyId: sseConfig.configuredMasterKeyId,
-            };
+            const { isAccountEncryptionEnabled, masterKeyId, algorithm, cryptoScheme } = sseConfig;
 
-            const { isAccountEncryptionEnabled } = sseConfig;
-            if (isAccountEncryptionEnabled) {
-                updatedConfig.isAccountEncryptionEnabled = isAccountEncryptionEnabled;
+            let updatedSseConfig = null;
+
+            if (!isAccountEncryptionEnabled && masterKeyId) {
+                // Keep the encryption configuration as a "cache" to avoid generating a new master key:
+                // - if the default encryption master key is defined at the bucket level (!isAccountEncryptionEnabled),
+                // - and if a bucket-level default encryption key is already set.
+                // This "cache" is implemented by storing the configuration in the bucket metadata
+                // with mandatory set to false, making sure it remains hidden for `getBucketEncryption` operations.
+                // There is no need to cache the configuration if the default encryption master key is
+                // managed at the account level, as the master key id in that case is stored directly in
+                // the account metadata.
+                updatedSseConfig = {
+                    mandatory: false,
+                    algorithm,
+                    cryptoScheme,
+                    masterKeyId,
+                };
             }
 
-            bucket.setServerSideEncryption(updatedConfig);
+            bucket.setServerSideEncryption(updatedSseConfig);
             return metadata.updateBucket(bucketName, bucket, log, err => next(err, bucket));
         },
     ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.70.21-10",
+  "version": "7.70.21-11",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {

--- a/tests/unit/api/bucketDeleteEncryption.js
+++ b/tests/unit/api/bucketDeleteEncryption.js
@@ -50,7 +50,7 @@ describe('bucketDeleteEncryption API', () => {
             });
         }));
 
-    it('should disable mandatory sse and clear key for aws:kms with a configured master key id', done => {
+    it('should remove sse and clear key for aws:kms with a configured master key id', done => {
         const post = templateSSEConfig({ algorithm: 'aws:kms', keyId: '12345' });
         bucketPutEncryption(authInfo, templateRequest(bucketName, { post }), log, err => {
             assert.ifError(err);
@@ -58,9 +58,7 @@ describe('bucketDeleteEncryption API', () => {
                 assert.ifError(err);
                 return getSSEConfig(bucketName, log, (err, sseInfo) => {
                     assert.ifError(err);
-                    assert(!sseInfo.masterKeyId);
-                    assert.strictEqual(sseInfo.mandatory, false);
-                    assert.strictEqual(sseInfo.configuredMasterKeyId, '12345');
+                    assert(!sseInfo);
                     done();
                 });
             });
@@ -227,7 +225,7 @@ describe('bucketDeleteEncryption API', () => {
             sinon.restore();
         });
 
-        it('should keep isAccountEncryptionEnabled after deleting AES256 bucket encryption', done => {
+        it('should clear the sse config after deleting AES256 bucket encryption', done => {
             const post = templateSSEConfig({ algorithm: 'AES256' });
             bucketPutEncryption(authInfo, templateRequest(bucketName, { post }), log, err => {
                 assert.ifError(err);
@@ -238,7 +236,7 @@ describe('bucketDeleteEncryption API', () => {
                         assert.ifError(err);
                         return getSSEConfig(bucketName, log, (err, sseInfoAfterDeletion) => {
                             assert.ifError(err);
-                            assert.strictEqual(sseInfoAfterDeletion.isAccountEncryptionEnabled, true);
+                            assert(!sseInfoAfterDeletion);
                             done();
                         });
                     });
@@ -246,7 +244,7 @@ describe('bucketDeleteEncryption API', () => {
             });
         });
 
-        it('should keep isAccountEncryptionEnabled after deleting aws:kms bucket encryption', done => {
+        it('should clear the sse config after deleting aws:kms bucket encryption', done => {
             const post = templateSSEConfig({ algorithm: 'aws:kms' });
             bucketPutEncryption(authInfo, templateRequest(bucketName, { post }), log, err => {
                 assert.ifError(err);
@@ -257,7 +255,7 @@ describe('bucketDeleteEncryption API', () => {
                         assert.ifError(err);
                         return getSSEConfig(bucketName, log, (err, sseInfoAfterDeletion) => {
                             assert.ifError(err);
-                            assert.strictEqual(sseInfoAfterDeletion.isAccountEncryptionEnabled, true);
+                            assert(!sseInfoAfterDeletion);
                             done();
                         });
                     });
@@ -265,7 +263,7 @@ describe('bucketDeleteEncryption API', () => {
             });
         });
 
-        it('should keep isAccountEncryptionEnabled after deleting aws:kms and key id bucket encryption', done => {
+        it('should clear the sse config after deleting aws:kms and key id bucket encryption', done => {
             const postAES256 = templateSSEConfig({ algorithm: 'AES256' });
             bucketPutEncryption(authInfo, templateRequest(bucketName, { post: postAES256 }), log, err => {
                 assert.ifError(err);
@@ -279,7 +277,7 @@ describe('bucketDeleteEncryption API', () => {
                             assert.ifError(err);
                             return getSSEConfig(bucketName, log, (err, sseInfoAfterDeletion) => {
                                 assert.ifError(err);
-                                assert.strictEqual(sseInfoAfterDeletion.isAccountEncryptionEnabled, true);
+                                assert(!sseInfoAfterDeletion);
                                 done();
                             });
                         });


### PR DESCRIPTION
After deleting a bucket's encryption configuration that was initially set with a custom AWS KMS master key ID, uploading an object with the aws:kms encryption algorithm header incorrectly uses the previously specified custom master key ID instead of the default one.


**Steps to reproduce**
- Create a bucket
- Set bucket encryption with custom KMS master key id
- Delete bucket encryption configuration
- Upload an object with aws:kms encryption header
- Head the object

**Current behavior**
The uploaded object is encrypted using the custom KMS master key id that was previously specified in the now-deleted bucket encryption configuration.

**Expected behavior**
After deleting the bucket encryption configuration, uploading an object with the aws:kms encryption algorithm header should use the default KMS master key id, not the previously specified custom one.