### PR TITLE
CLDSRV-735: Fix DEP0005: Buffer() constructor

### DIFF
--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -224,7 +224,7 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
                 if (mdOnlyHeader === 'true' && mdOnlySize > 0) {
                     log.debug('metadata only operation x-amz-meta-mdonly');
                     const md5 = request.headers['x-amz-meta-md5chksum']
-                        ? new Buffer(request.headers['x-amz-meta-md5chksum'],
+                        ? Buffer.from(request.headers['x-amz-meta-md5chksum'],
                         'base64').toString('hex') : null;
                     const numParts = request.headers['x-amz-meta-md5numparts'];
                     let _md5;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "9.0.24",
+  "version": "9.0.25",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {

--- a/tests/multipleBackend/routes/routeBackbeat.js
+++ b/tests/multipleBackend/routes/routeBackbeat.js
@@ -339,7 +339,7 @@ describe('backbeat routes', () => {
         it('should update metadata of a current null version', done => {
             let objMD;
             return async.series({
-                putObject: next => s3.putObject({ Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, next),
+                putObject: next => s3.putObject({ Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, next),
                 enableVersioningSource: next => s3.putBucketVersioning(
                     { Bucket: bucket, VersioningConfiguration: { Status: 'Enabled' } }, next),
                 getMetadata: next => makeBackbeatRequest({
@@ -420,11 +420,11 @@ describe('backbeat routes', () => {
             let expectedVersionId;
             return async.series({
                 putObjectInitial: next => s3.putObject(
-                    { Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, next),
+                    { Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, next),
                 enableVersioning: next => s3.putBucketVersioning(
                     { Bucket: bucket, VersioningConfiguration: { Status: 'Enabled' } }, next),
                 putObjectAgain: next => s3.putObject(
-                { Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, (err, data) => {
+                { Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, (err, data) => {
                     if (err) {
                         return next(err);
                     }
@@ -656,7 +656,7 @@ describe('backbeat routes', () => {
         it('should update metadata of a non-version object', done => {
             let objMD;
             return async.series([
-                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, next),
+                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, next),
                 next => makeBackbeatRequest({
                     method: 'GET',
                     resourceType: 'metadata',
@@ -717,7 +717,7 @@ describe('backbeat routes', () => {
             return async.series([
                 next => s3.putBucketVersioning({ Bucket: bucket, VersioningConfiguration: { Status: 'Suspended' } },
                     next),
-                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, next),
+                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, next),
                 next => makeBackbeatRequest({
                     method: 'GET',
                     resourceType: 'metadata',
@@ -781,7 +781,7 @@ describe('backbeat routes', () => {
             return async.series([
                 next => s3.putBucketVersioning({ Bucket: bucket, VersioningConfiguration: { Status: 'Suspended' } },
                     next),
-                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, next),
+                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, next),
                 next => makeBackbeatRequest({
                     method: 'GET',
                     resourceType: 'metadata',
@@ -843,7 +843,7 @@ describe('backbeat routes', () => {
             return async.series([
                 next => s3.putBucketVersioning({ Bucket: bucket, VersioningConfiguration: { Status: 'Enabled' } },
                     next),
-                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, (err, data) => {
+                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, (err, data) => {
                     if (err) {
                         return next(err);
                     }
@@ -852,7 +852,7 @@ describe('backbeat routes', () => {
                 }),
                 next => s3.putBucketVersioning({ Bucket: bucket, VersioningConfiguration: { Status: 'Suspended' } },
                     next),
-                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, next),
+                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, next),
                 next => makeBackbeatRequest({
                     method: 'GET',
                     resourceType: 'metadata',
@@ -916,7 +916,7 @@ describe('backbeat routes', () => {
         it('should update null version with no version id and versioning suspended', done => {
             let objMD;
             return async.series([
-                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, next),
+                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, next),
                 next => s3.putBucketVersioning({ Bucket: bucket, VersioningConfiguration: { Status: 'Suspended' } },
                     next),
                 next => makeBackbeatRequest({
@@ -978,7 +978,7 @@ describe('backbeat routes', () => {
             return async.series([
                 next => s3.putBucketVersioning({ Bucket: bucket, VersioningConfiguration: { Status: 'Suspended' } },
                     next),
-                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, next),
+                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, next),
                 next => makeBackbeatRequest({
                     method: 'GET',
                     resourceType: 'metadata',
@@ -1039,7 +1039,7 @@ describe('backbeat routes', () => {
             return async.series([
                 next => s3.putBucketVersioning({ Bucket: bucket, VersioningConfiguration: { Status: 'Suspended' } },
                     next),
-                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, next),
+                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, next),
                 next => makeBackbeatRequest({
                     method: 'GET',
                     resourceType: 'metadata',
@@ -1071,7 +1071,7 @@ describe('backbeat routes', () => {
                     authCredentials: backbeatAuthCredentials,
                     requestBody: objMD,
                 }, next),
-                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, next),
+                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, next),
                 next => s3.headObject({ Bucket: bucket, Key: keyName, VersionId: 'null' }, next),
                 next => s3.listObjectVersions({ Bucket: bucket }, next),
             ], (err, data) => {
@@ -1102,7 +1102,7 @@ describe('backbeat routes', () => {
             return async.series([
                 next => s3.putBucketVersioning({ Bucket: bucket, VersioningConfiguration: { Status: 'Suspended' } },
                     next),
-                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, next),
+                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, next),
                 next => makeBackbeatRequest({
                     method: 'GET',
                     resourceType: 'metadata',
@@ -1136,7 +1136,7 @@ describe('backbeat routes', () => {
                 }, next),
                 next => s3.putBucketVersioning({ Bucket: bucket, VersioningConfiguration: { Status: 'Enabled' } },
                     next),
-                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, (err, data) => {
+                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, (err, data) => {
                     if (err) {
                         return next(err);
                     }
@@ -1171,10 +1171,10 @@ describe('backbeat routes', () => {
             let expectedVersionId;
             let objMD;
             return async.series([
-                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, next),
+                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, next),
                 next => s3.putBucketVersioning({ Bucket: bucket, VersioningConfiguration: { Status: 'Enabled' } },
                     next),
-                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, (err, data) => {
+                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, (err, data) => {
                     if (err) {
                         return next(err);
                     }
@@ -1245,10 +1245,10 @@ describe('backbeat routes', () => {
             let objMD;
             let expectedVersionId;
             return async.series([
-                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, next),
+                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, next),
                 next => s3.putBucketVersioning({ Bucket: bucket, VersioningConfiguration: { Status: 'Enabled' } },
                     next),
-                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, (err, data) => {
+                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, (err, data) => {
                     if (err) {
                         return next(err);
                     }
@@ -1317,10 +1317,10 @@ describe('backbeat routes', () => {
             let objMD;
             let deletedVersionId;
             return async.series([
-                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, next),
+                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, next),
                 next => s3.putBucketVersioning({ Bucket: bucket, VersioningConfiguration: { Status: 'Enabled' } },
                     next),
-                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, (err, data) => {
+                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, (err, data) => {
                     if (err) {
                         return next(err);
                     }
@@ -1361,7 +1361,7 @@ describe('backbeat routes', () => {
                     authCredentials: backbeatAuthCredentials,
                     requestBody: objMD,
                 }, next),
-                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, next),
+                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, next),
                 next => s3.headObject({ Bucket: bucket, Key: keyName, VersionId: 'null' }, next),
                 next => s3.listObjectVersions({ Bucket: bucket }, next),
             ], (err, data) => {
@@ -1391,10 +1391,10 @@ describe('backbeat routes', () => {
             let deletedVersionId;
             let expectedVersionId;
             return async.series([
-                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, next),
+                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, next),
                 next => s3.putBucketVersioning({ Bucket: bucket, VersioningConfiguration: { Status: 'Enabled' } },
                     next),
-                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, (err, data) => {
+                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, (err, data) => {
                     if (err) {
                         return next(err);
                     }
@@ -1437,7 +1437,7 @@ describe('backbeat routes', () => {
                 }, next),
                 next => s3.putBucketVersioning({ Bucket: bucket, VersioningConfiguration: { Status: 'Enabled' } },
                     next),
-                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: new Buffer(testData) }, (err, data) => {
+                next => s3.putObject({ Bucket: bucket, Key: keyName, Body: Buffer.from(testData) }, (err, data) => {
                     if (err) {
                         return next(err);
                     }
@@ -1726,7 +1726,7 @@ describe('backbeat routes', () => {
                     next => s3.putObject({
                         Bucket: bucket,
                         Key: 'sourcekey',
-                        Body: new Buffer(testData) },
+                        Body: Buffer.from(testData) },
                         next),
                     (resp, next) => makeBackbeatRequest({
                         method: 'GET',
@@ -2542,7 +2542,7 @@ describe('backbeat routes', () => {
                 done => s3.putObject({
                     Bucket: TEST_BUCKET,
                     Key: testKey,
-                    Body: new Buffer('hello'),
+                    Body: Buffer.from('hello'),
                 }, (err, data) => {
                     assert.ifError(err);
                     versionId = data.VersionId;
@@ -2600,7 +2600,7 @@ describe('backbeat routes', () => {
                 done => awsClient.putObject({
                     Bucket: awsBucket,
                     Key: awsKey,
-                    Body: new Buffer('hello'),
+                    Body: Buffer.from('hello'),
                 }, (err, data) => {
                     assert.ifError(err);
                     versionId = data.VersionId;

--- a/tests/multipleBackend/routes/routeBackbeatForReplication.js
+++ b/tests/multipleBackend/routes/routeBackbeatForReplication.js
@@ -112,7 +112,7 @@ describe(`backbeat routes for replication (${name})`, () => {
             enableVersioningSource: next => srcS3.putBucketVersioning(
                 { Bucket: bucketSource, VersioningConfiguration: { Status: 'Enabled' } }, next),
             putObject: next => srcS3.putObject(
-                { Bucket: bucketSource, Key: keyName, Body: new Buffer(testData) }, (err, data) => {
+                { Bucket: bucketSource, Key: keyName, Body: Buffer.from(testData) }, (err, data) => {
                     if (err) {
                         return next(err);
                     }
@@ -177,7 +177,7 @@ describe(`backbeat routes for replication (${name})`, () => {
             enableVersioningSource: next => srcS3.putBucketVersioning(
                 { Bucket: bucketSource, VersioningConfiguration: { Status: 'Enabled' } }, next),
             putObject: next => srcS3.putObject(
-                { Bucket: bucketSource, Key: keyName, Body: new Buffer(testData) }, (err, data) => {
+                { Bucket: bucketSource, Key: keyName, Body: Buffer.from(testData) }, (err, data) => {
                     if (err) {
                         return next(err);
                     }
@@ -261,7 +261,7 @@ describe(`backbeat routes for replication (${name})`, () => {
             enableVersioningSource: next => srcS3.putBucketVersioning(
                 { Bucket: bucketSource, VersioningConfiguration: { Status: 'Enabled' } }, next),
             putObject: next => srcS3.putObject(
-                { Bucket: bucketSource, Key: keyName, Body: new Buffer(testData) }, (err, data) => {
+                { Bucket: bucketSource, Key: keyName, Body: Buffer.from(testData) }, (err, data) => {
                     if (err) {
                         return next(err);
                     }
@@ -338,7 +338,7 @@ describe(`backbeat routes for replication (${name})`, () => {
             enableVersioningSource: next => srcS3.putBucketVersioning(
                 { Bucket: bucketSource, VersioningConfiguration: { Status: 'Enabled' } }, next),
             putObject: next => srcS3.putObject(
-                { Bucket: bucketSource, Key: keyName, Body: new Buffer(testData) }, (err, data) => {
+                { Bucket: bucketSource, Key: keyName, Body: Buffer.from(testData) }, (err, data) => {
                     if (err) {
                         return next(err);
                     }
@@ -390,7 +390,7 @@ describe(`backbeat routes for replication (${name})`, () => {
             enableVersioningSource: next => srcS3.putBucketVersioning(
                 { Bucket: bucketSource, VersioningConfiguration: { Status: 'Enabled' } }, next),
             putObjectNonCurrent: next => srcS3.putObject(
-                { Bucket: bucketSource, Key: keyName, Body: new Buffer(testData) }, (err, data) => {
+                { Bucket: bucketSource, Key: keyName, Body: Buffer.from(testData) }, (err, data) => {
                     if (err) {
                         return next(err);
                     }
@@ -398,7 +398,7 @@ describe(`backbeat routes for replication (${name})`, () => {
                     return next();
                 }),
             putObjectCurrent: next => srcS3.putObject(
-                { Bucket: bucketSource, Key: keyName, Body: new Buffer(testData) }, (err, data) => {
+                { Bucket: bucketSource, Key: keyName, Body: Buffer.from(testData) }, (err, data) => {
                     if (err) {
                         return next(err);
                     }
@@ -492,7 +492,7 @@ describe(`backbeat routes for replication (${name})`, () => {
             enableVersioningSource: next => srcS3.putBucketVersioning(
                 { Bucket: bucketSource, VersioningConfiguration: { Status: 'Enabled' } }, next),
             putObject: next => srcS3.putObject(
-                { Bucket: bucketSource, Key: keyName, Body: new Buffer(testData) }, (err, data) => {
+                { Bucket: bucketSource, Key: keyName, Body: Buffer.from(testData) }, (err, data) => {
                     if (err) {
                         return next(err);
                     }
@@ -590,7 +590,7 @@ describe(`backbeat routes for replication (${name})`, () => {
 
         async.series({
             putObject: next => srcS3.putObject(
-                { Bucket: bucketSource, Key: keyName, Body: new Buffer(testData) }, next),
+                { Bucket: bucketSource, Key: keyName, Body: Buffer.from(testData) }, next),
             enableVersioningSource: next => srcS3.putBucketVersioning(
                 { Bucket: bucketSource, VersioningConfiguration: { Status: 'Enabled' } }, next),
             enableVersioningDestination: next => dstS3.putBucketVersioning(
@@ -652,7 +652,7 @@ describe(`backbeat routes for replication (${name})`, () => {
             suspendVersioningSource: next => srcS3.putBucketVersioning(
                 { Bucket: bucketSource, VersioningConfiguration: { Status: 'Suspended' } }, next),
             putObject: next => srcS3.putObject(
-                { Bucket: bucketSource, Key: keyName, Body: new Buffer(testData) }, next),
+                { Bucket: bucketSource, Key: keyName, Body: Buffer.from(testData) }, next),
             enableVersioningSource: next => srcS3.putBucketVersioning(
                 { Bucket: bucketSource, VersioningConfiguration: { Status: 'Enabled' } }, next),
             enableVersioningDestination: next => dstS3.putBucketVersioning(

--- a/tests/unit/management/testChannelMessageV0.js
+++ b/tests/unit/management/testChannelMessageV0.js
@@ -29,7 +29,7 @@ describe('ChannelMessageV0', () => {
         });
 
         it('should roundtrip channel data', () => {
-            const data = new Buffer('dummydata');
+            const data = Buffer.from('dummydata');
             const b = ChannelMessageV0.encodeChannelDataMessage(50, data);
             const m = new ChannelMessageV0(b);
 
@@ -51,7 +51,7 @@ describe('ChannelMessageV0', () => {
 
     describe('decoder', () => {
         it('should parse metrics request', () => {
-            const b = new Buffer([METRICS_REQUEST_MESSAGE, 0, 0]);
+            const b = Buffer.from([METRICS_REQUEST_MESSAGE, 0, 0]);
             const m = new ChannelMessageV0(b);
 
             assert.strictEqual(METRICS_REQUEST_MESSAGE, m.getType());
@@ -60,7 +60,7 @@ describe('ChannelMessageV0', () => {
         });
 
         it('should parse overlay push', () => {
-            const b = new Buffer([CONFIG_OVERLAY_MESSAGE, 0, 0, 34, 65, 34]);
+            const b = Buffer.from([CONFIG_OVERLAY_MESSAGE, 0, 0, 34, 65, 34]);
             const m = new ChannelMessageV0(b);
 
             assert.strictEqual(CONFIG_OVERLAY_MESSAGE, m.getType());


### PR DESCRIPTION
  Files Modified:

  1. Production Code:
  - lib/api/apiUtils/object/createAndStoreObject.js - Fixed 1 critical instance in MD5 checksum handling

  2. Test Files:
  - tests/multipleBackend/routes/routeBackbeat.js - Fixed 27 instances
  - tests/multipleBackend/routes/routeBackbeatForReplication.js - Fixed 9 instances
  - tests/unit/management/testChannelMessageV0.js - Fixed 3 instances

  Changes Made:

  All deprecated constructors were replaced with the secure Buffer.from() method

  Fixed critical security vulnerability - new Buffer() could expose uninitialized memory


