### PR TITLE
CLDSRV-552: Set originOp for putObjectRetention and putObjectLegalHold

### DIFF
--- a/lib/api/objectPutLegalHold.js
+++ b/lib/api/objectPutLegalHold.js
@@ -94,6 +94,8 @@ function objectPutLegalHold(authInfo, request, log, callback) {
                 objectMD.replicationInfo = Object.assign({},
                     objectMD.replicationInfo, replicationInfo);
             }
+            // eslint-disable-next-line no-param-reassign
+            objectMD.originOp = 's3:ObjectLegalHold:Put';
             metadata.putObjectMD(bucket.getName(), objectKey, objectMD, params,
                 log, err => next(err, bucket, objectMD));
         },

--- a/lib/api/objectPutRetention.js
+++ b/lib/api/objectPutRetention.js
@@ -131,6 +131,7 @@ function objectPutRetention(authInfo, request, log, callback) {
                 objectMD.replicationInfo = Object.assign({},
                     objectMD.replicationInfo, replicationInfo);
             }
+            objectMD.originOp = 's3:ObjectRetention:Put';
             /* eslint-enable no-param-reassign */
             metadata.putObjectMD(bucket.getName(), objectKey, objectMD, params,
                 log, err => next(err, bucket, objectMD));

--- a/tests/unit/api/objectPutLegalHold.js
+++ b/tests/unit/api/objectPutLegalHold.js
@@ -98,5 +98,17 @@ describe('putObjectLegalHold API', () => {
                 });
             });
         });
+
+        it('should set originOp in object\'s metadata to s3:ObjectLegalHold:Put', done => {
+            objectPutLegalHold(authInfo, putLegalHoldReq('ON'), log, err => {
+                assert.ifError(err);
+                return metadata.getObjectMD(bucketName, objectName, {}, log,
+                (err, objMD) => {
+                    assert.ifError(err);
+                    assert.strictEqual(objMD.originOp, 's3:ObjectLegalHold:Put');
+                    return done();
+                });
+            });
+        });
     });
 });

--- a/tests/unit/api/objectPutRetention.js
+++ b/tests/unit/api/objectPutRetention.js
@@ -160,6 +160,18 @@ describe('putObjectRetention API', () => {
             });
         });
 
+        it('should set originOp in object\'s metadata to s3:ObjectRetention:Put', done => {
+            objectPutRetention(authInfo, putObjRetRequestGovernance, log, err => {
+                assert.ifError(err);
+                return metadata.getObjectMD(bucketName, objectName, {}, log,
+                (err, objMD) => {
+                    assert.ifError(err);
+                    assert.strictEqual(objMD.originOp, 's3:ObjectRetention:Put');
+                    return done();
+                });
+            });
+        });
+
         it('should disallow COMPLIANCE => GOVERNANCE', done => {
             objectPutRetention(authInfo, putObjRetRequestCompliance, log, err => {
                 assert.ifError(err);


### PR DESCRIPTION
`putObjectRetention` and `putObjectLegalHold` operations do not set the `originOp` metadata field and as a result copy the `originOp` of the previous operation on the object (e.g. `s3:ObjectCreated`).

Issue: CLDSRV-552