### PR TITLE
bf: CLDSRV-642 bump bucketclient

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "async": "~2.5.0",
     "aws-sdk": "2.905.0",
     "azure-storage": "^2.1.0",
-    "bucketclient": "scality/bucketclient#7.10.4",
+    "bucketclient": "scality/bucketclient#7.10.20",
     "commander": "^2.9.0",
     "cron-parser": "^2.11.0",
     "diskusage": "1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -874,12 +874,12 @@ bson@^1.1.4:
   resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.6.tgz#fb819be9a60cd677e0853aee4ca712a785d6618a"
   integrity sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==
 
-bucketclient@scality/bucketclient#7.10.4:
-  version "7.10.4"
-  resolved "https://codeload.github.com/scality/bucketclient/tar.gz/08b8e1b1cd95651e231ccc88ec449f5b1c900304"
+bucketclient@scality/bucketclient#7.10.20:
+  version "7.10.20"
+  resolved "https://codeload.github.com/scality/bucketclient/tar.gz/b4123d0407c82d0bfa0072de976c5ef512831fb5"
   dependencies:
     agentkeepalive "^4.1.4"
-    arsenal "git+https://github.com/scality/Arsenal#7.10.28"
+    arsenal "git+https://github.com/scality/Arsenal#7.10.46"
     werelogs scality/werelogs#8.1.0
 
 bucketclient@scality/bucketclient#7.10.6:


### PR DESCRIPTION
Fixes a possible "callback was already called" exception.
