### PR TITLE
CLDSRV-657: Fix kmip tests to use pykmip

### DIFF
--- a/.github/docker/docker-compose.yaml
+++ b/.github/docker/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     network_mode: "host"
     volumes:
       - /tmp/ssl:/ssl
-      - /tmp/ssl-kmip:/ssl-kmip
+      - /tmp/ssl-kmip:/tmp/ssl-kmip
       - ${HOME}/.aws/credentials:/root/.aws/credentials
       - /tmp/artifacts/${JOB_NAME}:/artifacts
     environment:
@@ -28,7 +28,7 @@ services:
       - S3KMS
       - S3KMIP_PORT
       - S3KMIP_HOSTS
-      - S3KMIP-COMPOUND_CREATE
+      - S3KMIP_COMPOUND_CREATE
       - S3KMIP_BUCKET_ATTRIBUTE_NAME
       - S3KMIP_PIPELINE_DEPTH
       - S3KMIP_KEY

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -325,6 +325,15 @@ jobs:
       CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}
       PYKMIP_IMAGE: ghcr.io/${{ github.repository }}/pykmip:${{ github.sha }}
       JOB_NAME: ${{ github.job }}
+      S3KMS: kmip
+      S3KMIP_PORT: 5696
+      S3KMIP_HOSTS: pykmip.local
+      S3KMIP_COMPOUND_CREATE: false
+      S3KMIP_BUCKET_ATTRIBUTE_NAME: ''
+      S3KMIP_PIPELINE_DEPTH: 8
+      S3KMIP_KEY: /tmp/ssl-kmip/kmip-client-key.pem
+      S3KMIP_CERT: /tmp/ssl-kmip/kmip-client-cert.pem
+      S3KMIP_CA: /tmp/ssl-kmip/kmip-ca.pem
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/config.json
+++ b/config.json
@@ -95,5 +95,8 @@
         "endpoint": "http://127.0.0.1:8080",
         "ak": "tbd",
         "sk": "tbd"
+    },
+    "kmip": {
+        "providerName": "thales"
     }
 }


### PR DESCRIPTION
kmip tests were not using pykmip but file kms...

Seems to be since migration from eve to GHA (Issue [CLDSRV-244](https://scality.atlassian.net/browse/CLDSRV-244))
where the kmip config via env was forgotten.

Lost here: https://github.com/scality/cloudserver/pull/4926/files#diff-b0a705e0cbace75695b5e1e57b39c3a73ba96df02fd969ce4c16fd0a9a05df0cL96-L113

I change the ssl-kmip mount in container to match the same
path on host and container for certs as we will reuse the
same config on host to run tests (sse migration)

[CLDSRV-244]: https://scality.atlassian.net/browse/CLDSRV-244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ