### PR TITLE
CLDSRV-671: deactivate dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
----
-version: 2
-updates:
-  - package-ecosystem: npm
-    directory: "/"
-    schedule:
-      interval: weekly
-      time: "13:00"
-    open-pull-requests-limit: 10


### PR DESCRIPTION
As decided, deactivating dependabot until we make the necessary changes to be able to merge the PR made by the bot.