### PR TITLE
CLDSRV-744: add missing md5 checksum checks

### DIFF
--- a/lib/api/apiUtils/integrity/validateChecksums.js
+++ b/lib/api/apiUtils/integrity/validateChecksums.js
@@ -1,0 +1,20 @@
+const crypto = require('crypto');
+
+/**
+ * validateChecksumsNoChunking - Validate the checksums of a request.
+ * @param {object} headers - http headers
+ * @param {string} body - http request body
+ * @return {string} - error message
+ */
+function validateChecksumsNoChunking(headers, body) {
+    if (headers['content-md5']) {
+        const md5 = crypto.createHash('md5').update(body, 'utf8').digest('base64');
+        if (md5 !== headers['content-md5']) {
+            return `md5 mismatch, calculated ${md5} expected ${headers['content-md5']}`;
+        }
+    }
+
+    return null;
+}
+
+module.exports = { validateChecksumsNoChunking };

--- a/lib/api/bucketPutACL.js
+++ b/lib/api/bucketPutACL.js
@@ -9,6 +9,7 @@ const constants = require('../../constants');
 const { standardMetadataValidateBucket } = require('../metadata/metadataUtils');
 const vault = require('../auth/vault');
 const { pushMetric } = require('../utapi/utilities');
+const { validateChecksumsNoChunking } = require('./apiUtils/integrity/validateChecksums');
 
 /*
    Format of xml request:
@@ -42,6 +43,12 @@ const { pushMetric } = require('../utapi/utilities');
  */
 function bucketPutACL(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'bucketPutACL' });
+
+    const err = validateChecksumsNoChunking(request.headers, request.post);
+    if (err) {
+        log.debug(err, { error: errors.BadDigest });
+        return callback(errors.BadDigest);
+    }
 
     const { bucketName } = request;
     const canonicalID = authInfo.getCanonicalID();

--- a/lib/api/bucketPutCors.js
+++ b/lib/api/bucketPutCors.js
@@ -1,4 +1,3 @@
-const crypto = require('crypto');
 const async = require('async');
 const { errors } = require('arsenal');
 
@@ -9,7 +8,7 @@ const { isBucketAuthorized } =
 const metadata = require('../metadata/wrapper');
 const { parseCorsXml } = require('./apiUtils/bucket/bucketCors');
 const { pushMetric } = require('../utapi/utilities');
-
+const { validateChecksumsNoChunking } = require('./apiUtils/integrity/validateChecksums');
 const requestType = 'bucketPutCors';
 
 /**
@@ -31,12 +30,10 @@ function bucketPutCors(authInfo, request, log, callback) {
         return callback(errors.MissingRequestBodyError);
     }
 
-    if (request.headers['content-md5']) {
-        const md5 = crypto.createHash('md5').update(request.post, 'utf8').digest('base64');
-        if (md5 !== request.headers['content-md5']) {
-            log.debug('bad md5 digest', { error: errors.BadDigest });
-            return callback(errors.BadDigest);
-        }
+    const err = validateChecksumsNoChunking(request.headers, request.post);
+    if (err) {
+        log.debug(err, { error: errors.BadDigest });
+        return callback(errors.BadDigest);
     }
 
     if (parseInt(request.headers['content-length'], 10) > 65536) {

--- a/lib/api/bucketPutEncryption.js
+++ b/lib/api/bucketPutEncryption.js
@@ -1,4 +1,5 @@
 const async = require('async');
+const { errors } = require('arsenal');
 
 const { parseEncryptionXml } = require('./apiUtils/bucket/bucketEncryption');
 const { checkExpectedBucketOwner } = require('./apiUtils/authorization/bucketOwner');
@@ -7,6 +8,7 @@ const { standardMetadataValidateBucket } = require('../metadata/metadataUtils');
 const kms = require('../kms/wrapper');
 const { pushMetric } = require('../utapi/utilities');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
+const { validateChecksumsNoChunking } = require('./apiUtils/integrity/validateChecksums');
 
 /**
  * Bucket Put Encryption - Put bucket SSE configuration
@@ -19,6 +21,12 @@ const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 
 function bucketPutEncryption(authInfo, request, log, callback) {
     const { bucketName } = request;
+
+    const err = validateChecksumsNoChunking(request.headers, request.post);
+    if (err) {
+        log.debug(err, { error: errors.BadDigest });
+        return callback(errors.BadDigest);
+    }
 
     const metadataValParams = {
         authInfo,

--- a/lib/api/bucketPutLifecycle.js
+++ b/lib/api/bucketPutLifecycle.js
@@ -1,12 +1,13 @@
 const { waterfall } = require('async');
 const uuid = require('uuid/v4');
 const { LifecycleConfiguration } = require('arsenal').models;
-
+const { errors } = require('arsenal');
 const parseXML = require('../utilities/parseXML');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const metadata = require('../metadata/wrapper');
 const { standardMetadataValidateBucket } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
+const { validateChecksumsNoChunking } = require('./apiUtils/integrity/validateChecksums');
 
 /**
  * Bucket Put Lifecycle - Create or update bucket lifecycle configuration
@@ -19,6 +20,12 @@ const { pushMetric } = require('../utapi/utilities');
 
 function bucketPutLifecycle(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'bucketPutLifecycle' });
+
+    const err = validateChecksumsNoChunking(request.headers, request.post);
+    if (err) {
+        log.debug(err, { error: errors.BadDigest });
+        return callback(errors.BadDigest);
+    }
 
     const { bucketName } = request;
     const metadataValParams = {

--- a/lib/api/bucketPutNotification.js
+++ b/lib/api/bucketPutNotification.js
@@ -1,11 +1,12 @@
 const async = require('async');
-
+const { errors } = require('arsenal');
 const parseXML = require('../utilities/parseXML');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const getNotificationConfiguration = require('./apiUtils/bucket/getNotificationConfiguration');
 const metadata = require('../metadata/wrapper');
 const { standardMetadataValidateBucket } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
+const { validateChecksumsNoChunking } = require('./apiUtils/integrity/validateChecksums');
 
 /**
  * Bucket Put Notification - Create or update bucket notification configuration
@@ -18,6 +19,12 @@ const { pushMetric } = require('../utapi/utilities');
 
 function bucketPutNotification(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'bucketPutNotification' });
+
+    const err = validateChecksumsNoChunking(request.headers, request.post);
+    if (err) {
+        log.debug(err, { error: errors.BadDigest });
+        return callback(errors.BadDigest);
+    }
 
     const { bucketName } = request;
     const metadataValParams = {

--- a/lib/api/bucketPutObjectLock.js
+++ b/lib/api/bucketPutObjectLock.js
@@ -9,6 +9,7 @@ const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const metadata = require('../metadata/wrapper');
 const { standardMetadataValidateBucket } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
+const { validateChecksumsNoChunking } = require('./apiUtils/integrity/validateChecksums');
 
 /**
  * Bucket Put Object Lock - Create or update bucket object lock configuration
@@ -21,6 +22,12 @@ const { pushMetric } = require('../utapi/utilities');
 
 function bucketPutObjectLock(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'bucketPutObjectLock' });
+
+    const err = validateChecksumsNoChunking(request.headers, request.post);
+    if (err) {
+        log.debug(err, { error: errors.BadDigest });
+        return callback(errors.BadDigest);
+    }
 
     const bucketName = request.bucketName;
     const metadataValParams = {

--- a/lib/api/bucketPutPolicy.js
+++ b/lib/api/bucketPutPolicy.js
@@ -6,6 +6,7 @@ const { standardMetadataValidateBucket } = require('../metadata/metadataUtils');
 const { validatePolicyResource, validatePolicyConditions } =
     require('./apiUtils/authorization/permissionChecks');
 const { BucketPolicy } = models;
+const { validateChecksumsNoChunking } = require('./apiUtils/integrity/validateChecksums');
 
 /**
  * _checkNotImplementedPolicy - some bucket policy features have not been
@@ -30,6 +31,12 @@ function _checkNotImplementedPolicy(policyString) {
  */
 function bucketPutPolicy(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'bucketPutPolicy' });
+
+    const err = validateChecksumsNoChunking(request.headers, request.post);
+    if (err) {
+        log.debug(err, { error: errors.BadDigest });
+        return callback(errors.BadDigest);
+    }
 
     const { bucketName } = request;
     const metadataValParams = {

--- a/lib/api/bucketPutReplication.js
+++ b/lib/api/bucketPutReplication.js
@@ -7,6 +7,7 @@ const { pushMetric } = require('../utapi/utilities');
 const { getReplicationConfiguration } =
     require('./apiUtils/bucket/getReplicationConfiguration');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
+const { validateChecksumsNoChunking } = require('./apiUtils/integrity/validateChecksums');
 
 // The error response when a bucket does not have versioning 'Enabled'.
 const versioningNotEnabledError = errors.InvalidRequest.customizeDescription(
@@ -30,6 +31,13 @@ function bucketPutReplication(authInfo, request, log, callback) {
         requestType: request.apiMethods || 'bucketPutReplication',
         request,
     };
+
+    const err = validateChecksumsNoChunking(request.headers, request.post);
+    if (err) {
+        log.debug(err, { error: errors.BadDigest });
+        return callback(errors.BadDigest);
+    }
+
     return waterfall([
         // Validate the request XML and return the replication configuration.
         next => getReplicationConfiguration(post, log, next),

--- a/lib/api/bucketPutVersioning.js
+++ b/lib/api/bucketPutVersioning.js
@@ -9,6 +9,7 @@ const { pushMetric } = require('../utapi/utilities');
 const versioningNotImplBackends =
     require('../../constants').versioningNotImplBackends;
 const { config } = require('../Config');
+const { validateChecksumsNoChunking } = require('./apiUtils/integrity/validateChecksums');
 
 const externalVersioningErrorMessage = 'We do not currently support putting ' +
 'a versioned object to a location-constraint of type Azure.';
@@ -90,6 +91,12 @@ function bucketPutVersioning(authInfo, request, log, callback) {
         requestType: request.apiMethods || 'bucketPutVersioning',
         request,
     };
+
+    const err = validateChecksumsNoChunking(request.headers, request.post);
+    if (err) {
+        log.debug(err, { error: errors.BadDigest });
+        return callback(errors.BadDigest);
+    }
 
     return waterfall([
         next => _parseXML(request, log, next),

--- a/lib/api/bucketPutWebsite.js
+++ b/lib/api/bucketPutWebsite.js
@@ -10,6 +10,7 @@ const { parseWebsiteConfigXml } = require('./apiUtils/bucket/bucketWebsite');
 const { pushMetric } = require('../utapi/utilities');
 
 const requestType = 'bucketPutWebsite';
+const { validateChecksumsNoChunking } = require('./apiUtils/integrity/validateChecksums');
 
 /**
  * Bucket Put Website - Create bucket website configuration
@@ -27,6 +28,13 @@ function bucketPutWebsite(authInfo, request, log, callback) {
     if (!request.post) {
         return callback(errors.MissingRequestBodyError);
     }
+
+    const err = validateChecksumsNoChunking(request.headers, request.post);
+    if (err) {
+        log.debug(err, { error: errors.BadDigest });
+        return callback(errors.BadDigest);
+    }
+
     return async.waterfall([
         function parseXmlBody(next) {
             log.trace('parsing website configuration');

--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -1,5 +1,3 @@
-const crypto = require('crypto');
-
 const async = require('async');
 const { parseString } = require('xml2js');
 const { auth, errors, versioning, s3middleware, policies } = require('arsenal');
@@ -23,6 +21,7 @@ const { hasGovernanceBypassHeader, checkUserGovernanceBypass, ObjectLockInfo }
 const requestUtils = policies.requestUtils;
 
 const versionIdUtils = versioning.VersionID;
+const { validateChecksumsNoChunking } = require('./apiUtils/integrity/validateChecksums');
 
 
 /*
@@ -367,11 +366,10 @@ function multiObjectDelete(authInfo, request, log, callback) {
         return callback(errors.MissingRequestBodyError);
     }
 
-    if (request.headers['content-md5']) {
-        const md5 = crypto.createHash('md5').update(request.post, 'utf8').digest('base64');
-        if (md5 !== request.headers['content-md5']) {
-            return callback(errors.BadDigest);
-        }
+    const err = validateChecksumsNoChunking(request.headers, request.post);
+    if (err) {
+        log.debug(err, { error: errors.BadDigest });
+        return callback(errors.BadDigest);
     }
 
     const bucketName = request.bucketName;

--- a/lib/api/objectPutACL.js
+++ b/lib/api/objectPutACL.js
@@ -10,6 +10,7 @@ const vault = require('../auth/vault');
 const { decodeVersionId, getVersionIdResHeader }
     = require('./apiUtils/object/versioning');
 const { standardMetadataValidateBucketAndObj } = require('../metadata/metadataUtils');
+const { validateChecksumsNoChunking } = require('./apiUtils/integrity/validateChecksums');
 
 /*
    Format of xml request:
@@ -43,6 +44,13 @@ const { standardMetadataValidateBucketAndObj } = require('../metadata/metadataUt
  */
 function objectPutACL(authInfo, request, log, cb) {
     log.debug('processing request', { method: 'objectPutACL' });
+
+    const err = validateChecksumsNoChunking(request.headers, request.post);
+    if (err) {
+        log.debug(err, { error: errors.BadDigest });
+        return cb(errors.BadDigest);
+    }
+
     const { bucketName, objectKey } = request;
     const newCannedACL = request.headers['x-amz-acl'];
     const possibleCannedACL = [

--- a/lib/api/objectPutLegalHold.js
+++ b/lib/api/objectPutLegalHold.js
@@ -13,6 +13,7 @@ const { config } = require('../Config');
 const { parseLegalHoldXml } = s3middleware.objectLegalHold;
 
 const REPLICATION_ACTION = 'PUT_LEGAL_HOLD';
+const { validateChecksumsNoChunking } = require('./apiUtils/integrity/validateChecksums');
 
 /**
  * Object Put Legal Hold - Sets legal hold status of object
@@ -24,6 +25,12 @@ const REPLICATION_ACTION = 'PUT_LEGAL_HOLD';
  */
 function objectPutLegalHold(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'objectPutLegalHold' });
+
+    const err = validateChecksumsNoChunking(request.headers, request.post);
+    if (err) {
+        log.debug(err, { error: errors.BadDigest });
+        return callback(errors.BadDigest);
+    }
 
     const { bucketName, objectKey } = request;
 

--- a/lib/api/objectPutRetention.js
+++ b/lib/api/objectPutRetention.js
@@ -14,6 +14,7 @@ const { config } = require('../Config');
 
 const { parseRetentionXml } = s3middleware.retention;
 const REPLICATION_ACTION = 'PUT_RETENTION';
+const { validateChecksumsNoChunking } = require('./apiUtils/integrity/validateChecksums');
 
 /**
  * Object Put Retention - Adds retention information to object
@@ -25,6 +26,12 @@ const REPLICATION_ACTION = 'PUT_RETENTION';
  */
 function objectPutRetention(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'objectPutRetention' });
+
+    const err = validateChecksumsNoChunking(request.headers, request.post);
+    if (err) {
+        log.debug(err, { error: errors.BadDigest });
+        return callback(errors.BadDigest);
+    }
 
     const { bucketName, objectKey } = request;
 

--- a/lib/api/objectPutTagging.js
+++ b/lib/api/objectPutTagging.js
@@ -13,6 +13,7 @@ const { data } = require('../data/wrapper');
 const { config } = require('../Config');
 const { parseTagXml } = s3middleware.tagging;
 const REPLICATION_ACTION = 'PUT_TAGGING';
+const { validateChecksumsNoChunking } = require('./apiUtils/integrity/validateChecksums');
 
 /**
  * Object Put Tagging - Adds tag(s) to object
@@ -24,6 +25,12 @@ const REPLICATION_ACTION = 'PUT_TAGGING';
  */
 function objectPutTagging(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'objectPutTagging' });
+
+    const err = validateChecksumsNoChunking(request.headers, request.post);
+    if (err) {
+        log.debug(err, { error: errors.BadDigest });
+        return callback(errors.BadDigest);
+    }
 
     const { bucketName, objectKey } = request;
 

--- a/tests/unit/api/bucketPutACL.js
+++ b/tests/unit/api/bucketPutACL.js
@@ -723,4 +723,73 @@ describe('putBucketACL API', () => {
             done();
         });
     });
+
+    describe('checksum validation', () => {
+        const aclXml = '<AccessControlPolicy xmlns=' +
+                '"http://s3.amazonaws.com/doc/2006-03-01/">' +
+              '<Owner>' +
+                '<ID>79a59df900b949e55d96a1e698fbaced' +
+                'fd6e09d98eacf8f8d5218e7cd47ef2be</ID>' +
+                '<DisplayName>OwnerDisplayName</DisplayName>' +
+              '</Owner>' +
+              '<AccessControlList></AccessControlList>' +
+            '</AccessControlPolicy>';
+
+        it('should not return an error when Content-MD5 header is missing', done => {
+            const testACLRequest = {
+                bucketName,
+                namespace,
+                headers: { host: `${bucketName}.s3.amazonaws.com` },
+                post: aclXml,
+                url: '/?acl',
+                query: { acl: '' },
+                actionImplicitDenies: false,
+            };
+
+            bucketPutACL(authInfo, testACLRequest, log, err => {
+                assert.strictEqual(err, undefined);
+                done();
+            });
+        });
+
+        it('should return BadDigest error when Content-MD5 header mismatches', done => {
+            const testACLRequest = {
+                bucketName,
+                namespace,
+                headers: {
+                    'host': `${bucketName}.s3.amazonaws.com`,
+                    'content-md5': '+5yj3kZsXledyKr18eaUDg==', // incorrect MD5
+                },
+                post: aclXml,
+                url: '/?acl',
+                query: { acl: '' },
+                actionImplicitDenies: false,
+            };
+
+            bucketPutACL(authInfo, testACLRequest, log, err => {
+                assert.deepStrictEqual(err, errors.BadDigest);
+                done();
+            });
+        });
+
+        it('should not return an error when Content-MD5 header matches', done => {
+            const testACLRequest = {
+                bucketName,
+                namespace,
+                headers: {
+                    'host': `${bucketName}.s3.amazonaws.com`,
+                    'content-md5': 'df9VsEmHzngoooOMzLBPQA==', // correct MD5
+                },
+                post: aclXml,
+                url: '/?acl',
+                query: { acl: '' },
+                actionImplicitDenies: false,
+            };
+
+            bucketPutACL(authInfo, testACLRequest, log, err => {
+                assert.strictEqual(err, undefined);
+                done();
+            });
+        });
+    });
 });

--- a/tests/unit/api/bucketPutCors.js
+++ b/tests/unit/api/bucketPutCors.js
@@ -70,35 +70,67 @@ describe('putBucketCORS API', () => {
         });
     });
 
-    it('should accept request if md5 is omitted', done => {
-        const corsUtil = new CorsConfigTester();
-        const testBucketPutCorsRequest = corsUtil
-            .createBucketCorsRequest('PUT', bucketName);
-        testBucketPutCorsRequest.headers['content-md5'] = undefined;
-        bucketPutCors(authInfo, testBucketPutCorsRequest, log, err => {
-            if (err) {
-                process.stdout.write(`Err putting bucket cors ${err}`);
-                return done(err);
-            }
-            return metadata.getBucket(bucketName, log, (err, bucket) => {
-                if (err) {
-                    process.stdout.write(`Err retrieving bucket MD ${err}`);
-                    return done(err);
-                }
-                const uploadedCors = bucket.getCors();
-                assert.deepStrictEqual(uploadedCors, corsUtil.getCors());
-                return done();
+    describe('checksum validation', () => {
+        const corsXml = '<CORSConfiguration>' +
+            '<CORSRule>' +
+            '<AllowedMethod>PUT</AllowedMethod>' +
+            '<AllowedOrigin>www.example.com</AllowedOrigin>' +
+            '</CORSRule>' +
+            '</CORSConfiguration>';
+
+        it('should not return an error when Content-MD5 header is missing', done => {
+            const testBucketPutCorsRequest = {
+                bucketName,
+                headers: { host: `${bucketName}.s3.amazonaws.com` },
+                post: corsXml,
+                url: '/?cors',
+                query: { cors: '' },
+                actionImplicitDenies: false,
+            };
+
+            bucketPutCors(authInfo, testBucketPutCorsRequest, log, err => {
+                assert.strictEqual(err, undefined);
+                done();
             });
         });
-    });
 
-    it('should reject request if md5 is mismatch', done => {
-        const corsUtil = new CorsConfigTester();
-        const testBucketPutCorsRequest = corsUtil
-            .createBucketCorsRequest('PUT', bucketName);
-        testBucketPutCorsRequest.headers['content-md5'] = 'wrong md5';
-        _testPutBucketCors(authInfo, testBucketPutCorsRequest,
-            log, 'BadDigest', done);
+        it('should return BadDigest error when Content-MD5 header mismatches', done => {
+            const testBucketPutCorsRequest = {
+                bucketName,
+                headers: {
+                    'host': `${bucketName}.s3.amazonaws.com`,
+                    'content-md5': '+5yj3kZsXledyKr18eaUDg==', // incorrect MD5
+                },
+                post: corsXml,
+                url: '/?cors',
+                query: { cors: '' },
+                actionImplicitDenies: false,
+            };
+
+            bucketPutCors(authInfo, testBucketPutCorsRequest, log, err => {
+                assert.deepStrictEqual(err, errors.BadDigest);
+                done();
+            });
+        });
+
+        it('should not return an error when Content-MD5 header matches', done => {
+            const testBucketPutCorsRequest = {
+                bucketName,
+                headers: {
+                    'host': `${bucketName}.s3.amazonaws.com`,
+                    'content-md5': 'Fohe2S924ZfZyb6byNYGwA==', // correct MD5
+                },
+                post: corsXml,
+                url: '/?cors',
+                query: { cors: '' },
+                actionImplicitDenies: false,
+            };
+
+            bucketPutCors(authInfo, testBucketPutCorsRequest, log, err => {
+                assert.strictEqual(err, undefined);
+                done();
+            });
+        });
     });
 
     it('should return MalformedXML if body greater than 64KB', done => {

--- a/tests/unit/api/bucketPutEncryption.js
+++ b/tests/unit/api/bucketPutEncryption.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const { errors } = require('arsenal');
 
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const bucketPutEncryption = require('../../../lib/api/bucketPutEncryption');
@@ -254,6 +255,70 @@ describe('bucketPutEncryption API', () => {
                         });
                     });
                 });
+            });
+        });
+    });
+
+    describe('checksum validation', () => {
+        const encryptionXml = `
+    <?xml version="1.0" encoding="UTF-8"?>
+    <ServerSideEncryptionConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <Rule>
+            <ApplyServerSideEncryptionByDefault><SSEAlgorithm>AES256</SSEAlgorithm></ApplyServerSideEncryptionByDefault>
+        </Rule>
+    </ServerSideEncryptionConfiguration>`;
+
+        it('should not return an error when Content-MD5 header is missing', done => {
+            const testEncryptionRequest = {
+                bucketName,
+                headers: { host: `${bucketName}.s3.amazonaws.com` },
+                post: encryptionXml,
+                url: '/?encryption',
+                query: { encryption: '' },
+                actionImplicitDenies: false,
+            };
+
+            bucketPutEncryption(authInfo, testEncryptionRequest, log, err => {
+                assert.ifError(err);
+                done();
+            });
+        });
+
+        it('should return BadDigest error when Content-MD5 header mismatches', done => {
+            const testEncryptionRequest = {
+                bucketName,
+                headers: {
+                    'host': `${bucketName}.s3.amazonaws.com`,
+                    'content-md5': '+5yj3kZsXledyKr18eaUDg==', // incorrect MD5
+                },
+                post: encryptionXml,
+                url: '/?encryption',
+                query: { encryption: '' },
+                actionImplicitDenies: false,
+            };
+
+            bucketPutEncryption(authInfo, testEncryptionRequest, log, err => {
+                assert.deepStrictEqual(err, errors.BadDigest);
+                done();
+            });
+        });
+
+        it('should not return an error when Content-MD5 header matches', done => {
+            const testEncryptionRequest = {
+                bucketName,
+                headers: {
+                    'host': `${bucketName}.s3.amazonaws.com`,
+                    'content-md5': 'V5wJT/Iw7czHvcoFV+zZ1Q==', // correct MD5
+                },
+                post: encryptionXml,
+                url: '/?encryption',
+                query: { encryption: '' },
+                actionImplicitDenies: false,
+            };
+
+            bucketPutEncryption(authInfo, testEncryptionRequest, log, err => {
+                assert.ifError(err);
+                done();
             });
         });
     });

--- a/tests/unit/api/bucketPutLifecycle.js
+++ b/tests/unit/api/bucketPutLifecycle.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const { errors } = require('arsenal');
 
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const bucketPutLifecycle = require('../../../lib/api/bucketPutLifecycle');
@@ -100,6 +101,71 @@ describe('putBucketLifecycle API', () => {
                 assert.deepStrictEqual(
                     bucketLifecycleConfig, expectedLifecycleConfig);
                 return done();
+            });
+        });
+    });
+
+    describe('checksum validation', () => {
+        const lifecycleXml = '<LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+            '<Rule>' +
+            '<ID>test-rule</ID>' +
+            '<Status>Enabled</Status>' +
+            '<Prefix>test/</Prefix>' +
+            '<Expiration><Days>30</Days></Expiration>' +
+            '</Rule>' +
+            '</LifecycleConfiguration>';
+
+        it('should not return an error when Content-MD5 header is missing', done => {
+            const testLifecycleRequest = {
+                bucketName,
+                headers: { host: `${bucketName}.s3.amazonaws.com` },
+                post: lifecycleXml,
+                url: '/?lifecycle',
+                query: { lifecycle: '' },
+                actionImplicitDenies: false,
+            };
+
+            bucketPutLifecycle(authInfo, testLifecycleRequest, log, err => {
+                assert.ifError(err);
+                done();
+            });
+        });
+
+        it('should return BadDigest error when Content-MD5 header mismatches', done => {
+            const testLifecycleRequest = {
+                bucketName,
+                headers: {
+                    'host': `${bucketName}.s3.amazonaws.com`,
+                    'content-md5': '+5yj3kZsXledyKr18eaUDg==', // incorrect MD5
+                },
+                post: lifecycleXml,
+                url: '/?lifecycle',
+                query: { lifecycle: '' },
+                actionImplicitDenies: false,
+            };
+
+            bucketPutLifecycle(authInfo, testLifecycleRequest, log, err => {
+                assert.deepStrictEqual(err, errors.BadDigest);
+                done();
+            });
+        });
+
+        it('should not return an error when Content-MD5 header matches', done => {
+            const testLifecycleRequest = {
+                bucketName,
+                headers: {
+                    'host': `${bucketName}.s3.amazonaws.com`,
+                    'content-md5': 'atetz1xBS6pZndwhthYINg==', // correct MD5
+                },
+                post: lifecycleXml,
+                url: '/?lifecycle',
+                query: { lifecycle: '' },
+                actionImplicitDenies: false,
+            };
+
+            bucketPutLifecycle(authInfo, testLifecycleRequest, log, err => {
+                assert.ifError(err);
+                done();
             });
         });
     });

--- a/tests/unit/api/bucketPutNotification.js
+++ b/tests/unit/api/bucketPutNotification.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const { errors } = require('arsenal');
 
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const bucketPutNotification = require('../../../lib/api/bucketPutNotification');
@@ -82,6 +83,70 @@ describe('putBucketNotification API', () => {
                 assert.ifError(err);
                 const bucketNotifConfig = bucket.getNotificationConfiguration();
                 assert.deepStrictEqual(bucketNotifConfig, {});
+                done();
+            });
+        });
+    });
+
+    describe('checksum validation', () => {
+        const notificationXml = '<NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+            '<QueueConfiguration>' +
+            '<Id>test-notification</Id>' +
+            '<Queue>arn:scality:bucketnotif:::target1</Queue>' +
+            '<Event>s3:ObjectCreated:Put</Event>' +
+            '</QueueConfiguration>' +
+            '</NotificationConfiguration>';
+
+        it('should not return an error when Content-MD5 header is missing', done => {
+            const testNotificationRequest = {
+                bucketName,
+                headers: { host: `${bucketName}.s3.amazonaws.com` },
+                post: notificationXml,
+                url: '/?notification',
+                query: { notification: '' },
+                actionImplicitDenies: false,
+            };
+
+            bucketPutNotification(authInfo, testNotificationRequest, log, err => {
+                assert.ifError(err);
+                done();
+            });
+        });
+
+        it('should return BadDigest error when Content-MD5 header mismatches', done => {
+            const testNotificationRequest = {
+                bucketName,
+                headers: {
+                    'host': `${bucketName}.s3.amazonaws.com`,
+                    'content-md5': '+5yj3kZsXledyKr18eaUDg==', // incorrect MD5
+                },
+                post: notificationXml,
+                url: '/?notification',
+                query: { notification: '' },
+                actionImplicitDenies: false,
+            };
+
+            bucketPutNotification(authInfo, testNotificationRequest, log, err => {
+                assert.deepStrictEqual(err, errors.BadDigest);
+                done();
+            });
+        });
+
+        it('should not return an error when Content-MD5 header matches', done => {
+            const testNotificationRequest = {
+                bucketName,
+                headers: {
+                    'host': `${bucketName}.s3.amazonaws.com`,
+                    'content-md5': '7GuskjLog88KRxugTVDPWg==', // correct MD5
+                },
+                post: notificationXml,
+                url: '/?notification',
+                query: { notification: '' },
+                actionImplicitDenies: false,
+            };
+
+            bucketPutNotification(authInfo, testNotificationRequest, log, err => {
+                assert.ifError(err);
                 done();
             });
         });

--- a/tests/unit/api/bucketPutObjectLock.js
+++ b/tests/unit/api/bucketPutObjectLock.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const { errors } = require('arsenal');
 
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const bucketPutObjectLock = require('../../../lib/api/bucketPutObjectLock');
@@ -73,6 +74,70 @@ describe('putBucketObjectLock API', () => {
                     assert.deepStrictEqual(
                         bucketObjectLockConfig, expectedObjectLockConfig);
                     return done();
+                });
+            });
+        });
+
+        describe('checksum validation', () => {
+            const objectLockXmlTest = '<ObjectLockConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+                '<ObjectLockEnabled>Enabled</ObjectLockEnabled>' +
+                '<Rule><DefaultRetention>' +
+                '<Mode>GOVERNANCE</Mode>' +
+                '<Days>1</Days>' +
+                '</DefaultRetention></Rule>' +
+                '</ObjectLockConfiguration>';
+
+            it('should not return an error when Content-MD5 header is missing', done => {
+                const testObjectLockRequest = {
+                    bucketName,
+                    headers: { host: `${bucketName}.s3.amazonaws.com` },
+                    post: objectLockXmlTest,
+                    url: '/?object-lock',
+                    query: { 'object-lock': '' },
+                    actionImplicitDenies: false,
+                };
+
+                bucketPutObjectLock(authInfo, testObjectLockRequest, log, err => {
+                    assert.ifError(err);
+                    done();
+                });
+            });
+
+            it('should return BadDigest error when Content-MD5 header mismatches', done => {
+                const testObjectLockRequest = {
+                    bucketName,
+                    headers: {
+                        'host': `${bucketName}.s3.amazonaws.com`,
+                        'content-md5': '+5yj3kZsXledyKr18eaUDg==', // incorrect MD5
+                    },
+                    post: objectLockXmlTest,
+                    url: '/?object-lock',
+                    query: { 'object-lock': '' },
+                    actionImplicitDenies: false,
+                };
+
+                bucketPutObjectLock(authInfo, testObjectLockRequest, log, err => {
+                    assert.deepStrictEqual(err, errors.BadDigest);
+                    done();
+                });
+            });
+
+            it('should not return an error when Content-MD5 header matches', done => {
+                const testObjectLockRequest = {
+                    bucketName,
+                    headers: {
+                        'host': `${bucketName}.s3.amazonaws.com`,
+                        'content-md5': 'KX8zVPpu4gleE1JHJvOt6w==', // correct MD5
+                    },
+                    post: objectLockXmlTest,
+                    url: '/?object-lock',
+                    query: { 'object-lock': '' },
+                    actionImplicitDenies: false,
+                };
+
+                bucketPutObjectLock(authInfo, testObjectLockRequest, log, err => {
+                    assert.ifError(err);
+                    done();
                 });
             });
         });

--- a/tests/unit/api/bucketPutPolicy.js
+++ b/tests/unit/api/bucketPutPolicy.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const { errors } = require('arsenal');
 
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const bucketPutPolicy = require('../../../lib/api/bucketPutPolicy');
@@ -104,6 +105,75 @@ describe('putBucketPolicy API', () => {
         err => {
             assert.strictEqual(err.is.NotImplemented, true);
             done();
+        });
+    });
+
+    describe('checksum validation', () => {
+        const testPolicy = {
+            Version: '2012-10-17',
+            Statement: [
+                {
+                    Effect: 'Allow',
+                    Resource: `arn:aws:s3:::${bucketName}`,
+                    Principal: '*',
+                    Action: ['s3:GetBucketLocation'],
+                },
+            ],
+        };
+        const policyJson = JSON.stringify(testPolicy);
+
+        it('should not return an error when Content-MD5 header is missing', done => {
+            const testPolicyRequest = {
+                bucketName,
+                headers: { host: `${bucketName}.s3.amazonaws.com` },
+                post: policyJson,
+                url: '/?policy',
+                query: { policy: '' },
+                actionImplicitDenies: false,
+            };
+
+            bucketPutPolicy(authInfo, testPolicyRequest, log, err => {
+                assert.ifError(err);
+                done();
+            });
+        });
+
+        it('should return BadDigest error when Content-MD5 header mismatches', done => {
+            const testPolicyRequest = {
+                bucketName,
+                headers: {
+                    'host': `${bucketName}.s3.amazonaws.com`,
+                    'content-md5': '+5yj3kZsXledyKr18eaUDg==', // incorrect MD5
+                },
+                post: policyJson,
+                url: '/?policy',
+                query: { policy: '' },
+                actionImplicitDenies: false,
+            };
+
+            bucketPutPolicy(authInfo, testPolicyRequest, log, err => {
+                assert.deepStrictEqual(err, errors.BadDigest);
+                done();
+            });
+        });
+
+        it('should not return an error when Content-MD5 header matches', done => {
+            const testPolicyRequest = {
+                bucketName,
+                headers: {
+                    'host': `${bucketName}.s3.amazonaws.com`,
+                    'content-md5': 'Q5txAQ0vMnQbyv1+5xhpvA==', // correct MD5
+                },
+                post: policyJson,
+                url: '/?policy',
+                query: { policy: '' },
+                actionImplicitDenies: false,
+            };
+
+            bucketPutPolicy(authInfo, testPolicyRequest, log, err => {
+                assert.ifError(err);
+                done();
+            });
         });
     });
 });

--- a/tests/unit/api/bucketPutReplication.js
+++ b/tests/unit/api/bucketPutReplication.js
@@ -1,11 +1,24 @@
 const assert = require('assert');
+const { errors } = require('arsenal');
 
-const { DummyRequestLogger } = require('../helpers');
+const { bucketPut } = require('../../../lib/api/bucketPut');
+const bucketPutReplication = require('../../../lib/api/bucketPutReplication');
+const bucketPutVersioning = require('../../../lib/api/bucketPutVersioning');
+const { cleanup, DummyRequestLogger, makeAuthInfo } = require('../helpers');
 const { getReplicationConfiguration } =
     require('../../../lib/api/apiUtils/bucket/getReplicationConfiguration');
 const replicationUtils =
     require('../../functional/aws-node-sdk/lib/utility/replication');
 const log = new DummyRequestLogger();
+
+const authInfo = makeAuthInfo('accessKey1');
+const bucketName = 'bucketname';
+const testBucketPutRequest = {
+    bucketName,
+    headers: { host: `${bucketName}.s3.amazonaws.com` },
+    url: '/',
+    actionImplicitDenies: false,
+};
 
 // Check for the expected error response code and status code.
 function checkError(xml, expectedErr, cb) {
@@ -102,5 +115,84 @@ describe('\'getReplicationConfiguration\' function', () => {
     it('should create an \'ID\' if rule ID is \'\'', done => {
         const xml = createReplicationXML(undefined, { ID: '' });
         return checkGeneratedID(xml, done);
+    });
+});
+
+describe('bucketPutReplication API - Content-MD5 validation', () => {
+    const replicationXML = createReplicationXML();
+
+    before(() => cleanup());
+    beforeEach(done => {
+        // Create bucket first
+        bucketPut(authInfo, testBucketPutRequest, log, err => {
+            if (err) {
+                return done(err);
+            }
+            // Enable versioning (required for replication)
+            const versioningRequest = {
+                bucketName,
+                headers: { host: `${bucketName}.s3.amazonaws.com` },
+                post: '<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>',
+                url: '/?versioning',
+                query: { versioning: '' },
+                actionImplicitDenies: false,
+            };
+            return bucketPutVersioning(authInfo, versioningRequest, log, done);
+        });
+    });
+    afterEach(() => cleanup());
+
+    it('should not return an error when Content-MD5 header is missing', done => {
+        const testReplicationRequest = {
+            bucketName,
+            headers: { host: `${bucketName}.s3.amazonaws.com` },
+            post: replicationXML,
+            url: '/?replication',
+            query: { replication: '' },
+            actionImplicitDenies: false,
+        };
+
+        bucketPutReplication(authInfo, testReplicationRequest, log, err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+
+    it('should return BadDigest error when Content-MD5 header mismatches', done => {
+        const testReplicationRequest = {
+            bucketName,
+            headers: {
+                'host': `${bucketName}.s3.amazonaws.com`,
+                'content-md5': '+5yj3kZsXledyKr18eaUDg==', // incorrect MD5
+            },
+            post: replicationXML,
+            url: '/?replication',
+            query: { replication: '' },
+            actionImplicitDenies: false,
+        };
+
+        bucketPutReplication(authInfo, testReplicationRequest, log, err => {
+            assert.deepStrictEqual(err, errors.BadDigest);
+            done();
+        });
+    });
+
+    it('should not return an error when Content-MD5 header matches', done => {
+        const testReplicationRequest = {
+            bucketName,
+            headers: {
+                'host': `${bucketName}.s3.amazonaws.com`,
+                'content-md5': 'IKwQ83x91j3jaIvsiKstUQ==', // correct MD5
+            },
+            post: replicationXML,
+            url: '/?replication',
+            query: { replication: '' },
+            actionImplicitDenies: false,
+        };
+
+        bucketPutReplication(authInfo, testReplicationRequest, log, err => {
+            assert.ifError(err);
+            done();
+        });
     });
 });

--- a/tests/unit/api/bucketPutVersioning.js
+++ b/tests/unit/api/bucketPutVersioning.js
@@ -1,0 +1,81 @@
+const assert = require('assert');
+const { errors } = require('arsenal');
+
+const { bucketPut } = require('../../../lib/api/bucketPut');
+const bucketPutVersioning = require('../../../lib/api/bucketPutVersioning');
+const { cleanup, DummyRequestLogger, makeAuthInfo } = require('../helpers');
+
+const log = new DummyRequestLogger();
+const authInfo = makeAuthInfo('accessKey1');
+const bucketName = 'bucketname';
+const testBucketPutRequest = {
+    bucketName,
+    headers: { host: `${bucketName}.s3.amazonaws.com` },
+    url: '/',
+    actionImplicitDenies: false,
+};
+
+describe('bucketPutVersioning API - Content-MD5 validation', () => {
+    const versioningXML = '<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>';
+
+    before(() => cleanup());
+    beforeEach(done => {
+        // Create bucket first
+        bucketPut(authInfo, testBucketPutRequest, log, done);
+    });
+    afterEach(() => cleanup());
+
+    it('should not return an error when Content-MD5 header is missing', done => {
+        const testVersioningRequest = {
+            bucketName,
+            headers: { host: `${bucketName}.s3.amazonaws.com` },
+            post: versioningXML,
+            url: '/?versioning',
+            query: { versioning: '' },
+            actionImplicitDenies: false,
+        };
+
+        bucketPutVersioning(authInfo, testVersioningRequest, log, err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+
+    it('should return BadDigest error when Content-MD5 header mismatches', done => {
+        const testVersioningRequest = {
+            bucketName,
+            headers: {
+                'host': `${bucketName}.s3.amazonaws.com`,
+                'content-md5': '+5yj3kZsXledyKr18eaUDg==', // incorrect MD5
+            },
+            post: versioningXML,
+            url: '/?versioning',
+            query: { versioning: '' },
+            actionImplicitDenies: false,
+        };
+
+        bucketPutVersioning(authInfo, testVersioningRequest, log, err => {
+            assert.deepStrictEqual(err, errors.BadDigest);
+            done();
+        });
+    });
+
+    it('should not return an error when Content-MD5 header matches', done => {
+        const testVersioningRequest = {
+            bucketName,
+            headers: {
+                'host': `${bucketName}.s3.amazonaws.com`,
+                'content-md5': '8qj8HSeDu3APPMQZVG06WQ==', // correct MD5
+            },
+            post: versioningXML,
+            url: '/?versioning',
+            query: { versioning: '' },
+            actionImplicitDenies: false,
+        };
+
+        bucketPutVersioning(authInfo, testVersioningRequest, log, err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+});

--- a/tests/unit/api/bucketPutWebsite.js
+++ b/tests/unit/api/bucketPutWebsite.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const { parseString } = require('xml2js');
+const { errors } = require('arsenal');
 
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const bucketPutWebsite = require('../../../lib/api/bucketPutWebsite');
@@ -174,6 +175,78 @@ describe('putBucketWebsite API', () => {
                 assert.strictEqual(containsRes, true);
                 return done();
             });
+        });
+    });
+});
+
+describe('bucketPutWebsite API - Content-MD5 validation', () => {
+    const websiteXML = `
+    <WebsiteConfiguration>
+    <IndexDocument><Suffix>index.html</Suffix></IndexDocument>
+    <ErrorDocument><Key>error.html</Key></ErrorDocument>
+    </WebsiteConfiguration>
+    `;
+
+    before(() => cleanup());
+    beforeEach(done => {
+        bucketPut(authInfo, testBucketPutRequest, log, done);
+    });
+    afterEach(() => cleanup());
+
+    it('should not return an error when Content-MD5 header is missing', done => {
+        const testWebsiteRequest = {
+            bucketName,
+            headers: { host: `${bucketName}.s3.amazonaws.com` },
+            post: websiteXML,
+            url: '/?website',
+            query: { website: '' },
+            actionImplicitDenies: false,
+        };
+
+        bucketPutWebsite(authInfo, testWebsiteRequest, log, err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+
+    it('should return BadDigest error when Content-MD5 header mismatches', done => {
+        const testWebsiteRequest = {
+            bucketName,
+            headers: {
+                'host': `${bucketName}.s3.amazonaws.com`,
+                'content-md5': '+5yj3kZsXledyKr18eaUDg==', // incorrect MD5
+            },
+            post: websiteXML,
+            url: '/?website',
+            query: { website: '' },
+            actionImplicitDenies: false,
+        };
+
+        bucketPutWebsite(authInfo, testWebsiteRequest, log, err => {
+            assert.deepStrictEqual(err, errors.BadDigest);
+            done();
+        });
+    });
+
+    it('should not return an error when Content-MD5 header matches', done => {
+        const crypto = require('crypto');
+        const correctMd5 = crypto.createHash('md5').update(websiteXML, 'utf8').digest('base64');
+
+        const testWebsiteRequest = {
+            bucketName,
+            headers: {
+                'host': `${bucketName}.s3.amazonaws.com`,
+                'content-md5': correctMd5, // correct MD5
+            },
+            post: websiteXML,
+            url: '/?website',
+            query: { website: '' },
+            actionImplicitDenies: false,
+        };
+
+        bucketPutWebsite(authInfo, testWebsiteRequest, log, err => {
+            assert.ifError(err);
+            done();
         });
     });
 });

--- a/tests/unit/api/multiObjectDelete.js
+++ b/tests/unit/api/multiObjectDelete.js
@@ -310,4 +310,55 @@ describe('multiObjectDelete function', () => {
             done();
         });
     });
+
+    it('should not return an error when Content-MD5 header matches', done => {
+        const post = '<Delete><Object><Key>objectname</Key></Object></Delete>';
+        const correctMd5 = crypto.createHash('md5').update(post, 'utf8').digest('base64');
+        const testObjectKey = 'objectname';
+        const testBucketName = 'test-bucket';
+        const request = new DummyRequest({
+            bucketName: testBucketName,
+            objectKey: testObjectKey,
+            parsedHost: 'localhost',
+            headers: {
+                'content-md5': correctMd5, // correct MD5
+            },
+            post,
+            socket: {
+                remoteAddress: '127.0.0.1',
+            },
+            url: `/${testBucketName}`,
+        });
+        // Use the same canonicalID for both authInfo and bucket owner to avoid AccessDenied
+        const testAuthInfo = makeAuthInfo(canonicalID);
+
+        // Create bucket with proper ownership
+        const testBucketRequest = new DummyRequest({
+            bucketName: testBucketName,
+            namespace,
+            headers: {},
+            url: `/${testBucketName}`,
+        });
+        // Create object to delete
+        const testObjectRequest = new DummyRequest({
+            bucketName: testBucketName,
+            namespace,
+            objectKey: testObjectKey,
+            headers: {},
+            url: `/${testBucketName}/${testObjectKey}`,
+        }, postBody);
+
+        bucketPut(testAuthInfo, testBucketRequest, log, () => {
+            objectPut(testAuthInfo, testObjectRequest, undefined, log, () => {
+                multiObjectDelete.multiObjectDelete(testAuthInfo, request, log, (err, res) => {
+                    // Request should succeed with correct content-md5 header
+                    assert.strictEqual(err, null);
+                    assert.strictEqual(typeof res, 'string');
+                    // Should contain successful deletion response
+                    assert.strictEqual(res.includes('<Deleted><Key>objectname</Key></Deleted>'), true);
+                    done();
+                });
+            });
+        });
+    });
 });

--- a/tests/unit/api/objectPutACL.js
+++ b/tests/unit/api/objectPutACL.js
@@ -592,3 +592,86 @@ describe('putObjectACL API', () => {
         });
     });
 });
+
+describe('objectPutACL API - Content-MD5 validation', () => {
+    // Use the AccessControlPolicy helper that matches the existing test pattern
+    const acp = new AccessControlPolicy(defaultAcpParams);
+    acp.addGrantee('CanonicalUser', ownerID, 'FULL_CONTROL', 'OwnerDisplayName');
+    const aclXML = acp.getXml();
+
+    beforeEach(done => {
+        cleanup();
+        testPutObjectRequest = new DummyRequest({
+            bucketName,
+            namespace,
+            objectKey: objectName,
+            headers: {},
+            url: `/${bucketName}/${objectName}`,
+        }, postBody);
+
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log, done);
+        });
+    });
+
+    it('should not return an error when Content-MD5 header is missing', done => {
+        const testObjACLRequest = {
+            bucketName,
+            namespace,
+            objectKey: objectName,
+            headers: {},
+            post: Buffer.from(aclXML, 'utf8'),
+            url: `/${bucketName}/${objectName}?acl`,
+            query: { acl: '' },
+            actionImplicitDenies: false,
+        };
+
+        objectPutACL(authInfo, testObjACLRequest, log, err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+
+    it('should return BadDigest error when Content-MD5 header mismatches', done => {
+        const testObjACLRequest = {
+            bucketName,
+            namespace,
+            objectKey: objectName,
+            headers: {
+                'content-md5': '+5yj3kZsXledyKr18eaUDg==', // incorrect MD5
+            },
+            post: Buffer.from(aclXML, 'utf8'),
+            url: `/${bucketName}/${objectName}?acl`,
+            query: { acl: '' },
+            actionImplicitDenies: false,
+        };
+
+        objectPutACL(authInfo, testObjACLRequest, log, err => {
+            assert.deepStrictEqual(err, errors.BadDigest);
+            done();
+        });
+    });
+
+    it('should not return an error when Content-MD5 header matches', done => {
+        const crypto = require('crypto');
+        const correctMd5 = crypto.createHash('md5').update(aclXML, 'utf8').digest('base64');
+
+        const testObjACLRequest = {
+            bucketName,
+            namespace,
+            objectKey: objectName,
+            headers: {
+                'content-md5': correctMd5, // correct MD5
+            },
+            post: Buffer.from(aclXML, 'utf8'),
+            url: `/${bucketName}/${objectName}?acl`,
+            query: { acl: '' },
+            actionImplicitDenies: false,
+        };
+
+        objectPutACL(authInfo, testObjACLRequest, log, err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+});

--- a/tests/unit/api/objectPutLegalHold.js
+++ b/tests/unit/api/objectPutLegalHold.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const { errors } = require('arsenal');
 
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const objectPut = require('../../../lib/api/objectPut');
@@ -97,6 +98,74 @@ describe('putObjectLegalHold API', () => {
                     return done();
                 });
             });
+        });
+    });
+});
+
+describe('objectPutLegalHold API - Content-MD5 validation', () => {
+    const legalHoldXML = objectLegalHoldXml('ON');
+    const bucketObjLockRequest = Object.assign({}, putBucketRequest,
+        { headers: { 'x-amz-bucket-object-lock-enabled': 'true' } });
+
+    beforeEach(done => {
+        bucketPut(authInfo, bucketObjLockRequest, log, err => {
+            assert.ifError(err);
+            objectPut(authInfo, putObjectRequest, undefined, log, done);
+        });
+    });
+    afterEach(cleanup);
+
+    it('should not return an error when Content-MD5 header is missing', done => {
+        const testLegalHoldRequest = {
+            bucketName,
+            objectKey: objectName,
+            headers: { host: `${bucketName}.s3.amazonaws.com` },
+            post: legalHoldXML,
+            actionImplicitDenies: false,
+        };
+
+        objectPutLegalHold(authInfo, testLegalHoldRequest, log, err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+
+    it('should return BadDigest error when Content-MD5 header mismatches', done => {
+        const testLegalHoldRequest = {
+            bucketName,
+            objectKey: objectName,
+            headers: {
+                'host': `${bucketName}.s3.amazonaws.com`,
+                'content-md5': '+5yj3kZsXledyKr18eaUDg==', // incorrect MD5
+            },
+            post: legalHoldXML,
+            actionImplicitDenies: false,
+        };
+
+        objectPutLegalHold(authInfo, testLegalHoldRequest, log, err => {
+            assert.deepStrictEqual(err, errors.BadDigest);
+            done();
+        });
+    });
+
+    it('should not return an error when Content-MD5 header matches', done => {
+        const crypto = require('crypto');
+        const correctMd5 = crypto.createHash('md5').update(legalHoldXML, 'utf8').digest('base64');
+
+        const testLegalHoldRequest = {
+            bucketName,
+            objectKey: objectName,
+            headers: {
+                'host': `${bucketName}.s3.amazonaws.com`,
+                'content-md5': correctMd5, // correct MD5
+            },
+            post: legalHoldXML,
+            actionImplicitDenies: false,
+        };
+
+        objectPutLegalHold(authInfo, testLegalHoldRequest, log, err => {
+            assert.ifError(err);
+            done();
         });
     });
 });

--- a/tests/unit/api/objectPutRetention.js
+++ b/tests/unit/api/objectPutRetention.js
@@ -225,3 +225,77 @@ describe('putObjectRetention API', () => {
         });
     });
 });
+
+describe('objectPutRetention API - Content-MD5 validation', () => {
+    // Use a fixed date for consistent MD5 calculation
+    const testDate = '2025-09-13T00:00:00.000Z';
+    const retentionXML = '<Retention xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+        '<Mode>GOVERNANCE</Mode>' +
+        `<RetainUntilDate>${testDate}</RetainUntilDate>` +
+        '</Retention>';
+
+    const bucketObjLockRequest = Object.assign({}, bucketPutRequest,
+        { headers: { 'x-amz-bucket-object-lock-enabled': 'true' } });
+
+    beforeEach(done => {
+        bucketPut(authInfo, bucketObjLockRequest, log, err => {
+            assert.ifError(err);
+            objectPut(authInfo, putObjectRequest, undefined, log, done);
+        });
+    });
+    afterEach(() => cleanup());
+
+    it('should not return an error when Content-MD5 header is missing', done => {
+        const testRetentionRequest = {
+            bucketName,
+            objectKey: objectName,
+            headers: { host: `${bucketName}.s3.amazonaws.com` },
+            post: retentionXML,
+            actionImplicitDenies: false,
+        };
+
+        objectPutRetention(authInfo, testRetentionRequest, log, err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+
+    it('should return BadDigest error when Content-MD5 header mismatches', done => {
+        const testRetentionRequest = {
+            bucketName,
+            objectKey: objectName,
+            headers: {
+                'host': `${bucketName}.s3.amazonaws.com`,
+                'content-md5': '+5yj3kZsXledyKr18eaUDg==', // incorrect MD5
+            },
+            post: retentionXML,
+            actionImplicitDenies: false,
+        };
+
+        objectPutRetention(authInfo, testRetentionRequest, log, err => {
+            assert.deepStrictEqual(err, errors.BadDigest);
+            done();
+        });
+    });
+
+    it('should not return an error when Content-MD5 header matches', done => {
+        const crypto = require('crypto');
+        const correctMd5 = crypto.createHash('md5').update(retentionXML, 'utf8').digest('base64');
+
+        const testRetentionRequest = {
+            bucketName,
+            objectKey: objectName,
+            headers: {
+                'host': `${bucketName}.s3.amazonaws.com`,
+                'content-md5': correctMd5, // correct MD5
+            },
+            post: retentionXML,
+            actionImplicitDenies: false,
+        };
+
+        objectPutRetention(authInfo, testRetentionRequest, log, err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+});

--- a/tests/unit/api/objectPutTagging.js
+++ b/tests/unit/api/objectPutTagging.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const { errors } = require('arsenal');
 
 const { bucketPut } = require('../../../lib/api/bucketPut');
 const objectPut = require('../../../lib/api/objectPut');
@@ -185,6 +186,76 @@ describe('PUT object tagging :: helper validation functions ', () => {
                     return done();
                 });
             });
+        });
+    });
+});
+
+describe('objectPutTagging API - Content-MD5 validation', () => {
+    // Use the existing helper function to generate consistent XML
+    const taggingXML = _generateSampleXml('testkey', 'testvalue');
+
+    beforeEach(done => {
+        cleanup();
+        bucketPut(authInfo, testBucketPutRequest, log, err => {
+            if (err) {
+                return done(err);
+            }
+            return objectPut(authInfo, testPutObjectRequest, undefined, log, done);
+        });
+    });
+    afterEach(cleanup);
+
+    it('should not return an error when Content-MD5 header is missing', done => {
+        const testTaggingRequest = {
+            bucketName,
+            objectKey: objectName,
+            headers: { host: `${bucketName}.s3.amazonaws.com` },
+            post: taggingXML,
+            actionImplicitDenies: false,
+        };
+
+        objectPutTagging(authInfo, testTaggingRequest, log, err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+
+    it('should return BadDigest error when Content-MD5 header mismatches', done => {
+        const testTaggingRequest = {
+            bucketName,
+            objectKey: objectName,
+            headers: {
+                'host': `${bucketName}.s3.amazonaws.com`,
+                'content-md5': '+5yj3kZsXledyKr18eaUDg==', // incorrect MD5
+            },
+            post: taggingXML,
+            actionImplicitDenies: false,
+        };
+
+        objectPutTagging(authInfo, testTaggingRequest, log, err => {
+            assert.deepStrictEqual(err, errors.BadDigest);
+            done();
+        });
+    });
+
+    it('should not return an error when Content-MD5 header matches', done => {
+        const crypto = require('crypto');
+        const correctMd5 = crypto.createHash('md5').update(taggingXML, 'utf8').digest('base64');
+
+        const testTaggingRequest = {
+            bucketName,
+            objectKey: objectName,
+            headers: {
+                'host': `${bucketName}.s3.amazonaws.com`,
+                'content-md5': correctMd5, // correct MD5
+            },
+            post: taggingXML,
+            actionImplicitDenies: false,
+        };
+
+        objectPutTagging(authInfo, testTaggingRequest, log, err => {
+            assert.ifError(err);
+            done();
         });
     });
 });


### PR DESCRIPTION
CLDSRV-744: add missing md5 checksum checks

Support for the newer algorithms (CRC-64/NVME, CRC-32, CRC-32C, SHA-1, SHA-256) will be added inside `validateChecksumsNoChunking`  in another PR.