### PR TITLE
CLDSRV-718: fix debian apt-get urls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ COPY ./package.json yarn.lock ./
 ENV PYTHON=python3.9
 ENV PY_VERSION=3.9.7
 
+RUN sed -i 's|deb.debian.org/debian|archive.debian.org/debian|g' /etc/apt/sources.list && \
+    sed -i 's|security.debian.org/debian-security|archive.debian.org/debian-security|g' /etc/apt/sources.list
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     jq \


### PR DESCRIPTION
fix `apt-get` broken urls observed here https://github.com/scality/cloudserver/actions/runs/16341465257?pr=5855