### PR TITLE
OS-934 create dependabot PRs on default branch only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,3 @@ updates:
       interval: daily
       time: "13:00"
     open-pull-requests-limit: 10
-    target-branch: "development/7.4"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,6 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
       time: "13:00"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Part of our retro action at Hopo, is to stop targetting old branches for dependabot and focus only on the latest or default branch. 