### PR TITLE
Ensure signals are propagated to all nodejs processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,6 @@ COPY --from=builder /usr/src/app/node_modules ./node_modules/
 
 VOLUME ["/usr/src/app/localData","/usr/src/app/localMetadata"]
 
-ENTRYPOINT ["tini", "--", "/usr/src/app/docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "-g", "--", "/usr/src/app/docker-entrypoint.sh"]
 
 CMD [ "yarn", "start" ]


### PR DESCRIPTION
Pass the `-g` flag to tini, so that when a signal is received (typically
from k8s' pod lifecycle management) it gets propagated to all node.js
processes that were spawned.

This behavior is similar to Ctrl+C in a terminal:

> In macOS, as in other Unix-like operating systems (like Linux and BSD),
> when you press Ctrl+C in your terminal, the terminal driver sends the
> SIGINT (Signal Interrupt) signal to the entire foreground process group,
> not just the single process you might see running.

Issue: CLDSRV-727
