### PR TITLE
CLDSRV-741: Override Key limit for S3C-10370

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -22,6 +22,7 @@ const {
 const { ValidLifecycleRules: supportedLifecycleRules } = require('arsenal').models;
 const { utapiVersion } = require('utapi');
 const { scaleMsPerDay } = s3middleware.objectUtils;
+const { constants: arsenalConstants } = require('arsenal');
 
 const constants = require('../constants');
 const {
@@ -1782,6 +1783,20 @@ class Config extends EventEmitter {
          */
         this.bypassMaxPutObjectSize = process.env.BYPASS_MAX_PUT_OBJECT_SIZE === 'true'
             || config.bypassMaxPutObjectSize || false;
+
+        /**
+         * S3C-10370: Before 9.5.1, there was no limit on the key length.
+         * The current limit is 915, provide a way to ignore (set to 0) or override the limit
+         */
+        this.objectKeyByteLimit = arsenalConstants.objectKeyByteLimit;
+        const overrideObjectKeyByteLimit =
+            process.env.OVERRIDE_OBJECT_KEY_BYTE_LIMIT || config.overrideObjectKeyByteLimit;
+        if (overrideObjectKeyByteLimit !== null && overrideObjectKeyByteLimit !== undefined) {
+            this.objectKeyByteLimit = parseInt(overrideObjectKeyByteLimit, 10);
+            assert(Number.isInteger(this.objectKeyByteLimit) && this.objectKeyByteLimit >= 0,
+                'bad config: overrideObjectKeyByteLimit must be a positive integer');
+        }
+
         return config;
     }
 

--- a/lib/api/initiateMultipartUpload.js
+++ b/lib/api/initiateMultipartUpload.js
@@ -1,5 +1,6 @@
 const { v4: uuidv4 } = require('uuid');
-const { errors, errorInstances, s3middleware } = require('arsenal');
+const { errors, errorInstances, s3middleware, s3routes } = require('arsenal');
+const { validateObjectKeyLength } = s3routes.routesUtils;
 const async = require('async');
 const getMetaHeaders = s3middleware.userMetadata.getMetaHeaders;
 const convertToXml = s3middleware.convertToXml;
@@ -23,6 +24,7 @@ const { getObjectSSEConfiguration } = require('./apiUtils/bucket/bucketEncryptio
 const { setExpirationHeaders } = require('./apiUtils/object/expirationHeaders');
 const { setSSEHeaders } = require('./apiUtils/object/sseHeaders');
 const { updateEncryption } = require('./apiUtils/bucket/updateEncryption');
+const { config } = require('../Config');
 const kms = require('../kms/wrapper');
 
 /*
@@ -57,6 +59,11 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
         return callback(errorInstances.InvalidInput.customizeDescription(
             'object keys cannot contain non-printable characters',
         ));
+    }
+
+    const keyLengthError = validateObjectKeyLength(objectKey, config.objectKeyByteLimit);
+    if (keyLengthError) {
+        return callback(keyLengthError);
     }
 
     // Note that we are using the string set forth in constants.js

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -1,6 +1,7 @@
 const async = require('async');
 
-const { errors, errorInstances, versioning, s3middleware } = require('arsenal');
+const { errors, errorInstances, versioning, s3middleware, s3routes } = require('arsenal');
+const { validateObjectKeyLength } = s3routes.routesUtils;
 const getMetaHeaders = s3middleware.userMetadata.getMetaHeaders;
 const validateHeaders = s3middleware.validateConditionalHeaders;
 
@@ -218,6 +219,12 @@ function objectCopy(authInfo, request, sourceBucket,
     log.debug('processing request', { method: 'objectCopy' });
     const destBucketName = request.bucketName;
     const destObjectKey = request.objectKey;
+
+    const keyLengthError = validateObjectKeyLength(destObjectKey, config.objectKeyByteLimit);
+    if (keyLengthError) {
+        return callback(keyLengthError);
+    }
+
     const sourceIsDestination =
         destBucketName === sourceBucket && destObjectKey === sourceObject;
     const valGetParams = {

--- a/lib/api/objectPut.js
+++ b/lib/api/objectPut.js
@@ -1,5 +1,6 @@
 const async = require('async');
-const { errors, errorInstances, versioning } = require('arsenal');
+const { errors, errorInstances, versioning, s3routes } = require('arsenal');
+const { validateObjectKeyLength } = s3routes.routesUtils;
 
 const constants = require('../../constants');
 const aclUtils = require('../utilities/aclUtils');
@@ -89,6 +90,12 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
     if (queryContainsVersionId instanceof Error) {
         return callback(queryContainsVersionId);
     }
+
+    const keyLengthError = validateObjectKeyLength(objectKey, config.objectKeyByteLimit);
+    if (keyLengthError) {
+        return callback(keyLengthError);
+    }
+
     const size = request.parsedContentLength;
     if (Number.parseInt(size, 10) > constants.maximumAllowedUploadSize
         && !config.bypassMaxPutObjectSize) {

--- a/tests/functional/aws-node-sdk/test/object/get.js
+++ b/tests/functional/aws-node-sdk/test/object/get.js
@@ -227,6 +227,16 @@ describe('GET object', () => {
                 });
             });
 
+        it('should return NoSuchKey error when no such object even with key longer than 915 bytes',
+            done => {
+                s3.getObject({ Bucket: bucketName, Key: 'a'.repeat(2000) }, err => {
+                    assert.notEqual(err, null,
+                        'Expected failure but got success');
+                    assert.strictEqual(err.code, 'NoSuchKey');
+                    return done();
+                });
+            });
+
         describe('Additional headers: [Cache-Control, Content-Disposition, ' +
             'Content-Encoding, Expires, Accept-Ranges]', () => {
             describe('if specified in put object request', () => {

--- a/tests/functional/aws-node-sdk/test/object/get.js
+++ b/tests/functional/aws-node-sdk/test/object/get.js
@@ -210,9 +210,7 @@ describe('GET object', () => {
         'bucket name',
             done => {
                 s3.getObject({ Bucket: '', Key: 'somekey' }, err => {
-                    assert.notEqual(err, null,
-                        'Expected failure but got success');
-                    assert.strictEqual(err.code, 'MethodNotAllowed');
+                    checkError(err, 'MethodNotAllowed');
                     return done();
                 });
             });
@@ -220,9 +218,7 @@ describe('GET object', () => {
         it('should return NoSuchKey error when no such object',
             done => {
                 s3.getObject({ Bucket: bucketName, Key: 'nope' }, err => {
-                    assert.notEqual(err, null,
-                        'Expected failure but got success');
-                    assert.strictEqual(err.code, 'NoSuchKey');
+                    checkError(err, 'NoSuchKey');
                     return done();
                 });
             });
@@ -230,9 +226,7 @@ describe('GET object', () => {
         it('should return NoSuchKey error when no such object even with key longer than 915 bytes',
             done => {
                 s3.getObject({ Bucket: bucketName, Key: 'a'.repeat(2000) }, err => {
-                    assert.notEqual(err, null,
-                        'Expected failure but got success');
-                    assert.strictEqual(err.code, 'NoSuchKey');
+                    checkError(err, 'NoSuchKey');
                     return done();
                 });
             });

--- a/tests/functional/aws-node-sdk/test/object/initiateMPU.js
+++ b/tests/functional/aws-node-sdk/test/object/initiateMPU.js
@@ -52,6 +52,14 @@ describe('Initiate MPU', () => {
              })
         );
 
+        it('should return KeyTooLong error when key is longer than 915 bytes', done =>
+            s3.createMultipartUpload({ Bucket: bucket, Key: 'a'.repeat(916) }, err => {
+                assert.strictEqual(err.code, 'KeyTooLong');
+                assert.strictEqual(err.statusCode, 400);
+                done();
+            })
+        );
+
         it('should return error if initiating MPU w/ > 2KB user-defined md',
         done => {
             const metadata = genMaxSizeMetaHeaders();

--- a/tests/functional/aws-node-sdk/test/object/initiateMPU.js
+++ b/tests/functional/aws-node-sdk/test/object/initiateMPU.js
@@ -54,6 +54,7 @@ describe('Initiate MPU', () => {
 
         it('should return KeyTooLong error when key is longer than 915 bytes', done =>
             s3.createMultipartUpload({ Bucket: bucket, Key: 'a'.repeat(916) }, err => {
+                assert(err, 'Expected err but did not find one');
                 assert.strictEqual(err.code, 'KeyTooLong');
                 assert.strictEqual(err.statusCode, 400);
                 done();

--- a/tests/functional/aws-node-sdk/test/object/objectCopy.js
+++ b/tests/functional/aws-node-sdk/test/object/objectCopy.js
@@ -208,6 +208,15 @@ describe('Object Copy', () => {
                 });
         });
 
+        it('should return 400 KeyTooLong if key is longer than 915 bytes', done => {
+            s3.copyObject({ Bucket: destBucketName, Key: 'a'.repeat(916),
+                CopySource: `${sourceBucketName}/${sourceObjName}` },
+                err => {
+                    checkError(err, 'KeyTooLong');
+                    done();
+                });
+        });
+
         it('should copy an object from a source bucket to a different ' +
             'destination bucket and copy the tag set if COPY tagging ' +
             'directive header provided', done => {

--- a/tests/functional/aws-node-sdk/test/object/put.js
+++ b/tests/functional/aws-node-sdk/test/object/put.js
@@ -77,6 +77,16 @@ describe('PUT object', () => {
                 });
             });
 
+        it('should return KeyTooLong error when key is longer than 915 bytes', done => {
+            const params = { Bucket: bucket, Key: 'a'.repeat(916) };
+            s3.putObject(params, err => {
+                assert(err, 'Expected error but did not find one');
+                assert.strictEqual(err.code, 'KeyTooLong');
+                assert.match(err.message, /915/);
+                done();
+            });
+        });
+
         it('should return error if putting object w/ > 2KB user-defined md',
             done => {
                 const metadata = genMaxSizeMetaHeaders();

--- a/tests/unit/Config.js
+++ b/tests/unit/Config.js
@@ -922,4 +922,33 @@ describe('Config', () => {
             }
         });
     });
+
+    describe('objectKeyByteLimit', () => {
+        it('should use default objectKeyByteLimit (915) from arsenal constants', () => {
+            const config = new ConfigObject();
+            assert.strictEqual(config.objectKeyByteLimit, 915);
+        });
+
+        it('should override objectKeyByteLimit from environment variable', () => {
+            setEnv('OVERRIDE_OBJECT_KEY_BYTE_LIMIT', '2048');
+            const config = new ConfigObject();
+            assert.strictEqual(config.objectKeyByteLimit, 2048);
+        });
+
+        it('should allow setting objectKeyByteLimit to 0 (no limit)', () => {
+            setEnv('OVERRIDE_OBJECT_KEY_BYTE_LIMIT', '0');
+            const config = new ConfigObject();
+            assert.strictEqual(config.objectKeyByteLimit, 0);
+        });
+
+        it('should throw error for negative objectKeyByteLimit override', () => {
+            setEnv('OVERRIDE_OBJECT_KEY_BYTE_LIMIT', '-1');
+            assert.throws(() => new ConfigObject());
+        });
+
+        it('should throw error for invalid string objectKeyByteLimit override', () => {
+            setEnv('OVERRIDE_OBJECT_KEY_BYTE_LIMIT', 'invalid');
+            assert.throws(() => new ConfigObject());
+        });
+    });
 });

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -27,6 +27,7 @@ const DummyRequest = require('../DummyRequest');
 const changeObjectLock = require('../../utilities/objectLock-util');
 const metadataswitch = require('../metadataswitch');
 const { fakeMetadataArchive } = require('../../functional/aws-node-sdk/test/utils/init');
+const { config } = require('../../../lib/Config');
 
 const { data } = require('../../../lib/data/wrapper');
 const { metadata } = storage.metadata.inMemory.metadata;
@@ -3137,5 +3138,74 @@ describe('multipart upload in ingestion bucket', () => {
         });
         assert.strictEqual(headers['x-amz-version-id'], versionID);
         assert.strictEqual(dataClient.createMPU.lastCall.args[1]['x-amz-meta-scal-version-id'], undefined);
+    });
+});
+
+describe('initiateMultipartUpload with objectKeyByteLimit', () => {
+    const originalObjectKeyByteLimit = config.objectKeyByteLimit;
+
+    beforeEach(() => {
+        cleanup();
+    });
+
+    afterEach(() => {
+        config.objectKeyByteLimit = originalObjectKeyByteLimit;
+    });
+
+    const createTestInitiateRequest = longKey => new DummyRequest({
+        bucketName,
+        namespace,
+        objectKey: longKey,
+        headers: {},
+        url: `/${bucketName}/${longKey}?uploads`,
+        query: { uploads: '' },
+    });
+
+    it('should reject object key longer than 915 bytes by default', done => {
+        const longKey = 'a'.repeat(916);
+        const testInitiateRequest = createTestInitiateRequest(longKey);
+
+        bucketPut(authInfo, bucketPutRequest, log, err => {
+            assert.ifError(err);
+            initiateMultipartUpload(authInfo, testInitiateRequest, log, err => {
+                assert(err);
+                assert.strictEqual(err.KeyTooLong, true);
+                assert.match(err.description, /915/);
+                done();
+            });
+        });
+    });
+
+    it('should accept object key longer than 915 bytes with objectKeyByteLimit', done => {
+        config.objectKeyByteLimit = 1024;
+
+        const longKey = 'a'.repeat(1024);
+        const testInitiateRequest = createTestInitiateRequest(longKey);
+
+        bucketPut(authInfo, bucketPutRequest, log, err => {
+            assert.ifError(err);
+            initiateMultipartUpload(authInfo, testInitiateRequest, log, (err, xml) => {
+                assert.ifError(err);
+                assert(xml);
+                done();
+            });
+        });
+    });
+
+    it('should reject object key exceeding objectKeyByteLimit', done => {
+        config.objectKeyByteLimit = 1024;
+
+        const longKey = 'a'.repeat(1025);
+        const testInitiateRequest = createTestInitiateRequest(longKey);
+
+        bucketPut(authInfo, bucketPutRequest, log, err => {
+            assert.ifError(err);
+            initiateMultipartUpload(authInfo, testInitiateRequest, log, err => {
+                assert(err);
+                assert.strictEqual(err.KeyTooLong, true);
+                assert.match(err.description, /1024/);
+                done();
+            });
+        });
     });
 });

--- a/tests/unit/api/objectCopy.js
+++ b/tests/unit/api/objectCopy.js
@@ -16,6 +16,7 @@ const metadata = require('../metadataswitch');
 const { data } = require('../../../lib/data/wrapper');
 const { objectLocationConstraintHeader } = require('../../../constants');
 const { fakeMetadataArchive } = require('../../functional/aws-node-sdk/test/utils/init');
+const { config } = require('../../../lib/Config');
 
 const any = sinon.match.any;
 
@@ -537,5 +538,71 @@ describe('objectCopy in ingestion bucket', () => {
                     next();
                 }),
         ], done);
+    });
+});
+
+describe('objectCopy with objectKeyByteLimit', () => {
+    const originalObjectKeyByteLimit = config.objectKeyByteLimit;
+
+    beforeEach(done => {
+        cleanup();
+        async.series([
+            next => bucketPut(authInfo, putDestBucketRequest, log, next),
+            next => bucketPut(authInfo, putSourceBucketRequest, log, next),
+            next => objectPut(authInfo, versioningTestUtils.createPutObjectRequest(
+                sourceBucketName, objectKey, objData[0]), undefined, log, next),
+        ], done);
+    });
+
+    afterEach(() => {
+        config.objectKeyByteLimit = originalObjectKeyByteLimit;
+    });
+
+    it('should reject destination object key longer than 915 bytes by default', done => {
+        const longDestKey = 'a'.repeat(916);
+        const testCopyObjectRequest = _createObjectCopyRequest(destBucketName);
+        testCopyObjectRequest.objectKey = longDestKey;
+        testCopyObjectRequest.url = `/${destBucketName}/${longDestKey}`;
+
+        objectCopy(authInfo, testCopyObjectRequest, sourceBucketName, objectKey,
+            undefined, log, err => {
+                assert(err);
+                assert.strictEqual(err.KeyTooLong, true);
+                assert.match(err.description, /915/);
+                done();
+            });
+    });
+
+    it('should accept destination object key longer than 915 bytes with objectKeyByteLimit', done => {
+        config.objectKeyByteLimit = 1024;
+
+        const longDestKey = 'a'.repeat(1024);
+        const testCopyObjectRequest = _createObjectCopyRequest(destBucketName);
+        testCopyObjectRequest.objectKey = longDestKey;
+        testCopyObjectRequest.url = `/${destBucketName}/${longDestKey}`;
+
+        objectCopy(authInfo, testCopyObjectRequest, sourceBucketName, objectKey,
+            undefined, log, (err, xml) => {
+                assert.ifError(err);
+                assert(xml);
+                done();
+            });
+    });
+
+    it('should reject destination object key exceeding objectKeyByteLimit', done => {
+        config.objectKeyByteLimit = 1024;
+
+        const longDestKey = 'a'.repeat(1025);
+        const testCopyObjectRequest = _createObjectCopyRequest(destBucketName);
+        testCopyObjectRequest.objectKey = longDestKey;
+        testCopyObjectRequest.url = `/${destBucketName}/${longDestKey}`;
+
+        objectCopy(authInfo, testCopyObjectRequest, sourceBucketName, objectKey,
+            undefined, log, err => {
+                assert(err);
+                assert.strictEqual(err.KeyTooLong, true);
+                assert.match(err.description, /1024/);
+                done();
+            });
     });
 });

--- a/tests/unit/api/objectPut.js
+++ b/tests/unit/api/objectPut.js
@@ -24,6 +24,7 @@ const {
 } = require('../../../constants');
 const mpuUtils = require('../utils/mpuUtils');
 const { fakeMetadataArchive } = require('../../functional/aws-node-sdk/test/utils/init');
+const { config } = require('../../../lib/Config');
 
 const { ds } = storage.data.inMemory.datastore;
 
@@ -1217,5 +1218,72 @@ describe('objectPut API in ingestion bucket', () => {
                 next(err);
             }),
         ], done);
+    });
+});
+
+describe('objectPut with objectKeyByteLimit', () => {
+    const originalObjectKeyByteLimit = config.objectKeyByteLimit;
+
+    beforeEach(() => {
+        cleanup();
+    });
+
+    afterEach(() => {
+        config.objectKeyByteLimit = originalObjectKeyByteLimit;
+    });
+
+    const createTestPutObjectRequest = longKey => new DummyRequest({
+        bucketName,
+        namespace,
+        objectKey: longKey,
+        headers: {},
+        url: `/${bucketName}/${longKey}`,
+    }, postBody);
+
+    it('should reject object key longer than 915 bytes by default', done => {
+        const longKey = 'a'.repeat(916);
+        const testPutObjectRequest = createTestPutObjectRequest(longKey);
+
+        bucketPut(authInfo, testPutBucketRequest, log, err => {
+            assert.ifError(err);
+            objectPut(authInfo, testPutObjectRequest, undefined, log, err => {
+                assert(err);
+                assert.strictEqual(err.KeyTooLong, true);
+                assert.match(err.description, /915/);
+                done();
+            });
+        });
+    });
+
+    it('should accept object key longer than 915 bytes with objectKeyByteLimit', done => {
+        config.objectKeyByteLimit = 1024;
+
+        const longKey = 'a'.repeat(1024);
+        const testPutObjectRequest = createTestPutObjectRequest(longKey);
+
+        bucketPut(authInfo, testPutBucketRequest, log, err => {
+            assert.ifError(err);
+            objectPut(authInfo, testPutObjectRequest, undefined, log, err => {
+                assert.ifError(err);
+                done();
+            });
+        });
+    });
+
+    it('should reject object key exceeding objectKeyByteLimit', done => {
+        config.objectKeyByteLimit = 1024;
+
+        const longKey = 'a'.repeat(1025);
+        const testPutObjectRequest = createTestPutObjectRequest(longKey);
+
+        bucketPut(authInfo, testPutBucketRequest, log, err => {
+            assert.ifError(err);
+            objectPut(authInfo, testPutObjectRequest, undefined, log, err => {
+                assert(err);
+                assert.strictEqual(err.KeyTooLong, true);
+                assert.match(err.description, /1024/);
+                done();
+            });
+        });
     });
 });


### PR DESCRIPTION
Key length will only be check in PutObject, CopyObject, initMPU.

To enforce KeyTooLong only when creating new objects. If objects already exists with key too long, they can still be reached.

See related PR https://github.com/scality/Arsenal/pull/2510