### PR TITLE
Fix Ceph tests failing due to dependency issues

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -581,10 +581,10 @@ jobs:
       uses: ./.github/actions/setup-ci
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.5.9'
+        ruby-version: '3.2'
     - name: Install Ruby dependencies
       run: |
-        gem install nokogiri:1.12.5 excon:0.109.0 fog-aws:1.3.0 json:2.7.6 mime-types:3.1 rspec:3.5
+        gem install nokogiri:1.15.5 excon:0.111.0 fog-aws:3.19.0 json:2.7.6 mime-types:3.5.2 rspec:3.12.0
     - name: Install Java dependencies
       run: |
         sudo apt-get update && sudo apt-get install -y --fix-missing default-jdk maven


### PR DESCRIPTION
- Upgrade Ruby from 2.5.9 to 3.2 in ceph-backend-test job
- Update gem versions for Ruby 3.2 compatibility:
  - nokogiri: 1.12.5 → 1.15.5
  - excon: 0.109.0 → 0.111.0
  - fog-aws: 1.3.0 → 3.19.0
  - mime-types: 3.1 → 3.5.2
  - rspec: 3.5 → 3.12.0
- Fixes "Proc object without a block" and numbered parameter syntax errors
- Resolves multi_json dependency conflicts with modern Ruby versions

Issue: CLDSRV-715