### PR TITLE
CLDSRV-616: Fix bucket policy check for anonymous requests

### DIFF
--- a/lib/api/apiUtils/authorization/permissionChecks.js
+++ b/lib/api/apiUtils/authorization/permissionChecks.js
@@ -269,6 +269,10 @@ function _checkPrincipal(requester, principal) {
     if (principal === '*') {
         return true;
     }
+    // User in unauthenticated (anonymous request)
+    if (requester === undefined) {
+        return false;
+    }
     if (principal === requester) {
         return true;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.10.51",
+  "version": "7.10.52",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {

--- a/tests/unit/api/bucketPolicyAuth.js
+++ b/tests/unit/api/bucketPolicyAuth.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const { BucketInfo, BucketPolicy } = require('arsenal').models;
+const AuthInfo = require('arsenal').auth.AuthInfo;
 const constants = require('../../../constants');
 const { isBucketAuthorized, isObjAuthorized, validatePolicyResource }
     = require('../../../lib/api/apiUtils/authorization/permissionChecks');
@@ -35,6 +36,9 @@ const basePolicyObj = {
 };
 const bucketName = 'matchme';
 const log = new DummyRequestLogger();
+const publicUserAuthInfo = new AuthInfo({
+    canonicalID: constants.publicId,
+});
 
 const authTests = [
     {
@@ -292,8 +296,18 @@ describe('bucket policy authorization', () => {
         it('should allow access to public user if principal is set to "*"',
         done => {
             const allowed = isBucketAuthorized(bucket, bucAction,
-                constants.publicId, null, log);
+                constants.publicId, publicUserAuthInfo, log);
             assert.equal(allowed, true);
+            done();
+        });
+
+        it('should deny access to public user if principal is not set to "*"', function itFn(done) {
+            const newPolicy = this.test.basePolicy;
+            newPolicy.Statement[0].Principal = { AWS: authInfo.getArn() };
+            bucket.setBucketPolicy(newPolicy);
+            const allowed = isBucketAuthorized(bucket, bucAction,
+                constants.publicId, publicUserAuthInfo, log);
+            assert.equal(allowed, false);
             done();
         });
 
@@ -376,7 +390,7 @@ describe('bucket policy authorization', () => {
         it('should allow access to public user if principal is set to "*"',
         done => {
             const allowed = isObjAuthorized(bucket, object, objAction,
-                constants.publicId, null, log);
+                constants.publicId, publicUserAuthInfo, log);
             assert.equal(allowed, true);
             done();
         });


### PR DESCRIPTION
When checking bucket policies and the following conditions are true:
- The request is anonymous (`--no-sign-request`)
- There is a bucket policy with AWS principal

Then `_getAccountId` is called in `arn === undefined` and causes an exception to be thrown.

The reason is that vault return the following `authInfo` with anonymous requests:
`{
  arn: undefined,
  canonicalID: 'http://acs.amazonaws.com/groups/global/AllUsers',
  shortid: undefined,
  email: undefined,
  accountDisplayName: undefined,
  IAMdisplayName: undefined
}`

The fix is to check is to check is `arn === undefined` and fail the check if the policy principal is not `*`