### PR TITLE
CLDSRV-717: Unify ft tests for S3C

### DIFF
--- a/tests/functional/aws-node-sdk/test/bucket/putBucketReplication.js
+++ b/tests/functional/aws-node-sdk/test/bucket/putBucketReplication.js
@@ -126,7 +126,10 @@ describe('aws-node-sdk test putBucketReplication bucket status', () => {
         it('should put configuration on a bucket with versioning', done =>
             checkVersioningError(s3, 'Enabled', null, done));
 
-        it('should put configuration on a bucket with versioning if ' +
+        // S3C doesn't support service account. There is no cross account access for replication account.
+        // (canonicalId looking like http://acs.zenko.io/accounts/service/replication)
+        const itSkipS3C = process.env.S3_END_TO_END ? it.skip : it;
+        itSkipS3C('should put configuration on a bucket with versioning if ' +
         'user is a replication user', done =>
             checkVersioningError(replicationAccountS3, 'Enabled', null, done));
     });

--- a/tests/functional/aws-node-sdk/test/bucket/testBucketVersioning.js
+++ b/tests/functional/aws-node-sdk/test/bucket/testBucketVersioning.js
@@ -145,7 +145,10 @@ describe('aws-node-sdk test bucket versioning', function testSuite() {
         s3.putBucketVersioning(params, done);
     });
 
-    it('should accept valid versioning configuration if user is a ' +
+    // S3C doesn't support service account. There is no cross account access for replication account.
+    // (canonicalId looking like http://acs.zenko.io/accounts/service/replication)
+    const itSkipS3C = process.env.S3_END_TO_END ? it.skip : it;
+    itSkipS3C('should accept valid versioning configuration if user is a ' +
     'replication user', done => {
         const params = {
             Bucket: bucket,

--- a/tests/functional/aws-node-sdk/test/object/copyPart.js
+++ b/tests/functional/aws-node-sdk/test/object/copyPart.js
@@ -711,7 +711,9 @@ describe('Object Part Copy', () => {
                 });
             });
 
-        it('should not copy a part of a cold object', done => {
+        // S3C doesn't support cold storage and restore
+        const itSkipS3C = process.env.S3_END_TO_END ? it.skip : it;
+        itSkipS3C('should not copy a part of a cold object', done => {
             const archive = {
                 archiveInfo: {
                     archiveId: '97a71dfe-49c1-4cca-840a-69199e0b0322',
@@ -734,7 +736,7 @@ describe('Object Part Copy', () => {
             });
         });
 
-        it('should copy a part of an object when it\'s transitioning to cold', done => {
+        itSkipS3C('should copy a part of an object when it\'s transitioning to cold', done => {
             fakeMetadataTransition(sourceBucketName, sourceObjName, undefined, err => {
                 assert.ifError(err);
                 s3.uploadPartCopy({
@@ -752,7 +754,7 @@ describe('Object Part Copy', () => {
             });
         });
 
-        it('should copy a part of a restored object', done => {
+        itSkipS3C('should copy a part of a restored object', done => {
             const archiveCompleted = {
                 archiveInfo: {},
                 restoreRequestedAt: new Date(0),

--- a/tests/functional/aws-node-sdk/test/object/mpuVersion.js
+++ b/tests/functional/aws-node-sdk/test/object/mpuVersion.js
@@ -98,7 +98,7 @@ function checkObjMdAndUpdate(objMDBefore, objMDAfter, props) {
 
 // TODO: CLDSRV-721 RING 10 Support ObjectRestore (cold storage) with MD v1
 // The whole test suite is skipped as bad versionId breaks after each bucket cleanup
-const describeSkipNullMdV1 = isNullKeyMetadataV1 ? describe.skip : describe;
+const describeSkipNullMdV1 = isNullKeyMetadataV1 || process.env.S3_END_TO_END ? describe.skip : describe;
 
 describeSkipNullMdV1('MPU with x-scal-s3-version-id header', () => {
     withV4(sigCfg => {

--- a/tests/functional/aws-node-sdk/test/object/objectHead_replication.js
+++ b/tests/functional/aws-node-sdk/test/object/objectHead_replication.js
@@ -45,10 +45,13 @@ describe("Head object 'ReplicationStatus' value", () => {
             done => checkHeadObj(`${keyPrefix}-foobar`, undefined, done));
 
         describe('With bucket replication config', () => {
+            const role = process.env.S3_END_TO_END
+            ? 'arn:aws:iam::123456789012:role/src-resource,arn:aws:iam::123456789012:role/dest-resource'
+            : 'arn:aws:iam::123456789012:role/src-resource';
             beforeEach(done => s3.putBucketReplication({
                 Bucket: sourceBucket,
                 ReplicationConfiguration: {
-                    Role: 'arn:aws:iam::123456789012:role/src-resource',
+                    Role: role,
                     Rules: [
                         {
                             Destination: { StorageClass: 'us-east-2',

--- a/tests/functional/aws-node-sdk/test/object/putVersion.js
+++ b/tests/functional/aws-node-sdk/test/object/putVersion.js
@@ -49,7 +49,7 @@ function checkObjMdAndUpdate(objMDBefore, objMDAfter, props) {
 
 // TODO: CLDSRV-721 RING 10 Support ObjectRestore (cold storage) with MD v1
 // The whole test suite is skipped as bad versionId breaks after each bucket cleanup
-const describeSkipNullMdV1 = isNullKeyMetadataV1 ? describe.skip : describe;
+const describeSkipNullMdV1 = isNullKeyMetadataV1 || process.env.S3_END_TO_END ? describe.skip : describe;
 
 describeSkipNullMdV1('PUT object with x-scal-s3-version-id header', () => {
     withV4(sigCfg => {


### PR DESCRIPTION
S3C doesn't support:

- service account (replication) that have cross-account access
- 1 role only for src in replication config
- cold storage & restore: those tests create a bad key in the bucket that can't be deleted

We don't have config flags specific for these use cases.

I'm considering adding a config flag to block cold storage & ObjectRestore feature as if the header is passed the object key prevent bucket cleanup