### PR TITLE
CLDSRV-672: restore GHAS with proper actions trigger

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -3,9 +3,9 @@ name: codeQL
 
 on:
   push:
-    branches: [w/**, q/*]
+    branches: [development/*, hotfix/*]
   pull_request:
-    branches: [development/*, stabilization/*, hotfix/*]
+    branches: [development/*, hotfix/*]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Latest modification on the GitHub actions trigger stopped making the static security analysis made by codeql available on the [security page](https://github.com/scality/cloudserver/security/code-scanning).

This PR aims to restore it.

Also removing the trigger on stabilization branch since there's none on cloudserver, and there's no big use on the other branches as well, but they can arguably be added back if needed.