### PR TITLE
CLDSRV-598: Add overhreadField to metadata-only operations

### DIFF
--- a/lib/api/objectPutACL.js
+++ b/lib/api/objectPutACL.js
@@ -12,6 +12,7 @@ const { decodeVersionId, getVersionIdResHeader, getVersionSpecificMetadataOption
 const { standardMetadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const monitoring = require('../utilities/metrics');
 const { config } = require('../Config');
+const { overheadField } = require('../../constants');
 
 /*
    Format of xml request:
@@ -282,6 +283,7 @@ function objectPutACL(authInfo, request, log, cb) {
         function addAclsToObjMD(bucket, objectMD, ACLParams, next) {
             // Add acl's to object metadata
             const params = getVersionSpecificMetadataOptions(objectMD, config.nullVersionCompatMode);
+            params.overheadField = overheadField;
             acl.addObjectACL(bucket, objectKey, objectMD,
                 ACLParams, params, log, err => next(err, bucket, objectMD));
         },

--- a/lib/api/objectPutLegalHold.js
+++ b/lib/api/objectPutLegalHold.js
@@ -9,6 +9,7 @@ const metadata = require('../metadata/wrapper');
 const { standardMetadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
 const { config } = require('../Config');
+const { overheadField } = require('../../constants');
 
 const { parseLegalHoldXml } = s3middleware.objectLegalHold;
 
@@ -87,6 +88,7 @@ function objectPutLegalHold(authInfo, request, log, callback) {
             // eslint-disable-next-line no-param-reassign
             objectMD.legalHold = legalHold;
             const params = getVersionSpecificMetadataOptions(objectMD, config.nullVersionCompatMode);
+            params.overheadField = overheadField;
             const replicationInfo = getReplicationInfo(objectKey, bucket, true,
                 0, REPLICATION_ACTION, objectMD);
             if (replicationInfo) {

--- a/lib/api/objectPutRetention.js
+++ b/lib/api/objectPutRetention.js
@@ -11,6 +11,7 @@ const getReplicationInfo = require('./apiUtils/object/getReplicationInfo');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const metadata = require('../metadata/wrapper');
 const { config } = require('../Config');
+const { overheadField } = require('../../constants');
 
 const { parseRetentionXml } = s3middleware.retention;
 const REPLICATION_ACTION = 'PUT_RETENTION';
@@ -125,6 +126,7 @@ function objectPutRetention(authInfo, request, log, callback) {
             objectMD.retentionMode = retentionInfo.mode;
             objectMD.retentionDate = retentionInfo.date;
             const params = getVersionSpecificMetadataOptions(objectMD, config.nullVersionCompatMode);
+            params.overheadField = overheadField;
             const replicationInfo = getReplicationInfo(objectKey, bucket, true,
                 0, REPLICATION_ACTION, objectMD);
             if (replicationInfo) {

--- a/lib/api/objectPutTagging.js
+++ b/lib/api/objectPutTagging.js
@@ -13,6 +13,8 @@ const metadata = require('../metadata/wrapper');
 const { data } = require('../data/wrapper');
 const { parseTagXml } = s3middleware.tagging;
 const { config } = require('../Config');
+const { overheadField } = require('../../constants');
+
 const REPLICATION_ACTION = 'PUT_TAGGING';
 
 /**
@@ -81,6 +83,7 @@ function objectPutTagging(authInfo, request, log, callback) {
             // eslint-disable-next-line no-param-reassign
             objectMD.tags = tags;
             const params = getVersionSpecificMetadataOptions(objectMD, config.nullVersionCompatMode);
+            params.overheadField = overheadField;
             const replicationInfo = getReplicationInfo(objectKey, bucket, true,
                 0, REPLICATION_ACTION, objectMD);
             if (replicationInfo) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.70.58",
+  "version": "7.70.59",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {

--- a/tests/unit/api/objectPutACL.js
+++ b/tests/unit/api/objectPutACL.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const async = require('async');
+const sinon = require('sinon');
 
 const { errors } = require('arsenal');
 const AuthInfo = require('arsenal').auth.AuthInfo;
@@ -479,6 +480,57 @@ describe('putObjectACL API', () => {
                         done();
                     });
                 });
+        });
+
+        describe('overheadField', () => {
+            before(done => {
+                cleanup();
+                sinon.spy(metadata, 'putObjectMD');
+                return done();
+            });
+
+            after(() => {
+                metadata.putObjectMD.restore();
+                cleanup();
+            });
+
+            it('should pass overheadField', done => {
+                const testObjACLRequest = {
+                    bucketName,
+                    namespace,
+                    objectKey: objectName,
+                    headers: {
+                        'x-amz-grant-full-control':
+                        'emailaddress="sampleaccount1@sampling.com"' +
+                        ',emailaddress="sampleaccount2@sampling.com"',
+                        'x-amz-grant-read': `uri=${constants.logId}`,
+                        'x-amz-grant-read-acp': `id=${ownerID}`,
+                        'x-amz-grant-write-acp': `id=${anotherID}`,
+                    },
+                    url: `/${bucketName}/${objectName}?acl`,
+                    query: { acl: '' },
+                    actionImplicitDenies: false,
+                };
+                bucketPut(authInfo, testPutBucketRequest, log, () => {
+                    objectPut(authInfo, testPutObjectRequest, undefined, log,
+                        (err) => {
+                            assert.ifError(err);
+                            objectPutACL(authInfo, testObjACLRequest, log, err => {
+                                assert.ifError(err);
+                                sinon.assert.calledWith(
+                                    metadata.putObjectMD,
+                                    sinon.match.string,
+                                    objectName,
+                                    sinon.match.any,
+                                    sinon.match({ overheadField: sinon.match.array }),
+                                    sinon.match.any,
+                                    sinon.match.any
+                                );
+                                done();
+                            });
+                        });
+                });
+            });
         });
     });
 

--- a/tests/unit/api/objectPutLegalHold.js
+++ b/tests/unit/api/objectPutLegalHold.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const sinon = require('sinon');
 
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const objectPut = require('../../../lib/api/objectPut');
@@ -95,6 +96,35 @@ describe('putObjectLegalHold API', () => {
                     assert.ifError(err);
                     assert.strictEqual(objMD.legalHold, false);
                     return done();
+                });
+            });
+        });
+
+        describe('overheadField', () => {
+            before(done => {
+                cleanup();
+                sinon.spy(metadata, 'putObjectMD');
+                return done();
+            });
+
+            after(() => {
+                metadata.putObjectMD.restore();
+                cleanup();
+            });
+
+            it('should pass overheadField', done => {
+                objectPutLegalHold(authInfo, putLegalHoldReq('OFF'), log, err => {
+                    assert.ifError(err);
+                    sinon.assert.calledWith(
+                        metadata.putObjectMD,
+                        sinon.match.string,
+                        objectName,
+                        sinon.match.any,
+                        sinon.match({ overheadField: sinon.match.array }),
+                        sinon.match.any,
+                        sinon.match.any
+                    );
+                    done();
                 });
             });
         });

--- a/tests/unit/api/objectPutRetention.js
+++ b/tests/unit/api/objectPutRetention.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const moment = require('moment');
+const sinon = require('sinon');
 
 const { errors } = require('arsenal');
 const { bucketPut } = require('../../../lib/api/bucketPut');
@@ -219,6 +220,35 @@ describe('putObjectRetention API', () => {
                 assert.ifError(err);
                 return objectPutRetention(authInfo, putObjRetRequestGovernanceWithHeader, log, err => {
                     assert.ifError(err);
+                    done();
+                });
+            });
+        });
+
+        describe('overheadField', () => {
+            before(done => {
+                cleanup();
+                sinon.spy(metadata, 'putObjectMD');
+                return done();
+            });
+
+            after(() => {
+                metadata.putObjectMD.restore();
+                cleanup();
+            });
+
+            it('should pass overheadField', done => {
+                objectPutRetention(authInfo, putObjRetRequestGovernance, log, err => {
+                    assert.ifError(err);
+                    sinon.assert.calledWith(
+                        metadata.putObjectMD,
+                        sinon.match.string,
+                        objectName,
+                        sinon.match.any,
+                        sinon.match({ overheadField: sinon.match.array }),
+                        sinon.match.any,
+                        sinon.match.any
+                    );
                     done();
                 });
             });

--- a/tests/unit/api/objectPutTagging.js
+++ b/tests/unit/api/objectPutTagging.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const sinon = require('sinon');
 
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const objectPut = require('../../../lib/api/objectPut');
@@ -88,6 +89,38 @@ describe('putObjectTagging API', () => {
                 assert.deepStrictEqual(uploadedTags, taggingUtil.getTags());
                 assert.strictEqual(objectMD.originOp, 's3:ObjectTagging:Put');
                 return done();
+            });
+        });
+    });
+
+    describe('overheadField', () => {
+        before(done => {
+            cleanup();
+            sinon.spy(metadata, 'putObjectMD');
+            return done();
+        });
+
+        after(() => {
+            metadata.putObjectMD.restore();
+            cleanup();
+        });
+
+        it('should pass overheadField', done => {
+            const taggingUtil = new TaggingConfigTester();
+            const testObjectPutTaggingRequest = taggingUtil
+                .createObjectTaggingRequest('PUT', bucketName, objectName);
+            objectPutTagging(authInfo, testObjectPutTaggingRequest, log, err => {
+                assert.ifError(err);
+                sinon.assert.calledWith(
+                    metadata.putObjectMD,
+                    sinon.match.string,
+                    objectName,
+                    sinon.match.any,
+                    sinon.match({ overheadField: sinon.match.array }),
+                    sinon.match.any,
+                    sinon.match.any
+                );
+                done();
             });
         });
     });


### PR DESCRIPTION
Metadata-only operations (objectPutRetention, objectPutLegalHold, objectPutTagging, objectPutACL) overwrite the metadata of an object.

These operations currently do not attach the overheadField to metadata put operations.

As a result, the entries in the metadata op log for those operations do not include overhead information, and scuba interprets them as object puts, resulting in wrong metric updates.

Issue: CLDSRV-598