### PR TITLE
Evaluate policies in Backbeat routes

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -81,7 +81,68 @@ const monitoringMap = policies.actionMaps.actionMonitoringMapS3;
 
 auth.setHandler(vault);
 
+function checkAuthResults(authResults, apiMethod, log) {
+    let returnTagCount = true;
+    const isImplicitDeny = {};
+    let isOnlyImplicitDeny = true;
+    if (apiMethod === 'objectGet') {
+        // first item checks s3:GetObject(Version) action
+        if (!authResults[0].isAllowed && !authResults[0].isImplicit) {
+            log.trace('get object authorization denial from Vault');
+            return errors.AccessDenied;
+        }
+        isImplicitDeny[authResults[0].action] = authResults[0].isImplicit;
+        // second item checks s3:GetObject(Version)Tagging action
+        if (!authResults[1].isAllowed) {
+            log.trace('get tagging authorization denial ' +
+            'from Vault');
+            returnTagCount = false;
+        }
+    } else {
+        for (let i = 0; i < authResults.length; i++) {
+            isImplicitDeny[authResults[i].action] = true;
+            if (!authResults[i].isAllowed && !authResults[i].isImplicit) {
+                // Any explicit deny rejects the current API call
+                log.trace('authorization denial from Vault');
+                return errors.AccessDenied;
+            }
+            if (authResults[i].isAllowed) {
+                // If the action is allowed, the result is not implicit
+                // Deny.
+                isImplicitDeny[authResults[i].action] = false;
+                isOnlyImplicitDeny = false;
+            }
+        }
+    }
+    // These two APIs cannot use ACLs or Bucket Policies, hence, any
+    // implicit deny from vault must be treated as an explicit deny.
+    if ((apiMethod === 'bucketPut' || apiMethod === 'serviceGet') && isOnlyImplicitDeny) {
+        return errors.AccessDenied;
+    }
+    return { returnTagCount, isImplicitDeny };
+}
+
 /* eslint-disable no-param-reassign */
+function handleAuthorizationResults(request, authorizationResults, apiMethod, returnTagCount, log, callback) {
+    if (authorizationResults) {
+        const checkedResults = checkAuthResults(authorizationResults, apiMethod, log);
+        if (checkedResults instanceof Error) {
+            return callback(checkedResults);
+        }
+        returnTagCount = checkedResults.returnTagCount;
+        request.actionImplicitDenies = checkedResults.isImplicitDeny;
+    } else {
+        // create an object of keys apiMethods with all values to false:
+        // for backward compatibility, all apiMethods are allowed by default
+        // thus it is explicitly allowed, so implicit deny is false
+        request.actionImplicitDenies = request.apiMethods.reduce((acc, curr) => {
+            acc[curr] = false;
+            return acc;
+        }, {});
+    }
+    return callback(null, { returnTagCount });
+}
+
 const api = {
     callApiMethod(apiMethod, request, response, log, callback) {
         // Attach the apiMethod method to the request, so it can used by monitoring in the server
@@ -151,47 +212,6 @@ const api = {
         const apiMethods = requestContexts ? requestContexts.map(context => context._apiMethod) : [];
         // Attach the names to the current request
         request.apiMethods = apiMethods;
-
-        function checkAuthResults(authResults) {
-            let returnTagCount = true;
-            const isImplicitDeny = {};
-            let isOnlyImplicitDeny = true;
-            if (apiMethod === 'objectGet') {
-                // first item checks s3:GetObject(Version) action
-                if (!authResults[0].isAllowed && !authResults[0].isImplicit) {
-                    log.trace('get object authorization denial from Vault');
-                    return errors.AccessDenied;
-                }
-                isImplicitDeny[authResults[0].action] = authResults[0].isImplicit;
-                // second item checks s3:GetObject(Version)Tagging action
-                if (!authResults[1].isAllowed) {
-                    log.trace('get tagging authorization denial ' +
-                    'from Vault');
-                    returnTagCount = false;
-                }
-            } else {
-                for (let i = 0; i < authResults.length; i++) {
-                    isImplicitDeny[authResults[i].action] = true;
-                    if (!authResults[i].isAllowed && !authResults[i].isImplicit) {
-                        // Any explicit deny rejects the current API call
-                        log.trace('authorization denial from Vault');
-                        return errors.AccessDenied;
-                    }
-                    if (authResults[i].isAllowed) {
-                        // If the action is allowed, the result is not implicit
-                        // Deny.
-                        isImplicitDeny[authResults[i].action] = false;
-                        isOnlyImplicitDeny = false;
-                    }
-                }
-            }
-            // These two APIs cannot use ACLs or Bucket Policies, hence, any
-            // implicit deny from vault must be treated as an explicit deny.
-            if ((apiMethod === 'bucketPut' || apiMethod === 'serviceGet') && isOnlyImplicitDeny) {
-                return errors.AccessDenied;
-            }
-            return { returnTagCount, isImplicitDeny };
-        }
 
         return async.waterfall([
             next => auth.server.doAuth(
@@ -267,26 +287,18 @@ const api = {
                     return next(null, userInfo, authResultsWithTags, streamingV4Params, infos);
                 },
             ),
-        ], (err, userInfo, authorizationResults, streamingV4Params, infos) => {
+            (userInfo, authorizationResults, streamingV4Params, infos, next) => handleAuthorizationResults(
+                request, authorizationResults, apiMethod, returnTagCount, log, (err, res) => {
+                    request.accountQuotas = infos?.accountQuota;
+                    if (err) {
+                        return next(err);
+                    }
+                    returnTagCount = res.returnTagCount;
+                    return next(null, userInfo, authorizationResults, streamingV4Params);
+                }),
+        ], (err, userInfo, authorizationResults, streamingV4Params) => {
             if (err) {
                 return callback(err);
-            }
-            request.accountQuotas = infos?.accountQuota;
-            if (authorizationResults) {
-                const checkedResults = checkAuthResults(authorizationResults);
-                if (checkedResults instanceof Error) {
-                    return callback(checkedResults);
-                }
-                returnTagCount = checkedResults.returnTagCount;
-                request.actionImplicitDenies = checkedResults.isImplicitDeny;
-            } else {
-                // create an object of keys apiMethods with all values to false:
-                // for backward compatibility, all apiMethods are allowed by default
-                // thus it is explicitly allowed, so implicit deny is false
-                request.actionImplicitDenies = apiMethods.reduce((acc, curr) => {
-                    acc[curr] = false;
-                    return acc;
-                }, {});
             }
             const methodCallback = (err, ...results) => async.forEachLimit(request.finalizerHooks, 5,
                     (hook, done) => hook(err, done),
@@ -375,6 +387,8 @@ const api = {
     serviceGet,
     websiteGet: website,
     websiteHead: website,
+    checkAuthResults,
+    handleAuthorizationResults,
 };
 
 module.exports = api;

--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -1684,4 +1684,7 @@ function routeBackbeat(clientIP, request, response, log) {
 }
 
 
-module.exports = routeBackbeat;
+module.exports = {
+    backbeatRoutes,
+    routeBackbeat,
+};

--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -39,6 +39,7 @@ const { listLifecycleNonCurrents } = require('../api/backbeat/listLifecycleNonCu
 const { listLifecycleOrphanDeleteMarkers } = require('../api/backbeat/listLifecycleOrphanDeleteMarkers');
 const { objectDeleteInternal } = require('../api/objectDelete');
 const quotaUtils = require('../api/apiUtils/quotas/quotaUtils');
+const { handleAuthorizationResults } = require('../api/api');
 
 const { CURRENT_TYPE, NON_CURRENT_TYPE, ORPHAN_DM_TYPE } = constants.lifecycleListing;
 
@@ -1412,32 +1413,27 @@ const indexEntrySchema = joi.object({
 
 const indexingSchema = joi.array().items(indexEntrySchema).min(1);
 
-function routeIndexingAPIs(request, response, userInfo, log) {
+function routeIndexingAPIs(request, response, userInfo, log, callback) {
     const route = backbeatRoutes[request.method][request.resourceType];
 
     if (!['GET', 'POST'].includes(request.method)) {
-        return responseJSONBody(errors.MethodNotAllowed, null, response, log);
+        return callback(errors.MethodNotAllowed);
     }
 
     if (request.method === 'GET') {
-        return route(request, response, userInfo, log, err => {
-            if (err) {
-                return responseJSONBody(err, null, response, log);
-            }
-            return undefined;
-        });
+        return route(request, response, userInfo, log, callback);
     }
 
     const op = request.query.operation;
 
     if (!op || typeof route[op] !== 'function') {
-        log.error('Invalid operataion parameter', { operation: op });
-        return responseJSONBody(errors.BadRequest, null, response, log);
+        log.error('Invalid operation parameter', { operation: op });
+        return callback(errors.BadRequest);
     }
 
     return _getRequestPayload(request, (err, payload) => {
         if (err) {
-            return responseJSONBody(err, null, response, log);
+            return callback(err);
         }
 
         let parsedIndex;
@@ -1446,18 +1442,71 @@ function routeIndexingAPIs(request, response, userInfo, log) {
             parsedIndex = joi.attempt(JSON.parse(payload), indexingSchema, 'invalid payload');
         } catch (err) {
             log.error('Unable to parse index request body', { error: err });
-            return responseJSONBody(errors.BadRequest, null, response, log);
+            return callback(errors.BadRequest);
         }
 
-        return route[op](parsedIndex, request, response, userInfo, log, err => {
-            if (err) {
-                return responseJSONBody(err, null, response, log);
-            }
-            return undefined;
-        });
+        return route[op](parsedIndex, request, response, userInfo, log, callback);
     });
 }
 
+function routeBackbeatAPIProxy(request, response, requestContexts, log) {
+    const path = request.url.replace('/_/backbeat/api', '/_/');
+    const { host, port } = config.backbeat;
+    const target = `http://${host}:${port}${path}`;
+
+    auth.server.doAuth(request, log, (err, userInfo, authorizationResults, streamingV4Params, infos) => {
+        if (err) {
+            log.debug('authentication error', {
+                error: err,
+                method: request.method,
+                bucketName: request.bucketName,
+                objectKey: request.objectKey,
+            });
+            return responseJSONBody(err, null, response, log);
+        }
+        // We don't use the authorization results for now
+        // as the UI uses the external Cloudserver instance
+        // as a proxy to access the Backbeat API service.
+
+        // eslint-disable-next-line no-param-reassign
+        request.accountQuotas = infos?.accountQuota;
+        // FIXME for now, any authenticated user can access API
+        // routes. We should introduce admin accounts or accounts
+        // with admin privileges, and restrict access to those
+        // only.
+        if (userInfo.getCanonicalID() === constants.publicId) {
+            log.debug('unauthenticated access to API routes', {
+                method: request.method,
+                bucketName: request.bucketName,
+                objectKey: request.objectKey,
+            });
+            return responseJSONBody(errors.AccessDenied, null, response, log);
+        }
+        return backbeatProxy.web(request, response, { target }, err => {
+            log.error('error proxying request to api server',
+                { error: err.message });
+            return responseJSONBody(errors.ServiceUnavailable, null, response, log);
+        });
+    }, 's3', requestContexts);
+}
+
+function routeNonObjectRequest(request, response, userInfo, log, callback) {
+    if (userInfo.getCanonicalID() === constants.publicId) {
+        log.debug(`unauthenticated access to backbeat ${request.resourceType} routes`, {
+            method: request.method,
+            bucketName: request.bucketName,
+            objectKey: request.objectKey,
+        });
+        return callback(errors.AccessDenied);
+    }
+
+    if (request.resourceType === 'index') {
+        return routeIndexingAPIs(request, response, userInfo, log, callback);
+    }
+
+    const route = backbeatRoutes[request.method][request.resourceType];
+    return route(request, response, userInfo, log, callback);
+}
 
 function routeBackbeat(clientIP, request, response, log) {
     // Attach the apiMethod method to the request, so it can used by monitoring in the server
@@ -1495,47 +1544,21 @@ function routeBackbeat(clientIP, request, response, log) {
     // eslint-disable-next-line no-param-reassign
     request.finalizerHooks = [];
 
+    // Extract all the _apiMethods and store them in an array
+    const apiMethods = requestContexts ? requestContexts.map(context => context._apiMethod) : [];
+    // Attach the names to the current request
+    // eslint-disable-next-line no-param-reassign
+    request.apiMethods = apiMethods;
+
     // proxy api requests to Backbeat API server
     if (request.resourceType === 'api') {
         if (!config.backbeat) {
             log.debug('unable to proxy backbeat api request', {
                 backbeatConfig: config.backbeat,
             });
-            return responseJSONBody(errors.MethodNotAllowed, null, response,
-                log);
+            return responseJSONBody(errors.MethodNotAllowed, null, response, log);
         }
-        const path = request.url.replace('/_/backbeat/api', '/_/');
-        const { host, port } = config.backbeat;
-        const target = `http://${host}:${port}${path}`;
-
-        // TODO CLDSRV-591: shall we use the authorization results here?
-        return auth.server.doAuth(request, log, (err, userInfo, authorizationResults, streamingV4Params, infos) => {
-            if (err) {
-                log.debug('authentication error', {
-                    error: err,
-                });
-                return responseJSONBody(err, null, response, log);
-            }
-            // eslint-disable-next-line no-param-reassign
-            request.accountQuotas = infos?.accountQuota;
-            // FIXME for now, any authenticated user can access API
-            // routes. We should introduce admin accounts or accounts
-            // with admin privileges, and restrict access to those
-            // only.
-            if (userInfo.getCanonicalID() === constants.publicId) {
-                log.debug('unauthenticated access to API routes', {
-                    method: request.method,
-                });
-                return responseJSONBody(
-                    errors.AccessDenied, null, response, log);
-            }
-            return backbeatProxy.web(request, response, { target }, err => {
-                log.error('error proxying request to api server',
-                          { error: err.message });
-                return responseJSONBody(errors.ServiceUnavailable, null,
-                                        response, log);
-            });
-        }, 's3', requestContexts);
+        return routeBackbeatAPIProxy(request, response, requestContexts, log);
     }
 
     const useMultipleBackend =
@@ -1557,52 +1580,54 @@ function routeBackbeat(clientIP, request, response, log) {
         return responseJSONBody(errors.MethodNotAllowed, null, response, log);
     }
 
-    return async.waterfall([next => auth.server.doAuth(
-        // TODO CLDSRV-591: shall we use the authorization results here?
-        request, log, (err, userInfo, authorizationResults, streamingV4Params, infos) => {
-            if (err) {
-                log.debug('authentication error', {
-                    error: err,
-                });
+    const isObjectRequest = _isObjectRequest(request);
+
+    return async.waterfall([
+        next => auth.server.doAuth(
+            request, log, (err, userInfo, authorizationResults, streamingV4Params, infos) => {
+                if (err) {
+                    log.debug('authentication error', {
+                        error: err,
+                        bucketName: request.bucketName,
+                        objectKey: request.objectKey,
+                    });
+                }
+                // eslint-disable-next-line no-param-reassign
+                request.accountQuotas = infos?.accountQuota;
+                return next(err, userInfo, authorizationResults);
+            }, 's3', requestContexts),
+        (userInfo, authorizationResults, next) => {
+            // Using the same flag used to bypass user bucket policies
+            // for internal mode, so that we can bypass policy evaluation
+            // on backbeat routes. This ensures we don't break operations
+            // coming from internal services like backbeat
+            if (request.bypassUserBucketPolicies) {
+                return next(null, userInfo);
             }
-            // eslint-disable-next-line no-param-reassign
-            request.accountQuotas = infos?.accountQuota;
-            return next(err, userInfo);
-        }, 's3', requestContexts),
+            return handleAuthorizationResults(
+                request, authorizationResults, apiMethods[0], undefined, log, err => next(err, userInfo));
+        },
         (userInfo, next) => {
             // TODO: understand why non-object requests (batchdelete) were not authenticated
-            if (!_isObjectRequest(request)) {
-                if (userInfo.getCanonicalID() === constants.publicId) {
-                    log.debug(`unauthenticated access to backbeat ${request.resourceType} routes`);
-                    return responseJSONBody(
-                        errors.AccessDenied, null, response, log);
-                }
-
-                if (request.resourceType === 'index') {
-                    return routeIndexingAPIs(request, response, userInfo, log);
-                }
-
-                const route = backbeatRoutes[request.method][request.resourceType];
-                return route(request, response, userInfo, log, err => {
-                    if (err) {
-                        return responseJSONBody(err, null, response, log);
-                    }
-                    return undefined;
-                });
+            if (!isObjectRequest) {
+                return routeNonObjectRequest(request, response, userInfo, log, next);
             }
-
             const decodedVidResult = decodeVersionId(request.query);
             if (decodedVidResult instanceof Error) {
                 log.trace('invalid versionId query', {
                     versionId: request.query.versionId,
                     error: decodedVidResult,
                 });
-                return responseJSONBody(errors.InvalidArgument, null, response, log);
+                return next(errors.InvalidArgument);
             }
             const versionId = decodedVidResult;
             if (useMultipleBackend) {
-                // Bucket and object do not exist in metadata.
-                return next(null, null, null);
+                if (request.resourceType === 'multiplebackendmetadata') {
+                    return backbeatRoutes[request.method][request.resourceType](
+                        request, response, log, next);
+                }
+                return backbeatRoutes[request.method][request.resourceType]
+                    [request.query.operation](request, response, log, next);
             }
             const mdValParams = {
                 bucketName: request.bucketName,
@@ -1612,46 +1637,50 @@ function routeBackbeat(clientIP, request, response, log) {
                 requestType: request.apiMethods || 'ReplicateObject',
                 request,
             };
-            return standardMetadataValidateBucketAndObj(mdValParams, request.actionImplicitDenies, log, next);
-        },
-        (bucketInfo, objMd, next) => {
-            if (!useMultipleBackend) {
-                const versioningConfig = bucketInfo.getVersioningConfiguration();
-                // The following makes sure that only replication destination-related operations
-                // target buckets with versioning enabled.
-                const isVersioningRequired = request.headers['x-scal-versioning-required'] === 'true';
-                if (isVersioningRequired && (!versioningConfig || versioningConfig.Status !== 'Enabled')) {
-                    log.debug('bucket versioning is not enabled');
-                    return next(errors.InvalidBucketState);
-                }
-                return backbeatRoutes[request.method][request.resourceType](
-                    request, response, bucketInfo, objMd, log, next);
-            }
-            if (request.resourceType === 'multiplebackendmetadata') {
-                return backbeatRoutes[request.method][request.resourceType](
-                    request, response, log, next);
-            }
-            return backbeatRoutes[request.method][request.resourceType]
-                [request.query.operation](request, response, log, next);
+            return standardMetadataValidateBucketAndObj(mdValParams, request.actionImplicitDenies, log,
+                (err, bucketInfo, objMd) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    const versioningConfig = bucketInfo.getVersioningConfiguration();
+                    // The following makes sure that only replication destination-related operations
+                    // target buckets with versioning enabled.
+                    const isVersioningRequired = request.headers['x-scal-versioning-required'] === 'true';
+                    if (isVersioningRequired && (!versioningConfig || versioningConfig.Status !== 'Enabled')) {
+                        log.debug('bucket versioning is not enabled');
+                        return next(errors.InvalidBucketState);
+                    }
+                    return backbeatRoutes[request.method][request.resourceType](
+                        request, response, bucketInfo, objMd, log, next);
+                });
         }],
-        err => async.forEachLimit(
-            // Finalizer hooks are used in a quota context and ensure consistent
-            // metrics in case of API errors. No operation required if the API
-            // completed successfully.
-            request.finalizerHooks,
-            5,
-            (hook, done) => hook(err, done),
-            () => {
-                if (err) {
-                    log.error('error processing backbeat request', {
-                        error: err,
+        err => {
+            async.forEachLimit(
+                // Finalizer hooks are used in a quota context and ensure consistent
+                // metrics in case of API errors. No operation required if the API
+                // completed successfully.
+                request.finalizerHooks,
+                5,
+                (hook, done) => hook(err, done),
+                () => {
+                    if (err) {
+                        log.error('error processing backbeat request', {
+                            error: err,
+                            method: request.method,
+                            bucketName: request.bucketName,
+                            objectKey: request.objectKey,
+                        });
+                        return responseJSONBody(err, null, response, log);
+                    }
+                    log.debug('backbeat route response sent successfully', {
+                        method: request.method,
+                        bucketName: request.bucketName,
+                        objectKey: request.objectKey,
                     });
-                    return responseJSONBody(err, null, response, log);
-                }
-                log.debug('backbeat route response sent successfully');
-                return undefined;
-            },
-        ));
+                    return responseJSONBody(null, null, response, log);
+                },
+            );
+    });
 }
 
 

--- a/lib/utilities/internalHandlers.js
+++ b/lib/utilities/internalHandlers.js
@@ -1,4 +1,4 @@
-const routeBackbeat = require('../routes/routeBackbeat');
+const { routeBackbeat } = require('../routes/routeBackbeat');
 const routeMetadata = require('../routes/routeMetadata');
 const routeWorkflowEngineOperator =
       require('../routes/routeWorkflowEngineOperator');

--- a/tests/unit/DummyRequest.js
+++ b/tests/unit/DummyRequest.js
@@ -25,6 +25,12 @@ class DummyRequest extends http.IncomingMessage {
             this.push(msg);
         }
         this.push(null);
+        this.socket ??= {
+            remoteAddress: '127.0.0.1',
+            destroy: () => {},
+            on: () => {},
+            removeListener: () => {},
+        };
     }
 
     _destroy(err, cb) {

--- a/tests/unit/routes/routeBackbeat.js
+++ b/tests/unit/routes/routeBackbeat.js
@@ -1,15 +1,23 @@
 const assert = require('assert');
 const sinon = require('sinon');
+const async = require('async');
 const { promisify } = require('util');
 const metadataUtils = require('../../../lib/metadata/metadataUtils');
 const storeObject = require('../../../lib/api/apiUtils/object/storeObject');
 const metadata = require('../../../lib/metadata/wrapper');
-const { DummyRequestLogger } = require('../helpers');
+const { routeBackbeat } = require('../../../lib/routes/routeBackbeat');
+const { DummyRequestLogger, versioningTestUtils, makeAuthInfo } = require('../helpers');
 const dataWrapper = require('../../../lib/data/wrapper');
 const DummyRequest = require('../DummyRequest');
-const { auth } = require('arsenal');
+const { auth, errors } = require('arsenal');
+const AuthInfo = auth.AuthInfo;
 const { config } = require('../../../lib/Config');
 const quotaUtils = require('../../../lib/api/apiUtils/quotas/quotaUtils');
+const { bucketPut } = require('../../../lib/api/bucketPut');
+const bucketDelete = require('../../../lib/api/bucketDelete');
+const bucketPutVersioning = require('../../../lib/api/bucketPutVersioning');
+const objectPut = require('../../../lib/api/objectPut');
+const { objectDelete } = require('../../../lib/api/objectDelete');
 
 const log = new DummyRequestLogger();
 
@@ -67,7 +75,7 @@ describe('routeBackbeat', () => {
 
         // Clear require cache for routeBackbeat to make sure fresh module with stubbed dependencies
         delete require.cache[require.resolve('../../../lib/routes/routeBackbeat')];
-        routeBackbeat = require('../../../lib/routes/routeBackbeat');
+        routeBackbeat = require('../../../lib/routes/routeBackbeat').routeBackbeat;
     });
 
     afterEach(() => {
@@ -692,5 +700,340 @@ describe('routeBackbeat', () => {
         assert.strictEqual(mockResponse.statusCode, 200);
         assert.deepStrictEqual(mockResponse.body, null);
     });
+    });
+});
+
+describe('routeBackbeat authorization', () => {
+    let endPromise;
+    let resolveEnd;
+    const bucketName = 'bucketname';
+    const authInfo = makeAuthInfo('cannonicalID',);
+    const namespace = 'default';
+    const objectName = 'objectName';
+
+    const testBucket = {
+        bucketName,
+        namespace,
+        headers: {
+            'host': `${bucketName}.s3.amazonaws.com`,
+        },
+        url: `/${bucketName}`,
+        actionImplicitDenies: false,
+    };
+
+    const testObject = new DummyRequest({
+        bucketName,
+        namespace,
+        objectKey: objectName,
+        headers: {
+            'x-amz-meta-test': 'some metadata',
+            'content-length': '12',
+        },
+        parsedContentLength: 12,
+        url: `/${bucketName}/${objectName}`,
+    }, Buffer.from('I am a body', 'utf8'));
+
+    let request;
+    let response;
+
+    beforeEach(() => {
+        // create a Promise that resolves when response.end is called
+        endPromise = new Promise(resolve => { resolveEnd = resolve; });
+
+        request = new DummyRequest(
+            {
+                method: 'GET',
+                headers: { 'content-length': '123' },
+                url: '/_/backbeat/multiplebackendmetadata/bucketName/objectKey?operation=putobject',
+            },
+            'body'
+        );
+        response = {
+            setHeader: sinon.stub(),
+            writeHead: sinon.stub(),
+            end: sinon.stub().callsFake((body, encoding, callback) => {
+                resolveEnd();
+                callback();
+            })
+        };
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('should reject if the request is invalid', done => {
+        request.url = '/_/backbeat//bucketName/objectKey?operation=putobject';
+        response.end.callsFake((body, format, cb) => {
+            const err = JSON.parse(response.end.getCall(0).args[0]);
+            assert.strictEqual(err.code, 'MethodNotAllowed');
+            cb();
+            return done();
+        });
+        // Cover the case invalidRequest === true
+        routeBackbeat('127.0.0.1', request, response, log);
+    });
+
+    it('should reject if the route is invalid', done => {
+        request.url = '/_/backbeat/wrong/bucketName/objectKey?operation=putobject';
+        response.end.callsFake((body, format, cb) => {
+            const err = JSON.parse(response.end.getCall(0).args[0]);
+            assert.strictEqual(err.code, 'MethodNotAllowed');
+            cb();
+            return done();
+        });
+        // Cover the case invalidRoute === true
+        routeBackbeat('127.0.0.1', request, response, log);
+    });
+
+    [
+        {
+            method: 'PUT',
+            resourceType: 'metadata',
+            target: `${bucketName}/${objectName}`,
+            operation: null,
+            versionId: false,
+            expect: errors.MalformedPOSTRequest,
+        },
+        {
+            method: 'GET',
+            resourceType: 'metadata',
+            target: `${bucketName}/${objectName}`,
+            operation: null,
+            versionId: true,
+        },
+        {
+            method: 'PUT',
+            resourceType: 'data',
+            target: `${bucketName}/${objectName}`,
+            operation: null,
+            versionId: false,
+            expect: errors.BadRequest,
+        },
+        {
+            method: 'PUT',
+            resourceType: 'multiplebackenddata',
+            target: `${bucketName}/${objectName}`,
+            operation: 'putobject',
+            versionId: false,
+            expect: errors.BadRequest,
+        },
+        {
+            method: 'PUT',
+            resourceType: 'multiplebackenddata',
+            target: `${bucketName}/${objectName}`,
+            operation: 'putpart',
+            versionId: false,
+            expect: errors.BadRequest,
+        },
+        {
+            method: 'DELETE',
+            resourceType: 'multiplebackenddata',
+            target: `${bucketName}/${objectName}`,
+            operation: 'deleteobject',
+            versionId: false,
+            expect: errors.BadRequest,
+        },
+        {
+            method: 'DELETE',
+            resourceType: 'multiplebackenddata',
+            target: `${bucketName}/${objectName}`,
+            operation: 'abortmpu',
+            versionId: false,
+            expect: errors.BadRequest,
+        },
+        {
+            method: 'DELETE',
+            resourceType: 'multiplebackenddata',
+            target: `${bucketName}/${objectName}`,
+            operation: 'deleteobjecttagging',
+            versionId: false,
+            expect: errors.BadRequest,
+        },
+        {
+            method: 'POST',
+            resourceType: 'multiplebackenddata',
+            target: `${bucketName}/${objectName}`,
+            operation: 'initiatempu',
+            versionId: false,
+            expect: errors.BadRequest,
+        },
+        {
+            method: 'POST',
+            resourceType: 'multiplebackenddata',
+            target: `${bucketName}/${objectName}`,
+            operation: 'completempu',
+            versionId: false,
+            expect: errors.BadRequest,
+        },
+        {
+            method: 'POST',
+            resourceType: 'multiplebackenddata',
+            target: `${bucketName}/${objectName}`,
+            operation: 'puttagging',
+            versionId: false,
+            expect: errors.BadRequest,
+        },
+        {
+            method: 'GET',
+            resourceType: 'multiplebackendmetadata',
+            target: `${bucketName}/${objectName}`,
+            operation: null,
+            versionId: false,
+            expect: errors.BadRequest,
+        },
+        {
+            method: 'POST',
+            resourceType: 'batchdelete',
+            target: null,
+            operation: null,
+            versionId: false,
+            expect: errors.MalformedPOSTRequest,
+        },
+        {
+            method: 'GET',
+            resourceType: 'lifecycle',
+            target: `${bucketName}?list-type=wrong`,
+            operation: null,
+            versionId: false,
+            expect: errors.BadRequest,
+        },
+        {
+            method: 'POST',
+            resourceType: 'index',
+            target: bucketName,
+            operation: 'add',
+            versionId: false,
+            expect: errors.BadRequest,
+        },
+        {
+            method: 'POST',
+            resourceType: 'index',
+            target: bucketName,
+            operation: 'delete',
+            versionId: false,
+            expect: errors.BadRequest,
+        },
+        {
+            method: 'GET',
+            resourceType: 'index',
+            target: null,
+            operation: 'delete',
+            versionId: false,
+            expect: errors.NotImplemented,
+        }
+    ].forEach(testCase => {
+        describe(`${testCase.method} ${testCase.resourceType}`, () => {
+            let versionIdParsed = null;
+            let hasQuery = false;
+
+            beforeEach(done => {
+                hasQuery = false;
+                versionIdParsed = null;
+                request.method = testCase.method;
+                request.url = `/_/backbeat/${testCase.resourceType}/${testCase.target}`;
+                if (testCase.operation) {
+                    request.url += `?operation=${testCase.operation}`;
+                    hasQuery = true;
+                }
+
+                const enableVersioningRequest =
+                    versioningTestUtils.createBucketPutVersioningReq(bucketName, 'Enabled');
+
+                return async.series([
+                    next => bucketPut(authInfo, testBucket, log, next),
+                    next => bucketPutVersioning(authInfo, enableVersioningRequest, log, next),
+                    next => objectPut(authInfo, testObject, undefined, log, (err, res) => {
+                        if (!err && res) {
+                            versionIdParsed = res['x-amz-version-id'];
+                            if (testCase.versionId) {
+                                request.url += `${(hasQuery ? '&' : '?')}&versionId=${versionIdParsed}`;
+                            }
+                        }
+                        next(err);
+                    }),
+                ], done);
+            });
+
+            afterEach(done => {
+                async.series([
+                    next => {
+                        const deleteRequest = {
+                            bucketName,
+                            objectKey: objectName,
+                            headers: {},
+                            query: versionIdParsed ? { versionId: versionIdParsed } : {},
+                        };
+                        objectDelete(authInfo, deleteRequest, log, next);
+                    },
+                    next => {
+                        bucketDelete(authInfo, testBucket, log, next);
+                    }
+                ], done);
+            });
+
+            it('should call method successfully', async () => {
+                // Mock auth server to ignore auth in this test
+                sinon.stub(auth.server, 'doAuth').yields(null, new AuthInfo({
+                    canonicalID: 'abcdef/lifecycle',
+                    accountDisplayName: 'Lifecycle Service Account',
+                }), undefined, undefined, {
+                    accountQuota: 1000,
+                });
+
+                routeBackbeat('127.0.0.1', request, response, log);
+
+                void await endPromise;
+
+                if (testCase.expect) {
+                    const errCode = response.writeHead.getCall(0).args[0];
+                    assert.strictEqual(errCode, testCase.expect.code);
+                }
+                assert.strictEqual(Array.isArray(request.finalizerHooks), true);
+                assert.strictEqual(request.apiMethods[0], 'objectReplicate');
+                assert.strictEqual(request.apiMethods.length, 1);
+                assert.strictEqual(request.accountQuotas, 1000);
+            });
+
+            it('should return access denied user is not authorized', async () => {
+                sinon.stub(auth.server, 'doAuth').yields(null, new AuthInfo({
+                    canonicalID: '123456789',
+                    accountDisplayName: 'user1',
+                }), [{
+                    isAllowed: false,
+                    implicitDeny: true,
+                    action: 'objectReplicate',
+                }], undefined, undefined);
+
+                routeBackbeat('127.0.0.1', request, response, log);
+
+                void await endPromise;
+
+                const err = JSON.parse(response.end.getCall(0).args[0]);
+                assert.strictEqual(err.code, 'AccessDenied');
+            });
+
+            it('should bypass policy evaluation', async () => {
+                sinon.stub(auth.server, 'doAuth').yields(null, new AuthInfo({
+                    canonicalID: 'abcdef/lifecycle',
+                    accountDisplayName: 'Lifecycle Service Account',
+                }), [{
+                    isAllowed: false,
+                    implicitDeny: true,
+                    action: 'objectReplicate',
+                }], undefined, undefined);
+
+                request.bypassUserBucketPolicies = true;
+
+                routeBackbeat('127.0.0.1', request, response, log);
+
+                void await endPromise;
+
+                if (testCase.expect) {
+                    const errCode = response.writeHead.getCall(0).args[0];
+                    assert.strictEqual(errCode, testCase.expect.code);
+                }
+            });
+        });
     });
 });


### PR DESCRIPTION
Evaluate policies in Backbeat routes when running in the external Cloudserver.

_This PR is based on the implementation in https://github.com/scality/cloudserver/pull/5714_

Issue: CLDSRV-728