### PR TITLE
Introduce "internal" cloudserver and allow bypass policies on that port

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -872,14 +872,26 @@ class Config extends EventEmitter {
             }
         }
 
-        this.port = 8000;
         if (config.port !== undefined) {
             assert(Number.isInteger(config.port) && config.port > 0,
                 'bad config: port must be a positive integer');
-            this.port = config.port;
         }
 
+        if (config.internalPort !== undefined) {
+            assert(Number.isInteger(config.internalPort) && config.internalPort > 0,
+                'bad config: internalPort must be a positive integer');
+        }
+
+        this.port = config.port;
         this.listenOn = this._parseEndpoints(config.listenOn, 'listenOn');
+        this.internalPort = config.internalPort;
+        this.internalListenOn = this._parseEndpoints(config.internalListenOn, 'internalListenOn');
+
+        if (this.listenOn.length || (!this.internalPort && !this.internalListenOn.length)) {
+            // default to 8000 unless running in "internal" API mode only (i.e. internalPort/ListenOn)
+            // i.e. when either no port config is specified, or only listenOn is specified.
+            this.port ||= 8000;
+        }
 
         this.metricsPort = 8002;
         if (config.metricsPort !== undefined) {

--- a/lib/api/apiUtils/authorization/permissionChecks.js
+++ b/lib/api/apiUtils/authorization/permissionChecks.js
@@ -358,7 +358,7 @@ function processBucketPolicy(requestType, bucket, canonicalID, arn, bucketOwner,
     request, aclPermission, results, actionImplicitDenies) {
     const bucketPolicy = bucket.getBucketPolicy();
     let processedResult = results[requestType];
-    if (!bucketPolicy) {
+    if (!bucketPolicy || request?.bypassUserBucketPolicies) {
         processedResult = actionImplicitDenies[requestType] === false && aclPermission;
     } else {
         const bucketPolicyPermission = checkBucketPolicy(bucketPolicy, requestType, canonicalID, arn,

--- a/lib/server.js
+++ b/lib/server.js
@@ -62,9 +62,11 @@ class S3Server {
     /**
      * This represents our S3 connector.
      * @constructor
+     * @param {Object} config - Configuration object
      * @param {Worker} [worker=null] - Track the worker when using cluster
      */
-    constructor(worker) {
+    constructor(config, worker) {
+        this.config = config;
         this.worker = worker;
         this.cluster = true;
         this.servers = [];
@@ -144,14 +146,14 @@ class S3Server {
             dataRetrievalParams: {
                 client,
                 implName,
-                config: _config,
+                config: this.config,
                 kms,
                 metadata,
                 locStorageCheckFn: locationStorageCheck,
                 vault,
             },
         };
-        routes(req, res, params, logger, _config);
+        routes(req, res, params, logger, this.config);
     }
 
     /**
@@ -210,11 +212,11 @@ class S3Server {
     _startServer(listener, port, ipAddress) {
         // Todo: http.globalAgent.maxSockets, http.globalAgent.maxFreeSockets
         let server;
-        if (_config.https) {
+        if (this.config.https) {
             server = https.createServer({
-                cert: _config.https.cert,
-                key: _config.https.key,
-                ca: _config.https.ca,
+                cert: this.config.https.cert,
+                key: this.config.https.key,
+                ca: this.config.https.ca,
                 ciphers: arsenal.https.ciphers.ciphers,
                 dhparam: arsenal.https.dhparam.dhparam,
                 rejectUnauthorized: true,
@@ -305,21 +307,30 @@ class S3Server {
             }
 
             // Start API server(s)
-            if (_config.listenOn.length > 0) {
-                _config.listenOn.forEach(item => {
+            if (this.config.listenOn.length > 0) {
+                this.config.listenOn.forEach(item => {
                     this._startServer(this.routeRequest, item.port, item.ip);
                 });
-            } else {
-                this._startServer(this.routeRequest, _config.port);
+            } else if (this.config.port) {
+                this._startServer(this.routeRequest, this.config.port);
+            }
+
+            // Start internal API server(s)
+            if (this.config.internalListenOn.length > 0) {
+                this.config.internalListenOn.forEach(item => {
+                    this._startServer(this.routeRequest, item.port, item.ip);
+                });
+            } else if (this.config.internalPort) {
+                this._startServer(this.routeRequest, this.config.internalPort);
             }
 
             // Start metrics server(s)
-            if (_config.metricsListenOn.length > 0) {
-                _config.metricsListenOn.forEach(item => {
+            if (this.config.metricsListenOn.length > 0) {
+                this.config.metricsListenOn.forEach(item => {
                     this._startServer(this.routeAdminRequest, item.port, item.ip);
                 });
             } else {
-                this._startServer(this.routeAdminRequest, _config.metricsPort);
+                this._startServer(this.routeAdminRequest, this.config.metricsPort);
             }
 
             // Start quota service health checks
@@ -353,7 +364,7 @@ function main() {
     this.cluster = workers > 1;
     if (!this.cluster) {
         process.env.REPORT_TOKEN = _config.reportToken;
-        const server = new S3Server();
+        const server = new S3Server(_config);
         server.initiateStartup(logger.newRequestLogger());
     }
     if (this.cluster && cluster.isMaster) {
@@ -399,10 +410,11 @@ function main() {
         });
     }
     if (this.cluster && cluster.isWorker) {
-        const server = new S3Server(cluster.worker);
+        const server = new S3Server(_config, cluster.worker);
         server.initiateStartup(logger.newRequestLogger());
     }
     monitoringClient.collectDefaultMetrics({ timeout: 5000 });
 }
 
 module.exports = main;
+module.exports.S3Server = S3Server;

--- a/lib/server.js
+++ b/lib/server.js
@@ -26,7 +26,6 @@ const {
 
 const HttpAgent = require('agentkeepalive');
 const QuotaService = require('./quotas/quotas');
-const routes = arsenal.s3routes.routes;
 const { parseLC, MultipleBackendGateway } = arsenal.storage.data;
 const websiteEndpoints = _config.websiteEndpoints;
 let client = dataWrapper.client;
@@ -96,10 +95,28 @@ class S3Server {
     }
 
     /**
+     * Route requests on 'internal s3' port
+     * Same as routeRequest, but ignoring user's bucket policy. This should be used only for
+     * backbeat and other internal/system processes that must not be affected by user's bucket
+     * policy.
+     * Note that this is not a temporary measure: eventually this should be improved to better
+     * identify and isolate internal/system calls vs user calls, so that "system" bucket policies
+     * may be applied to system requests, and the existing "user" bucket policies apply only to
+     * user requests.
+     * @param {http.IncomingMessage} req - http request object
+     * @param {http.ServerResponse} res - http response object
+     * @returns {undefined}
+     */
+    internalRouteRequest(req, res) {
+        req.bypassUserBucketPolicies = true; // eslint-disable-line no-param-reassign
+        return this.routeRequest(req, res);
+    }
+
+    /**
      * Route requests on 's3' port
      * @param {http.IncomingMessage} req - http request object
      * @param {http.ServerResponse} res - http response object
-     * @returns {void}
+     * @returns {undefined}
      */
     routeRequest(req, res) {
         monitoringClient.httpActiveRequests.inc();
@@ -153,14 +170,14 @@ class S3Server {
                 vault,
             },
         };
-        routes(req, res, params, logger, this.config);
+        arsenal.s3routes.routes(req, res, params, logger, this.config);
     }
 
     /**
      * Route requests on 'admin' port
      * @param {http.IncomingMessage} req - http request object
      * @param {http.ServerResponse} res - http response object
-     * @returns {void}
+     * @returns {undefined}
      */
     routeAdminRequest(req, res) {
         // use proxied hostname if needed
@@ -207,7 +224,7 @@ class S3Server {
      * @param {http.RequestListener} listener - Callback to handle requests
      * @param {number} port - Port to listen on
      * @param {string | undefined} ipAddress - IpAddress to listen on
-     * @returns {void}
+     * @returns {undefined}
      */
     _startServer(listener, port, ipAddress) {
         // Todo: http.globalAgent.maxSockets, http.globalAgent.maxFreeSockets
@@ -318,10 +335,10 @@ class S3Server {
             // Start internal API server(s)
             if (this.config.internalListenOn.length > 0) {
                 this.config.internalListenOn.forEach(item => {
-                    this._startServer(this.routeRequest, item.port, item.ip);
+                    this._startServer(this.internalRouteRequest, item.port, item.ip);
                 });
             } else if (this.config.internalPort) {
-                this._startServer(this.routeRequest, this.config.internalPort);
+                this._startServer(this.internalRouteRequest, this.config.internalPort);
             }
 
             // Start metrics server(s)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "9.0.11",
+  "version": "9.0.12",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {

--- a/tests/unit/Config.js
+++ b/tests/unit/Config.js
@@ -12,6 +12,8 @@ const {
 const { ValidLifecycleRules: supportedLifecycleRules } = require('arsenal').models;
 
 describe('Config', () => {
+    const defaultConfig = JSON.parse(fs.readFileSync('config.json'), { encoding: 'utf-8' });
+
     const envToRestore = [];
     const setEnv = (key, value) => {
         if (key in process.env) {
@@ -446,7 +448,6 @@ describe('Config', () => {
     });
 
     describe('multiObjectDeleteEnableOptimizations', () => {
-        const defaultConfig = JSON.parse(fs.readFileSync('config.json'), { encoding: 'utf-8' });
         let sandbox;
         let readFileStub;
 
@@ -677,6 +678,136 @@ describe('Config', () => {
             ];
             const parsedRules = parseSupportedLifecycleRules(rules);
             assert.deepStrictEqual(parsedRules, rules);
+        });
+    });
+
+    describe('port and internalPort configuration', () => {
+        // same as `defaultConfig` (i.e. config.json) but without the port settings
+        const baseConfig = (() => {
+            const config = { ...defaultConfig };
+            delete config.port;
+            delete config.listenOn;
+            delete config.internalPort;
+            delete config.internalListenOn;
+            delete config.metricsPort;
+            delete config.metricsListenOn;
+            return config;
+        })();
+
+        let sandbox;
+        let readFileStub;
+
+        beforeEach(() => {
+            sandbox = sinon.createSandbox();
+            readFileStub = sandbox.stub(fs, 'readFileSync');
+            readFileStub.callThrough();
+        });
+
+        afterEach(() => {
+            sandbox.restore();
+        });
+
+        it('should throw an error for negative port number', () => {
+            const testConfig = { ...baseConfig, port: -1 };
+            readFileStub.withArgs(sinon.match(/config.json$/)).returns(JSON.stringify(testConfig));
+
+            assert.throws(() => new ConfigObject(), /bad config: port must be a positive integer/);
+        });
+
+        it('should throw an error for non-integer port number', () => {
+            const testConfig = { ...baseConfig, port: 8000.5 };
+            readFileStub.withArgs(sinon.match(/config.json$/)).returns(JSON.stringify(testConfig));
+
+            assert.throws(() => new ConfigObject(), /bad config: port must be a positive integer/);
+        });
+
+        it('should throw an error for negative internalPort number', () => {
+            const testConfig = { ...baseConfig, internalPort: -1 };
+            readFileStub.withArgs(sinon.match(/config.json$/)).returns(JSON.stringify(testConfig));
+
+            assert.throws(() => new ConfigObject(), /bad config: internalPort must be a positive integer/);
+        });
+
+        it('should throw an error for non-integer internalPort number', () => {
+            const testConfig = { ...baseConfig, internalPort: 9000.5 };
+            readFileStub.withArgs(sinon.match(/config.json$/)).returns(JSON.stringify(testConfig));
+
+            assert.throws(() => new ConfigObject(), /bad config: internalPort must be a positive integer/);
+        });
+
+        it('should accept a valid port number', () => {
+            const testConfig = { ...baseConfig, port: 8765 };
+            readFileStub.withArgs(sinon.match(/config.json$/)).returns(JSON.stringify(testConfig));
+
+            const config = new ConfigObject();
+            assert.strictEqual(config.port, 8765);
+            assert.strictEqual(config.internalPort, undefined);
+        });
+
+        it('should accept a valid internalPort number', () => {
+            const testConfig = { ...baseConfig, internalPort: 9000 };
+            readFileStub.withArgs(sinon.match(/config.json$/)).returns(JSON.stringify(testConfig));
+
+            const config = new ConfigObject();
+            assert.strictEqual(config.port, undefined);
+            assert.strictEqual(config.internalPort, 9000);
+        });
+
+        it('should accept both port and internalPort when provided', () => {
+            const testConfig = { ...baseConfig, port: 8000, internalPort: 9000 };
+            readFileStub.withArgs(sinon.match(/config.json$/)).returns(JSON.stringify(testConfig));
+
+            const config = new ConfigObject();
+            assert.strictEqual(config.port, 8000);
+            assert.strictEqual(config.internalPort, 9000);
+        });
+
+        it('should use default port 8000 if no port or internalPort specified', () => {
+            readFileStub.withArgs(sinon.match(/config.json$/)).returns(JSON.stringify(baseConfig));
+
+            const config = new ConfigObject();
+            assert.strictEqual(config.port, 8000);
+            assert.strictEqual(config.internalPort, undefined);
+        });
+
+        it('should default port if listenOn is provided', () => {
+            const testConfig = {
+                ...baseConfig,
+                listenOn: ['127.0.0.1:9000'],
+            };
+            readFileStub.withArgs(sinon.match(/config.json$/)).returns(JSON.stringify(testConfig));
+
+            const config = new ConfigObject();
+            assert.strictEqual(config.port, 8000);
+            assert.strictEqual(config.internalPort, undefined);
+            assert.deepEqual(config.listenOn, [{ ip: '127.0.0.1', port: 9000 }]);
+        });
+
+        it('should not default port if internalListenOn is provided', () => {
+            const testConfig = {
+                ...baseConfig,
+                internalListenOn: ['127.0.0.1:9000'],
+            };
+            readFileStub.withArgs(sinon.match(/config.json$/)).returns(JSON.stringify(testConfig));
+
+            const config = new ConfigObject();
+            assert.strictEqual(config.port, undefined);
+            assert.strictEqual(config.internalPort, undefined);
+            assert.deepEqual(config.internalListenOn, [{ ip: '127.0.0.1', port: 9000 }]);
+        });
+
+        it('should properly handle listenOn and internalListenOn configuration', () => {
+            const testConfig = {
+                ...baseConfig,
+                listenOn: ['0.0.0.0:8000'],
+                internalListenOn: ['127.0.0.1:9000'],
+            };
+            readFileStub.withArgs(sinon.match(/config.json$/)).returns(JSON.stringify(testConfig));
+
+            const config = new ConfigObject();
+            assert.strictEqual(config.port, 8000);
+            assert.deepEqual(config.listenOn, [{ ip: '0.0.0.0', port: 8000 }]);
+            assert.deepEqual(config.internalListenOn, [{ ip: '127.0.0.1', port: 9000 }]);
         });
     });
 });

--- a/tests/unit/api/bucketPolicyAuth.js
+++ b/tests/unit/api/bucketPolicyAuth.js
@@ -346,6 +346,34 @@ describe('bucket policy authorization', () => {
             assert.equal(allowed, false);
             done();
         });
+
+        it('should bypass bucket policy when request.bypassUserBucketPolicies is true', function () {
+            // Create a request with the bypassUserBucketPolicies flag initially not set
+            const request = {
+                bucketName,
+                socket: {},
+            };
+
+            // Add a policy to explicitely deny access
+            const newPolicy = this.test.basePolicy;
+            newPolicy.Statement[0] = {
+                Effect: 'Deny',
+                Principal: { CanonicalUser: [bucketOwnerCanonicalId] },
+                Resource: `arn:aws:s3:::${bucketName}`,
+                Action: 's3:*',
+            };
+            bucket.setBucketPolicy(newPolicy);
+
+            // Check that the policy denies access, as expected
+            assert.ok(!isBucketAuthorized(bucket, bucAction,
+                bucketOwnerCanonicalId, user1AuthInfo, log, request));
+
+            // But with bypassUserBucketPolicies set to true, it should still be authorized
+            // based on ACL permissions (which we mock to return true)
+            request.bypassUserBucketPolicies = true;
+            assert.ok(isBucketAuthorized(bucket, bucAction,
+                bucketOwnerCanonicalId, user1AuthInfo, log, request));
+        });
     });
 
     describe('isObjAuthorized with no policy set', () => {
@@ -427,6 +455,35 @@ describe('bucket policy authorization', () => {
             assert.equal(allowed, false);
             done();
         });
+
+        it('should bypass bucket policy when request.bypassUserBucketPolicies is true', function () {
+            // Create a request with the bypassUserBucketPolicies flag initially not set
+            const request = {
+                bucketName,
+                socket: {},
+            };
+
+            // Add a policy to explicitely deny access
+            const newPolicy = this.test.basePolicy;
+            newPolicy.Statement[0] = {
+                Effect: 'Deny',
+                Principal: { CanonicalUser: [bucketOwnerCanonicalId] },
+                Resource: `arn:aws:s3:::${bucketName}`,
+                Action: 's3:*',
+            };
+            bucket.setBucketPolicy(newPolicy);
+
+            // Check that the policy denies access, as expected
+            assert.ok(!isObjAuthorized(bucket, object, 'objectGet',
+                bucketOwnerCanonicalId, user1AuthInfo, log, request));
+
+            // But with bypassUserBucketPolicies set to true, it should still be authorized
+            // based on ACL permissions (which we mock to return true)
+            request.bypassUserBucketPolicies = true;
+            assert.ok(isObjAuthorized(bucket, object, 'objectGet',
+                bucketOwnerCanonicalId, user1AuthInfo, log, request));
+        });
+
         it('should deny access to non-object owner if two statements apply ' +
         'to principal but one denies access', function itFn(done) {
             const newPolicy = this.test.basePolicy;

--- a/tests/unit/server.js
+++ b/tests/unit/server.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert');
 const sinon = require('sinon');
+const arsenal = require('arsenal');
 const logger = require('../../lib/utilities/logger');
 const { config: defaultConfig } = require('../../lib/Config');
 const { S3Server } = require('../../lib/server');
@@ -83,7 +84,7 @@ describe('S3Server', () => {
             await waitReady();
 
             assert.strictEqual(startServerStub.callCount, 2);
-            assert(startServerStub.calledWith(server.routeRequest, 9000));
+            assert(startServerStub.calledWith(server.internalRouteRequest, 9000));
         });
         
         it('should start internal API servers from internalListenOn array', async () => {
@@ -98,8 +99,8 @@ describe('S3Server', () => {
             await waitReady();
 
             assert.strictEqual(startServerStub.callCount, 3);
-            assert(startServerStub.calledWith(server.routeRequest, 9000, '127.0.0.1'));
-            assert(startServerStub.calledWith(server.routeRequest, 9001, '0.0.0.0'));
+            assert(startServerStub.calledWith(server.internalRouteRequest, 9000, '127.0.0.1'));
+            assert(startServerStub.calledWith(server.internalRouteRequest, 9001, '0.0.0.0'));
             assert(startServerStub.calledWith(server.routeAdminRequest));
             assert.strictEqual(startServerStub.neverCalledWith(server.routeRequest, 9999), true);
         });
@@ -143,8 +144,53 @@ describe('S3Server', () => {
 
             assert.strictEqual(startServerStub.callCount, 3);
             assert(startServerStub.calledWith(server.routeRequest, 8000));
-            assert(startServerStub.calledWith(server.routeRequest, 9000));
+            assert(startServerStub.calledWith(server.internalRouteRequest, 9000));
             assert(startServerStub.calledWith(server.routeAdminRequest, 8002));
+        });
+    });
+
+    describe('internalRouteRequest', () => {
+        const resp = {
+            on: () => { },
+            setHeader: () => { },
+            writeHead: () => { },
+            end: () => { },
+        };
+
+        let req;
+
+        beforeEach(() => {
+            req = {
+                headers: {},
+                socket: {
+                    setNoDelay: () => { },
+                },
+                url: 'http://localhost:8000',
+            };
+        });
+
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        it('should bypass bucket policy for internal requests', () => {
+            const routesMock = sinon.stub().callsFake(req => {
+                assert(req.bypassUserBucketPolicies);
+            });
+            sinon.stub(arsenal.s3routes, 'routes').value(routesMock);
+
+            server.internalRouteRequest(req, resp);
+            sinon.assert.calledOnce(routesMock);
+        });
+
+        it('should bypass bucket policy for routes requests', () => {
+            const routesMock = sinon.stub().callsFake(req => {
+                assert(!req.bypassUserBucketPolicies);
+            });
+            sinon.stub(arsenal.s3routes, 'routes').value(routesMock);
+
+            server.routeRequest(req, resp);
+            sinon.assert.calledOnce(routesMock);
         });
     });
 });

--- a/tests/unit/server.js
+++ b/tests/unit/server.js
@@ -1,0 +1,150 @@
+'use strict';
+
+const assert = require('assert');
+const sinon = require('sinon');
+const logger = require('../../lib/utilities/logger');
+const { config: defaultConfig } = require('../../lib/Config');
+const { S3Server } = require('../../lib/server');
+
+describe('S3Server', () => {
+    let server;
+    let startServerStub;
+    let log;
+    let config;
+
+    beforeEach(() => {
+        log = logger.newRequestLogger();
+
+        config = {
+            ...defaultConfig,
+            port: undefined,
+            listenOn: [],
+            internalPort: undefined,
+            internalListenOn: [],
+            metricsListenOn: [],
+            metricsPort: 8002
+        };
+        server = new S3Server(config);
+
+        // Stub the _startServer method to verify it's called correctly
+        startServerStub = sinon.stub(server, '_startServer');
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    const waitReady = () => new Promise(resolve => {
+        const interval = setInterval(() => {
+            if (server.started) {
+                clearInterval(interval);
+                resolve();
+            }
+        }, 100);
+    });
+
+    describe('initiateStartup', () => {
+        it('should start API server with default port if no listenOn is provided', async () => {
+            config.port = 8000;
+
+            server.initiateStartup(log);
+
+            await waitReady();
+
+            assert.strictEqual(startServerStub.callCount, 2);
+            assert(startServerStub.calledWith(server.routeRequest, 8000));
+            assert(startServerStub.calledWith(server.routeAdminRequest));
+
+        });
+        
+        it('should start API servers from listenOn array', async () => {
+            config.listenOn = [
+                { port: 8000, ip: '127.0.0.1' },
+                { port: 8001, ip: '0.0.0.0' }
+            ];
+            config.port = 9999; // Should be ignored since listenOn is provided
+
+            server.initiateStartup(log);
+
+            await waitReady();
+
+            assert.strictEqual(startServerStub.callCount, 3);
+            assert(startServerStub.calledWith(server.routeRequest, 8000, '127.0.0.1'));
+            assert(startServerStub.calledWith(server.routeRequest, 8001, '0.0.0.0'));
+            assert(startServerStub.calledWith(server.routeAdminRequest));
+            assert.strictEqual(startServerStub.neverCalledWith(server.routeRequest, 9999), true);
+        });
+        
+        it('should start internal API server with internalPort if no internalListenOn is provided', async () => {
+            config.internalPort = 9000;
+
+            server.initiateStartup(log);
+
+            await waitReady();
+
+            assert.strictEqual(startServerStub.callCount, 2);
+            assert(startServerStub.calledWith(server.routeRequest, 9000));
+        });
+        
+        it('should start internal API servers from internalListenOn array', async () => {
+            config.internalListenOn = [
+                { port: 9000, ip: '127.0.0.1' },
+                { port: 9001, ip: '0.0.0.0' }
+            ];
+            config.internalPort = 9999; // Should be ignored since internalListenOn is provided
+
+            server.initiateStartup(log);
+
+            await waitReady();
+
+            assert.strictEqual(startServerStub.callCount, 3);
+            assert(startServerStub.calledWith(server.routeRequest, 9000, '127.0.0.1'));
+            assert(startServerStub.calledWith(server.routeRequest, 9001, '0.0.0.0'));
+            assert(startServerStub.calledWith(server.routeAdminRequest));
+            assert.strictEqual(startServerStub.neverCalledWith(server.routeRequest, 9999), true);
+        });
+        
+        it('should start metrics server with metricsPort if no metricsListenOn is provided', async () => {
+            config.metricsPort = 8012;
+
+            server.initiateStartup(log);
+
+            await waitReady();
+            
+            assert.strictEqual(startServerStub.callCount, 1);
+            assert(startServerStub.calledWith(server.routeAdminRequest, 8012));
+        });
+        
+        it('should start metrics servers from metricsListenOn array', async () => {
+            config.metricsListenOn = [
+                { port: 8002, ip: '127.0.0.1' },
+                { port: 8003, ip: '0.0.0.0' }
+            ];
+            config.metricsPort = 9999; // Should be ignored since metricsListenOn is provided
+
+            server.initiateStartup(log);
+
+            await waitReady();
+            
+            assert.strictEqual(startServerStub.callCount, 2);
+            assert(startServerStub.calledWith(server.routeAdminRequest, 8002, '127.0.0.1'));
+            assert(startServerStub.calledWith(server.routeAdminRequest, 8003, '0.0.0.0'));
+            assert.strictEqual(startServerStub.neverCalledWith(server.routeAdminRequest, 9999), true);
+        });
+
+        it('should start all servers with the correct parameters', async () => {
+            config.port = 8000;
+            config.internalPort = 9000;
+            config.metricsPort = 8002;
+
+            server.initiateStartup(log);
+
+            await waitReady();
+
+            assert.strictEqual(startServerStub.callCount, 3);
+            assert(startServerStub.calledWith(server.routeRequest, 8000));
+            assert(startServerStub.calledWith(server.routeRequest, 9000));
+            assert(startServerStub.calledWith(server.routeAdminRequest, 8002));
+        });
+    });
+});


### PR DESCRIPTION
In order to ensure backbeat (and internal processes in general) are not affected by user's bucket policies, allow starting cloudserver with a separate "internal" port, through which bucket policies are currently bypassed.

More details here: https://scality.atlassian.net/wiki/spaces/OS/pages/2895347722/Authorizing+Internal+Services+S3+Operations

Issue: CLDSRV-650
