### PR TITLE
CLDSRV-717: Fix & drop config root redis for utapi

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -120,15 +120,15 @@ if [[ "$REDIS_PORT" ]] && [[ ! "$REDIS_SENTINELS" ]]; then
 fi
 
 if [[ "$REDIS_SENTINELS" ]]; then
-    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .redis.name=\"$REDIS_HA_NAME\""
-    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .redis.sentinels=\"$REDIS_SENTINELS\""
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .utapi.redis.name=\"$REDIS_HA_NAME\""
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .utapi.redis.sentinels=\"$REDIS_SENTINELS\""
 elif [[ "$REDIS_HA_HOST" ]]; then
-    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .redis.host=\"$REDIS_HA_HOST\""
-    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .redis.port=6379"
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .utapi.redis.host=\"$REDIS_HA_HOST\""
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .utapi.redis.port=6379"
 fi
 
 if [[ "$REDIS_HA_PORT" ]] && [[ ! "$REDIS_SENTINELS" ]]; then
-    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .redis.port=$REDIS_HA_PORT"
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .utapi.redis.port=$REDIS_HA_PORT"
 fi
 
 if [[ "$RECORDLOG_ENABLED" ]]; then

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1298,7 +1298,10 @@ class Config extends EventEmitter {
         }
 
         if (config.redis) {
-            this.redis = parseRedisConfig(config.redis);
+            // Fail fast to make sure we detect any bad config
+            throw new Error(
+                'config.redis is not supported anymore: it should be config.utapi.redis or config.localCache'
+            );
         }
         if (config.scuba) {
             this.scuba = {};

--- a/lib/utapi/utapi.js
+++ b/lib/utapi/utapi.js
@@ -4,8 +4,7 @@ const { utapiVersion, UtapiServer: utapiServer } = require('utapi');
 
 // start utapi server
 if (utapiVersion === 1 && _config.utapi) {
-    const fullConfig = Object.assign({}, _config.utapi,
-        { redis: _config.redis });
+    const fullConfig = Object.assign({}, _config.utapi);
     if (_config.vaultd) {
         Object.assign(fullConfig, { vaultd: _config.vaultd });
     }

--- a/lib/utapi/utapiReplay.js
+++ b/lib/utapi/utapiReplay.js
@@ -2,7 +2,6 @@ require('werelogs').stderrUtils.catchAndTimestampStderr();
 const UtapiReplay = require('utapi').UtapiReplay;
 const _config = require('../Config').config;
 
-const utapiConfig = _config.utapi &&
-    Object.assign({}, _config.utapi, { redis: _config.redis });
+const utapiConfig = _config.utapi && Object.assign({}, _config.utapi);
 const replay = new UtapiReplay(utapiConfig); // start utapi server
 replay.start();

--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -10,11 +10,7 @@ const { suppressedUtapiEventFields: suppressedEventFields } = require('../../con
 let utapiConfig;
 
 if (utapiVersion === 1 && _config.utapi) {
-    if (_config.utapi.redis === undefined) {
-        utapiConfig = Object.assign({}, _config.utapi, { redis: _config.redis });
-    } else {
-        utapiConfig = Object.assign({}, _config.utapi);
-    }
+    utapiConfig = Object.assign({}, _config.utapi);
 } else if (utapiVersion === 2) {
     utapiConfig = Object.assign({
         tls: _config.https,

--- a/tests/unit/Config.js
+++ b/tests/unit/Config.js
@@ -629,10 +629,6 @@ describe('Config', () => {
             const config = new ConfigObject();
 
             assert.deepStrictEqual(
-                config.redis,
-                { name: 'zenko', sentinels: [{ host: 'localhost', port: 6379 }] },
-            );
-            assert.deepStrictEqual(
                 config.utapi.redis,
                 {
                     host: 'localhost',

--- a/tests/unit/testConfigs/allOptsConfig/config.json
+++ b/tests/unit/testConfigs/allOptsConfig/config.json
@@ -96,10 +96,6 @@
         "name": "zenko",
         "sentinels": "localhost:6379"
     },
-    "redis": {
-        "name": "zenko",
-        "sentinels": "localhost:6379"
-    },
     "scuba": {
         "host": "localhost",
         "port": 8100


### PR DESCRIPTION
Currently, root redis is not defined neither by zenko or s3c. This breaks utapi replay with overrided redis config.

There has been multiple tickets S3C-1399 ZENKO-345 ZENKO-1051 ZENKO-3294

In the end root redis is not used and utapi should use utapi.redis and cloudserver uses localCache.