### PR TITLE
CLDSRV-732: Fix flakiness starting cloudserver in CI

### DIFF
--- a/.github/docker/docker-compose.yaml
+++ b/.github/docker/docker-compose.yaml
@@ -1,21 +1,6 @@
 services:
   cloudserver:
     image: ${CLOUDSERVER_IMAGE}
-    command: |
-      bash -c "
-        # Using tini to handle signals properly
-        tini -s -g -- npx nyc --clean --silent yarn start > /artifacts/s3.log 2> /artifacts/s3-stderr.log &
-        PID=$$!
-        generate_coverage() {
-          echo 'Stopping NodeJS processes...'
-          kill -TERM $$PID 2>/dev/null || true
-          wait $$PID
-          echo 'Generating coverage report...'
-          npx nyc report --report-dir /coverage/test --reporter=lcov --reporter=text-summary
-        }
-        trap generate_coverage SIGTERM
-        wait $$PID
-      "
     network_mode: "host"
     volumes:
       - /tmp/ssl:/ssl

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,18 @@ jobs:
         with:
           context: .
           push: true
+          target: production
           tags: ghcr.io/${{ github.repository }}:${{ github.event.inputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push test coverage image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          target: testcoverage
+          tags: ghcr.io/${{ github.repository }}:${{ github.event.inputs.tag }}-testcoverage
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -178,9 +178,25 @@ jobs:
         with:
           push: true
           context: .
+          target: production
           provenance: false
           tags: |
             ghcr.io/${{ github.repository }}:${{ github.sha }}
+          labels: |
+            git.repository=${{ github.repository }}
+            git.commit-sha=${{ github.sha }}
+          cache-from: type=gha,scope=cloudserver
+          cache-to: type=gha,mode=max,scope=cloudserver
+
+      - name: Build and push cloudserver image test coverage
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          context: .
+          target: testcoverage
+          provenance: false
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.sha }}-testcoverage
           labels: |
             git.repository=${{ github.repository }}
             git.commit-sha=${{ github.sha }}
@@ -229,7 +245,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build
     env:
-      CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}
+      CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}-testcoverage
       MONGODB_IMAGE: ghcr.io/${{ github.repository }}/ci-mongodb:${{ github.sha }}
       S3BACKEND: mem
       S3_LOCATION_FILE: /usr/src/app/tests/locationConfig/locationConfigTests.json
@@ -295,7 +311,7 @@ jobs:
       S3_LOCATION_FILE: /usr/src/app/tests/locationConfig/locationConfigTests.json
       DEFAULT_BUCKET_KEY_FORMAT: v0
       MONGODB_IMAGE: ghcr.io/${{ github.repository }}/ci-mongodb:${{ github.sha }}
-      CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}
+      CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}-testcoverage
       JOB_NAME: ${{ github.job }}
     steps:
     - name: Checkout
@@ -348,7 +364,7 @@ jobs:
       DEFAULT_BUCKET_KEY_FORMAT: v1
       METADATA_MAX_CACHED_BUCKETS: 1
       MONGODB_IMAGE: ghcr.io/${{ github.repository }}/ci-mongodb:${{ github.sha }}
-      CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}
+      CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}-testcoverage
       JOB_NAME: ${{ github.job }}
     steps:
     - name: Checkout
@@ -405,7 +421,7 @@ jobs:
     env:
       S3BACKEND: file
       S3VAULT: mem
-      CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}
+      CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}-testcoverage
       MONGODB_IMAGE: ghcr.io/${{ github.repository }}/ci-mongodb:${{ github.sha }}
       MPU_TESTING: "yes"
       ENABLE_NULL_VERSION_COMPAT_MODE: "${{ matrix.enable-null-compat }}"
@@ -459,7 +475,7 @@ jobs:
       ENABLE_UTAPI_V2: t
       S3BACKEND: mem
       BUCKET_DENY_FILTER: utapi-event-filter-deny-bucket
-      CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}
+      CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}-testcoverage
       MONGODB_IMAGE: ghcr.io/${{ github.repository }}/ci-mongodb:${{ github.sha }}
       JOB_NAME: ${{ github.job }}
     steps:
@@ -515,7 +531,7 @@ jobs:
       SCUBA_HOST: localhost
       SCUBA_PORT: 8100
       SCUBA_HEALTHCHECK_FREQUENCY: 100
-      CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}
+      CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}-testcoverage
       MONGODB_IMAGE: ghcr.io/${{ github.repository }}/ci-mongodb:${{ github.sha }}
       JOB_NAME: ${{ github.job }}
     steps:
@@ -562,7 +578,7 @@ jobs:
       S3BACKEND: file
       S3VAULT: mem
       MPU_TESTING: "yes" 
-      CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}
+      CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}-testcoverage
       PYKMIP_IMAGE: ghcr.io/${{ github.repository }}/pykmip:${{ github.sha }}
       MONGODB_IMAGE: ghcr.io/${{ github.repository }}/ci-mongodb:${{ github.sha }}
       JOB_NAME: ${{ github.job }}
@@ -622,7 +638,7 @@ jobs:
       S3BACKEND: file
       S3VAULT: mem
       MPU_TESTING: true
-      CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}
+      CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}-testcoverage
       PYKMIP_IMAGE: ghcr.io/${{ github.repository }}/pykmip:${{ github.sha }}
       JOB_NAME: ${{ github.job }}
       COMPOSE_FILE: docker-compose.yaml:docker-compose.sse.yaml
@@ -688,7 +704,7 @@ jobs:
       MPU_TESTING: "yes" 
       S3_LOCATION_FILE: /usr/src/app/tests/locationConfig/locationConfigCeph.json
       MONGODB_IMAGE: ghcr.io/${{ github.repository }}/ci-mongodb:${{ github.sha }}
-      CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}
+      CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}-testcoverage
       JOB_NAME: ${{ github.job }}
       ENABLE_NULL_VERSION_COMPAT_MODE: true # needed with mongodb backend
     steps:
@@ -809,7 +825,7 @@ jobs:
       VAULT_VERSION_CURRENT: 7.70.32
       CLOUDSERVER_IMAGE_BEFORE_SSE_MIGRATION: ghcr.io/${{ github.repository }}:9.0.8
       VAULT_IMAGE_BEFORE_SSE_MIGRATION: ghcr.io/scality/vault:7.70.31
-      CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}
+      CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}-testcoverage
       VAULT_IMAGE: ghcr.io/scality/vault:7.70.32
       KMS_IMAGE: nsmithuk/local-kms:3.11.7
       MPU_TESTING: "yes"

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY package.json yarn.lock /usr/src/app/
 RUN yarn install --production --ignore-optional --frozen-lockfile --ignore-engines --network-concurrency 1
 
 ################################################################################
-FROM node:${NODE_VERSION}
+FROM node:${NODE_VERSION} AS production
 
 ENV NO_PROXY=localhost,127.0.0.1
 ENV no_proxy=localhost,127.0.0.1
@@ -55,3 +55,10 @@ VOLUME ["/usr/src/app/localData","/usr/src/app/localMetadata"]
 ENTRYPOINT ["tini", "-g", "--", "/usr/src/app/docker-entrypoint.sh"]
 
 CMD [ "yarn", "start" ]
+
+################################################################################
+FROM production AS testcoverage
+
+RUN yarn global add nyc
+
+CMD [ "./docker-test-with-coverage.sh" ]

--- a/docker-test-with-coverage.sh
+++ b/docker-test-with-coverage.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+nyc --clean --silent yarn start > /artifacts/s3.log 2> /artifacts/s3-stderr.log &
+
+PID=$!
+
+generate_coverage() {
+    echo 'Stopping NodeJS processes...'
+    kill -TERM $PID 2>/dev/null || true
+    wait $PID
+    echo 'Generating coverage report...'
+    nyc report --report-dir /coverage/test --reporter=lcov --reporter=text-summary
+}
+
+trap generate_coverage SIGTERM
+wait $PID


### PR DESCRIPTION
The CI fails to wait for S3 after 40s recently

s3-stderr has those logs:
```
npm error code E403
npm error 403 403 Forbidden - GET https://registry.npmjs.org/nyc
npm error 403 In most cases, you or one of your dependencies are requesting
npm error 403 a package version that is forbidden by your security policy, or
npm error 403 on a server you do not have access to.
npm error A complete log of this run can be found in: /root/.npm/_logs/2025-08-26T12_00_55_746Z-debug-0.log
```

Build another image to include nyc and a command for coverage during tests
