### PR TITLE
Support transitions in OOB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN apt-get update && \
         jq \
     && rm -rf /var/lib/apt/lists/*
 
-ENV NO_PROXY localhost,127.0.0.1
-ENV no_proxy localhost,127.0.0.1
+ENV NO_PROXY=localhost,127.0.0.1
+ENV no_proxy=localhost,127.0.0.1
 
 EXPOSE 8000
 EXPOSE 8002
@@ -51,7 +51,6 @@ WORKDIR /usr/src/app
 # Keep the .git directory in order to properly report version
 COPY . /usr/src/app
 COPY --from=builder /usr/src/app/node_modules ./node_modules/
-
 
 VOLUME ["/usr/src/app/localData","/usr/src/app/localMetadata"]
 

--- a/constants.js
+++ b/constants.js
@@ -221,6 +221,7 @@ const constants = {
         'versionId',
         'isNull',
         'isDeleteMarker',
+        'x-amz-meta-scal-version-id',
     ],
     unsupportedSignatureChecksums: new Set([
         'STREAMING-UNSIGNED-PAYLOAD-TRAILER',

--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -195,6 +195,14 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
         metadataStoreParams.oldReplayId = objMD.uploadId;
     }
 
+    if (isPutVersion && location === bucketMD.getLocationConstraint() && bucketMD.isIngestionBucket()) {
+        // When restoring to OOB bucket, we cannot force the versionId of the object written to the
+        // backend, and it is thus not match the versionId of the ingested object. Thus we add extra
+        // user metadata to allow OOB to allow ingestion processor to "match" the (new) restored
+        // object with the existing ingested object.
+        objectKeyContext.metaHeaders['x-amz-meta-scal-version-id'] = putVersionId;
+    }
+
     /* eslint-disable camelcase */
     const dontSkipBackend = externalBackends;
     /* eslint-enable camelcase */
@@ -291,8 +299,8 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
                 });
         },
         function storeMDAndDeleteData(options, infoArr, next) {
-            const location = infoArr[0].dataStoreName;
-            if (location === bucketMD.getLocationConstraint() && bucketMD.isIngestionBucket()) {
+            const location = infoArr?.[0]?.dataStoreName;
+            if (!isPutVersion && location === bucketMD.getLocationConstraint() && bucketMD.isIngestionBucket()) {
                 // If the object is being written to the "ingested" storage location, keep the same
                 // versionId for consistency and to avoid creating an extra version when it gets
                 // ingested

--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -7,7 +7,7 @@ const { data } = require('../../../data/wrapper');
 const services = require('../../../services');
 const { dataStore } = require('./storeObject');
 const locationConstraintCheck = require('./locationConstraintCheck');
-const { versioningPreprocessing, overwritingVersioning } = require('./versioning');
+const { versioningPreprocessing, overwritingVersioning, decodeVID } = require('./versioning');
 const removeAWSChunked = require('./removeAWSChunked');
 const getReplicationInfo = require('./getReplicationInfo');
 const { config } = require('../../../Config');
@@ -15,7 +15,6 @@ const validateWebsiteHeader = require('./websiteServing')
     .validateWebsiteHeader;
 const applyZenkoUserMD = require('./applyZenkoUserMD');
 
-const versionIdUtils = versioning.VersionID;
 const { externalBackends, versioningNotImplBackends } = constants;
 
 const externalVersioningErrorMessage = 'We do not currently support putting ' +
@@ -295,19 +294,23 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
                             method: 'versioningPreprocessing',
                         });
                     }
+
+                    const location = infoArr?.[0]?.dataStoreName;
+                    if (location === bucketMD.getLocationConstraint() && bucketMD.isIngestionBucket()) {
+                        // If the object is being written to the "ingested" storage location, keep the same
+                        // versionId for consistency and to avoid creating an extra version when it gets
+                        // ingested
+                        const backendVersionId = decodeVID(infoArr[0].dataStoreVersionId);
+                        if (!(backendVersionId instanceof Error)) {
+                            options.versionId = backendVersionId; // eslint-disable-line no-param-reassign
+                        }
+                    }
+
                     return next(err, options, infoArr);
                 });
         },
         function storeMDAndDeleteData(options, infoArr, next) {
-            const location = infoArr?.[0]?.dataStoreName;
-            if (!isPutVersion && location === bucketMD.getLocationConstraint() && bucketMD.isIngestionBucket()) {
-                // If the object is being written to the "ingested" storage location, keep the same
-                // versionId for consistency and to avoid creating an extra version when it gets
-                // ingested
-                metadataStoreParams.versionId = versionIdUtils.decode(infoArr[0].dataStoreVersionId);
-            } else {
-                metadataStoreParams.versionId = options.versionId;
-            }
+            metadataStoreParams.versionId = options.versionId;
             metadataStoreParams.versioning = options.versioning;
             metadataStoreParams.isNull = options.isNull;
             metadataStoreParams.deleteNullKey = options.deleteNullKey;

--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -1,5 +1,5 @@
 const async = require('async');
-const { errors, s3middleware, versioning } = require('arsenal');
+const { errors, s3middleware } = require('arsenal');
 const getMetaHeaders = s3middleware.userMetadata.getMetaHeaders;
 
 const constants = require('../../../../constants');

--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -1,5 +1,5 @@
 const async = require('async');
-const { errors, s3middleware } = require('arsenal');
+const { errors, s3middleware, versioning } = require('arsenal');
 const getMetaHeaders = s3middleware.userMetadata.getMetaHeaders;
 
 const constants = require('../../../../constants');
@@ -14,6 +14,8 @@ const { config } = require('../../../Config');
 const validateWebsiteHeader = require('./websiteServing')
     .validateWebsiteHeader;
 const applyZenkoUserMD = require('./applyZenkoUserMD');
+
+const versionIdUtils = versioning.VersionID;
 const { externalBackends, versioningNotImplBackends } = constants;
 
 const externalVersioningErrorMessage = 'We do not currently support putting ' +
@@ -289,7 +291,15 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
                 });
         },
         function storeMDAndDeleteData(options, infoArr, next) {
-            metadataStoreParams.versionId = options.versionId;
+            const location = infoArr[0].dataStoreName;
+            if (location === bucketMD.getLocationConstraint() && bucketMD.isIngestionBucket()) {
+                // If the object is being written to the "ingested" storage location, keep the same
+                // versionId for consistency and to avoid creating an extra version when it gets
+                // ingested
+                metadataStoreParams.versionId = versionIdUtils.decode(infoArr[0].dataStoreVersionId);
+            } else {
+                metadataStoreParams.versionId = options.versionId;
+            }
             metadataStoreParams.versioning = options.versioning;
             metadataStoreParams.isNull = options.isNull;
             metadataStoreParams.deleteNullKey = options.deleteNullKey;

--- a/lib/api/apiUtils/object/deleteObject.js
+++ b/lib/api/apiUtils/object/deleteObject.js
@@ -1,18 +1,22 @@
 /**
  * _bucketRequiresOplogUpdate - DELETE an object from a bucket
- * @param {BucketInfo} bucket - bucket object
+ * @param {ObjectMD} objMD - object metadata
+ * @param {BucketInfo} bucket - bucket info
  * @return {boolean} whether objects require oplog updates on deletion, or not
  */
-function _bucketRequiresOplogUpdate(bucket) {
-    // Default behavior is to require an oplog update
-    if (!bucket || !bucket.getLifecycleConfiguration || !bucket.getNotificationConfiguration) {
+function _deleteRequiresOplogUpdate(objMD, bucket) {
+    // If the object is archived, an oplog update is required
+    if (objMD.archive) {
         return true;
     }
-    // If the bucket has lifecycle configuration or notification configuration
-    // set, we also require an oplog update
-    return bucket.getLifecycleConfiguration() || bucket.getNotificationConfiguration();
+    // Default behavior is to require an oplog update
+    if (!bucket || !bucket.getNotificationConfiguration) {
+        return true;
+    }
+    // If the bucket has notification configuration set, we also require an oplog update
+    return Boolean(bucket.getNotificationConfiguration());
 }
 
 module.exports = {
-    _bucketRequiresOplogUpdate,
+    _deleteRequiresOplogUpdate,
 };

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -405,6 +405,18 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                         });
                         return next(err, destBucket);
                     }
+
+                    const location = dataLocations?.[0]?.dataStoreName;
+                    if (location === destBucket.getLocationConstraint() && destBucket.isIngestionBucket()) {
+                        // If the object is being written to the "ingested" storage location, keep the same
+                        // versionId for consistency and to avoid creating an extra version when it gets
+                        // ingested
+                        const backendVersionId = decodeVID(dataLocations[0].dataStoreVersionId);
+                        if (!(backendVersionId instanceof Error)) {
+                            options.versionId = backendVersionId; // eslint-disable-line no-param-reassign
+                        }
+                    }
+
                     return next(null, destBucket, dataLocations,
                         metaStoreParams, mpuBucket, keysToDelete, aggregateETag,
                         objMD, extraPartLocations, pseudoCipherBundle,
@@ -416,18 +428,8 @@ function completeMultipartUpload(authInfo, request, log, callback) {
             extraPartLocations, pseudoCipherBundle,
             completeObjData, options, droppedMPUSize, next) {
             const dataToDelete = options.dataToDelete;
-            const location = dataLocations?.[0]?.dataStoreName;
             /* eslint-disable no-param-reassign */
-            if (!isPutVersion &&
-                location === destinationBucket.getLocationConstraint() &&
-                destinationBucket.isIngestionBucket()) {
-                // If the object is being written to the "ingested" storage location, keep the same
-                // versionId for consistency and to avoid creating an extra version when it gets
-                // ingested
-                metaStoreParams.versionId = versionIdUtils.decode(dataLocations[0].dataStoreVersionId);
-            } else {
-                metaStoreParams.versionId = options.versionId;
-            }
+            metaStoreParams.versionId = options.versionId;
             metaStoreParams.versioning = options.versioning;
             metaStoreParams.isNull = options.isNull;
             metaStoreParams.deleteNullKey = options.deleteNullKey;

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -416,8 +416,16 @@ function completeMultipartUpload(authInfo, request, log, callback) {
             extraPartLocations, pseudoCipherBundle,
             completeObjData, options, droppedMPUSize, next) {
             const dataToDelete = options.dataToDelete;
+            const location = dataLocations?.[0]?.dataStoreName;
             /* eslint-disable no-param-reassign */
-            metaStoreParams.versionId = options.versionId;
+            if (location === destinationBucket.getLocationConstraint() && destinationBucket.isIngestionBucket()) {
+                // If the object is being written to the "ingested" storage location, keep the same
+                // versionId for consistency and to avoid creating an extra version when it gets
+                // ingested
+                metaStoreParams.versionId = versionIdUtils.decode(dataLocations[0].dataStoreVersionId);
+            } else {
+                metaStoreParams.versionId = options.versionId;
+            }
             metaStoreParams.versioning = options.versioning;
             metaStoreParams.isNull = options.isNull;
             metaStoreParams.deleteNullKey = options.deleteNullKey;

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -418,7 +418,9 @@ function completeMultipartUpload(authInfo, request, log, callback) {
             const dataToDelete = options.dataToDelete;
             const location = dataLocations?.[0]?.dataStoreName;
             /* eslint-disable no-param-reassign */
-            if (location === destinationBucket.getLocationConstraint() && destinationBucket.isIngestionBucket()) {
+            if (!isPutVersion &&
+                location === destinationBucket.getLocationConstraint() &&
+                destinationBucket.isIngestionBucket()) {
                 // If the object is being written to the "ingested" storage location, keep the same
                 // versionId for consistency and to avoid creating an extra version when it gets
                 // ingested

--- a/lib/api/initiateMultipartUpload.js
+++ b/lib/api/initiateMultipartUpload.js
@@ -247,6 +247,19 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
             destinationBucket,
             tagging,
         };
+
+        const putVersionId = request.headers['x-scal-s3-version-id'];
+        const isPutVersion = putVersionId || putVersionId === '';
+        if (isPutVersion &&
+            locConstraint === destinationBucket.getLocationConstraint() &&
+            destinationBucket.isIngestionBucket()) {
+            // When restoring to OOB bucket, we cannot force the versionId of the object written to the
+            // backend, and it is thus not match the versionId of the ingested object. Thus we add extra
+            // user metadata to allow OOB to allow ingestion processor to "match" the (new) restored
+            // object with the existing ingested object.
+            mpuInfo.metaHeaders['x-amz-meta-scal-version-id'] = putVersionId;
+        }
+
         return data.initiateMPU(mpuInfo, websiteRedirectHeader, log,
         (err, dataBackendResObj, isVersionedObj) => {
             // will return as true and a custom error if external backend does

--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -25,7 +25,7 @@ const { hasGovernanceBypassHeader, checkUserGovernanceBypass, ObjectLockInfo }
 const requestUtils = policies.requestUtils;
 const { validObjectKeys } = require('../routes/routeVeeam');
 const { deleteVeeamCapabilities } = require('../routes/veeam/delete');
-const { _bucketRequiresOplogUpdate } = require('./apiUtils/object/deleteObject');
+const { _deleteRequiresOplogUpdate } = require('./apiUtils/object/deleteObject');
 const { overheadField } = require('../../constants');
 
 const versionIdUtils = versioning.VersionID;
@@ -345,7 +345,7 @@ function getObjMetadataAndDelete(authInfo, canonicalID, request,
                     if (options && options.deleteData) {
                         options.overheadField = overheadField;
                         deleteInfo.deleted = true;
-                        if (!_bucketRequiresOplogUpdate(bucket)) {
+                        if (!_deleteRequiresOplogUpdate(objMD, bucket)) {
                             options.doesNotNeedOpogUpdate = true;
                         }
                         if (objMD.uploadId) {

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -8,7 +8,7 @@ const constants = require('../../constants');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const locationConstraintCheck
     = require('./apiUtils/object/locationConstraintCheck');
-const { checkQueryVersionId, versioningPreprocessing }
+const { checkQueryVersionId, versioningPreprocessing, decodeVID }
     = require('./apiUtils/object/versioning');
 const getReplicationInfo = require('./apiUtils/object/getReplicationInfo');
 const { data } = require('../data/wrapper');

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -499,11 +499,14 @@ function objectCopy(authInfo, request, sourceBucket,
                         // versionId for consistency and to avoid creating an extra version when it gets
                         // ingested
                         // eslint-disable-next-line
-                        storeMetadataParams.versionId = versionIdUtils.decode(destDataGetInfoArr[0].dataStoreVersionId);
-                    } else {
-                        // eslint-disable-next-line
-                        storeMetadataParams.versionId = options.versionId;
+                        const backendVersionId = decodeVID(destDataGetInfoArr[0].dataStoreVersionId);
+                        if (!(backendVersionId instanceof Error)) {
+                            options.versionId = backendVersionId; // eslint-disable-line no-param-reassign
+                        }
                     }
+
+                    // eslint-disable-next-line
+                    storeMetadataParams.versionId = options.versionId;
                     // eslint-disable-next-line
                     storeMetadataParams.versioning = options.versioning;
                     // eslint-disable-next-line

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -492,8 +492,18 @@ function objectCopy(authInfo, request, sourceBucket,
                         { error: err });
                         return next(err, null, destBucketMD);
                     }
-                    // eslint-disable-next-line
-                    storeMetadataParams.versionId = options.versionId;
+
+                    const location = destDataGetInfoArr?.[0]?.dataStoreName;
+                    if (location === destBucketMD.getLocationConstraint() && destBucketMD.isIngestionBucket()) {
+                        // If the object is being written to the "ingested" storage location, keep the same
+                        // versionId for consistency and to avoid creating an extra version when it gets
+                        // ingested
+                        // eslint-disable-next-line
+                        storeMetadataParams.versionId = versionIdUtils.decode(destDataGetInfoArr[0].dataStoreVersionId);
+                    } else {
+                        // eslint-disable-next-line
+                        storeMetadataParams.versionId = options.versionId;
+                    }
                     // eslint-disable-next-line
                     storeMetadataParams.versioning = options.versioning;
                     // eslint-disable-next-line

--- a/lib/api/objectDelete.js
+++ b/lib/api/objectDelete.js
@@ -13,7 +13,7 @@ const monitoring = require('../utilities/monitoringHandler');
 const { hasGovernanceBypassHeader, ObjectLockInfo }
     = require('./apiUtils/object/objectLockHelpers');
 const { config } = require('../Config');
-const { _bucketRequiresOplogUpdate } = require('./apiUtils/object/deleteObject');
+const { _deleteRequiresOplogUpdate } = require('./apiUtils/object/deleteObject');
 
 const versionIdUtils = versioning.VersionID;
 const objectLockedError = new Error('object locked');
@@ -182,7 +182,7 @@ function objectDeleteInternal(authInfo, request, log, isExpiration, cb) {
                     delOptions.replayId = objectMD.uploadId;
                 }
 
-                if (!_bucketRequiresOplogUpdate(bucketMD)) {
+                if (!_deleteRequiresOplogUpdate(objectMD, bucketMD)) {
                     delOptions.doesNotNeedOpogUpdate = true;
                 }
 

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -1,11 +1,12 @@
-const { errors, storage } = require('arsenal');
+const { errors, storage, versioning } = require('arsenal');
 
 const assert = require('assert');
 const async = require('async');
 const crypto = require('crypto');
 const moment = require('moment');
 const sinon = require('sinon');
-const { parseString } = require('xml2js');
+const util = require('util');
+const { parseString, parseStringPromise } = require('xml2js');
 
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const bucketPutPolicy = require('../../../lib/api/bucketPutPolicy');
@@ -25,8 +26,9 @@ const objectPutPart = require('../../../lib/api/objectPutPart');
 const DummyRequest = require('../DummyRequest');
 const changeObjectLock = require('../../utilities/objectLock-util');
 const metadataswitch = require('../metadataswitch');
+const { fakeMetadataArchive } = require('../../functional/aws-node-sdk/test/utils/init');
 
-
+const { data } = require('../../../lib/data/wrapper');
 const { metadata } = storage.metadata.inMemory.metadata;
 const metadataBackend = storage.metadata.inMemory.metastore;
 const { ds } = storage.data.inMemory.datastore;
@@ -2627,5 +2629,184 @@ describe('complete mpu with bucket policy', () => {
             assert.ifError(err);
             done();
         });
+    });
+});
+
+describe('multipart upload in ingestion bucket', () => {
+    const dataClient = data.client;
+    const prevDataImplName = data.implName;
+    const prevConfigBackendsData = data.config.backends.data;
+
+    let versionID;
+
+    before(() => {
+        versionID = versioning.VersionID.encode(versioning.VersionID.generateVersionId('0', ''));
+
+        // Setup multi-backend, this is required for ingestion
+        data.switch(new storage.data.MultipleBackendGateway({
+            'us-east-1': dataClient,
+            'us-east-2': dataClient,
+        }, metadata, data.locStorageCheckFn));
+        data.implName = 'multipleBackends';
+
+        // "mock" the data location, simulating a backend supporting MPU
+        data.config.backends.data = 'multiple';
+        dataClient.clientType = 'aws_s3';
+    });
+
+    after(() => {
+        data.switch(dataClient);
+        data.implName = prevDataImplName;
+        data.config.backends.data = prevConfigBackendsData;
+        delete dataClient.clientType;
+    });
+
+    beforeEach(() => {
+        cleanup();
+
+        // "mock" the data location, simulating a backend supporting MPU
+        dataClient.createMPU = sinon.stub().yields(undefined, {
+            uploadId: 'mock-uploadId',
+        });
+        dataClient.uploadPart = sinon.stub().yields(undefined, {
+            dataStoreType: dataClient.clientType,
+            dataStoreETag: 'mock-part-eTag',
+        });
+        dataClient.completeMPU = sinon.stub().yields(undefined, {
+            key: objectKey,
+            eTag: 'mock-eTag',
+            dataStoreVersionId: versionID,
+            contentLength: 12,
+        });
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    const newPutIngestBucketRequest = location => new DummyRequest({
+        bucketName,
+        namespace,
+        headers: { host: `${bucketName}.s3.amazonaws.com` },
+        url: '/',
+        post: '<?xml version="1.0" encoding="UTF-8"?>' +
+            '<CreateBucketConfiguration ' +
+            'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+            `<LocationConstraint>${location}</LocationConstraint>` +
+            '</CreateBucketConfiguration>',
+    });
+    const archiveRestoreRequested = {
+        archiveInfo: { foo: 0, bar: 'stuff' }, // opaque, can be anything...
+        restoreRequestedAt: new Date().toString(),
+        restoreRequestedDays: 5,
+    };
+
+    const _bucketPut = util.promisify(bucketPut);
+    const _initiateMultipartUpload = async (...params) => {
+        const result = await util.promisify(initiateMultipartUpload)(...params);
+        const json = await parseStringPromise(result);
+        return json.InitiateMultipartUploadResult.UploadId[0];
+    };
+    const _objectPutPart = util.promisify(objectPutPart);
+    const _completeMultipartUpload = (...params) => util.promisify(cb =>
+        completeMultipartUpload(...params, (err, xml, headers) => cb(err, { xml, headers })))();
+    const uploadMpuObject = async (params = {}) => {
+        const headers = { ...initiateRequest.headers };
+        if (params.location) {
+            headers[constants.objectLocationConstraintHeader] = params.location;
+        }
+        if (params.versionID) {
+            headers['x-scal-s3-version-id'] = params.versionID;
+        }
+
+        const uploadId = await _initiateMultipartUpload(authInfo, { ...initiateRequest, headers }, log);
+
+        const partRequest = _createPutPartRequest(uploadId, 1, Buffer.from('I am a part\n', 'utf8'));
+        partRequest.headers = headers;
+        const eTag = await _objectPutPart(authInfo, partRequest, undefined, log);
+
+        const completeRequest = _createCompleteMpuRequest(uploadId, [{ partNumber: 1, eTag }]);
+        const resp = await _completeMultipartUpload(authInfo, { ...completeRequest, headers }, log);
+
+        return resp.headers;
+    };
+
+    it('should use the versionID from the backend', async () => {
+        await _bucketPut(authInfo, newPutIngestBucketRequest('us-east-1:ingest'), log);
+
+        const headers = await uploadMpuObject();
+        assert.strictEqual(headers['x-amz-version-id'], versionID);
+    });
+
+    it('should not use the versionID from the backend when writing in another location', async () => {
+        await _bucketPut(authInfo, newPutIngestBucketRequest('us-east-1:ingest'), log);
+
+        const headers = await uploadMpuObject({ location: 'us-east-2' });
+        assert.notEqual(headers['x-amz-version-id'], versionID);
+    });
+
+    it('should not use the versionID from the backend when it is not a valid versionID', async () => {
+        dataClient.completeMPU.onCall(0).yields(undefined, {
+            key: objectKey,
+            eTag: 'mock-eTag',
+            dataStoreVersionId: undefined,
+            contentLength: 12,
+        });
+
+        await _bucketPut(authInfo, newPutIngestBucketRequest('us-east-1:ingest'), log);
+
+        const headers = await uploadMpuObject();
+        assert.notEqual(headers['x-amz-version-id'], versionID);
+    });
+
+    it('should add versionID to backend putObject when restoring object', async () => {
+        const restoredVersionID = versioning.VersionID.encode(versioning.VersionID.generateVersionId('0', ''));
+        dataClient.completeMPU.onCall(0).callThrough();
+        dataClient.completeMPU.onCall(1).yields(undefined, {
+            key: objectKey,
+            eTag: 'mock-eTag',
+            dataStoreVersionId: restoredVersionID,
+            contentLength: 12,
+        });
+
+        await _bucketPut(authInfo, newPutIngestBucketRequest('us-east-1:ingest'), log);
+
+        let headers = await uploadMpuObject();
+        assert.strictEqual(headers['x-amz-version-id'], versionID);
+        assert.strictEqual(dataClient.createMPU.firstCall.args[1]['x-amz-meta-scal-version-id'], undefined);
+
+        await util.promisify(fakeMetadataArchive)(bucketName, objectKey, versionID, archiveRestoreRequested);
+
+        headers = await uploadMpuObject({
+            versionID,
+        });
+        assert.strictEqual(headers['x-amz-version-id'], versionID);
+        assert.strictEqual(dataClient.createMPU.lastCall.args[1]['x-amz-meta-scal-version-id'], versionID);
+    });
+
+    it('should not add versionID to backend putObject when restoring object to another location', async () => {
+        const restoredVersionID = versioning.VersionID.encode(versioning.VersionID.generateVersionId('0', ''));
+        dataClient.completeMPU.onCall(0).callThrough();
+        dataClient.completeMPU.onCall(1).yields(undefined, {
+            key: objectKey,
+            eTag: 'mock-eTag',
+            dataStoreVersionId: restoredVersionID,
+            contentLength: 12,
+        });
+
+        await _bucketPut(authInfo, newPutIngestBucketRequest('us-east-1:ingest'), log);
+
+        let headers = await uploadMpuObject();
+        assert.strictEqual(headers['x-amz-version-id'], versionID);
+        assert.strictEqual(dataClient.createMPU.firstCall.args[1]['x-amz-meta-scal-version-id'], undefined);
+
+        await util.promisify(fakeMetadataArchive)(bucketName, objectKey, versionID, archiveRestoreRequested);
+
+        headers = await uploadMpuObject({
+            versionID,
+            location: 'us-east-2',
+        });
+        assert.strictEqual(headers['x-amz-version-id'], versionID);
+        assert.strictEqual(dataClient.createMPU.lastCall.args[1]['x-amz-meta-scal-version-id'], undefined);
     });
 });

--- a/tests/unit/api/objectCopy.js
+++ b/tests/unit/api/objectCopy.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const async = require('async');
-const { storage } = require('arsenal');
+const { storage, versioning } = require('arsenal');
 const sinon = require('sinon');
 
 const { bucketPut } = require('../../../lib/api/bucketPut');
@@ -12,6 +12,8 @@ const { cleanup, DummyRequestLogger, makeAuthInfo, versioningTestUtils }
     = require('../helpers');
 const mpuUtils = require('../utils/mpuUtils');
 const metadata = require('../metadataswitch');
+const { data } = require('../../../lib/data/wrapper');
+const { objectLocationConstraintHeader } = require('../../../constants');
 
 const any = sinon.match.any;
 
@@ -245,5 +247,128 @@ describe('objectCopy overheadField', () => {
                 );
             });
         });
+    });
+});
+
+describe('objectCopy in ingestion bucket', () => {
+    const dataClient = data.client;
+    const prevDataImplName = data.implName;
+    const prevConfigBackendsData = data.config.backends.data;
+    const prevConfigLocationConstraints1Type = data.config.locationConstraints['us-east-1'].type;
+    const prevConfigLocationConstraints2Type = data.config.locationConstraints['us-east-2'].type;
+
+    before(() => {
+        // Setup multi-backend, this is required for ingestion
+        data.switch(new storage.data.MultipleBackendGateway({
+            'us-east-1': dataClient,
+            'us-east-2': dataClient,
+        }, metadata, data.locStorageCheckFn));
+        data.implName = 'multipleBackends';
+
+        // "mock" the data location, simulating a backend supporting server-side copy
+        data.config.backends.data = 'multiple';
+        data.config.locationConstraints['us-east-1'].type = 'aws_s3';
+        data.config.locationConstraints['us-east-2'].type = 'aws_s3';
+    });
+
+    after(() => {
+        data.switch(dataClient);
+        data.implName = prevDataImplName;
+        data.config.backends.data = prevConfigBackendsData;
+        data.config.locationConstraints['us-east-1'].type = prevConfigLocationConstraints1Type;
+        data.config.locationConstraints['us-east-2'].type = prevConfigLocationConstraints2Type;
+    });
+
+    const versionIDs = [];
+
+    beforeEach(() => {
+        cleanup();
+
+        sinon.stub(dataClient, 'put').callsFake((writeStream, size, keyContext, reqUids, cb) => {
+            const versionID = versioning.VersionID.encode(versioning.VersionID.generateVersionId('0', ''));
+            versionIDs.push(versionID);
+            cb(null, `${keyContext.bucketName}/${keyContext.objectKey}`, versionID, size, 'md5');
+        });
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    const newPutIngestBucketRequest = location => new DummyRequest({
+        bucketName: destBucketName,
+        namespace,
+        headers: { host: `${destBucketName}.s3.amazonaws.com` },
+        url: '/',
+        post: '<?xml version="1.0" encoding="UTF-8"?>' +
+            '<CreateBucketConfiguration ' +
+            'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+            `<LocationConstraint>${location}</LocationConstraint>` +
+            '</CreateBucketConfiguration>',
+    });
+    const putSourceObjectRequest = versioningTestUtils.createPutObjectRequest(
+        sourceBucketName, objectKey, objData[0]);
+    const newPutObjectRequest = params => {
+        const { location } = params || {};
+        const r = _createObjectCopyRequest(destBucketName);
+        if (location) {
+            r.headers[objectLocationConstraintHeader] = location;
+
+            // Need to 'replace' the metadata for the constraint to be taken into account
+            r.headers['x-amz-metadata-directive'] = 'REPLACE';
+        }
+        return r;
+    };
+
+    it('should use the versionID from the backend', done => {
+        const versionID = versioning.VersionID.encode(versioning.VersionID.generateVersionId('0', ''));
+        dataClient.copyObject = sinon.stub().yields(null, objectKey, versionID);
+
+        async.series([
+            next => bucketPut(authInfo, putSourceBucketRequest, log, next),
+            next => bucketPut(authInfo, newPutIngestBucketRequest('us-east-1:ingest'), log, next),
+            next => objectPut(authInfo, putSourceObjectRequest, undefined, log, next),
+            next => objectCopy(authInfo, newPutObjectRequest(), sourceBucketName, objectKey, undefined, log,
+                (err, xml, headers) => {
+                    assert.ifError(err);
+                    assert.strictEqual(headers['x-amz-version-id'], versionID);
+                    next();
+                }),
+        ], done);
+    });
+
+    it('should not use the versionID from the backend when writing in another location', done => {
+        const versionID = versioning.VersionID.encode(versioning.VersionID.generateVersionId('0', ''));
+        dataClient.copyObject = sinon.stub().yields(null, objectKey, versionID);
+
+        const copyObjectRequest = newPutObjectRequest({ location: 'us-east-2' });
+        async.series([
+            next => bucketPut(authInfo, putSourceBucketRequest, log, next),
+            next => bucketPut(authInfo, newPutIngestBucketRequest('us-east-1:ingest'), log, next),
+            next => objectPut(authInfo, putSourceObjectRequest, undefined, log, next),
+            next => objectCopy(authInfo, copyObjectRequest, sourceBucketName, objectKey, undefined, log,
+                (err, xml, headers) => {
+                    assert.ifError(err);
+                    assert.notEqual(headers['x-amz-version-id'], versionID);
+                    next();
+                }),
+        ], done);
+    });
+
+    it('should not use the versionID from the backend when it is not a valid versionID', done => {
+        const versionID = undefined;
+        dataClient.copyObject = sinon.stub().yields(null, objectKey, versionID);
+
+        async.series([
+            next => bucketPut(authInfo, putSourceBucketRequest, log, next),
+            next => bucketPut(authInfo, newPutIngestBucketRequest('us-east-1:ingest'), log, next),
+            next => objectPut(authInfo, putSourceObjectRequest, undefined, log, next),
+            next => objectCopy(authInfo, newPutObjectRequest(), sourceBucketName, objectKey, undefined, log,
+                (err, xml, headers) => {
+                    assert.ifError(err);
+                    assert.notEqual(headers['x-amz-version-id'], versionID);
+                    next();
+                }),
+        ], done);
     });
 });

--- a/tests/unit/api/objectDelete.js
+++ b/tests/unit/api/objectDelete.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const async = require('async');
 const { errors } = require('arsenal');
 const sinon = require('sinon');
 
@@ -13,6 +14,8 @@ const objectGet = require('../../../lib/api/objectGet');
 const DummyRequest = require('../DummyRequest');
 const mpuUtils = require('../utils/mpuUtils');
 const metadataswitch = require('../metadataswitch');
+const { fakeMetadataArchive } = require('../../functional/aws-node-sdk/test/utils/init');
+const bucketPutNotification = require('../../../lib/api/bucketPutNotification');
 
 const any = sinon.match.any;
 const originalDeleteObject = services.deleteObject;
@@ -48,13 +51,6 @@ function testAuth(bucketOwner, authUser, bucketPutReq, objPutReq, objDelReq,
 describe('objectDelete API', () => {
     let testPutObjectRequest;
 
-    before(() => {
-        sinon.stub(services, 'deleteObject')
-            .callsFake(originalDeleteObject);
-        sinon.spy(metadataswitch, 'putObjectMD');
-        sinon.spy(metadataswitch, 'deleteObjectMD');
-    });
-
     beforeEach(() => {
         cleanup();
         testPutObjectRequest = new DummyRequest({
@@ -64,9 +60,13 @@ describe('objectDelete API', () => {
             headers: {},
             url: `/${bucketName}/${objectKey}`,
         }, postBody);
+
+        sinon.stub(services, 'deleteObject').callsFake(originalDeleteObject);
+        sinon.spy(metadataswitch, 'putObjectMD');
+        sinon.spy(metadataswitch, 'deleteObjectMD');
     });
 
-    after(() => {
+    afterEach(() => {
         sinon.restore();
     });
 
@@ -93,19 +93,72 @@ describe('objectDelete API', () => {
     });
 
     it('should delete an object', done => {
-        bucketPut(authInfo, testBucketPutRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest,
-                undefined, log, () => {
-                    objectDelete(authInfo, testDeleteRequest, log, err => {
-                        assert.strictEqual(err, null);
-                        objectGet(authInfo, testGetObjectRequest, false,
-                            log, err => {
-                                assert.strictEqual(err.is.NoSuchKey, true);
-                                done();
-                            });
-                    });
-                });
-        });
+        async.series([
+            next => bucketPut(authInfo, testBucketPutRequest, log, next),
+            next => objectPut(authInfo, testPutObjectRequest, undefined, log, next),
+            next => objectDelete(authInfo, testDeleteRequest, log, next),
+            async () => sinon.assert.calledWith(services.deleteObject,
+                any, any, any,
+                sinon.match({
+                    deleteData: true,
+                    doesNotNeedOpogUpdate: true,
+                }),
+                any, any, any),
+            next => objectGet(authInfo, testGetObjectRequest, false, log, err => {
+                assert.strictEqual(err.is.NoSuchKey, true);
+                next();
+            }),
+        ], done);
+    });
+
+    it('should delete an object with oplog update when object is archived', done => {
+        const archived = { archiveInfo: { foo: 0, bar: 'stuff' } };
+        async.series([
+            next => bucketPut(authInfo, testBucketPutRequest, log, next),
+            next => objectPut(authInfo, testPutObjectRequest, undefined, log, next),
+            next => fakeMetadataArchive(bucketName, objectKey, undefined, archived, next),
+            next => objectDelete(authInfo, testDeleteRequest, log, next),
+            async () => sinon.assert.calledWith(services.deleteObject,
+                any, any, any,
+                sinon.match({
+                    deleteData: true,
+                    doesNotNeedOpogUpdate: undefined,
+                }),
+                any, any, any),
+            next => objectGet(authInfo, testGetObjectRequest, false, log, err => {
+                assert.strictEqual(err.is.NoSuchKey, true);
+                next();
+            }),
+        ], done);
+    });
+
+    it('should delete an object with oplog update when bucket has bucket notification', done => {
+        const putNotifConfigRequest = {
+            bucketName,
+            headers: {
+                host: `${bucketName}.s3.amazonaws.com`,
+            },
+            post: '<NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+                '</NotificationConfiguration>',
+            actionImplicitDenies: false,
+        };
+        async.series([
+            next => bucketPut(authInfo, testBucketPutRequest, log, next),
+            next => bucketPutNotification(authInfo, putNotifConfigRequest, log, next),
+            next => objectPut(authInfo, testPutObjectRequest, undefined, log, next),
+            next => objectDelete(authInfo, testDeleteRequest, log, next),
+            async () => sinon.assert.calledWith(services.deleteObject,
+                any, any, any,
+                sinon.match({
+                    deleteData: true,
+                    doesNotNeedOpogUpdate: undefined,
+                }),
+                any, any, any),
+            next => objectGet(authInfo, testGetObjectRequest, false, log, err => {
+                assert.strictEqual(err.is.NoSuchKey, true);
+                next();
+            }),
+        ], done);
     });
 
     it('should delete a 0 bytes object', done => {

--- a/tests/unit/api/objectPut.js
+++ b/tests/unit/api/objectPut.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const async = require('async');
 const moment = require('moment');
-const { s3middleware, storage } = require('arsenal');
+const { s3middleware, storage, versioning } = require('arsenal');
 const sinon = require('sinon');
 
 const { bucketPut } = require('../../../lib/api/bucketPut');
@@ -12,12 +12,17 @@ const { parseTagFromQuery } = s3middleware.tagging;
 const { cleanup, DummyRequestLogger, makeAuthInfo, versioningTestUtils }
     = require('../helpers');
 const metadata = require('../metadataswitch');
+const { data } = require('../../../lib/data/wrapper');
 const objectPut = require('../../../lib/api/objectPut');
 const { objectLockTestUtils } = require('../helpers');
 const DummyRequest = require('../DummyRequest');
-const { maximumAllowedUploadSize } = require('../../../constants');
+const {
+    lastModifiedHeader,
+    maximumAllowedUploadSize,
+    objectLocationConstraintHeader,
+} = require('../../../constants');
 const mpuUtils = require('../utils/mpuUtils');
-const { lastModifiedHeader } = require('../../../constants');
+const { fakeMetadataArchive } = require('../../functional/aws-node-sdk/test/utils/init');
 
 const { ds } = storage.data.inMemory.datastore;
 
@@ -787,5 +792,193 @@ describe('objectPut API with versioning', () => {
                 });
             });
         });
+    });
+});
+
+describe('objectPut API in ingestion bucket', () => {
+    const dataClient = data.client;
+    const prevDataImplName = data.implName;
+
+    before(() => {
+        // Setup multi-backend, this is required for ingestion
+        data.switch(new storage.data.MultipleBackendGateway({
+            'us-east-1': dataClient,
+            'us-east-2': dataClient,
+        }, metadata, data.locStorageCheckFn));
+        data.implName = 'multipleBackends';
+    });
+
+    after(() => {
+        data.switch(dataClient);
+        data.implName = prevDataImplName;
+    });
+
+    beforeEach(() => {
+        cleanup();
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    const newPutObjectRequest = params => {
+        const { location, versionID } = params || {};
+        const r = versioningTestUtils
+            .createPutObjectRequest(bucketName, objectName, Buffer.from('I am another body', 'utf8'));
+        if (location) {
+            r.headers[objectLocationConstraintHeader] = location;
+        }
+        if (versionID) {
+            r.headers['x-scal-s3-version-id'] = versionID;
+        }
+        return r;
+    };
+    const newPutIngestBucketRequest = location => new DummyRequest({
+        bucketName,
+        namespace,
+        headers: { host: `${bucketName}.s3.amazonaws.com` },
+        url: '/',
+        post: '<?xml version="1.0" encoding="UTF-8"?>' +
+            '<CreateBucketConfiguration ' +
+            'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+            `<LocationConstraint>${location}</LocationConstraint>` +
+            '</CreateBucketConfiguration>',
+    });
+    const archiveRestoreRequested = {
+        archiveInfo: { foo: 0, bar: 'stuff' }, // opaque, can be anything...
+        restoreRequestedAt: new Date().toString(),
+        restoreRequestedDays: 5,
+    };
+
+    it('should use the versionID from the backend', done => {
+        const versionID = versioning.VersionID.encode(versioning.VersionID.generateVersionId('0', ''));
+
+        // Use a "mock" data location, simulating a write to an ingest location
+        sinon.stub(dataClient, 'put').callsFake((writeStream, size, keyContext, reqUids, cb) => {
+            cb(null, `${keyContext.bucketName}/${keyContext.objectKey}`, versionID, size, 'md5');
+        });
+
+        async.series([
+            next => bucketPut(authInfo, newPutIngestBucketRequest('us-east-1:ingest'), log, next),
+            next => objectPut(authInfo, newPutObjectRequest(), undefined, log, (err, headers) => {
+                assert.strictEqual(headers['x-amz-version-id'], versionID);
+                next(err);
+            }),
+        ], done);
+    });
+
+    it('should not use the versionID from the backend when writing in another location', done => {
+        const versionID = versioning.VersionID.encode(versioning.VersionID.generateVersionId('0', ''));
+
+        // Use a "mock" data location, simulating a write to an ingest location
+        sinon.stub(dataClient, 'put').callsFake((writeStream, size, keyContext, reqUids, cb) => {
+            cb(null, `${keyContext.bucketName}/${keyContext.objectKey}`, versionID, size, 'md5');
+        });
+
+        async.series([
+            next => bucketPut(authInfo, newPutIngestBucketRequest('us-east-1:ingest'), log, next),
+            next => objectPut(authInfo, newPutObjectRequest({
+                location: 'us-east-2',
+            }), undefined, log, (err, headers) => {
+                assert.ok(headers['x-amz-version-id']);
+                assert.notEqual(headers['x-amz-version-id'], versionID);
+                next(err);
+            }),
+        ], done);
+    });
+
+    it('should not use the versionID from the backend when it is not a valid versionID', done => {
+        const versionID = undefined;
+
+        // Use a "mock" data location, simulating a write to an ingest location
+        sinon.stub(dataClient, 'put').callsFake((writeStream, size, keyContext, reqUids, cb) => {
+            cb(null, `${keyContext.bucketName}/${keyContext.objectKey}`, versionID, size, 'md5');
+        });
+
+        async.series([
+            next => bucketPut(authInfo, newPutIngestBucketRequest('us-east-1:ingest'), log, next),
+            next => objectPut(authInfo, newPutObjectRequest(), undefined, log, (err, headers) => {
+                assert.ok(headers['x-amz-version-id']);
+                assert.notEqual(headers['x-amz-version-id'], versionID);
+                next(err);
+            }),
+        ], done);
+    });
+
+    it('should not use the versionID from the backend when it is not provided', done => {
+        async.series([
+            next => bucketPut(authInfo, newPutIngestBucketRequest('us-east-1:ingest'), log, next),
+            next => objectPut(authInfo, newPutObjectRequest(), undefined, log, (err, headers) => {
+                assert.ok(headers['x-amz-version-id']);
+                next(err);
+            }),
+        ], done);
+    });
+
+    it('should add versionID to backend putObject when restoring object', done => {
+        const versionID = versioning.VersionID.encode(versioning.VersionID.generateVersionId('0', ''));
+        const restoredVersionID = versioning.VersionID.encode(versioning.VersionID.generateVersionId('0', ''));
+
+        // Use a "mock" data location, simulating a write to an ingest location
+        sinon.stub(dataClient, 'put')
+            .onCall(0).callsFake((writeStream, size, keyContext, reqUids, cb) => {
+                // First call: regular object creation, should not pass extra metadata header
+                assert.strictEqual(keyContext.metaHeaders['x-amz-meta-scal-version-id'], undefined);
+                cb(null, `${keyContext.bucketName}/${keyContext.objectKey}`, versionID, size, 'md5');
+            })
+            .onCall(1).callsFake((writeStream, size, keyContext, reqUids, cb) => {
+                // Second call: "restored" data, should pass extra metadata header
+                assert.strictEqual(keyContext.metaHeaders['x-amz-meta-scal-version-id'], versionID);
+                cb(null, `${keyContext.bucketName}/${keyContext.objectKey}`, restoredVersionID, size, 'md5');
+            });
+
+        async.series([
+            next => bucketPut(authInfo, newPutIngestBucketRequest('us-east-1:ingest'), log, next),
+            next => objectPut(authInfo, newPutObjectRequest(), undefined, log, (err, headers) => {
+                assert.strictEqual(headers['x-amz-version-id'], versionID);
+                next(err);
+            }),
+            next => fakeMetadataArchive(bucketName, objectName, versionID, archiveRestoreRequested, next),
+            next => objectPut(authInfo, newPutObjectRequest({ versionID }), undefined, log, (err, headers) => {
+                assert.ok(headers['x-amz-version-id']);
+                assert.strictEqual(headers['x-amz-version-id'], versionID); // keep the same versionID
+                next(err);
+            }),
+        ], done);
+    });
+
+    it('should not add versionID to backend putObject when restoring object to another location', done => {
+        const versionID = versioning.VersionID.encode(versioning.VersionID.generateVersionId('0', ''));
+        const restoredVersionID = versioning.VersionID.encode(versioning.VersionID.generateVersionId('0', ''));
+
+        // Use a "mock" data location, simulating a write to an ingest location
+        sinon.stub(dataClient, 'put')
+            .onCall(0).callsFake((writeStream, size, keyContext, reqUids, cb) => {
+                // First call: regular object creation, should not pass extra metadata header
+                assert.strictEqual(keyContext.metaHeaders['x-amz-meta-scal-version-id'], undefined);
+                cb(null, `${keyContext.bucketName}/${keyContext.objectKey}`, versionID, size, 'md5');
+            })
+            .onCall(1).callsFake((writeStream, size, keyContext, reqUids, cb) => {
+                // Second call: "restored" data, should not pass extra metadata header (different location)
+                assert.strictEqual(keyContext.metaHeaders['x-amz-meta-scal-version-id'], undefined);
+                cb(null, `${keyContext.bucketName}/${keyContext.objectKey}`, restoredVersionID, size, 'md5');
+            });
+
+        async.series([
+            next => bucketPut(authInfo, newPutIngestBucketRequest('us-east-1:ingest'), log, next),
+            next => objectPut(authInfo, newPutObjectRequest(), undefined, log, (err, headers) => {
+                assert.strictEqual(headers['x-amz-version-id'], versionID);
+                next(err);
+            }),
+            next => fakeMetadataArchive(bucketName, objectName, versionID, archiveRestoreRequested, next),
+            next => objectPut(authInfo, newPutObjectRequest({
+                versionID,
+                location: 'us-east-2',
+            }), undefined, log, (err, headers) => {
+                assert.ok(headers['x-amz-version-id']);
+                assert.strictEqual(headers['x-amz-version-id'], versionID); // keep the same versionID
+                next(err);
+            }),
+        ], done);
     });
 });


### PR DESCRIPTION
Transition in OOB really only requires that an extra x-amz-meta-scal-version-id metadata is added when restoring the object, to allow backbeat to map the new objet being ingested with the existing metadata object.
This also requires this field to be added to overhead field, so it is provided in the oplog if the object is removed (from "backend" side) while restored.

In addition, as it requires using both endpoint, this opens new risk: to ensure OOB is "in-sync", writes through the OOB will not have the same VersionID as the backend. This is acutally not really a new behavior, as it allows this case to be consistent with the state of metadata when the object is simply ingested.

Issue: CLDSRV-563
