### PR TITLE
fix site replication status not displayed for crr

### DIFF
--- a/lib/utilities/collectResponseHeaders.js
+++ b/lib/utilities/collectResponseHeaders.js
@@ -104,10 +104,7 @@ function collectResponseHeaders(objectMD, corsHeaders, versioningCfg,
         responseMetaHeaders['x-amz-replication-status'] =
             objectMD.replicationInfo.status;
     }
-    if (objectMD.replicationInfo &&
-        // Use storageType to determine if user metadata is needed.
-        objectMD.replicationInfo.storageType &&
-        Array.isArray(objectMD.replicationInfo.backends)) {
+    if (Array.isArray(objectMD?.replicationInfo?.backends)) {
         objectMD.replicationInfo.backends.forEach(backend => {
             const { status, site, dataStoreVersionId } = backend;
             responseMetaHeaders[`x-amz-meta-${site}-replication-status`] =

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "9.1.0-preview.1",
+  "version": "9.1.0",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {

--- a/tests/unit/utils/collectResponseHeaders.js
+++ b/tests/unit/utils/collectResponseHeaders.js
@@ -9,6 +9,26 @@ describe('Middleware: Collect Response Headers', () => {
         assert.deepStrictEqual(headers['x-amz-replication-status'], 'REPLICA');
     });
 
+    it('should set the replication status of each site', () => {
+        const objectMD = {
+            replicationInfo: {
+                status: 'COMPLETED',
+                backends: [
+                    { site: 'us-east-1', status: 'COMPLETED', dataStoreVersionId: '123' },
+                    { site: 'us-west-2', status: 'COMPLETED', dataStoreVersionId: '' },
+                ],
+            },
+        };
+        const headers = collectResponseHeaders(objectMD);
+        assert.deepStrictEqual(headers['x-amz-replication-status'], 'COMPLETED');
+        assert.deepStrictEqual(headers['x-amz-meta-us-east-1-replication-status'],
+            'COMPLETED');
+        assert.deepStrictEqual(headers['x-amz-meta-us-east-1-version-id'], '123');
+        assert.deepStrictEqual(headers['x-amz-meta-us-west-2-replication-status'],
+            'COMPLETED');
+        assert.deepStrictEqual(headers['x-amz-meta-us-west-2-version-id'], undefined);
+    });
+    
     [
         { md: { replicationInfo: null }, test: 'when config is not set' },
         { md: {}, test: 'for older objects' },


### PR DESCRIPTION
Replication status of each site is returned as a custom user metadata
when performing a HeadObject. Returning these headers for all location
types.

Issue: [CLDSRV-737](https://scality.atlassian.net/browse/CLDSRV-737)

[CLDSRV-737]: https://scality.atlassian.net/browse/CLDSRV-737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ