### PR TITLE
CLDSRV-636: Hardcode outscale config for container

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -419,6 +419,20 @@ class Config extends EventEmitter {
         }
         let kmsAWS = {};
 
+        if (config.kmsAWS
+            && !config.kmsAWS.providerName
+            && config.kmsAWS.endpoint
+            && config.kmsAWS.ak
+            && config.kmsAWS.sk
+        ) {
+            // eslint-disable-next-line no-param-reassign
+            config.kmsAWS.providerName = 'okms';
+        }
+        if (config.kmsAWS) {
+            // eslint-disable-next-line no-param-reassign
+            config.kmsAWS.noAwsArn = true;
+        }
+
         const { providerName, region, endpoint, ak, sk, tls, noAwsArn } = config.kmsAWS;
 
         assert(providerName, 'Configuration Error: providerName must be defined in kmsAWS');
@@ -1518,6 +1532,14 @@ class Config extends EventEmitter {
     }
 
     _sseMigration(config) {
+        if (!config.sseMigration) {
+            // eslint-disable-next-line no-param-reassign
+            config.sseMigration = {
+                previousKeyType: KmsType.internal,
+                previousKeyProtocol: KmsProtocol.file,
+                previousKeyProvider: 'scality',
+            };
+        }
         if (config.sseMigration) {
             /**
              * For data that was encrypted internally by default and a new external provider is setup.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3",
-  "version": "7.70.21-12",
+  "version": "7.70.21-12-outscale",
   "description": "S3 connector",
   "main": "index.js",
   "engines": {

--- a/tests/unit/testConfigs/parseKmsAWS.js
+++ b/tests/unit/testConfigs/parseKmsAWS.js
@@ -48,6 +48,7 @@ describe('parseKmsAWS Function', () => {
             endpoint: 'https://example.com',
             ak: 'accessKey',
             sk: 'secretKey',
+            noAwsArn: true,
         });
     });
 
@@ -68,6 +69,7 @@ describe('parseKmsAWS Function', () => {
             ak: 'accessKey',
             sk: 'secretKey',
             region: 'us-west-2',
+            noAwsArn: true,
         });
     });
 
@@ -91,6 +93,7 @@ describe('parseKmsAWS Function', () => {
             endpoint: 'https://example.com',
             ak: 'accessKey',
             sk: 'secretKey',
+            noAwsArn: true,
             tls: {
                 rejectUnauthorized: true,
                 minVersion: 'TLSv1.2',


### PR DESCRIPTION
We will provide container as is to patch outscale
without generating a whole S3C

This will be merged in a new branch hotfix for outscale
___

Ignore failing tests because if hardcoded config value