### PR TITLE
CLDSRV-635: Bump arsenal for kmip logs (backport)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "arsenal": "git+https://github.com/scality/arsenal#7.10.62",
+    "arsenal": "git+https://github.com/scality/arsenal#7.10.66",
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -488,9 +488,9 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#7.10.62":
-  version "7.10.62"
-  resolved "git+https://github.com/scality/arsenal#e9d815cc9d212932924a5388173548ff804edc6b"
+"arsenal@git+https://github.com/scality/arsenal#7.10.66":
+  version "7.10.66"
+  resolved "git+https://github.com/scality/arsenal#63d3c943d0a4f32a71c0753e67340d18e6db47f9"
   dependencies:
     "@types/async" "^3.2.12"
     "@types/utf8" "^3.0.1"


### PR DESCRIPTION
~~Arsenal changes: https://github.com/scality/Arsenal/compare/7.10.62...improvement/ARSN-483-kmip-logs~~


Arsenal changes: https://github.com/scality/Arsenal/compare/7.10.62...7.10.66