### PR TITLE
CLDSRV-667 build on dev branches for codecov results

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,6 @@ on:
 
   push:
     branches-ignore:
-      - 'development/**'
       - 'q/*/**'
 
 env:


### PR DESCRIPTION
The lack of build on the `development/*` branches impacts codecov ability in providing an actual meaningful view of both our code coverage and some of the test results that are currently being uploaded.
