### PR TITLE
CLDSRV-734: Revert back from go to python supervisord

### DIFF
--- a/images/federation/Dockerfile
+++ b/images/federation/Dockerfile
@@ -2,17 +2,12 @@ ARG CLOUDSERVER_VERSION=latest
 FROM ghcr.io/scality/cloudserver:${CLOUDSERVER_VERSION} AS builder
 
 ####################################################################################################
-FROM ghcr.io/scality/cloudserver:${CLOUDSERVER_VERSION} AS supervisord
-
-ARG SUPERVISORD_VERSION=0.7.3
-ADD https://github.com/ochinchina/supervisord/releases/download/v${SUPERVISORD_VERSION}/supervisord_${SUPERVISORD_VERSION}_Linux_64-bit.tar.gz /tmp/supervisord.tar.gz
-RUN tar -xzvf /tmp/supervisord.tar.gz -C /usr/local/bin --strip-components 1 --wildcards '*/supervisord'
-
-####################################################################################################
 FROM ghcr.io/scality/cloudserver:${CLOUDSERVER_VERSION}
 
-# Install external dependencies
-COPY --from=supervisord /usr/local/bin/supervisord /usr/local/bin/
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      supervisor \
+    && rm -rf /var/lib/apt/lists/*
 
 # Prepare runtime environment
 ENV USER="scality"


### PR DESCRIPTION
This will fix fluent-bit access to s3 log files

The go version is not a perfect replacement it has multiple changes that would require to update supervisor conf.

Breaking changes includes:

- log files name changes
  - process number starts count at 1 instead of 0
  - include full process_name with number in logfile
  - s3_1-1.log instead of s3-0.log
- no supervisorctl, replaced by superivsord ctl with less option
- no interactive supervisor ctl, if used without command it rewrite the superivsord.sock and then we lose access to supervisord ctl
- replaced priority with depends_on
- replaced %(ENV_X)s with envFiles

Overrall we’d like to avoid breaking changes until we resolve correct usage of the go version and apply it in every component at once.
