### PR TITLE
make supportedLifecycleRules configurable through the config

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -246,6 +246,13 @@ const constants = {
     // if requester is not bucket owner, bucket policy actions should be denied with
     // MethodNotAllowed error
     onlyOwnerAllowed: ['bucketDeletePolicy', 'bucketGetPolicy', 'bucketPutPolicy'],
+    supportedLifecycleRules: [
+        'expiration',
+        'noncurrentVersionExpiration',
+        'abortIncompleteMultipartUpload',
+        'transitions',
+        'noncurrentVersionTransition',
+    ],
 };
 
 module.exports = constants;

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -13,8 +13,12 @@ const { isValidBucketName } = s3routes.routesUtils;
 const validateAuthConfig = arsenalAuth.inMemory.validateAuthConfig;
 const { buildAuthDataAccount } = require('./auth/in_memory/builder');
 const validExternalBackends = require('../constants').externalBackends;
-const { azureAccountNameRegex, base64Regex,
-    allowedUtapiEventFilterFields, allowedUtapiEventFilterStates,
+const {
+    azureAccountNameRegex,
+    base64Regex,
+    allowedUtapiEventFilterFields,
+    allowedUtapiEventFilterStates,
+    supportedLifecycleRules,
 } = require('../constants');
 const { utapiVersion } = require('utapi');
 const { scaleMsPerDay } = s3middleware.objectUtils;
@@ -146,6 +150,18 @@ function parseRedisConfig(redisConfig) {
           .without('host', ['sentinels', 'sentinelPassword']);
 
     return joi.attempt(redisConfig, joiSchema, 'bad config');
+}
+
+function parseSupportedLifecycleRules(supportedLifecycleRulesConfig) {
+    const supportedLifecycleRulesSchema = joi.array()
+        .items(joi.string().valid(...supportedLifecycleRules))
+        .default(supportedLifecycleRules)
+        .min(1);
+    return joi.attempt(
+        supportedLifecycleRulesConfig,
+        supportedLifecycleRulesSchema,
+        'bad supported lifecycle rules config',
+    );
 }
 
 function restEndpointsAssert(restEndpoints, locationConstraints) {
@@ -1713,6 +1729,8 @@ class Config extends EventEmitter {
                 'bad config: maxScannedLifecycleListingEntries must be greater than 2');
             this.maxScannedLifecycleListingEntries = config.maxScannedLifecycleListingEntries;
         }
+
+        this.supportedLifecycleRules = parseSupportedLifecycleRules(config.supportedLifecycleRules);
     }
 
     _setTimeOptions() {
@@ -1978,4 +1996,5 @@ module.exports = {
     azureGetStorageAccountName,
     azureGetLocationCredentials,
     azureArchiveLocationConstraintAssert,
+    parseSupportedLifecycleRules,
 };

--- a/lib/api/apiUtils/object/expirationHeaders.js
+++ b/lib/api/apiUtils/object/expirationHeaders.js
@@ -1,4 +1,3 @@
-const { supportedLifecycleRules } = require('arsenal').constants;
 const { LifecycleConfiguration } = require('arsenal').models;
 const {
     LifecycleDateTime,
@@ -19,7 +18,7 @@ const lifecycleDateTime = new LifecycleDateTime({
     timeProgressionFactor,
 });
 
-const lifecycleUtils = new LifecycleUtils(supportedLifecycleRules, lifecycleDateTime, timeProgressionFactor);
+const lifecycleUtils = new LifecycleUtils(config.supportedLifecycleRules, lifecycleDateTime, timeProgressionFactor);
 
 function calculateDate(objDate, expDays, datetime) {
     return new Date(datetime.getTimestamp(objDate) + (expDays * scaledMsPerDay));

--- a/tests/unit/Config.js
+++ b/tests/unit/Config.js
@@ -1,8 +1,13 @@
 const assert = require('assert');
 const {
     azureArchiveLocationConstraintAssert,
+    parseSupportedLifecycleRules,
     ConfigObject: ConfigObjectForTest,
 } = require('../../lib/Config');
+
+const {
+    supportedLifecycleRules,
+} = require('../../constants');
 
 describe('Config', () => {
     const envToRestore = [];
@@ -666,6 +671,32 @@ describe('Config', () => {
                 }
             };
             assert.throws(() => azureArchiveLocationConstraintAssert(locationObj));
+        });
+    });
+
+    describe('parseSupportedLifecycleRules', () => {
+        it('should throw when an empty array is provided', () => {
+            assert.throws(() => parseSupportedLifecycleRules([]));
+        });
+
+        it('should use default values when no value is provided', () => {
+            const rules = parseSupportedLifecycleRules(undefined);
+            assert.deepStrictEqual(rules, [...supportedLifecycleRules]);
+        });
+
+        it('should throw when rule name is not valid', () => {
+            const rules = ['invalid'];
+            assert.throws(() => parseSupportedLifecycleRules(rules));
+        });
+
+        it('should return the rules provided when they are valid', () => {
+            const rules = [
+                'expiration',
+                'noncurrentVersionExpiration',
+                'abortIncompleteMultipartUpload',
+            ];
+            const parsedRules = parseSupportedLifecycleRules(rules);
+            assert.deepStrictEqual(parsedRules, rules);
         });
     });
 });


### PR DESCRIPTION
This will help when unifying Cloudserver, as currently the value of the rules is a constant in Arsenal that is different between the 7.x and 8.x branches.

Issue: CLDSRV-588
