### PR TITLE
CLDSRV-741: Bypass PutObj max size 5GB S3C-10336

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1742,6 +1742,13 @@ class Config extends EventEmitter {
         }
 
         this.supportedLifecycleRules = parseSupportedLifecycleRules(config.supportedLifecycleRules);
+
+        /**
+         * S3C-10336: PutObject max size of 5GB is new in 9.5.1
+         * Provides a way to bypass the new validation if it breaks customer workflows
+         */
+        this.bypassMaxPutObjectSize = process.env.BYPASS_MAX_PUT_OBJECT_SIZE === 'true'
+            || config.bypassMaxPutObjectSize || false;
         return config;
     }
 

--- a/lib/api/objectPut.js
+++ b/lib/api/objectPut.js
@@ -20,6 +20,7 @@ const validateChecksumHeaders = require('./apiUtils/object/validateChecksumHeade
 
 const writeContinue = require('../utilities/writeContinue');
 const { overheadField } = require('../../constants');
+const { config } = require('../Config');
 
 const versionIdUtils = versioning.VersionID;
 const { updateEncryption } = require('./apiUtils/bucket/updateEncryption');
@@ -89,7 +90,8 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
         return callback(queryContainsVersionId);
     }
     const size = request.parsedContentLength;
-    if (Number.parseInt(size, 10) > constants.maximumAllowedUploadSize) {
+    if (Number.parseInt(size, 10) > constants.maximumAllowedUploadSize
+        && !config.bypassMaxPutObjectSize) {
         log.debug('Upload size exceeds maximum allowed for a single PUT',
             { size });
         return callback(errors.EntityTooLarge);


### PR DESCRIPTION
We don't want to disable by default.
But in case a customer has problems with this new limit in S3C,
we want a way to easily disable the limit to give time to customer
to migrate its applications to MPU