### PR TITLE
Fix crash on internalRoute

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -326,28 +326,28 @@ class S3Server {
             // Start API server(s)
             if (this.config.listenOn.length > 0) {
                 this.config.listenOn.forEach(item => {
-                    this._startServer(this.routeRequest, item.port, item.ip);
+                    this._startServer(this.routeRequest.bind(this), item.port, item.ip);
                 });
             } else if (this.config.port) {
-                this._startServer(this.routeRequest, this.config.port);
+                this._startServer(this.routeRequest.bind(this), this.config.port);
             }
 
             // Start internal API server(s)
             if (this.config.internalListenOn.length > 0) {
                 this.config.internalListenOn.forEach(item => {
-                    this._startServer(this.internalRouteRequest, item.port, item.ip);
+                    this._startServer(this.internalRouteRequest.bind(this), item.port, item.ip);
                 });
             } else if (this.config.internalPort) {
-                this._startServer(this.internalRouteRequest, this.config.internalPort);
+                this._startServer(this.internalRouteRequest.bind(this), this.config.internalPort);
             }
 
             // Start metrics server(s)
             if (this.config.metricsListenOn.length > 0) {
                 this.config.metricsListenOn.forEach(item => {
-                    this._startServer(this.routeAdminRequest, item.port, item.ip);
+                    this._startServer(this.routeAdminRequest.bind(this), item.port, item.ip);
                 });
             } else {
-                this._startServer(this.routeAdminRequest, this.config.metricsPort);
+                this._startServer(this.routeAdminRequest.bind(this), this.config.metricsPort);
             }
 
             // Start quota service health checks

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "9.0.14",
+  "version": "9.0.15",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {

--- a/tests/unit/server.js
+++ b/tests/unit/server.js
@@ -3,6 +3,7 @@
 const assert = require('assert');
 const sinon = require('sinon');
 const arsenal = require('arsenal');
+const uuid = require('uuid');
 const logger = require('../../lib/utilities/logger');
 const { config: defaultConfig } = require('../../lib/Config');
 const { S3Server } = require('../../lib/server');
@@ -45,6 +46,21 @@ describe('S3Server', () => {
     });
 
     describe('initiateStartup', () => {
+        beforeEach(() => {
+            sinon.stub(server, 'routeRequest');
+            sinon.stub(server, 'internalRouteRequest');
+            sinon.stub(server, 'routeAdminRequest');
+        });
+
+        // `sinon` matcher to match when the callback argument actually invokes the expected
+        // function
+        const wrapperFor = expected => sinon.match(actual => {
+            const req = uuid.v4();
+            const res = uuid.v4();
+            actual(req, res);
+            return expected.calledWith(req, res);
+        });
+
         it('should start API server with default port if no listenOn is provided', async () => {
             config.port = 8000;
 
@@ -53,8 +69,8 @@ describe('S3Server', () => {
             await waitReady();
 
             assert.strictEqual(startServerStub.callCount, 2);
-            assert(startServerStub.calledWith(server.routeRequest, 8000));
-            assert(startServerStub.calledWith(server.routeAdminRequest));
+            assert(startServerStub.calledWith(wrapperFor(server.routeRequest), 8000));
+            assert(startServerStub.calledWith(wrapperFor(server.routeAdminRequest)));
 
         });
         
@@ -70,10 +86,10 @@ describe('S3Server', () => {
             await waitReady();
 
             assert.strictEqual(startServerStub.callCount, 3);
-            assert(startServerStub.calledWith(server.routeRequest, 8000, '127.0.0.1'));
-            assert(startServerStub.calledWith(server.routeRequest, 8001, '0.0.0.0'));
-            assert(startServerStub.calledWith(server.routeAdminRequest));
-            assert.strictEqual(startServerStub.neverCalledWith(server.routeRequest, 9999), true);
+            assert(startServerStub.calledWith(wrapperFor(server.routeRequest), 8000, '127.0.0.1'));
+            assert(startServerStub.calledWith(wrapperFor(server.routeRequest), 8001, '0.0.0.0'));
+            assert(startServerStub.calledWith(wrapperFor(server.routeAdminRequest)));
+            assert.strictEqual(startServerStub.neverCalledWith(sinon.any, 9999), true);
         });
         
         it('should start internal API server with internalPort if no internalListenOn is provided', async () => {
@@ -84,7 +100,7 @@ describe('S3Server', () => {
             await waitReady();
 
             assert.strictEqual(startServerStub.callCount, 2);
-            assert(startServerStub.calledWith(server.internalRouteRequest, 9000));
+            assert(startServerStub.calledWith(wrapperFor(server.internalRouteRequest), 9000));
         });
         
         it('should start internal API servers from internalListenOn array', async () => {
@@ -99,10 +115,10 @@ describe('S3Server', () => {
             await waitReady();
 
             assert.strictEqual(startServerStub.callCount, 3);
-            assert(startServerStub.calledWith(server.internalRouteRequest, 9000, '127.0.0.1'));
-            assert(startServerStub.calledWith(server.internalRouteRequest, 9001, '0.0.0.0'));
-            assert(startServerStub.calledWith(server.routeAdminRequest));
-            assert.strictEqual(startServerStub.neverCalledWith(server.routeRequest, 9999), true);
+            assert(startServerStub.calledWith(wrapperFor(server.internalRouteRequest), 9000, '127.0.0.1'));
+            assert(startServerStub.calledWith(wrapperFor(server.internalRouteRequest), 9001, '0.0.0.0'));
+            assert(startServerStub.calledWith(wrapperFor(server.routeAdminRequest)));
+            assert.strictEqual(startServerStub.neverCalledWith(sinon.any, 9999), true);
         });
         
         it('should start metrics server with metricsPort if no metricsListenOn is provided', async () => {
@@ -113,7 +129,7 @@ describe('S3Server', () => {
             await waitReady();
             
             assert.strictEqual(startServerStub.callCount, 1);
-            assert(startServerStub.calledWith(server.routeAdminRequest, 8012));
+            assert(startServerStub.calledWith(wrapperFor(server.routeAdminRequest), 8012));
         });
         
         it('should start metrics servers from metricsListenOn array', async () => {
@@ -128,9 +144,9 @@ describe('S3Server', () => {
             await waitReady();
             
             assert.strictEqual(startServerStub.callCount, 2);
-            assert(startServerStub.calledWith(server.routeAdminRequest, 8002, '127.0.0.1'));
-            assert(startServerStub.calledWith(server.routeAdminRequest, 8003, '0.0.0.0'));
-            assert.strictEqual(startServerStub.neverCalledWith(server.routeAdminRequest, 9999), true);
+            assert(startServerStub.calledWith(wrapperFor(server.routeAdminRequest), 8002, '127.0.0.1'));
+            assert(startServerStub.calledWith(wrapperFor(server.routeAdminRequest), 8003, '0.0.0.0'));
+            assert.strictEqual(startServerStub.neverCalledWith(server.any, 9999), true);
         });
 
         it('should start all servers with the correct parameters', async () => {
@@ -143,9 +159,9 @@ describe('S3Server', () => {
             await waitReady();
 
             assert.strictEqual(startServerStub.callCount, 3);
-            assert(startServerStub.calledWith(server.routeRequest, 8000));
-            assert(startServerStub.calledWith(server.internalRouteRequest, 9000));
-            assert(startServerStub.calledWith(server.routeAdminRequest, 8002));
+            assert(startServerStub.calledWith(wrapperFor(server.routeRequest), 8000));
+            assert(startServerStub.calledWith(wrapperFor(server.internalRouteRequest), 9000));
+            assert(startServerStub.calledWith(wrapperFor(server.routeAdminRequest), 8002));
         });
     });
 


### PR DESCRIPTION
In server.js, the `_startServer` method takes a callback _function_, but we pass it a _method_.
This used to work as the method was in fact "static" (in the sense it did not use `this`), but was changed in CLDSRV-650, causing the following crash:

```
2025-06-04T21:31:40.085589835Z stderr F 2025-06-04T21:31:40.085Z: uncaughtException:
2025-06-04T21:31:40.085602389Z stderr F TypeError: this.routeRequest is not a function
2025-06-04T21:31:40.085606166Z stderr F     at Server.internalRouteRequest (/usr/src/app/lib/server.js:112:21)
2025-06-04T21:31:40.085609332Z stderr F     at Server.emit (node:events:518:28)
2025-06-04T21:31:40.085612257Z stderr F     at Server.emit (node:domain:489:12)
2025-06-04T21:31:40.085628358Z stderr F     at parserOnIncoming (node:_http_server:1153:12)
2025-06-04T21:31:40.085630341Z stderr F     at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17)
```

Issue: CLDSRV-660
