### PR TITLE
bf(CLDSRV-617): Send overheadField when deleting null version MD

### DIFF
--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -3,6 +3,7 @@ const async = require('async');
 
 const metadata = require('../../../metadata/wrapper');
 const { config } = require('../../../Config');
+const { overheadField } = require('../../../../constants');
 
 const versionIdUtils = versioning.VersionID;
 // Use Arsenal function to generate a version ID used internally by metadata
@@ -346,7 +347,7 @@ function versioningPreprocessing(bucketName, bucketMD, objectKey, objMD,
                 delOptions.versionId !== 'null') {
                 // backward-compat: delete old null versioned key
                 return _deleteNullVersionMD(
-                    bucketName, objectKey, { versionId: delOptions.versionId }, log, next);
+                    bucketName, objectKey, { versionId: delOptions.versionId, overheadField }, log, next);
             }
             return process.nextTick(next);
         },


### PR DESCRIPTION
Differing from normal operations, null version MD is deleted in a separate step prior to storing the new object, which causes the overhead code not to be able to retrieve the data. 

This PR passes `overheadField` when doing the delete which allows the overhead to be retrieved and attached.