### PR TITLE
Fixes for running cloudserver on s3c

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -205,7 +205,9 @@ const constants = {
     ],
     allowedUtapiEventFilterStates: ['allow', 'deny'],
     allowedRestoreObjectRequestTierValues: ['Standard'],
-    validStorageClasses: [
+    // Only STANDARD class is supported, but keep the option to override supported values for now.
+    // This should be removed in CLDSRV-639.
+    validStorageClasses: process.env.VALID_STORAGE_CLASSES?.split(',') || [
         'STANDARD',
     ],
     lifecycleListing: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,7 +18,7 @@ export default [...compat.extends('@scality/scality'), {
     },
 
     languageOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: 2021,
         sourceType: "script",
     },
 

--- a/images/federation/Dockerfile
+++ b/images/federation/Dockerfile
@@ -32,7 +32,7 @@ USER ${USER}
 WORKDIR ${HOME_DIR}/s3
 
 # Keep same output as chown command without group (use group 0)
-COPY --chown=${USER}:0 --from=builder /usr/src/app ${HOME_DIR}/cloudserver
+COPY --chown=${USER}:0 --from=builder /usr/src/app ${HOME_DIR}/s3
 
 ENV S3_CONFIG_FILE=${CONF_DIR}/config.json
 ENV S3_LOCATION_FILE=${CONF_DIR}/locationConfig.json

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1284,21 +1284,19 @@ class Config extends EventEmitter {
                 assert(config.localCache, 'missing required property of utapi ' +
                     'configuration: localCache');
                 this.utapi.localCache = this.localCache;
-                assert(config.redis, 'missing required property of utapi ' +
+                assert(config.utapi.redis, 'missing required property of utapi ' +
                     'configuration: redis');
-                if (config.utapi.redis) {
-                    this.utapi.redis = parseRedisConfig(config.utapi.redis);
-                    if (this.utapi.redis.retry === undefined) {
-                        this.utapi.redis.retry = {
-                            connectBackoff: {
-                                min: 10,
-                                max: 1000,
-                                jitter: 0.1,
-                                factor: 1.5,
-                                deadline: 10000,
-                            },
-                        };
-                    }
+                this.utapi.redis = parseRedisConfig(config.utapi.redis);
+                if (this.utapi.redis.retry === undefined) {
+                    this.utapi.redis.retry = {
+                        connectBackoff: {
+                            min: 10,
+                            max: 1000,
+                            jitter: 0.1,
+                            factor: 1.5,
+                            deadline: 10000,
+                        },
+                    };
                 }
                 if (config.utapi.metrics) {
                     this.utapi.metrics = config.utapi.metrics;

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1611,10 +1611,6 @@ class Config extends EventEmitter {
             requestsConfigAssert(config.requests);
             this.requests = config.requests;
         }
-        // CLDSRV-378: on 8.x branches, null version compatibility
-        // mode is enforced because null keys are not supported by the
-        // MongoDB backend.
-        this.nullVersionCompatMode = true;
         if (config.bucketNotificationDestinations) {
             this.bucketNotificationDestinations = bucketNotifAssert(config.bucketNotificationDestinations);
         }
@@ -1770,6 +1766,12 @@ class Config extends EventEmitter {
             kms,
             quota,
         };
+
+        // Mongodb backend does not support null keys, so we must enforce null version compatibility
+        // mode. With other backends (esp. metadata), this is used during migration from v0 to v1
+        // bucket format.
+        this.nullVersionCompatMode = (metadata === 'mongodb') ||
+            (process.env.ENABLE_NULL_VERSION_COMPAT_MODE === 'true');
     }
 
     setAuthDataAccounts(accounts) {

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1772,6 +1772,11 @@ class Config extends EventEmitter {
         // bucket format.
         this.nullVersionCompatMode = (metadata === 'mongodb') ||
             (process.env.ENABLE_NULL_VERSION_COMPAT_MODE === 'true');
+
+        // Multi-object delete optimizations is only supported for MongoDB at the moment. It relies
+        // on `getObjectsMD()` to return the objects in a single call, which is not supported by
+        // other backends.
+        this.multiObjectDeleteEnableOptimizations &&= (metadata === 'mongodb');
     }
 
     setAuthDataAccounts(accounts) {

--- a/lib/api/apiUtils/object/getReplicationInfo.js
+++ b/lib/api/apiUtils/object/getReplicationInfo.js
@@ -43,6 +43,8 @@ function _getReplicationInfo(rule, replicationConfig, content, operationType,
         const storageClassName =
               storageClass.endsWith(':preferred_read') ?
               storageClass.split(':')[0] : storageClass;
+        // TODO CLDSRV-646: for consistency, should we look at replicationEndpoints instead, like
+        // `_getStorageClasses()` ?
         const location = s3config.locationConstraints[storageClassName];
         if (location && replicationBackends[location.type]) {
             storageTypes.push(location.type);
@@ -110,6 +112,7 @@ function getReplicationInfo(objKey, bucketMD, isMD, objSize, operationType,
             const rule = config.rules.find(
                 rule => (objKey.startsWith(rule.prefix) && rule.enabled));
             if (rule) {
+                // TODO CLDSRV-646 : should "merge" the replicationInfo for different rules
                 return _getReplicationInfo(
                     rule, config, content, operationType, objectMD, bucketMD);
             }

--- a/lib/api/bucketPutVersioning.js
+++ b/lib/api/bucketPutVersioning.js
@@ -21,10 +21,6 @@ const replicationVersioningErrorMessage = 'A replication configuration is ' +
 const ingestionVersioningErrorMessage = 'Versioning cannot be suspended for '
 + 'buckets setup with Out of Band updates from a location';
 
-const invalidBucketStateMessage = 'A replication configuration is present on ' +
- 'this bucket, so you cannot change the versioning state. To change the ' +
- 'versioning state, first delete the replication configuration.';
-
 const objectLockErrorMessage = 'An Object Lock configuration is present on ' +
   'this bucket, so the versioning state cannot be changed.';
 
@@ -89,21 +85,6 @@ function _checkBackendVersioningImplemented(bucket) {
     return true;
 }
 
-function _isValidVersioningRequest(result, bucket) {
-    if (result.VersioningConfiguration &&
-        result.VersioningConfiguration.Status) {
-        const restricted = bucket.getReplicationConfiguration()
-            || (bucket.isIngestionBucket && bucket.isIngestionBucket());
-        // Is there a replication configuration set on the bucket or the bucket
-        // is an ingestion bucket and is the user attempting to suspend
-        // versioning?
-        if (restricted) {
-            return result.VersioningConfiguration.Status[0] !== 'Suspended';
-        }
-    }
-    return true;
-}
-
 /**
  * Bucket Put Versioning - Create or update bucket Versioning
  * @param {AuthInfo} authInfo - Instance of AuthInfo class with requester's info
@@ -147,19 +128,6 @@ function bucketPutVersioning(authInfo, request, log, callback) {
                     externalVersioningErrorMessage);
                 return next(error, bucket);
             }
-            if (!_isValidVersioningRequest(result, bucket)) {
-                const errorMsg =
-                (bucket.isIngestionBucket && bucket.isIngestionBucket()) ?
-                    ingestionVersioningErrorMessage :
-                    replicationVersioningErrorMessage;
-                log.debug(errorMsg, {
-                    method: 'bucketPutVersioning',
-                    error: errors.InvalidBucketState,
-                });
-                const error = errorInstances.InvalidBucketState
-                    .customizeDescription(errorMsg);
-                return next(error, bucket);
-            }
             const versioningConfiguration = {};
             if (result.VersioningConfiguration.Status) {
                 versioningConfiguration.Status =
@@ -175,14 +143,15 @@ function bucketPutVersioning(authInfo, request, log, callback) {
         (bucket, versioningConfiguration, next) => {
             // check if replication is enabled if versioning is being suspended
             const replicationConfig = bucket.getReplicationConfiguration();
+            const isIngestionBucket = bucket.isIngestionBucket && bucket.isIngestionBucket();
             const invalidAction =
                 versioningConfiguration.Status === 'Suspended'
-                && replicationConfig
-                && replicationConfig.rules
-                && replicationConfig.rules.some(r => r.enabled);
+                && (isIngestionBucket || replicationConfig?.rules?.some(r => r.enabled));
             if (invalidAction) {
+                const errorMsg = isIngestionBucket ?
+                    ingestionVersioningErrorMessage : replicationVersioningErrorMessage;
                 next(errorInstances.InvalidBucketState
-                    .customizeDescription(invalidBucketStateMessage));
+                    .customizeDescription(errorMsg));
                 return;
             }
             const objectLockEnabled = bucket.isObjectLockEnabled();

--- a/lib/api/initiateMultipartUpload.js
+++ b/lib/api/initiateMultipartUpload.js
@@ -92,11 +92,11 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
     // TODO: Add this as a utility function for all object put requests
     // but after authentication so that string to sign is not impacted
     // This is GH Issue#89
+    // TODO: remove in CLDSRV-639
     const storageClassOptions =
         ['standard', 'standard_ia', 'reduced_redundancy'];
     let storageClass = 'STANDARD';
-    if (storageClassOptions.indexOf(request
-        .headers['x-amz-storage-class']) > -1) {
+    if (storageClassOptions.indexOf(request.headers['x-amz-storage-class']) > -1) {
         storageClass = request.headers['x-amz-storage-class']
             .toUpperCase();
     }

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -69,7 +69,7 @@ function _prepMetadata(request, sourceObjMD, headers, sourceIsDestination,
         overrideMetadata['x-amz-server-side-encryption'] =
             headers['x-amz-server-side-encryption'];
     }
-    if (headers['x-amz-storage-class']) {
+    if (headers['x-amz-storage-class']) {  // TODO: remove in CLDSRV-639
         overrideMetadata['x-amz-storage-class'] =
             headers['x-amz-storage-class'];
     }

--- a/lib/api/objectGet.js
+++ b/lib/api/objectGet.js
@@ -18,7 +18,6 @@ const checkReadLocation = require('./apiUtils/object/checkReadLocation');
 
 const { standardMetadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { config } = require('../Config');
-const { locationConstraints } = config;
 const monitoring = require('../utilities/monitoringHandler');
 const { getPartCountFromMd5 } = require('./apiUtils/object/partInfo');
 const { setExpirationHeaders } = require('./apiUtils/object/expirationHeaders');
@@ -120,10 +119,6 @@ function objectGet(authInfo, request, returnTagCount, log, callback) {
             objMD['last-modified'], objMD['content-md5']);
         if (headerValResult.error) {
             return callback(headerValResult.error, null, corsHeaders);
-        }
-        if (locationConstraints[bucket.getLocationConstraint()]?.isCold) {
-            // eslint-disable-next-line no-param-reassign
-            objMD['x-amz-storage-class'] = bucket.getLocationConstraint();
         }
         const responseMetaHeaders = collectResponseHeaders(objMD,
             corsHeaders, verCfg, returnTagCount);

--- a/lib/api/objectHead.js
+++ b/lib/api/objectHead.js
@@ -10,8 +10,6 @@ const { getVersionIdResHeader } = require('./apiUtils/object/versioning');
 const monitoring = require('../utilities/monitoringHandler');
 const { getPartNumber, getPartSize, getPartCountFromMd5 } =
     require('./apiUtils/object/partInfo');
-const { config } = require('../Config');
-const { locationConstraints } = config;
 
 const { standardMetadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { maximumAllowedPartCount } = require('../../constants');
@@ -93,10 +91,6 @@ function objectHead(authInfo, request, log, callback) {
                 objMD['last-modified'], objMD['content-md5']);
             if (headerValResult.error) {
                 return callback(headerValResult.error, corsHeaders);
-            }
-            if (locationConstraints[bucket.getLocationConstraint()]?.isCold) {
-                // eslint-disable-next-line no-param-reassign
-                objMD['x-amz-storage-class'] = bucket.getLocationConstraint();
             }
             const responseHeaders = collectResponseHeaders(objMD, corsHeaders,
                 verCfg);

--- a/lib/api/objectHead.js
+++ b/lib/api/objectHead.js
@@ -151,10 +151,14 @@ function objectHead(authInfo, request, log, callback) {
                     return callback(errors.BadRequest, corsHeaders);
                 }
                 const partSize = getPartSize(objMD, partNumber);
-                if (!partSize) {
+                if (partSize) {
+                    responseHeaders['content-length'] = partSize;
+                } else if (objLength === 0 && partNumber === 1) {
+                    // Match AWS behavior: consider a 0-byte object as having a single part
+                    responseHeaders['content-length'] = 0;
+                } else {
                     return callback(errors.InvalidRange, corsHeaders);
                 }
-                responseHeaders['content-length'] = partSize;
                 const partsCount = getPartCountFromMd5(objMD);
                 if (partsCount) {
                     responseHeaders['x-amz-mp-parts-count'] = partsCount;

--- a/lib/metadata/acl.js
+++ b/lib/metadata/acl.js
@@ -1,5 +1,6 @@
 const { errors } = require('arsenal');
 
+const getReplicationInfo = require('../api/apiUtils/object/getReplicationInfo');
 const aclUtils = require('../utilities/aclUtils');
 const constants = require('../../constants');
 const metadata = require('../metadata/wrapper');
@@ -41,8 +42,21 @@ const acl = {
             /* eslint-disable no-param-reassign */
             objectMD.acl = addACLParams;
             objectMD.originOp = 's3:ObjectAcl:Put';
-            return metadata.putObjectMD(bucket.getName(), objectKey, objectMD, params, log,
-                cb);
+
+            // Use storageType to determine if replication update is needed, as it is set only for
+            // "cloud" locations. This  ensures that we reset replication when CRR is used, but not
+            // when multi-backend replication (i.e. Zenko) is used.
+            // TODO: this should be refactored to properly update the replication info, accounting
+            // for multiple rules and resetting the status only if needed CLDSRV-646
+            const replicationInfo = getReplicationInfo(objectKey, bucket, true);
+            if (replicationInfo && !replicationInfo.storageType) {
+                objectMD.replicationInfo = {
+                    ...objectMD.replicationInfo,
+                    ...replicationInfo,
+                };
+            }
+
+            return metadata.putObjectMD(bucket.getName(), objectKey, objectMD, params, log, cb);
         }
         return cb();
     },

--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -673,8 +673,10 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
                             versionId &&
                             // The new data location is set to null when archiving to a Cold site.
                             // In that case "removing old data location key" is handled by the lifecycle
-                            // transition processor.
-                            omVal.location && Array.isArray(omVal.location) &&
+                            // transition processor. Check the content-length as a null location can
+                            // also be from an empty object.
+                            (omVal['content-length'] === 0 ||
+                             (omVal.location && Array.isArray(omVal.location))) &&
                             locationKeysHaveChanged(objMd.location, omVal.location)) {
                             log.info('removing old data locations', {
                                 method: 'putMetadata',

--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -38,7 +38,7 @@ const { listLifecycleCurrents } = require('../api/backbeat/listLifecycleCurrents
 const { listLifecycleNonCurrents } = require('../api/backbeat/listLifecycleNonCurrents');
 const { listLifecycleOrphanDeleteMarkers } = require('../api/backbeat/listLifecycleOrphanDeleteMarkers');
 const { objectDeleteInternal } = require('../api/objectDelete');
-const { validateQuotas } = require('../api/apiUtils/quotas/quotaUtils');
+const quotaUtils = require('../api/apiUtils/quotas/quotaUtils');
 
 const { CURRENT_TYPE, NON_CURRENT_TYPE, ORPHAN_DM_TYPE } = constants.lifecycleListing;
 
@@ -336,7 +336,7 @@ POST /_/backbeat/multiplebackenddata/<bucket name>/<object key>
 POST /_/backbeat/multiplebackenddata/<bucket name>/<object key>
     ?operation=puttagging
 GET /_/backbeat/multiplebackendmetadata/<bucket name>/<object key>
-POST /_/backbeat/batchdelete
+POST /_/backbeat/batchdelete/<bucket name>
 GET /_/backbeat/lifecycle/<bucket name>?list-type=current
 GET /_/backbeat/lifecycle/<bucket name>?list-type=noncurrent
 GET /_/backbeat/lifecycle/<bucket name>?list-type=orphan
@@ -1255,9 +1255,17 @@ function batchDelete(request, response, userInfo, log, callback) {
             // Update inflight metrics for the data which has just been freed
             const bucket = request.bucketName;
             const contentLength = locations.reduce((length, loc) => length + loc.size, 0);
+
+            // TODO: `bucket` should probably always be passed, to be confirmed in CLDSRV-643
+            // For now be leniant and skip inflight updates if it is not specified, to avoid any
+            // impact esp. on CRR
+            if (!bucket || !config.isQuotaEnabled() || contentLength == 0) {
+                return _respond(response, null, log, callback);
+            }
+
             return async.waterfall([
                 next => metadata.getBucket(bucket, log, next),
-                (bucketMD, next) => validateQuotas(request, bucketMD, request.accountQuotas,
+                (bucketMD, next) => quotaUtils.validateQuotas(request, bucketMD, request.accountQuotas,
                     ['objectDelete'], 'objectDelete', -contentLength, false, log, next),
             ], err => {
                 if (err) {

--- a/lib/services.js
+++ b/lib/services.js
@@ -483,7 +483,7 @@ const services = {
             params.headers['content-type'];
         multipartObjectMD.expires =
             params.headers.expires;
-        multipartObjectMD['x-amz-storage-class'] = params.storageClass;
+        multipartObjectMD['x-amz-storage-class'] = params.storageClass;  // TODO: removed CLDSRV-639
         multipartObjectMD['x-amz-website-redirect-location'] =
             params.headers['x-amz-website-redirect-location'];
         if (cipherBundle) {

--- a/tests/functional/aws-node-sdk/test/object/getPartSize.js
+++ b/tests/functional/aws-node-sdk/test/object/getPartSize.js
@@ -7,6 +7,8 @@ const { maximumAllowedPartCount } = require('../../../../../constants');
 
 const bucket = 'mpu-test-bucket';
 const object = 'mpu-test-object';
+const emptyObject = 'empty-object';
+const nonMpuObject = 'simple-object';
 
 const bodySize = 1024 * 1024 * 5;
 const bodyContent = 'a';
@@ -36,17 +38,18 @@ describe('Part size tests with object head', () => {
         let s3;
 
         function headObject(fields, cb) {
-            s3.headObject(Object.assign({
+            s3.headObject({
                 Bucket: bucket,
                 Key: object,
-            }, fields), cb);
+                ...fields,
+            }, cb);
         }
 
-        beforeEach(function beforeF(done) {
+        before(function beforeF(done) {
             bucketUtil = new BucketUtility('default', sigCfg);
             s3 = bucketUtil.s3;
 
-            async.waterfall([
+            async.series([
                 next => s3.createBucket({ Bucket: bucket }, err => next(err)),
                 next => s3.createMultipartUpload({
                     Bucket: bucket,
@@ -91,17 +94,28 @@ describe('Part size tests with object head', () => {
                     };
                     return s3.completeMultipartUpload(params, next);
                 },
+                next => s3.putObject({
+                    Bucket: bucket,
+                    Key: emptyObject,
+                    Body: '',
+                }, next),
+                next => s3.putObject({
+                    Bucket: bucket,
+                    Key: nonMpuObject,
+                    Body: generateContent(0),
+                }, next),
             ], err => {
                 checkNoError(err);
                 done();
             });
         });
 
-        afterEach(done => {
-            async.waterfall([
-                next => s3.deleteObject({ Bucket: bucket, Key: object },
-                    err => next(err)),
-                next => s3.deleteBucket({ Bucket: bucket }, err => next(err)),
+        after(done => {
+            async.series([
+                next => s3.deleteObject({ Bucket: bucket, Key: object }, next),
+                next => s3.deleteObject({ Bucket: bucket, Key: emptyObject }, next),
+                next => s3.deleteObject({ Bucket: bucket, Key: nonMpuObject }, next),
+                next => s3.deleteBucket({ Bucket: bucket }, next),
             ], done);
         });
 
@@ -149,5 +163,37 @@ describe('Part size tests with object head', () => {
                     done();
                 });
             });
+
+        it('should return content-length 0 when requesting part 1 of empty object', done => {
+            headObject({ Key: emptyObject, PartNumber: 1 }, (err, data) => {
+                checkNoError(err);
+                assert.strictEqual(data.ContentLength, 0);
+                done();
+            });
+        });
+
+        it('should return an error when requesting part 2 of empty object', done => {
+            headObject({ Key: emptyObject, PartNumber: 2 }, (err, data) => {
+                checkError(err, 416, 'InvalidRange');
+                assert.strictEqual(data, null);
+                done();
+            });
+        });
+
+        it('should return content-length requesting part 1 of non-MPU object', done => {
+            headObject({ Key: nonMpuObject, PartNumber: 1 }, (err, data) => {
+                checkNoError(err);
+                assert.strictEqual(data.ContentLength, 0);
+                done();
+            });
+        });
+
+        it('should return an error when requesting part 2 of non-MPU object', done => {
+            headObject({ Key: nonMpuObject, PartNumber: 1 }, (err, data) => {
+                checkError(err, 416, 'InvalidRange');
+                assert.strictEqual(data.ContentLength, bodySize);
+                done();
+            });
+        });
     });
 });

--- a/tests/functional/aws-node-sdk/test/object/objectCopy.js
+++ b/tests/functional/aws-node-sdk/test/object/objectCopy.js
@@ -7,6 +7,7 @@ const { fakeMetadataTransition, fakeMetadataArchive } = require('../utils/init')
 const { taggingTests } = require('../../lib/utility/tagging');
 const genMaxSizeMetaHeaders
     = require('../../lib/utility/genMaxSizeMetaHeaders');
+const constants = require('../../../../constants');
 
 const sourceBucketName = 'supersourcebucket8102016';
 const sourceObjName = 'supersourceobject';
@@ -564,16 +565,15 @@ describe('Object Copy', () => {
             });
         });
 
-        // TODO: disabled in CLDSRV-184 as only STANDARD class is supported
-        it.skip('should copy a 0 byte object to same destination', done => {
-            const emptyFileETag = '"d41d8cd98f00b204e9800998ecf8427e"';
-            s3.putObject({ Bucket: sourceBucketName, Key: sourceObjName,
-                Body: '' }, () => {
-                s3.copyObject({ Bucket: sourceBucketName, Key: sourceObjName,
-                    CopySource: `${sourceBucketName}/${sourceObjName}`,
-                    StorageClass: 'REDUCED_REDUNDANCY',
-                },
-                    (err, res) => {
+        // TODO: remove (or update to use different location constraint) in CLDSRV-639
+        if (constants.validStorageClasses.includes('REDUCED_REDUNDANCY')) {
+            it('should copy a 0 byte object to same destination', done => {
+                const emptyFileETag = '"d41d8cd98f00b204e9800998ecf8427e"';
+                s3.putObject({ Bucket: sourceBucketName, Key: sourceObjName, Body: '' }, () => {
+                    s3.copyObject({ Bucket: sourceBucketName, Key: sourceObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        StorageClass: 'REDUCED_REDUNDANCY',
+                    }, (err, res) => {
                         checkNoError(err);
                         assert.strictEqual(res.ETag, emptyFileETag);
                         s3.getObject({ Bucket: sourceBucketName,
@@ -586,17 +586,15 @@ describe('Object Copy', () => {
                             done();
                         });
                     });
+                });
             });
-        });
 
-        // TODO: disabled in CLDSRV-184 as only STANDARD class is supported
-        it.skip('should copy an object to a different destination and change ' +
-            'the storage class if storage class header provided', done => {
-            s3.copyObject({ Bucket: destBucketName, Key: destObjName,
-                CopySource: `${sourceBucketName}/${sourceObjName}`,
-                StorageClass: 'REDUCED_REDUNDANCY',
-            },
-                err => {
+            it('should copy an object to a different destination and change ' +
+                'the storage class if storage class header provided', done => {
+                s3.copyObject({ Bucket: destBucketName, Key: destObjName,
+                    CopySource: `${sourceBucketName}/${sourceObjName}`,
+                    StorageClass: 'REDUCED_REDUNDANCY',
+                }, err => {
                     checkNoError(err);
                     s3.getObject({ Bucket: destBucketName,
                         Key: destObjName }, (err, res) => {
@@ -605,16 +603,14 @@ describe('Object Copy', () => {
                         done();
                     });
                 });
-        });
+            });
 
-        // TODO: disabled in CLDSRV-184 as only STANDARD class is supported
-        it.skip('should copy an object to the same destination and change the ' +
-            'storage class if the storage class header provided', done => {
-            s3.copyObject({ Bucket: sourceBucketName, Key: sourceObjName,
-                CopySource: `${sourceBucketName}/${sourceObjName}`,
-                StorageClass: 'REDUCED_REDUNDANCY',
-            },
-                err => {
+            it('should copy an object to the same destination and change the ' +
+                'storage class if the storage class header provided', done => {
+                s3.copyObject({ Bucket: sourceBucketName, Key: sourceObjName,
+                    CopySource: `${sourceBucketName}/${sourceObjName}`,
+                    StorageClass: 'REDUCED_REDUNDANCY',
+                }, err => {
                     checkNoError(err);
                     s3.getObject({ Bucket: sourceBucketName,
                         Key: sourceObjName }, (err, res) => {
@@ -624,7 +620,8 @@ describe('Object Copy', () => {
                         done();
                     });
                 });
-        });
+            });
+        }
 
         it('should copy an object to a new bucket and overwrite an already ' +
             'existing object in the destination bucket', done => {

--- a/tests/functional/aws-node-sdk/test/versioning/objectCopy.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectCopy.js
@@ -7,6 +7,7 @@ const { removeAllVersions } = require('../../lib/utility/versioning-util');
 const customS3Request = require('../../lib/utility/customS3Request');
 
 const { taggingTests } = require('../../lib/utility/tagging');
+const constants = require('../../lib/constants');
 
 const sourceBucketName = 'supersourcebucket8102016';
 const sourceObjName = 'supersourceobject';
@@ -466,24 +467,29 @@ describe('Object Version Copy', () => {
             });
         });
 
-        // TODO: disabled in CLDSRV-184 as only STANDARD class is supported
-        it.skip('should copy a 0 byte object to same destination', done => {
-            const emptyFileETag = '"d41d8cd98f00b204e9800998ecf8427e"';
-            s3.putObject({ Bucket: sourceBucketName, Key: sourceObjName,
-                Body: '' }, (err, putRes) => {
-                checkNoError(err);
-                copySource = `${sourceBucketName}/${sourceObjName}` +
-                    `?versionId=${putRes.VersionId}`;
-                s3.copyObject({ Bucket: sourceBucketName, Key: sourceObjName,
-                    CopySource: copySource,
-                    StorageClass: 'REDUCED_REDUNDANCY',
-                },
-                    (err, copyRes) => {
+        // TODO: remove (or update to use different location constraint) in CLDSRV-639
+        if (constants.validStorageClasses.includes('REDUCED_REDUNDANCY')) {
+            it('should copy a 0 byte object to same destination', done => {
+                const emptyFileETag = '"d41d8cd98f00b204e9800998ecf8427e"';
+                s3.putObject({
+                    Bucket: sourceBucketName, Key: sourceObjName,
+                    Body: ''
+                }, (err, putRes) => {
+                    checkNoError(err);
+                    copySource = `${sourceBucketName}/${sourceObjName}` +
+                        `?versionId=${putRes.VersionId}`;
+                    s3.copyObject({
+                        Bucket: sourceBucketName, Key: sourceObjName,
+                        CopySource: copySource,
+                        StorageClass: 'REDUCED_REDUNDANCY',
+                    }, (err, copyRes) => {
                         checkNoError(err);
                         assert.notEqual(copyRes.VersionId, putRes.VersionId);
                         assert.strictEqual(copyRes.ETag, emptyFileETag);
-                        s3.getObject({ Bucket: sourceBucketName,
-                            Key: sourceObjName }, (err, res) => {
+                        s3.getObject({
+                            Bucket: sourceBucketName,
+                            Key: sourceObjName
+                        }, (err, res) => {
                             assert.deepStrictEqual(res.Metadata,
                                 {});
                             assert.deepStrictEqual(res.StorageClass,
@@ -492,45 +498,48 @@ describe('Object Version Copy', () => {
                             done();
                         });
                     });
+                });
             });
-        });
 
-        // TODO: disabled in CLDSRV-184 as only STANDARD class is supported
-        it.skip('should copy an object to a different destination and change ' +
-            'the storage class if storage class header provided', done => {
-            s3.copyObject({ Bucket: destBucketName, Key: destObjName,
-                CopySource: copySource,
-                StorageClass: 'REDUCED_REDUNDANCY',
-            },
-                err => {
+            it('should copy an object to a different destination and change ' +
+                'the storage class if storage class header provided', done => {
+                s3.copyObject({
+                    Bucket: destBucketName, Key: destObjName,
+                    CopySource: copySource,
+                    StorageClass: 'REDUCED_REDUNDANCY',
+                }, err => {
                     checkNoError(err);
-                    s3.getObject({ Bucket: destBucketName,
-                        Key: destObjName }, (err, res) => {
+                    s3.getObject({
+                        Bucket: destBucketName,
+                        Key: destObjName
+                    }, (err, res) => {
                         assert.strictEqual(res.StorageClass,
                             'REDUCED_REDUNDANCY');
                         done();
                     });
                 });
-        });
+            });
 
-        // TODO: disabled in CLDSRV-184 as only STANDARD class is supported
-        it.skip('should copy an object to the same destination and change the ' +
-            'storage class if the storage class header provided', done => {
-            s3.copyObject({ Bucket: sourceBucketName, Key: sourceObjName,
-                CopySource: copySource,
-                StorageClass: 'REDUCED_REDUNDANCY',
-            },
-                err => {
+            it('should copy an object to the same destination and change the ' +
+                'storage class if the storage class header provided', done => {
+                s3.copyObject({
+                    Bucket: sourceBucketName, Key: sourceObjName,
+                    CopySource: copySource,
+                    StorageClass: 'REDUCED_REDUNDANCY',
+                }, err => {
                     checkNoError(err);
-                    s3.getObject({ Bucket: sourceBucketName,
-                        Key: sourceObjName }, (err, res) => {
+                    s3.getObject({
+                        Bucket: sourceBucketName,
+                        Key: sourceObjName
+                    }, (err, res) => {
                         checkNoError(err);
                         assert.strictEqual(res.StorageClass,
                             'REDUCED_REDUNDANCY');
                         done();
                     });
                 });
-        });
+            });
+        }
 
         it('should copy an object to a new bucket and overwrite an already ' +
             'existing object in the destination bucket', done => {

--- a/tests/functional/aws-node-sdk/test/versioning/replicationBucket.js
+++ b/tests/functional/aws-node-sdk/test/versioning/replicationBucket.js
@@ -75,10 +75,10 @@ describe('Versioning on a replication source bucket', () => {
             });
         });
 
-        it('should not be able to suspend versioning if replication disabled',
+        it('should be able to suspend versioning if replication disabled',
         done => {
             testVersioning(s3, 'Suspended', 'Disabled', false, err => {
-                checkError(err, 'InvalidBucketState');
+                checkNoError(err);
                 done();
             });
         });

--- a/tests/multipleBackend/routes/routeBackbeat.js
+++ b/tests/multipleBackend/routes/routeBackbeat.js
@@ -2509,7 +2509,8 @@ describe('backbeat routes', () => {
                 }),
                 done => {
                     makeBackbeatRequest({
-                        method: 'GET', bucket: TEST_BUCKET,
+                        method: 'GET',
+                        bucket: TEST_BUCKET,
                         objectKey: testKey,
                         resourceType: 'metadata',
                         authCredentials: backbeatAuthCredentials,
@@ -2531,7 +2532,7 @@ describe('backbeat routes', () => {
                         hostname: ipAddress,
                         port: 8000,
                         method: 'POST',
-                        path: '/_/backbeat/batchdelete',
+                        path: `/_/backbeat/batchdelete/${TEST_BUCKET}/${testKey}`,
                         requestBody:
                         `{"Locations":${JSON.stringify(location)}}`,
                         jsonResponse: true,

--- a/tests/unit/Config.js
+++ b/tests/unit/Config.js
@@ -1,8 +1,10 @@
 const assert = require('assert');
 const {
+    azureGetStorageAccountName,
+    azureGetLocationCredentials,
     locationConstraintAssert,
     parseSupportedLifecycleRules,
-    ConfigObject: ConfigObjectForTest,
+    ConfigObject: ConfigObject,
 } = require('../../lib/Config');
 
 const {
@@ -30,7 +32,6 @@ describe('Config', () => {
     });
 
     it('should emit an event when auth data is updated', done => {
-        const { ConfigObject } = require('../../lib/Config');
         const config = new ConfigObject();
         let emitted = false;
         config.on('authdata-update', () => {
@@ -44,8 +45,6 @@ describe('Config', () => {
     });
 
     describe('azureGetStorageAccountName', () => {
-        const { azureGetStorageAccountName } = require('../../lib/Config');
-
         it('should return the azureStorageAccountName', done => {
             const accountName = azureGetStorageAccountName('us-west-1', {
                 azureStorageAccountName: 'someaccount'
@@ -66,8 +65,6 @@ describe('Config', () => {
     });
 
     describe('azureGetLocationCredentials', () => {
-        const { azureGetLocationCredentials } = require('../../lib/Config');
-
         const locationDetails = {
             azureStorageAccountName: 'someaccount',
             azureStorageAccessKey: 'ZW5jcnlwdGVkCg==',
@@ -214,8 +211,6 @@ describe('Config', () => {
     });
 
     describe('getAzureStorageAccountName', () => {
-        const { ConfigObject } = require('../../lib/Config');
-
         it('should return account name from config', () => {
             setEnv('azurebackend_AZURE_STORAGE_ACCOUNT_NAME', '');
             const config = new ConfigObject();
@@ -330,7 +325,7 @@ describe('Config', () => {
 
     describe('time options', () => {
         it('should getTimeOptions', () => {
-            const config = new ConfigObjectForTest();
+            const config = new ConfigObject();
             const expectedOptions = {
                 expireOneDayEarlier: false,
                 transitionOneDayEarlier: false,
@@ -344,7 +339,7 @@ describe('Config', () => {
         it('should getTimeOptions with TIME_PROGRESSION_FACTOR', () => {
             setEnv('TIME_PROGRESSION_FACTOR', 2);
 
-            const config = new ConfigObjectForTest();
+            const config = new ConfigObject();
             const expectedOptions = {
                 expireOneDayEarlier: false,
                 transitionOneDayEarlier: false,
@@ -358,7 +353,7 @@ describe('Config', () => {
         it('should getTimeOptions with EXPIRE_ONE_DAY_EARLIER', () => {
             setEnv('EXPIRE_ONE_DAY_EARLIER', true);
 
-            const config = new ConfigObjectForTest();
+            const config = new ConfigObject();
             const expectedOptions = {
                 expireOneDayEarlier: true,
                 transitionOneDayEarlier: false,
@@ -372,7 +367,7 @@ describe('Config', () => {
         it('should getTimeOptions with TRANSITION_ONE_DAY_EARLIER', () => {
             setEnv('TRANSITION_ONE_DAY_EARLIER', true);
 
-            const config = new ConfigObjectForTest();
+            const config = new ConfigObject();
             const expectedOptions = {
                 expireOneDayEarlier: false,
                 transitionOneDayEarlier: true,
@@ -387,7 +382,7 @@ describe('Config', () => {
             setEnv('EXPIRE_ONE_DAY_EARLIER', true);
             setEnv('TRANSITION_ONE_DAY_EARLIER', true);
 
-            const config = new ConfigObjectForTest();
+            const config = new ConfigObject();
             const expectedOptions = {
                 expireOneDayEarlier: true,
                 transitionOneDayEarlier: true,
@@ -402,14 +397,14 @@ describe('Config', () => {
             setEnv('EXPIRE_ONE_DAY_EARLIER', true);
             setEnv('TIME_PROGRESSION_FACTOR', 2);
 
-            assert.throws(() => new ConfigObjectForTest());
+            assert.throws(() => new ConfigObject());
         });
 
         it('should throw error if TRANSITION_ONE_DAY_EARLIER and TIME_PROGRESSION_FACTOR', () => {
             setEnv('TRANSITION_ONE_DAY_EARLIER', true);
             setEnv('TIME_PROGRESSION_FACTOR', 2);
 
-            assert.throws(() => new ConfigObjectForTest());
+            assert.throws(() => new ConfigObject());
         });
 
         it('should throw error if both EXPIRE/TRANSITION_ONE_DAY_EARLIER and TIME_PROGRESSION_FACTOR', () => {
@@ -417,7 +412,36 @@ describe('Config', () => {
             setEnv('TRANSITION_ONE_DAY_EARLIER', true);
             setEnv('TIME_PROGRESSION_FACTOR', 2);
 
-            assert.throws(() => new ConfigObjectForTest());
+            assert.throws(() => new ConfigObject());
+        });
+    });
+
+    describe('nullVersionCompatMode', () => {
+        it('should be true when metadata backend is mongodb', () => {
+            setEnv('S3METADATA', 'mongodb');
+            setEnv('ENABLE_NULL_VERSION_COMPAT_MODE', 'false'); // should be ignored
+            const config = new ConfigObject();
+            assert.strictEqual(config.nullVersionCompatMode, true);
+        });
+
+        it('should be true when ENABLE_NULL_VERSION_COMPAT_MODE is true', () => {
+            setEnv('S3METADATA', 'file'); // Not MongoDB
+            setEnv('ENABLE_NULL_VERSION_COMPAT_MODE', 'true');
+            const config = new ConfigObject();
+            assert.strictEqual(config.nullVersionCompatMode, true);
+        });
+
+        it('should be false when ENABLE_NULL_VERSION_COMPAT_MODE is false', () => {
+            setEnv('S3METADATA', 'file'); // Not MongoDB
+            setEnv('ENABLE_NULL_VERSION_COMPAT_MODE', 'false');
+            const config = new ConfigObject();
+            assert.strictEqual(config.nullVersionCompatMode, false);
+        });
+
+        it('should be false when metadata backend is not mongodb and env var not set', () => {
+            setEnv('S3METADATA', 'file'); // Not MongoDB
+            const config = new ConfigObject();
+            assert.strictEqual(config.nullVersionCompatMode, false);
         });
     });
 
@@ -435,7 +459,6 @@ describe('Config', () => {
         });
 
         it('should set up scuba', () => {
-            const { ConfigObject } = require('../../lib/Config');
             const config = new ConfigObject();
 
             assert.deepStrictEqual(
@@ -451,7 +474,6 @@ describe('Config', () => {
             setEnv('SCUBA_HOST', 'scubahost');
             setEnv('SCUBA_PORT', 1234);
 
-            const { ConfigObject } = require('../../lib/Config');
             const config = new ConfigObject();
 
             assert.deepStrictEqual(
@@ -478,7 +500,6 @@ describe('Config', () => {
         });
 
         it('should set up quota', () => {
-            const { ConfigObject } = require('../../lib/Config');
             const config = new ConfigObject();
 
             assert.deepStrictEqual(
@@ -494,7 +515,6 @@ describe('Config', () => {
             setEnv('QUOTA_MAX_STALENESS_MS', 1234);
             setEnv('QUOTA_ENABLE_INFLIGHTS', 'true');
 
-            const { ConfigObject } = require('../../lib/Config');
             const config = new ConfigObject();
 
             assert.deepStrictEqual(
@@ -510,7 +530,6 @@ describe('Config', () => {
             setEnv('QUOTA_MAX_STALENESS_MS', 'notanumber');
             setEnv('QUOTA_ENABLE_INFLIGHTS', 'true');
 
-            const { ConfigObject } = require('../../lib/Config');
             const config = new ConfigObject();
 
             assert.deepStrictEqual(
@@ -537,7 +556,6 @@ describe('Config', () => {
         });
 
         it('should set up utapi local cache', () => {
-            const { ConfigObject } = require('../../lib/Config');
             const config = new ConfigObject();
 
             assert.deepStrictEqual(
@@ -551,7 +569,6 @@ describe('Config', () => {
         });
 
         it('should set up utapi redis', () => {
-            const { ConfigObject } = require('../../lib/Config');
             const config = new ConfigObject();
 
             assert.deepStrictEqual(

--- a/tests/unit/Config.js
+++ b/tests/unit/Config.js
@@ -1,10 +1,12 @@
 const assert = require('assert');
+const fs = require('fs');
+const sinon = require('sinon');
 const {
     azureGetStorageAccountName,
     azureGetLocationCredentials,
     locationConstraintAssert,
     parseSupportedLifecycleRules,
-    ConfigObject: ConfigObject,
+    ConfigObject,
 } = require('../../lib/Config');
 
 const {
@@ -442,6 +444,61 @@ describe('Config', () => {
             setEnv('S3METADATA', 'file'); // Not MongoDB
             const config = new ConfigObject();
             assert.strictEqual(config.nullVersionCompatMode, false);
+        });
+    });
+
+    describe('multiObjectDeleteEnableOptimizations', () => {
+        const defaultConfig = JSON.parse(fs.readFileSync('config.json'), { encoding: 'utf-8' });
+        let sandbox;
+        let readFileStub;
+
+        beforeEach(() => {
+            sandbox = sinon.createSandbox();
+            readFileStub = sandbox.stub(fs, 'readFileSync');
+            readFileStub.callThrough();
+        });
+
+        afterEach(() => {
+            sandbox.restore();
+        });
+
+        it('should be true by default when metadata backend is mongodb', () => {
+            process.env.S3METADATA = 'mongodb';
+            const config = new ConfigObject();
+            assert.strictEqual(config.multiObjectDeleteEnableOptimizations, true);
+        });
+
+        it('should be false by default when metadata backend is not mongodb', () => {
+            process.env.S3METADATA = 'file';
+            const config = new ConfigObject();
+            assert.strictEqual(config.multiObjectDeleteEnableOptimizations, false);
+        });
+
+        it('should respect config file setting when set to false', () => {
+            process.env.S3METADATA = 'mongodb';
+            const modifiedConfig = { ...defaultConfig, multiObjectDeleteEnableOptimizations: false };
+            readFileStub.withArgs(sinon.match(/config.json$/)).returns(JSON.stringify(modifiedConfig));
+
+            const config = new ConfigObject();
+            assert.strictEqual(config.multiObjectDeleteEnableOptimizations, false);
+        });
+
+        it('should respect config file setting when set to true', () => {
+            process.env.S3METADATA = 'mongodb';
+            const modifiedConfig = { ...defaultConfig, multiObjectDeleteEnableOptimizations: true };
+            readFileStub.withArgs(sinon.match(/config.json$/)).returns(JSON.stringify(modifiedConfig));
+
+            const config = new ConfigObject();
+            assert.strictEqual(config.multiObjectDeleteEnableOptimizations, true);
+        });
+
+        it('should ignore config file setting for non-mongodb backend', () => {
+            process.env.S3METADATA = 'file';
+            const modifiedConfig = { ...defaultConfig, multiObjectDeleteEnableOptimizations: true };
+            readFileStub.withArgs('config.json').returns(JSON.stringify(modifiedConfig));
+
+            const config = new ConfigObject();
+            assert.strictEqual(config.multiObjectDeleteEnableOptimizations, false);
         });
     });
 

--- a/tests/unit/api/apiUtils/quotas/quotaUtils.js
+++ b/tests/unit/api/apiUtils/quotas/quotaUtils.js
@@ -40,7 +40,7 @@ describe('validateQuotas (buckets)', () => {
             maxStaleness: 24 * 60 * 60 * 1000,
             enableInflights: true,
         };
-        config.isQuotaEnabled = sinon.stub().returns(true);
+        sinon.stub(config, 'isQuotaEnabled').returns(true);
         QuotaService.enabled = true;
         QuotaService._getLatestMetricsCallback = sinon.stub().resolves({});
         request.finalizerHooks = [];
@@ -388,7 +388,7 @@ describe('validateQuotas (with accounts)', () => {
             enableInflights: true,
         };
         request.finalizerHooks = [];
-        config.isQuotaEnabled = sinon.stub().returns(true);
+        sinon.stub(config, 'isQuotaEnabled').returns(true);
         QuotaService.enabled = true;
         QuotaService._getLatestMetricsCallback = sinon.stub().resolves({});
     });

--- a/tests/unit/api/multiObjectDelete.js
+++ b/tests/unit/api/multiObjectDelete.js
@@ -10,6 +10,7 @@ const DummyRequest = require('../DummyRequest');
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const metadataWrapper = require('../../../lib/metadata/wrapper');
 const objectPut = require('../../../lib/api/objectPut');
+const { config } = require('../../../lib/Config');
 const log = new DummyRequestLogger();
 
 const { metadata } = storage.metadata.inMemory.metadata;
@@ -267,15 +268,20 @@ describe('initializeMultiObjectDeleteWithBatchingSupport', () => {
     let log;
     let callback;
 
+    const wasMultiObjectDeleteEnabled = config.multiObjectDeleteEnableOptimizations;
+
     beforeEach(() => {
         bucketName = 'myBucket';
         inPlay = { one: 'object1', two: 'object2' };
         log = {};
         callback = sinon.spy();
+
+        config.multiObjectDeleteEnableOptimizations = true;
     });
 
     afterEach(() => {
         sinon.restore();
+        config.multiObjectDeleteEnableOptimizations = wasMultiObjectDeleteEnabled;
     });
 
     it('should not throw if the decodeObjectVersion function fails', done => {

--- a/tests/unit/api/objectGet.js
+++ b/tests/unit/api/objectGet.js
@@ -401,7 +401,7 @@ describe('objectGet API', () => {
             url: `/${bucketName}/${objectName}`,
         };
         mdColdHelper.putBucketMock(bucketName, null, () => {
-            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getArchiveArchivedMD(), () => {
+            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getArchivedObjectMD(), () => {
                 objectGet(authInfo, testGetRequest, false, log, err => {
                     assert.strictEqual(err.is.InvalidObjectState, true);
                     done();
@@ -419,7 +419,7 @@ describe('objectGet API', () => {
             url: `/${bucketName}/${objectName}`,
         };
         mdColdHelper.putBucketMock(bucketName, null, () => {
-            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getArchiveOngoingRequestMD(), () => {
+            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getRestoringObjectMD(), () => {
                 objectGet(authInfo, testGetRequest, false, log, err => {
                     assert.strictEqual(err.is.InvalidObjectState, true);
                     done();
@@ -437,11 +437,13 @@ describe('objectGet API', () => {
             url: `/${bucketName}/${objectName}`,
         };
         mdColdHelper.putBucketMock(bucketName, null, () => {
-            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getTransitionInProgressMD(), () => {
+            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getTransitionInProgressObjectMD(), () => {
                 objectGet(authInfo, testGetRequest, false, log, (err, res, headers) => {
                     assert.ifError(err);
                     assert.ok(res);
-                    assert.strictEqual(headers['x-amz-storage-class'], mdColdHelper.defaultLocation);
+                    // Object is not yet cold, so storage class is still same as the bucket ("STANDARD")
+                    // and thus not set in the response
+                    assert.strictEqual(headers['x-amz-storage-class'], undefined);
                     done();
                 });
             });
@@ -457,7 +459,7 @@ describe('objectGet API', () => {
             url: `/${bucketName}/${objectName}`,
         };
         mdColdHelper.putBucketMock(bucketName, 'scality-internal-file', () => {
-            mdColdHelper.putObjectMock(bucketName, objectName, {}, () => {
+            mdColdHelper.putObjectMock(bucketName, objectName, undefined, () => {
                 objectGet(authInfo, testGetRequest, false, log, (err, res, headers) => {
                     assert.ifError(err);
                     assert.ok(res);
@@ -477,13 +479,14 @@ describe('objectGet API', () => {
             url: `/${bucketName}/${objectName}`,
         };
         mdColdHelper.putBucketMock(bucketName, null, () => {
-            const objectCustomMDFields = mdColdHelper.getArchiveRestoredMD();
+            const objectCustomMDFields = mdColdHelper.getRestoredObjectMD();
+            const restoreInfo = objectCustomMDFields.getAmzRestore();
             mdColdHelper.putObjectMock(bucketName, objectName, objectCustomMDFields, () => {
                 objectGet(authInfo, testGetRequest, false, log, (err, res, headers) => {
                     assert.ifError(err);
                     assert.ok(res);
                     assert.strictEqual(headers['x-amz-storage-class'], mdColdHelper.defaultLocation);
-                    const utcDate = new Date(objectCustomMDFields['x-amz-restore']['expiry-date']).toUTCString();
+                    const utcDate = new Date(restoreInfo.getExpiryDate()).toUTCString();
                     assert.strictEqual(headers['x-amz-restore'], `ongoing-request="false", expiry-date="${utcDate}"`);
                     done();
                 });
@@ -501,13 +504,14 @@ describe('objectGet API', () => {
             url: `/${bucketName}/${objectName}`,
         };
         mdColdHelper.putBucketMock(bucketName, null, () => {
-            const objectCustomMDFields = mdColdHelper.getArchiveRestoredMD();
+            const objectCustomMDFields = mdColdHelper.getRestoredObjectMD();
+            const restoreInfo = objectCustomMDFields.getAmzRestore();
             mdColdHelper.putObjectMock(bucketName, objectName, objectCustomMDFields, () => {
                 objectGet(authInfo, testGetRequest, false, log, (err, res, headers) => {
                     assert.ifError(err);
                     assert.ok(res);
                     assert.strictEqual(headers['x-amz-storage-class'], mdColdHelper.defaultLocation);
-                    const utcDate = new Date(objectCustomMDFields['x-amz-restore']['expiry-date']).toUTCString();
+                    const utcDate = new Date(restoreInfo.getExpiryDate()).toUTCString();
                     assert.strictEqual(headers['x-amz-restore'], `ongoing-request="false", expiry-date="${utcDate}"`);
                     done();
                 });

--- a/tests/unit/api/objectHead.js
+++ b/tests/unit/api/objectHead.js
@@ -332,7 +332,7 @@ describe('objectHead API', () => {
             url: `/${bucketName}/${objectName}`,
         };
         mdColdHelper.putBucketMock(bucketName, null, () => {
-            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getArchiveArchivedMD(), () => {
+            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getArchivedObjectMD(), () => {
                 objectHead(authInfo, testGetRequest, log, (err, res) => {
                     assert.strictEqual(res[userMetadataKey], userMetadataValue);
                     assert.strictEqual(res.ETag, `"${correctMD5}"`);
@@ -355,7 +355,7 @@ describe('objectHead API', () => {
             url: `/${bucketName}/${objectName}`,
         };
         mdColdHelper.putBucketMock(bucketName, 'scality-internal-file', () => {
-            mdColdHelper.putObjectMock(bucketName, objectName, {}, () => {
+            mdColdHelper.putObjectMock(bucketName, objectName, undefined, () => {
                 objectHead(authInfo, testGetRequest, log, (err, res) => {
                     assert.strictEqual(res[userMetadataKey], userMetadataValue);
                     assert.strictEqual(res.ETag, `"${correctMD5}"`);
@@ -375,7 +375,7 @@ describe('objectHead API', () => {
             url: `/${bucketName}/${objectName}`,
         };
         mdColdHelper.putBucketMock(bucketName, null, () => {
-            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getArchiveOngoingRequestMD(), () => {
+            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getRestoringObjectMD(), () => {
                 objectHead(authInfo, testGetRequest, log, (err, res) => {
                     assert.strictEqual(res[userMetadataKey], userMetadataValue);
                     assert.strictEqual(res.ETag, `"${correctMD5}"`);
@@ -403,13 +403,14 @@ describe('objectHead API', () => {
             url: `/${bucketName}/${objectName}`,
         };
         mdColdHelper.putBucketMock(bucketName, null, () => {
-            const objectCustomMDFields = mdColdHelper.getArchiveRestoredMD();
+            const objectCustomMDFields = mdColdHelper.getRestoredObjectMD();
             mdColdHelper.putObjectMock(bucketName, objectName, objectCustomMDFields, () => {
                 objectHead(authInfo, testGetRequest, log, (err, res) => {
+                    const restoreInfo = objectCustomMDFields.getAmzRestore();
                     assert.strictEqual(res[userMetadataKey], userMetadataValue);
                     assert.strictEqual(res.ETag, `"${correctMD5}"`);
                     assert.strictEqual(res['x-amz-storage-class'], mdColdHelper.defaultLocation);
-                    const utcDate = new Date(objectCustomMDFields['x-amz-restore']['expiry-date']).toUTCString();
+                    const utcDate = new Date(restoreInfo.getExpiryDate()).toUTCString();
                     assert.strictEqual(res['x-amz-restore'], `ongoing-request="false", expiry-date="${utcDate}"`);
                     // Check we do not leak non-standard fields
                     assert.strictEqual(res['x-amz-scal-transition-in-progress'], undefined);
@@ -433,9 +434,10 @@ describe('objectHead API', () => {
             url: `/${bucketName}/${objectName}`,
         };
         mdColdHelper.putBucketMock(bucketName, null, () => {
-            const objectCustomMDFields = mdColdHelper.getTransitionInProgressMD();
+            const objectCustomMDFields = mdColdHelper.getTransitionInProgressObjectMD();
             mdColdHelper.putObjectMock(bucketName, objectName, objectCustomMDFields, () => {
                 objectHead(authInfo, testGetRequest, log, (err, res) => {
+                    assert.strictEqual(res['x-amz-storage-class'], undefined);
                     assert.strictEqual(res['x-amz-meta-scal-s3-transition-in-progress'], true);
                     assert.strictEqual(res['x-amz-scal-transition-in-progress'], undefined);
                     assert.strictEqual(res['x-amz-scal-transition-time'], undefined);
@@ -458,13 +460,13 @@ describe('objectHead API', () => {
             url: `/${bucketName}/${objectName}`,
         };
         mdColdHelper.putBucketMock(bucketName, null, () => {
-            const objectCustomMDFields = mdColdHelper.getTransitionInProgressMD();
+            const objectCustomMDFields = mdColdHelper.getTransitionInProgressObjectMD();
             mdColdHelper.putObjectMock(bucketName, objectName, objectCustomMDFields, () => {
                 objectHead(authInfo, testGetRequest, log, (err, res) => {
                     assert.strictEqual(res['x-amz-meta-scal-s3-transition-in-progress'], true);
                     assert.strictEqual(res['x-amz-scal-transition-in-progress'], true);
                     assert.strictEqual(res['x-amz-scal-transition-time'],
-                        new Date(objectCustomMDFields['x-amz-scal-transition-time']).toUTCString());
+                        new Date(objectCustomMDFields.getTransitionTime()).toUTCString());
                     assert.strictEqual(res['x-amz-scal-archive-info'], undefined);
                     assert.strictEqual(res['x-amz-scal-owner-id'], mdColdHelper.defaultOwnerId);
                     done(err);
@@ -484,7 +486,7 @@ describe('objectHead API', () => {
             url: `/${bucketName}/${objectName}`,
         };
         mdColdHelper.putBucketMock(bucketName, null, () => {
-            const objectCustomMDFields = mdColdHelper.getArchiveArchivedMD();
+            const objectCustomMDFields = mdColdHelper.getArchivedObjectMD();
             mdColdHelper.putObjectMock(bucketName, objectName, objectCustomMDFields, () => {
                 objectHead(authInfo, testGetRequest, log, (err, res) => {
                     assert.strictEqual(res['x-amz-meta-scal-s3-transition-in-progress'], undefined);
@@ -509,16 +511,17 @@ describe('objectHead API', () => {
             url: `/${bucketName}/${objectName}`,
         };
         mdColdHelper.putBucketMock(bucketName, null, () => {
-            const objectCustomMDFields = mdColdHelper.getArchiveOngoingRequestMD();
+            const objectCustomMDFields = mdColdHelper.getRestoringObjectMD();
+            const archive = objectCustomMDFields.getArchive();
             mdColdHelper.putObjectMock(bucketName, objectName, objectCustomMDFields, () => {
                 objectHead(authInfo, testGetRequest, log, (err, res) => {
                     assert.strictEqual(res['x-amz-meta-scal-s3-transition-in-progress'], undefined);
                     assert.strictEqual(res['x-amz-scal-transition-in-progress'], undefined);
                     assert.strictEqual(res['x-amz-scal-archive-info'], '{"foo":0,"bar":"stuff"}');
                     assert.strictEqual(res['x-amz-scal-restore-requested-at'],
-                        new Date(objectCustomMDFields.archive.restoreRequestedAt).toUTCString());
+                        new Date(archive.restoreRequestedAt).toUTCString());
                     assert.strictEqual(res['x-amz-scal-restore-requested-days'],
-                        objectCustomMDFields.archive.restoreRequestedDays);
+                        archive.restoreRequestedDays);
                     assert.strictEqual(res['x-amz-storage-class'], mdColdHelper.defaultLocation);
                     assert.strictEqual(res['x-amz-scal-owner-id'], mdColdHelper.defaultOwnerId);
                     done(err);
@@ -538,20 +541,21 @@ describe('objectHead API', () => {
             url: `/${bucketName}/${objectName}`,
         };
         mdColdHelper.putBucketMock(bucketName, null, () => {
-            const objectCustomMDFields = mdColdHelper.getArchiveRestoredMD();
+            const objectCustomMDFields = mdColdHelper.getRestoredObjectMD();
+            const archive = objectCustomMDFields.getArchive();
             mdColdHelper.putObjectMock(bucketName, objectName, objectCustomMDFields, () => {
                 objectHead(authInfo, testGetRequest, log, (err, res) => {
                     assert.strictEqual(res['x-amz-meta-scal-s3-transition-in-progress'], undefined);
                     assert.strictEqual(res['x-amz-scal-transition-in-progress'], undefined);
                     assert.strictEqual(res['x-amz-scal-archive-info'], '{"foo":0,"bar":"stuff"}');
                     assert.strictEqual(res['x-amz-scal-restore-requested-at'],
-                        new Date(objectCustomMDFields.archive.restoreRequestedAt).toUTCString());
+                        new Date(archive.restoreRequestedAt).toUTCString());
                     assert.strictEqual(res['x-amz-scal-restore-requested-days'],
-                        objectCustomMDFields.archive.restoreRequestedDays);
+                        archive.restoreRequestedDays);
                     assert.strictEqual(res['x-amz-scal-restore-completed-at'],
-                        new Date(objectCustomMDFields.archive.restoreCompletedAt).toUTCString());
+                        new Date(archive.restoreCompletedAt).toUTCString());
                     assert.strictEqual(res['x-amz-scal-restore-will-expire-at'],
-                        new Date(objectCustomMDFields.archive.restoreWillExpireAt).toUTCString());
+                        new Date(archive.restoreWillExpireAt).toUTCString());
                     assert.strictEqual(res['x-amz-scal-restore-etag'], mdColdHelper.restoredEtag);
                     assert.strictEqual(res['x-amz-storage-class'], mdColdHelper.defaultLocation);
                     assert.strictEqual(res['x-amz-scal-owner-id'], mdColdHelper.defaultOwnerId);

--- a/tests/unit/api/objectHead.js
+++ b/tests/unit/api/objectHead.js
@@ -560,4 +560,66 @@ describe('objectHead API', () => {
             });
         });
     });
+
+    [
+        {
+            name: 'should return content-length of 0 when requesting part 1 of empty object',
+            partNumber: '1',
+            expectedError: null,
+            expectedContentLength: 0
+        },
+        {
+            name: 'should return InvalidRange error when requesting part > 1 of empty object',
+            partNumber: '2',
+            expectedError: 'InvalidRange',
+            expectedContentLength: undefined
+        }
+    ].forEach(testCase => {
+        it(testCase.name, done => {
+            const emptyBody = '';
+            const emptyMD5 = 'd41d8cd98f00b204e9800998ecf8427e';
+            const testPutEmptyObjectRequest = new DummyRequest({
+                bucketName,
+                namespace,
+                objectKey: objectName,
+                headers: {
+                    'content-length': '0',
+                    'x-amz-meta-test': userMetadataValue,
+                },
+                parsedContentLength: 0,
+                url: `/${bucketName}/${objectName}`,
+                calculatedHash: emptyMD5,
+            }, emptyBody);
+
+            const testGetRequest = {
+                bucketName,
+                namespace,
+                objectKey: objectName,
+                headers: {},
+                url: `/${bucketName}/${objectName}`,
+                query: {
+                    partNumber: testCase.partNumber,
+                },
+                actionImplicitDenies: false,
+            };
+
+            bucketPut(authInfo, testPutBucketRequest, log, () => {
+                objectPut(authInfo, testPutEmptyObjectRequest, undefined, log, (err, resHeaders) => {
+                    assert.strictEqual(err, null, `Error putting object: ${err}`);
+                    assert.strictEqual(resHeaders.ETag, `"${emptyMD5}"`);
+                    objectHead(authInfo, testGetRequest, log, (err, res) => {
+                        if (testCase.expectedError) {
+                            assert.strictEqual(err.is[testCase.expectedError], true);
+                        } else {
+                            assert.strictEqual(err, null);
+                            assert.strictEqual(res[userMetadataKey], userMetadataValue);
+                            assert.strictEqual(res.ETag, `"${emptyMD5}"`);
+                            assert.strictEqual(res['content-length'], testCase.expectedContentLength);
+                        }
+                        done();
+                    });
+                });
+            });
+        });
+    });
 });

--- a/tests/unit/api/objectReplicationMD.js
+++ b/tests/unit/api/objectReplicationMD.js
@@ -17,6 +17,7 @@ const completeMultipartUpload =
 const objectPutACL = require('../../../lib/api/objectPutACL');
 const objectPutTagging = require('../../../lib/api/objectPutTagging');
 const objectDeleteTagging = require('../../../lib/api/objectDeleteTagging');
+const { config } = require('../../../lib/Config');
 
 const log = new DummyRequestLogger();
 const authInfo = makeAuthInfo('accessKey1');
@@ -318,7 +319,10 @@ describe('Replication object MD without bucket replication config', () => {
             createBucketWithReplication(hasStorageClass);
         });
 
-        afterEach(() => cleanup());
+        afterEach(() => {
+            cleanup();
+            delete config.locationConstraints['zenko'];
+        });
 
         it('should update metadata when replication config prefix matches ' +
         'an object key', done =>
@@ -358,14 +362,45 @@ describe('Replication object MD without bucket replication config', () => {
                     return done();
                 }));
 
-        it('should not update metadata if putting object ACL', done => {
-            let completedReplicationInfo;
+        it('should update metadata if putting object ACL and CRR replication', done => {
+            // Set 'zenko' as a typical CRR location (i.e. no type)
+            config.locationConstraints['zenko'] = {
+                ...config.locationConstraints['zenko'],
+                type: '',
+            };
+
             async.series([
                 next => putObjectAndCheckMD(keyA, newReplicationMD, next),
                 next => {
                     const objectMD = metadata.keyMaps.get(bucketName).get(keyA);
-                    // Update metadata to a status after replication
-                    // has occurred.
+                    // Update metadata to a status after replication has occurred.
+                    objectMD.replicationInfo.status = 'COMPLETED';
+                    objectPutACL(authInfo, objectACLReq, log, next);
+                },
+            ], err => {
+                if (err) {
+                    return done(err);
+                }
+                checkObjectReplicationInfo(keyA, replicateMetadataOnly);
+                return done();
+            });
+        });
+
+        it('should not update metadata if putting object ACL and cloud replication', done => {
+            // Set 'zenko' as a typical cloud location (i.e.  type)
+            config.locationConstraints['zenko'] = {
+                ...config.locationConstraints['zenko'],
+                type: 'aws_s3',
+            };
+
+            const replicationMD = { ...newReplicationMD, storageType: 'aws_s3' };
+
+            let completedReplicationInfo;
+            async.series([
+                next => putObjectAndCheckMD(keyA, replicationMD, next),
+                next => {
+                    const objectMD = metadata.keyMaps.get(bucketName).get(keyA);
+                    // Update metadata to a status after replication has occurred.
                     objectMD.replicationInfo.status = 'COMPLETED';
                     completedReplicationInfo = JSON.parse(
                         JSON.stringify(objectMD.replicationInfo));

--- a/tests/unit/api/objectRestore.js
+++ b/tests/unit/api/objectRestore.js
@@ -76,7 +76,7 @@ describe('restoreObject API', () => {
 
     it('should return RestoreAlreadyInProgress error when object restore is already in progress', done => {
         mdColdHelper.putBucketMock(bucketName, null, () => {
-            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getArchiveOngoingRequestMD(), () => {
+            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getRestoringObjectMD(), () => {
                 objectRestore(authInfo, objectRestoreRequest(objectRestoreXml), log, err => {
                     assert.strictEqual(err.is.RestoreAlreadyInProgress, true);
                     done();
@@ -87,7 +87,7 @@ describe('restoreObject API', () => {
 
     it('should return NotImplemented error when object restore Tier is \'Bulk\'', done => {
         mdColdHelper.putBucketMock(bucketName, null, () => {
-            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getArchiveArchivedMD(), () => {
+            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getArchivedObjectMD(), () => {
                 objectRestore(authInfo, objectRestoreRequest(objectRestoreXmlBulkTier), log, err => {
                     assert.strictEqual(err.is.NotImplemented, true);
                     done();
@@ -98,7 +98,7 @@ describe('restoreObject API', () => {
 
     it('should return NotImplemented error when object restore Tier is \'Expedited\'', done => {
         mdColdHelper.putBucketMock(bucketName, null, () => {
-            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getArchiveArchivedMD(), () => {
+            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getArchivedObjectMD(), () => {
                 objectRestore(authInfo, objectRestoreRequest(objectRestoreXmlExpeditedTier), log, err => {
                     assert.strictEqual(err.is.NotImplemented, true);
                     done();
@@ -112,7 +112,7 @@ describe('restoreObject API', () => {
         'and the object doesn\'t have a restored copy in bucket', done => {
         const testStartTime = new Date(Date.now());
         mdColdHelper.putBucketMock(bucketName, null, () => {
-            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getArchiveArchivedMD(), () => {
+            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getArchivedObjectMD(), () => {
                 objectRestore(authInfo, objectRestoreRequest(objectRestoreXml), log, (err, statusCode) => {
                     assert.ifError(err);
                     assert.strictEqual(statusCode, 202);
@@ -132,7 +132,7 @@ describe('restoreObject API', () => {
         'and the object have a restored copy in bucket', done => {
         const testStartTime = new Date(Date.now());
         mdColdHelper.putBucketMock(bucketName, null, () => {
-            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getArchiveRestoredMD(), () => {
+            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getRestoredObjectMD(), () => {
                 objectRestore(authInfo, objectRestoreRequest(objectRestoreXml), log, (err, statusCode) => {
                     assert.ifError(err);
                     assert.strictEqual(statusCode, 200);
@@ -150,7 +150,7 @@ describe('restoreObject API', () => {
     it('should return InvalidObjectState ' +
         'while restoring an expired restored object', () => {
         mdColdHelper.putBucketMock(bucketName, null, () => {
-            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getArchiveExpiredMD(), () => {
+            mdColdHelper.putObjectMock(bucketName, objectName, mdColdHelper.getExpiredObjectMD(), () => {
                 objectRestore(authInfo, objectRestoreRequest(objectRestoreXml), log, err => {
                     assert.strictEqual(err.is.InvalidObjectState, true);
                 });

--- a/tests/unit/api/utils/metadataMockColdStorage.js
+++ b/tests/unit/api/utils/metadataMockColdStorage.js
@@ -2,9 +2,7 @@ const assert = require('assert');
 const metadata = require('../../metadataswitch');
 const { DummyRequestLogger } = require('../../helpers');
 const log = new DummyRequestLogger();
-const ObjectMDAmzRestore = require('arsenal').models.ObjectMDAmzRestore;
-const ObjectMDArchive = require('arsenal').models.ObjectMDArchive;
-const BucketInfo = require('arsenal').models.BucketInfo;
+const { BucketInfo, ObjectMD, ObjectMDAmzRestore, ObjectMDArchive } = require('arsenal').models;
 
 const defaultLocation = 'location-dmf-v1';
 const defaultOwnerId = '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be';
@@ -53,7 +51,7 @@ const baseMd = {
         dataStoreVersionId: '',
         isNFS: null
     },
-    dataStoreName: 'location-dmf-v1',
+    dataStoreName: 'mem',
     originOp: 's3:ObjectCreated:Put',
     'last-modified': '2022-05-10T08:31:51.878Z',
     'md-model-version': 5,
@@ -79,7 +77,7 @@ function putBucketMock(bucketName, location, cb) {
         null,
         null,
         null,
-        location ?? defaultLocation);
+        location);
     return metadata.createBucket(bucketName, bucket, log, cb);
 }
 
@@ -87,101 +85,106 @@ function putBucketMock(bucketName, location, cb) {
  * Mocks a Put Object to store custom metadata
  * @param {string} bucketName - the bucket name
  * @param {string} objectName - the object name
- * @param {object} fields - custom MD fields to add to the object
+ * @param {ObjectMD} fields - custom MD fields to add to the object
  * @param {Function} cb - callback once the object MD is created
  * @returns {undefined}
  */
 function putObjectMock(bucketName, objectName, fields, cb) {
-    return metadata.putObjectMD(bucketName, objectName, {
-        ...baseMd,
-        ...fields,
-    }, {}, log, err => {
+    const md = fields ? fields.getValue() : baseMd;
+    return metadata.putObjectMD(bucketName, objectName, md, {}, log, err => {
         assert.ifError(err);
         return cb();
     });
 }
 
 /**
- * Computes the 'archive' field of the object MD as an archived object
- * @returns {ObjectMDArchive} the MD object
+ * Computes the 'archive' field of the object MD as an object being restored
+ * @returns {ObjectMD} the MD object
  */
-function getArchiveArchivedMD() {
-    return {
-        archive: new ObjectMDArchive(
-            { foo: 0, bar: 'stuff' }, // opaque, can be anything...
-        ).getValue(),
-    };
+function getTransitionInProgressObjectMD() {
+    return new ObjectMD(baseMd)
+        .setTransitionInProgress(true, new Date(Date.now() - 60))
+        .setOriginOp('s3:LifecycleTransition:Start');
 }
 
 /**
- * Computes the 'archive' field of the object MD as an object being restored
- * @returns {ObjectMDArchive} the MD object
+ * Computes the object MD of an archived object
+ * @returns {ObjectMD} the MD object
  */
-function getArchiveOngoingRequestMD() {
-    return {
-        archive: new ObjectMDArchive(
+function getArchivedObjectMD() {
+    return getTransitionInProgressObjectMD()
+        .setArchive(new ObjectMDArchive(
             { foo: 0, bar: 'stuff' }, // opaque, can be anything...
+        ))
+        .setDataStoreName(defaultLocation)
+        .setAmzStorageClass(defaultLocation)
+        .setTransitionInProgress(false)
+        .setOriginOp('s3:LifecycleTransition');
+}
+
+/**
+ * Computes the object MD of an archived object being restored
+ * @returns {ObjectMD} the MD object
+ */
+function getRestoringObjectMD() {
+    const archivedObjectMD = getArchivedObjectMD();
+    return archivedObjectMD
+        .setAmzRestore(new ObjectMDAmzRestore(
+            true,
+        ))
+        .setArchive(new ObjectMDArchive(
+            archivedObjectMD.getArchive().getArchiveInfo(),
             new Date(Date.now() - 60),
-            5).getValue(),
-        'x-amz-restore': new ObjectMDAmzRestore(true, new Date(Date.now() + 60 * 60 * 24)),
-    };
+            5,
+        ))
+        .setOriginOp('s3:ObjectRestore:Post');
 }
 
 /**
- * Computes the 'archive' field of the object MD as an object being restored
- * @returns {ObjectMDArchive} the MD object
+ * Computes the object MD as a restored object from cold storage
+ * @param {Date} date - the expiry date of the restored object
+ * @returns {ObjectMD} the MD object
  */
-function getTransitionInProgressMD() {
-    return {
-        'x-amz-scal-transition-in-progress': true,
-        'x-amz-scal-transition-time': new Date(Date.now() - 60),
-    };
-}
+function getRestoredObjectMD(date) {
+    const restoreDays = 5;
+    const restoreDate = new Date((date || Date.now()) - 10000);
+    const expiryDate = date || new Date(restoreDate.getTime() + 1000 * 60 * 60 * 24 * restoreDays);
 
-/**
- * Computes the 'archive' field of the object MD as a restored object from cold storage
- * @returns {ObjectMDArchive} the MD object
- */
-function getArchiveRestoredMD() {
-    return {
-        archive: new ObjectMDArchive(
-            { foo: 0, bar: 'stuff' }, // opaque, can be anything...
+    const restoringObjectMD = getRestoringObjectMD();
+    const restoreInfo = new ObjectMDAmzRestore(
+        false,
+        expiryDate,
+    );
+    restoreInfo['content-md5'] = restoredEtag;
+
+    return restoringObjectMD
+        .setAmzRestore(restoreInfo)
+        .setArchive(new ObjectMDArchive(
+            restoringObjectMD.getArchive().getArchiveInfo(),
             new Date(Date.now() - 60000),
-            5,
-            new Date(Date.now() - 10000),
-            new Date(Date.now() + 60000 * 60 * 24)).getValue(),
-        'x-amz-restore': {
-            'ongoing-request': false,
-            'expiry-date': new Date(Date.now() + 60 * 60 * 24),
-            'content-md5': restoredEtag,
-        },
-    };
+            restoreDays,
+            restoreDate,
+            expiryDate,
+        ))
+        .setDataStoreName('mem')
+        .setOriginOp('s3:ObjectRestore:Completed');
 }
 
 /**
- * Computes the 'archive' field of the object MD as a restored object from cold storage
- * @returns {ObjectMDArchive} the MD object
+ * Computes the object MD of an restored object from cold storage which has expired
+ * @returns {ObjectMD} the MD object
  */
-function getArchiveExpiredMD() {
-    return {
-        archive: new ObjectMDArchive(
-            { foo: 0, bar: 'stuff' }, // opaque, can be anything...
-            new Date(Date.now() - 30000),
-            5,
-            new Date(Date.now() - 20000),
-            new Date(Date.now() - 10000)).getValue(),
-        'x-amz-restore': new ObjectMDAmzRestore(false, new Date(Date.now() + 60 * 60 * 24)),
-    };
+function getExpiredObjectMD() {
+    return getRestoredObjectMD(Date.now() - 10000);
 }
-
 
 module.exports = {
     putObjectMock,
-    getArchiveArchivedMD,
-    getArchiveOngoingRequestMD,
-    getArchiveRestoredMD,
-    getArchiveExpiredMD,
-    getTransitionInProgressMD,
+    getArchivedObjectMD,
+    getRestoringObjectMD,
+    getRestoredObjectMD,
+    getExpiredObjectMD,
+    getTransitionInProgressObjectMD,
     putBucketMock,
     defaultLocation,
     defaultOwnerId,

--- a/tests/unit/routes/routeBackbeat.js
+++ b/tests/unit/routes/routeBackbeat.js
@@ -130,35 +130,6 @@ describe('routeBackbeat', () => {
         assert.deepStrictEqual(mockResponse.body, { Body: '{}' });
     });
 
-    it('should allow CRR destination requests (putMetadata) when versioning is enabled', async () => {
-        mockRequest.method = 'PUT';
-        mockRequest.url = '/_/backbeat/metadata/bucket0/key0';
-        mockRequest.headers = {
-            'x-scal-versioning-required': 'true',
-        };
-        mockRequest.destroy = () => {};
-
-        sandbox.stub(metadata, 'putObjectMD').callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
-            cb(null, {});
-        });
-
-        metadataUtils.standardMetadataValidateBucketAndObj.callsFake((params, denies, log, callback) => {
-            const bucketInfo = {
-                getVersioningConfiguration: () => ({ Status: 'Enabled' }),
-                isVersioningEnabled: () => true,
-            };
-            const objMd = {};
-            callback(null, bucketInfo, objMd);
-        });
-
-        routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-
-        void await endPromise;
-
-        assert.strictEqual(mockResponse.statusCode, 200);
-        assert.deepStrictEqual(mockResponse.body, {});
-    });
-
     it('should allow CRR destination requests (putData) when versioning is enabled', async () => {
         const md5 = '1234';
         mockRequest.method = 'PUT';
@@ -193,194 +164,363 @@ describe('routeBackbeat', () => {
         assert.deepStrictEqual(mockResponse.body, [{}]);
     });
 
-    it('should put non versioned metadata', async () => {
-        mockRequest.method = 'PUT';
-        mockRequest.url = '/_/backbeat/metadata/bucket0/key0';
-        mockRequest.headers = {
-            'x-scal-versioning-required': 'true',
+    describe('putMetadata', () => {
+        const bucketInfo = {
+            getVersioningConfiguration: () => ({ Status: 'Enabled' }),
+            isVersioningEnabled: () => true,
         };
-        mockRequest.destroy = () => {};
+        let dataDeleteSpy;
 
-        sandbox.stub(metadata, 'putObjectMD').callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
-            cb(null, {});
+        function preparePutMetadataRequest(body = {}) {
+            const req = prepareDummyRequest({
+                'x-scal-versioning-required': 'true',
+            }, JSON.stringify({
+                replicationInfo: {},
+                ...body,
+            }));
+            req.method = 'PUT';
+            req.url = '/_/backbeat/metadata/bucket0/key0';
+            req.destroy = () => { };
+            return req;
+        }
+
+        beforeEach(() => {
+            mockRequest = preparePutMetadataRequest();
+            dataDeleteSpy = sandbox.stub(dataWrapper.data, 'delete').callsFake((loc, log, cb) => cb(null));
+
+            // Setup default version enabled bucket and empty object metadata
+            metadataUtils.standardMetadataValidateBucketAndObj.callsFake((params, denies, log, callback) => {
+                callback(null, bucketInfo, {});
+            });
         });
 
-        metadataUtils.standardMetadataValidateBucketAndObj.callsFake((params, denies, log, callback) => {
-            const bucketInfo = {
-                getVersioningConfiguration: () => ({ Status: 'Enabled' }),
-                isVersioningEnabled: () => true,
+        it('should allow CRR destination requests (putMetadata) when versioning is enabled', async () => {
+            sandbox.stub(metadata, 'putObjectMD').callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
+                cb(null, {});
+            });
+
+            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+            void await endPromise;
+            assert.strictEqual(mockResponse.statusCode, 200);
+            assert.deepStrictEqual(mockResponse.body, {});
+        });
+
+        it('should put non versioned metadata', async () => {
+            sandbox.stub(metadata, 'putObjectMD').callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
+                cb(null, {});
+            });
+
+            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+            void await endPromise;
+
+            assert.strictEqual(mockResponse.statusCode, 200);
+            assert.deepStrictEqual(mockResponse.body, {});
+        });
+
+        it('should put metadata after updating account info', async () => {
+            mockRequest.url = '/_/backbeat/metadata/bucket0/key0?accountId=123456789012';
+
+            sandbox.stub(metadata, 'putObjectMD').callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
+                assert.strictEqual(omVal['owner-display-name'], 'Bart');
+                assert.strictEqual(omVal['owner-id'],
+                    '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be');
+                cb(null, {});
+            });
+
+            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+            void await endPromise;
+
+            assert.strictEqual(mockResponse.statusCode, 200);
+            assert.deepStrictEqual(mockResponse.body, {});
+        });
+
+        it('should fail to put metadata when accountId is invalid', async () => {
+            mockRequest.url = '/_/backbeat/metadata/bucket0/key0?accountId=invalid';
+
+            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+            void await endPromise;
+
+            assert.strictEqual(mockResponse.statusCode, 404);
+            assert.deepStrictEqual(mockResponse.body.code, 'AccountNotFound');
+        });
+
+        it('should repair master when putting metadata of a new version', async () => {
+            mockRequest.url = '/_/backbeat/metadata/bucket0/key0' +
+                '?accountId=123456789012&versionId=aIXVkw5Tw2Pd00000000001I4j3QKsvf';
+
+            sandbox.stub(metadata, 'putObjectMD').callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
+                assert.strictEqual(options.repairMaster, true);
+                cb(null, {});
+            });
+
+            // Override default callback to return undefined for objMd to simulate new version
+            metadataUtils.standardMetadataValidateBucketAndObj.callsFake((params, denies, log, callback) => {
+                callback(null, bucketInfo, undefined);
+            });
+
+            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+            void await endPromise;
+
+            assert.strictEqual(mockResponse.statusCode, 200);
+            assert.deepStrictEqual(mockResponse.body, {});
+        });
+
+        it('should not repair master when updating metadata of an existing version', async () => {
+            mockRequest.url = '/_/backbeat/metadata/bucket0/key0' +
+                '?accountId=123456789012&versionId=aIXVkw5Tw2Pd00000000001I4j3QKsvf';
+
+            sandbox.stub(metadata, 'putObjectMD').callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
+                assert.strictEqual(options.repairMaster, undefined);
+                cb(null, {});
+            });
+
+            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+            void await endPromise;
+            assert.strictEqual(mockResponse.statusCode, 200);
+            assert.deepStrictEqual(mockResponse.body, {});
+        });
+
+        it('should handle error when putting metadata', async () => {
+            sandbox.stub(metadata, 'putObjectMD').callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
+                cb(new Error('error'));
+            });
+
+            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+            void await endPromise;
+
+            assert.strictEqual(mockResponse.statusCode, 500);
+        });
+
+        it('should be rejected when using a wrong route', async () => {
+            mockRequest.url = '/_/backbeat/metadata/bucket0';
+
+            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+            void await endPromise;
+            assert.strictEqual(mockResponse.statusCode, 405);
+        });
+
+        it('should delete data when replacing with empty object', async () => {
+            const existingMd = {
+                location: [{
+                    key: 'key0',
+                    dataStoreName: 'location1',
+                    size: 100,
+                }],
             };
-            const objMd = {};
-            callback(null, bucketInfo, objMd);
+            metadataUtils.standardMetadataValidateBucketAndObj.callsFake((params, denies, log, callback) => {
+                callback(null, bucketInfo, existingMd);
+            });
+
+            sandbox.stub(metadata, 'putObjectMD').callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
+                assert.deepStrictEqual(omVal.location, undefined);
+                cb(null, {});
+            });
+
+            mockRequest = preparePutMetadataRequest({
+                'content-length': 0,
+            });
+            mockRequest.url += '?versionId=aIXVkw5Tw2Pd00000000001I4j3QKsvf';
+
+            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+            void await endPromise;
+
+            assert.strictEqual(mockResponse.statusCode, 200);
+            assert.deepStrictEqual(mockResponse.body, {});
+            assert.strictEqual(dataDeleteSpy.calledOnce, true);
+            sinon.assert.calledWith(dataDeleteSpy, existingMd.location[0]);
         });
 
-        routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+        it('should preserve existing locations when x-scal-replication-content is METADATA', async () => {
+            const existingLocations = [{
+                key: 'key0',
+                dataStoreName: 'location1',
+                size: 100,
+            }];
+            metadataUtils.standardMetadataValidateBucketAndObj.callsFake((params, denies, log, callback) => {
+                callback(null, bucketInfo, {
+                    location: existingLocations,
+                    'x-amz-server-side-encryption': 'AES256',
+                });
+            });
 
-        void await endPromise;
+            sandbox.stub(metadata, 'putObjectMD').callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
+                // Verify that original locations and encryption info are preserved
+                assert.deepStrictEqual(omVal.location, existingLocations);
+                assert.strictEqual(omVal['x-amz-server-side-encryption'], 'AES256');
+                cb(null, {});
+            });
 
-        assert.strictEqual(mockResponse.statusCode, 200);
-        assert.deepStrictEqual(mockResponse.body, {});
-    });
-
-    it('should put metadata after updating account info', async () => {
-        mockRequest.method = 'PUT';
-        mockRequest.url = '/_/backbeat/metadata/bucket0/key0'+
-            '?accountId=123456789012';
-        mockRequest.headers = {
-            'x-scal-versioning-required': 'true',
-        };
-        mockRequest.destroy = () => {};
-
-        sandbox.stub(metadata, 'putObjectMD').callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
-            assert.strictEqual(omVal['owner-display-name'], 'Bart');
-            assert.strictEqual(omVal['owner-id'], '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be');
-            cb(null, {});
-        });
-
-        metadataUtils.standardMetadataValidateBucketAndObj.callsFake((params, denies, log, callback) => {
-            const bucketInfo = {
-                getVersioningConfiguration: () => ({ Status: 'Enabled' }),
-                isVersioningEnabled: () => true,
+            // New metadata without location info
+            mockRequest = preparePutMetadataRequest({
+                tags: { tag1: 'value1' },
+            });
+            mockRequest.headers = {
+                'x-scal-versioning-required': 'true',
+                'x-scal-replication-content': 'METADATA',
             };
-            const objMd = {};
-            callback(null, bucketInfo, objMd);
+            mockRequest.url += '?versionId=aIXVkw5Tw2Pd00000000001I4j3QKsvf';
+
+            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+            void await endPromise;
+
+            assert.strictEqual(mockResponse.statusCode, 200);
+            assert.deepStrictEqual(mockResponse.body, {});
+            assert.strictEqual(dataDeleteSpy.called, false);
         });
 
-        routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-
-        void await endPromise;
-
-        assert.strictEqual(mockResponse.statusCode, 200);
-        assert.deepStrictEqual(mockResponse.body, {});
-    });
-
-    it('should fail to put metadata when accountId is invalid', async () => {
-        mockRequest.method = 'PUT';
-        mockRequest.url = '/_/backbeat/metadata/bucket0/key0'+
-            '?accountId=invalid';
-        mockRequest.headers = {
-            'x-scal-versioning-required': 'true',
-        };
-        mockRequest.destroy = () => {};
-
-        metadataUtils.standardMetadataValidateBucketAndObj.callsFake((params, denies, log, callback) => {
-            const bucketInfo = {
-                getVersioningConfiguration: () => ({ Status: 'Enabled' }),
-                isVersioningEnabled: () => true,
+        it('should delete data when no more locations', async () => {
+            const existingMd = {
+                location: [{
+                    key: 'key0',
+                    dataStoreName: 'location1',
+                    size: 100,
+                }],
             };
-            const objMd = {};
-            callback(null, bucketInfo, objMd);
+            metadataUtils.standardMetadataValidateBucketAndObj.callsFake((params, denies, log, callback) => {
+                callback(null, bucketInfo, existingMd);
+            });
+
+            sandbox.stub(metadata, 'putObjectMD').callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
+                // Verify that the location array is empty, indicating data deletion
+                assert.deepStrictEqual(omVal.location, []);
+                cb(null, {});
+            });
+
+            mockRequest = preparePutMetadataRequest({ location: [] });
+            mockRequest.url += '?versionId=aIXVkw5Tw2Pd00000000001I4j3QKsvf';
+
+            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+            void await endPromise;
+
+            assert.strictEqual(mockResponse.statusCode, 200);
+            assert.deepStrictEqual(mockResponse.body, {});
+            assert.strictEqual(dataDeleteSpy.calledOnce, true);
+            sinon.assert.calledWith(dataDeleteSpy, existingMd.location[0]);
         });
 
-        routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-
-        void await endPromise;
-
-        assert.strictEqual(mockResponse.statusCode, 404);
-        assert.deepStrictEqual(mockResponse.body.code, 'AccountNotFound');
-    });
-
-    it('should repair master when putting metadata of a new version', async () => {
-        mockRequest.method = 'PUT';
-        mockRequest.url = '/_/backbeat/metadata/bucket0/key0'+
-            '?accountId=123456789012&versionId=aIXVkw5Tw2Pd00000000001I4j3QKsvf';
-        mockRequest.headers = {
-            'x-scal-versioning-required': 'true',
-        };
-        mockRequest.destroy = () => {};
-
-        sandbox.stub(metadata, 'putObjectMD').callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
-            assert.strictEqual(options.repairMaster, true);
-            cb(null, {});
-        });
-
-        metadataUtils.standardMetadataValidateBucketAndObj.callsFake((params, denies, log, callback) => {
-            const bucketInfo = {
-                getVersioningConfiguration: () => ({ Status: 'Enabled' }),
-                isVersioningEnabled: () => true,
+        it('should delete data when locations change', async () => {
+            const existingMd = {
+                location: [{
+                    key: 'key0',
+                    dataStoreName: 'location1',
+                    size: 100,
+                }],
+                'content-length': 100,
             };
-            callback(null, bucketInfo, undefined);
-        });
+            metadataUtils.standardMetadataValidateBucketAndObj.callsFake((params, denies, log, callback) => {
+                callback(null, bucketInfo, existingMd);
+            });
 
-        routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-
-        void await endPromise;
-
-        assert.strictEqual(mockResponse.statusCode, 200);
-        assert.deepStrictEqual(mockResponse.body, {});
-    });
-
-    it('should not repair master when updating metadata of an existing version', async () => {
-        mockRequest.method = 'PUT';
-        mockRequest.url = '/_/backbeat/metadata/bucket0/key0'+
-            '?accountId=123456789012&versionId=aIXVkw5Tw2Pd00000000001I4j3QKsvf';
-        mockRequest.headers = {
-            'x-scal-versioning-required': 'true',
-        };
-        mockRequest.destroy = () => {};
-
-        sandbox.stub(metadata, 'putObjectMD').callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
-            assert.strictEqual(options.repairMaster, undefined);
-            cb(null, {});
-        });
-
-        metadataUtils.standardMetadataValidateBucketAndObj.callsFake((params, denies, log, callback) => {
-            const bucketInfo = {
-                getVersioningConfiguration: () => ({ Status: 'Enabled' }),
-                isVersioningEnabled: () => true,
+            // New metadata has different locations
+            const reqBody = {
+                location: [{
+                    key: 'key1',
+                    dataStoreName: 'location1',
+                    size: 100,
+                }],
+                'content-length': 100,
             };
-            callback(null, bucketInfo, {});
+            mockRequest = preparePutMetadataRequest(reqBody);
+            mockRequest.url += '?versionId=aIXVkw5Tw2Pd00000000001I4j3QKsvf';
+
+            sandbox.stub(metadata, 'putObjectMD').callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
+                // Verify that the location array contains the new location
+                assert.deepStrictEqual(omVal.location, reqBody.location);
+                cb(null, {});
+            });
+
+            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+            void await endPromise;
+
+            assert.strictEqual(mockResponse.statusCode, 200);
+            assert.deepStrictEqual(mockResponse.body, {});
+            assert.strictEqual(dataDeleteSpy.calledOnce, true);
+            sinon.assert.calledWith(dataDeleteSpy, existingMd.location[0]);
         });
 
-        routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-
-        void await endPromise;
-
-        assert.strictEqual(mockResponse.statusCode, 200);
-        assert.deepStrictEqual(mockResponse.body, {});
-    });
-
-    it('should handle error when putting metadata', async () => {
-        mockRequest.method = 'PUT';
-        mockRequest.url = '/_/backbeat/metadata/bucket0/key0';
-        mockRequest.headers = {
-            'x-scal-versioning-required': 'true',
-        };
-        mockRequest.destroy = () => {};
-
-        sandbox.stub(metadata, 'putObjectMD').callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
-            cb(new Error('error'));
-        });
-
-        metadataUtils.standardMetadataValidateBucketAndObj.callsFake((params, denies, log, callback) => {
-            const bucketInfo = {
-                getVersioningConfiguration: () => ({ Status: 'Enabled' }),
-                isVersioningEnabled: () => true,
+        it('should not delete data when some keys are still used', async () => {
+            const existingMd = {
+                location: [{
+                    key: 'key0',
+                    dataStoreName: 'location1',
+                    size: 100,
+                }, {
+                    key: 'key1',
+                    dataStoreName: 'location1',
+                    size: 100,
+                }],
+                'content-length': 100,
             };
-            const objMd = {};
-            callback(null, bucketInfo, objMd);
+            metadataUtils.standardMetadataValidateBucketAndObj.callsFake((params, denies, log, callback) => {
+                callback(null, bucketInfo, existingMd);
+            });
+
+            // New metadata has different locations
+            const reqBody = {
+                location: [{
+                    key: 'key1',
+                    dataStoreName: 'location1',
+                    size: 100,
+                }, {
+                    key: 'key2',
+                    dataStoreName: 'location1',
+                    size: 100,
+                }],
+                'content-length': 100,
+            };
+            mockRequest = preparePutMetadataRequest(reqBody);
+            mockRequest.url += '?versionId=aIXVkw5Tw2Pd00000000001I4j3QKsvf';
+
+            sandbox.stub(metadata, 'putObjectMD').callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
+                // Verify that the location array contains the new location
+                assert.deepStrictEqual(omVal.location, reqBody.location);
+                cb(null, {});
+            });
+
+            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+            void await endPromise;
+
+            assert.strictEqual(mockResponse.statusCode, 200);
+            assert.deepStrictEqual(mockResponse.body, {});
+            assert.strictEqual(dataDeleteSpy.calledOnce, false);
         });
 
-        routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+        it('should not delete data when object is archived', async () => {
+            const existingMd = {
+                location: [{
+                    key: 'key0',
+                    dataStoreName: 'location1',
+                    size: 100,
+                }],
+                'content-length': 100,
+            };
+            metadataUtils.standardMetadataValidateBucketAndObj.callsFake((params, denies, log, callback) => {
+                callback(null, bucketInfo, existingMd);
+            });
 
-        void await endPromise;
+            // New metadata has empty location array but keeps content-length (cold storage case)
+            mockRequest = prepareDummyRequest(mockRequest.headers, JSON.stringify({
+                location: undefined,
+                'content-length': 100,
+                replicationInfo: {},
+            }));
+            mockRequest.url += '?versionId=aIXVkw5Tw2Pd00000000001I4j3QKsvf';
 
-        assert.strictEqual(mockResponse.statusCode, 500);
-    });
+            sandbox.stub(metadata, 'putObjectMD').callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
+                // Verify that the location array is empty
+                assert.deepStrictEqual(omVal.location, undefined);
+                // Content length should be preserved
+                assert.strictEqual(omVal['content-length'], 100);
+                cb(null, {});
+            });
 
-    it('should be rejected when using a wrong route', async () => {
-        mockRequest.method = 'PUT';
-        mockRequest.url = '/_/backbeat/metadata/bucket0';
-        mockRequest.headers = {
-            'x-scal-versioning-required': 'true',
-        };
-        mockRequest.destroy = () => {};
+            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+            void await endPromise;
 
-        routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-
-        void await endPromise;
-
-        assert.strictEqual(mockResponse.statusCode, 405);
+            assert.strictEqual(mockResponse.statusCode, 200);
+            assert.deepStrictEqual(mockResponse.body, {});
+            assert.strictEqual(dataDeleteSpy.called, false);
+        });
     });
 
     describe('batchDelete', () => {

--- a/tests/unit/routes/routeBackbeat.js
+++ b/tests/unit/routes/routeBackbeat.js
@@ -8,6 +8,8 @@ const { DummyRequestLogger } = require('../helpers');
 const dataWrapper = require('../../../lib/data/wrapper');
 const DummyRequest = require('../DummyRequest');
 const { auth } = require('arsenal');
+const { config } = require('../../../lib/Config');
+const quotaUtils = require('../../../lib/api/apiUtils/quotas/quotaUtils');
 
 const log = new DummyRequestLogger();
 
@@ -381,118 +383,141 @@ describe('routeBackbeat', () => {
         assert.strictEqual(mockResponse.statusCode, 405);
     });
 
-    it('should be rejected when trying batchDelete as a public user', async () => {
-        mockRequest = prepareDummyRequest(null, JSON.stringify({
-            Locations: [
-                {
+    describe('batchDelete', () => {
+        let doAuthStub;
+        let validateQuotasSpy;
+
+        const prepareBatchDeleteRequest = (locations = undefined) => {
+            const mockRequest = prepareDummyRequest({
+                'x-scal-versioning-required': 'true'
+            }, JSON.stringify({
+                Locations: locations || [{
                     key: 'key0',
                     bucket: 'bucket0',
-                },
-            ],
-        }));
-
-        mockRequest.method = 'POST';
-        mockRequest.url = '/_/backbeat/batchdelete';
-        mockRequest.headers = {
-            'x-scal-versioning-required': 'true',
+                    size: 100,
+                }],
+            }));
+            mockRequest.method = 'POST';
+            mockRequest.url = '/_/backbeat/batchdelete/bucket0/key0';
+            mockRequest.destroy = () => { };
+            return mockRequest;
         };
-        mockRequest.destroy = () => {};
-        routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
 
-        void await endPromise;
-        assert.strictEqual(mockResponse.statusCode, 403);
-    });
-
-    it('should batchDelete', async () => {
-        mockRequest = prepareDummyRequest(null, JSON.stringify({
-            Locations: [
-                {
-                    key: 'key0',
-                    bucket: 'bucket0',
-                },
-            ],
-        }));
-
-        mockRequest.method = 'POST';
-        mockRequest.url = '/_/backbeat/batchdelete';
-        mockRequest.headers = {
-            'x-scal-versioning-required': 'true',
-        };
-        mockRequest.destroy = () => {};
-        const doAuthStub = sandbox.stub(auth.server, 'doAuth');
-        doAuthStub.callsFake((req, log, cb) => {
-            cb(null, {
-                canonicalID: 'id',
-                getCanonicalID: () => 'id',
+        beforeEach(() => {
+            validateQuotasSpy = sandbox.spy(quotaUtils, 'validateQuotas');
+            doAuthStub = sandbox.stub(auth.server, 'doAuth');
+            doAuthStub.callsFake((req, log, cb) => {
+                cb(null, {
+                    canonicalID: 'id',
+                    getCanonicalID: () => 'id',
+                });
             });
+
+            // Initialize mock request with default properties
+            mockRequest = prepareBatchDeleteRequest();
         });
 
-        routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+        it('should be rejected when trying batchDelete as a public user', async () => {
+            doAuthStub.reset();
+            doAuthStub.callThrough();
 
-        void await endPromise;
-        assert.strictEqual(mockResponse.statusCode, 200);
-        assert.deepStrictEqual(mockResponse.body, null);
-    });
-
-    it('should batchDelete with conditions and azure location', async () => {
-        mockRequest = prepareDummyRequest({
-            'if-unmodified-since': '1980-01-01T00:00:00.000Z',
-            'x-scal-versioning-required': 'true',
-            'x-scal-storage-class': 'azurebackend',
-        }, JSON.stringify({
-            Locations: [
-                {
-                    key: 'key0',
-                    bucket: 'bucket0',
-                },
-            ],
-        }));
-
-        mockRequest.method = 'POST';
-        mockRequest.url = '/_/backbeat/batchdelete';
-        mockRequest.destroy = () => {};
-        const doAuthStub = sandbox.stub(auth.server, 'doAuth');
-        doAuthStub.callsFake((req, log, cb) => {
-            cb(null, {
-                canonicalID: 'id',
-                getCanonicalID: () => 'id',
-            });
+            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+            void await endPromise;
+            assert.strictEqual(mockResponse.statusCode, 403);
         });
 
-        routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+        it('should update quotas when batch deleting data', async () => {
+            sandbox.stub(config, 'isQuotaEnabled').returns(true);
+            const bucketMD = {
+                getName: () => 'bucket0',
+                getQuota: () => 0n,
+            };
+            sandbox.stub(metadata, 'getBucket').callsFake((bucket, log, cb) => cb(null, bucketMD));
 
+            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+            await endPromise;
+
+            sinon.assert.calledOnce(validateQuotasSpy);
+            sinon.assert.calledWith(validateQuotasSpy,
+                mockRequest,
+                bucketMD,
+                mockRequest.accountQuotas,
+                ['objectDelete'],
+                'objectDelete',
+                -100,
+                false,
+                log,
+                sinon.match.any,
+            );
+
+            assert.strictEqual(mockResponse.statusCode, 200);
+            assert.deepStrictEqual(mockResponse.body, null);
+        });
+
+        it('should skip quota updates when no bucket provided', async () => {
+            sandbox.stub(config, 'isQuotaEnabled').returns(true);
+            mockRequest.url = '/_/backbeat/batchdelete';
+
+            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+            void await endPromise;
+
+            assert(!validateQuotasSpy.called);
+
+            assert.strictEqual(mockResponse.statusCode, 200);
+            assert.deepStrictEqual(mockResponse.body, null);
+        });
+
+        it('should skip quota updates when quotas disabled', async () => {
+            sandbox.stub(config, 'isQuotaEnabled').returns(false);
+
+            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+            void await endPromise;
+
+            assert(!validateQuotasSpy.called);
+
+            assert.strictEqual(mockResponse.statusCode, 200);
+            assert.deepStrictEqual(mockResponse.body, null);
+        });
+
+        it('should skip quota updates when content length is 0', async () => {
+            sandbox.stub(config, 'isQuotaEnabled').returns(true);
+            mockRequest = prepareBatchDeleteRequest([{
+                key: 'key0',
+                bucket: 'bucket0',
+                size: 0,
+            }]);
+
+            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+            void await endPromise;
+
+            assert(!validateQuotasSpy.called);
+
+            assert.strictEqual(mockResponse.statusCode, 200);
+            assert.deepStrictEqual(mockResponse.body, null);
+        });
+
+        it('should batchDelete with conditions and azure location', async () => {
+            mockRequest.headers = {
+                'x-scal-versioning-required': 'true',
+                'if-unmodified-since': '1980-01-01T00:00:00.000Z',
+                'x-scal-storage-class': 'azurebackend',
+            };
+
+            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
         void await endPromise;
         assert.strictEqual(mockResponse.statusCode, 200);
         assert.deepStrictEqual(mockResponse.body, {});
     });
 
     it('should not batchDelete with conditions if "if-unmodified-since" header unset', async () => {
-        mockRequest = prepareDummyRequest({
+        mockRequest.headers = {
             'x-scal-versioning-required': 'true',
             'x-scal-storage-class': 'azurebackend',
-        }, JSON.stringify({
-            Locations: [
-                {
-                    key: 'key0',
-                    bucket: 'bucket0',
-                },
-            ],
-        }));
-
-        mockRequest.method = 'POST';
-        mockRequest.url = '/_/backbeat/batchdelete';
-        mockRequest.destroy = () => {};
-        const doAuthStub = sandbox.stub(auth.server, 'doAuth');
-        doAuthStub.callsFake((req, log, cb) => {
-            cb(null, {
-                canonicalID: 'id',
-                getCanonicalID: () => 'id',
-            });
-        });
+        };
 
         routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-
         void await endPromise;
+
         assert.strictEqual(mockResponse.statusCode, 200);
     });
 
@@ -508,36 +533,24 @@ describe('routeBackbeat', () => {
                 },
             ],
         }));
-        putRequest.destroy = () => { };
         await promisify(dataWrapper.client.put)(putRequest, 91, 1, 'reqUids');
-        mockRequest = prepareDummyRequest({
+
+        mockRequest = prepareBatchDeleteRequest([{
+            key: '1',
+            bucket: 'bucket0',
+        }]);
+        mockRequest.headers = {
             'if-unmodified-since': '2000-01-01T00:00:00.000Z',
             'x-scal-versioning-required': 'true',
             'x-scal-storage-class': 'gcpbackend',
             'x-scal-tags': JSON.stringify({ key: 'value' }),
-        }, JSON.stringify({
-            Locations: [
-                {
-                    key: 1,
-                    bucket: 'bucket0',
-                },
-            ],
-        }));
-        mockRequest.method = 'POST';
-        mockRequest.url = '/_/backbeat/batchdelete';
-        mockRequest.destroy = () => {};
-        const doAuthStub = sandbox.stub(auth.server, 'doAuth');
-        doAuthStub.callsFake((req, log, cb) => {
-            cb(null, {
-                canonicalID: 'id',
-                getCanonicalID: () => 'id',
-            });
-        });
+        };
 
         routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-
         void await endPromise;
+
         assert.strictEqual(mockResponse.statusCode, 200);
         assert.deepStrictEqual(mockResponse.body, null);
+    });
     });
 });


### PR DESCRIPTION
- fix project path
- fix utapi config
- support null compatibility mode
- Enable multiObjectDelete optim' for mongo only
- do not fail on head with part number if object is empty
- All headObject on part1 for non mpu objects
- Allow disabling versioning if replication rules are disabled
- Remove useless storage class update
- Allow configuring valid storage classes
- Support batchDelete route when bucketName is not present
- Delete data when replacing object metadata with an empty object
- Trigger replication on putACL only for CRR

Issue: CLDSRV-638

