### PR TITLE
CLDSRV-741: Reorganize some cold storage tests 

### DIFF
--- a/tests/functional/aws-node-sdk/lib/utility/test-utils.js
+++ b/tests/functional/aws-node-sdk/lib/utility/test-utils.js
@@ -15,6 +15,14 @@ function hasLocation(lc) {
     return config.locationConstraints[lc] !== undefined;
 }
 
+/**
+ * We consider cold storage & restore supported if Transition lifecycle rule is supported.
+ * In our implementation, it's the only way to move objects to cold storage (can't write directly to cold)
+ * Even if Transition could be used without cold storage location (hot transition), but both features are
+ * enabled together at the moment.
+*/
+const hasColdStorage = config.supportedLifecycleRules.some(rule => rule.endsWith('Transition'));
+
 module.exports = {
     isCEPH,
     itSkipCeph,
@@ -22,4 +30,5 @@ module.exports = {
     describeSkipIfNotMultiple,
     describeSkipIfNotMultipleOrCeph,
     hasLocation,
+    hasColdStorage,
 };

--- a/tests/functional/aws-node-sdk/test/object/copyPart.js
+++ b/tests/functional/aws-node-sdk/test/object/copyPart.js
@@ -8,6 +8,7 @@ const BucketUtility = require('../../lib/utility/bucket-util');
 const { createEncryptedBucketPromise } =
     require('../../lib/utility/createEncryptedBucket');
 const { fakeMetadataTransition, fakeMetadataArchive } = require('../utils/init');
+const { hasColdStorage } = require('../../lib/utility/test-utils');
 
 const sourceBucketName = 'supersourcebucket81033016532';
 const sourceObjName = 'supersourceobject';
@@ -728,70 +729,71 @@ describe('Object Part Copy', () => {
                 });
             });
 
-        // S3C doesn't support cold storage and restore
-        const itSkipS3C = process.env.S3_END_TO_END ? it.skip : it;
-        itSkipS3C('should not copy a part of a cold object', done => {
-            const archive = {
-                archiveInfo: {
-                    archiveId: '97a71dfe-49c1-4cca-840a-69199e0b0322',
-                    archiveVersion: 5577006791947779
-                },
-            };
-            fakeMetadataArchive(sourceBucketName, sourceObjName, undefined, archive, err => {
-                assert.ifError(err);
-                s3.uploadPartCopy({
-                    Bucket: destBucketName,
-                    Key: destObjName,
-                    CopySource: `${sourceBucketName}/${sourceObjName}`,
-                    PartNumber: 1,
-                    UploadId: uploadId,
-                }, err => {
-                        assert.strictEqual(err.code, 'InvalidObjectState');
-                        assert.strictEqual(err.statusCode, 403);
-                        done();
-                    });
-            });
-        });
-
-        itSkipS3C('should copy a part of an object when it\'s transitioning to cold', done => {
-            fakeMetadataTransition(sourceBucketName, sourceObjName, undefined, err => {
-                assert.ifError(err);
-                s3.uploadPartCopy({
-                    Bucket: destBucketName,
-                    Key: destObjName,
-                    CopySource: `${sourceBucketName}/${sourceObjName}`,
-                    PartNumber: 1,
-                    UploadId: uploadId,
-                }, (err, res) => {
-                    checkNoError(err);
-                    assert.strictEqual(res.ETag, etag);
-                    assert(res.LastModified);
-                    done();
+        const describeColdStorage = hasColdStorage ? describe : describe.skip;
+        describeColdStorage('with cold storage', () => {
+            it('should not copy a part of a cold object', done => {
+                const archive = {
+                    archiveInfo: {
+                        archiveId: '97a71dfe-49c1-4cca-840a-69199e0b0322',
+                        archiveVersion: 5577006791947779
+                    },
+                };
+                fakeMetadataArchive(sourceBucketName, sourceObjName, undefined, archive, err => {
+                    assert.ifError(err);
+                    s3.uploadPartCopy({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        PartNumber: 1,
+                        UploadId: uploadId,
+                    }, err => {
+                            assert.strictEqual(err.code, 'InvalidObjectState');
+                            assert.strictEqual(err.statusCode, 403);
+                            done();
+                        });
                 });
             });
-        });
 
-        itSkipS3C('should copy a part of a restored object', done => {
-            const archiveCompleted = {
-                archiveInfo: {},
-                restoreRequestedAt: new Date(0),
-                restoreRequestedDays: 5,
-                restoreCompletedAt: new Date(10),
-                restoreWillExpireAt: new Date(10 + (5 * 24 * 60 * 60 * 1000)),
-            };
-            fakeMetadataArchive(sourceBucketName, sourceObjName, undefined, archiveCompleted, err => {
-                assert.ifError(err);
-                s3.uploadPartCopy({
-                    Bucket: destBucketName,
-                    Key: destObjName,
-                    CopySource: `${sourceBucketName}/${sourceObjName}`,
-                    PartNumber: 1,
-                    UploadId: uploadId,
-                }, (err, res) => {
-                    checkNoError(err);
-                    assert.strictEqual(res.ETag, etag);
-                    assert(res.LastModified);
-                    done();
+            it('should copy a part of an object when it\'s transitioning to cold', done => {
+                fakeMetadataTransition(sourceBucketName, sourceObjName, undefined, err => {
+                    assert.ifError(err);
+                    s3.uploadPartCopy({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        PartNumber: 1,
+                        UploadId: uploadId,
+                    }, (err, res) => {
+                        checkNoError(err);
+                        assert.strictEqual(res.ETag, etag);
+                        assert(res.LastModified);
+                        done();
+                    });
+                });
+            });
+
+            it('should copy a part of a restored object', done => {
+                const archiveCompleted = {
+                    archiveInfo: {},
+                    restoreRequestedAt: new Date(0),
+                    restoreRequestedDays: 5,
+                    restoreCompletedAt: new Date(10),
+                    restoreWillExpireAt: new Date(10 + (5 * 24 * 60 * 60 * 1000)),
+                };
+                fakeMetadataArchive(sourceBucketName, sourceObjName, undefined, archiveCompleted, err => {
+                    assert.ifError(err);
+                    s3.uploadPartCopy({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        PartNumber: 1,
+                        UploadId: uploadId,
+                    }, (err, res) => {
+                        checkNoError(err);
+                        assert.strictEqual(res.ETag, etag);
+                        assert(res.LastModified);
+                        done();
+                    });
                 });
             });
         });

--- a/tests/functional/aws-node-sdk/test/object/mpuVersion.js
+++ b/tests/functional/aws-node-sdk/test/object/mpuVersion.js
@@ -7,6 +7,7 @@ const metadata = require('../../../../../lib/metadata/wrapper');
 const { DummyRequestLogger } = require('../../../../unit/helpers');
 const checkError = require('../../lib/utility/checkError');
 const { getMetadata, fakeMetadataArchive, isNullKeyMetadataV1 } = require('../utils/init');
+const { hasColdStorage } = require('../../lib/utility/test-utils');
 
 const log = new DummyRequestLogger();
 
@@ -97,10 +98,10 @@ function checkObjMdAndUpdate(objMDBefore, objMDAfter, props) {
 }
 
 // TODO: CLDSRV-721 RING 10 Support ObjectRestore (cold storage) with MD v1
-// The whole test suite is skipped as bad versionId breaks after each bucket cleanup
-const describeSkipNullMdV1 = isNullKeyMetadataV1 || process.env.S3_END_TO_END ? describe.skip : describe;
+// The cold storage test suite is skipped as bad versionId while faking archive breaks after each bucket cleanup
+const describeSkipNullMdV1 = isNullKeyMetadataV1 || !hasColdStorage ? describe.skip : describe;
 
-describeSkipNullMdV1('MPU with x-scal-s3-version-id header', () => {
+describe('MPU with x-scal-s3-version-id header', () => {
     withV4(sigCfg => {
         let bucketUtil;
         let s3;
@@ -128,879 +129,882 @@ describeSkipNullMdV1('MPU with x-scal-s3-version-id header', () => {
             });
         });
 
-        it('should overwrite an MPU object', done => {
-            let objMDBefore;
-            let objMDAfter;
-            let versionsBefore;
-            let versionsAfter;
+        describe('error handling validation (without cold storage location)', () => {
+            it('should fail if version is invalid', done => {
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                const params = { Bucket: bucketName, Key: objectName };
 
-            async.series([
-                next => putMPU(s3, bucketName, objectName, next),
-                next => fakeMetadataArchive(bucketName, objectName, undefined, archive, next),
-                next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
-                    objMDBefore = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsBefore = res.Versions;
-                    return next(err);
-                }),
-                next => putMPUVersion(s3, bucketName, objectName, '', next),
-                next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
-                    objMDAfter = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsAfter = res.Versions;
-                    return next(err);
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+                async.series([
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => s3.putObject(params, next),
+                    next => putMPUVersion(s3, bucketName, objectName, 'aJLWKz4Ko9IjBBgXKj5KQT.G9UHv0g7P', err => {
+                        checkError(err, 'InvalidArgument', 400);
+                        return next();
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+                    return done();
+                });
+            });
 
-                assert.deepStrictEqual(versionsAfter, versionsBefore);
+            it('should fail if key does not exist', done => {
+                async.series([
+                    next => putMPUVersion(s3, bucketName, objectName, '', err => {
+                        checkError(err, 'NoSuchKey', 404);
+                        return next();
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+                    return done();
+                });
+            });
 
-                checkObjMdAndUpdate(objMDBefore, objMDAfter,
-                    ['location', 'uploadId', 'microVersionId', 'x-amz-restore',
-                    'archive', 'dataStoreName', 'originOp']);
+            it('should fail if version does not exist', done => {
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                const params = { Bucket: bucketName, Key: objectName };
 
-                assert.deepStrictEqual(objMDAfter, objMDBefore);
-                return done();
+                async.series([
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => s3.putObject(params, next),
+                    next => putMPUVersion(s3, bucketName, objectName,
+                    '393833343735313131383832343239393939393952473030312020313031', err => {
+                        checkError(err, 'NoSuchVersion', 404);
+                        return next();
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+                    return done();
+                });
+            });
+
+            it('should fail if archiving is not in progress', done => {
+                const params = { Bucket: bucketName, Key: objectName };
+
+                async.series([
+                    next => s3.putObject(params, next),
+                    next => putMPUVersion(s3, bucketName, objectName, '', err => {
+                        checkError(err, 'InvalidObjectState', 403);
+                        return next();
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+                    return done();
+                });
+            });
+
+            it('should fail if trying to overwrite a delete marker', done => {
+                const params = { Bucket: bucketName, Key: objectName };
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                let vId;
+
+                async.series([
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => s3.putObject(params, next),
+                    next => s3.deleteObject(params, (err, res) => {
+                        vId = res.VersionId;
+                        return next(err);
+                    }),
+                    next => putMPUVersion(s3, bucketName, objectName, vId, err => {
+                        checkError(err, 'MethodNotAllowed', 405);
+                        return next();
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+                    return done();
+                });
             });
         });
 
-        it('should overwrite an object', done => {
-            const params = { Bucket: bucketName, Key: objectName };
-            let objMDBefore;
-            let objMDAfter;
-            let versionsBefore;
-            let versionsAfter;
+        describeSkipNullMdV1('with cold storage location', () => {
+            it('should overwrite an MPU object', done => {
+                let objMDBefore;
+                let objMDAfter;
+                let versionsBefore;
+                let versionsAfter;
 
-            async.series([
-                next => s3.putObject(params, next),
-                next => fakeMetadataArchive(bucketName, objectName, undefined, archive, next),
-                next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
-                    objMDBefore = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsBefore = res.Versions;
-                    return next(err);
-                }),
-                next => putMPUVersion(s3, bucketName, objectName, '', next),
-                next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
-                    objMDAfter = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsAfter = res.Versions;
-                    return next(err);
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+                async.series([
+                    next => putMPU(s3, bucketName, objectName, next),
+                    next => fakeMetadataArchive(bucketName, objectName, undefined, archive, next),
+                    next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                        objMDBefore = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsBefore = res.Versions;
+                        return next(err);
+                    }),
+                    next => putMPUVersion(s3, bucketName, objectName, '', next),
+                    next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                        objMDAfter = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsAfter = res.Versions;
+                        return next(err);
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
 
-                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
-                assert.deepStrictEqual(versionsAfter, versionsBefore);
+                    assert.deepStrictEqual(versionsAfter, versionsBefore);
 
-                checkObjMdAndUpdate(objMDBefore, objMDAfter,
-                    ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
-                    'x-amz-restore', 'archive', 'dataStoreName']);
+                    checkObjMdAndUpdate(objMDBefore, objMDAfter,
+                        ['location', 'uploadId', 'microVersionId', 'x-amz-restore',
+                        'archive', 'dataStoreName', 'originOp']);
 
-                assert.deepStrictEqual(objMDAfter, objMDBefore);
-                return done();
+                    assert.deepStrictEqual(objMDAfter, objMDBefore);
+                    return done();
+                });
             });
-        });
 
-        it('should overwrite a version', done => {
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            const params = { Bucket: bucketName, Key: objectName };
-            let objMDBefore;
-            let objMDAfter;
-            let versionsBefore;
-            let versionsAfter;
-            let vId;
-
-            async.series([
-                next => s3.putBucketVersioning(vParams, next),
-                next => s3.putObject(params, (err, res) => {
-                    vId = res.VersionId;
-                    return next(err);
-                }),
-                next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsBefore = res.Versions;
-                    return next(err);
-                }),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDBefore = objMD;
-                    return next(err);
-                }),
-                next => putMPUVersion(s3, bucketName, objectName, vId, next),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDAfter = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsAfter = res.Versions;
-                    return next(err);
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-
-                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
-                assert.deepStrictEqual(versionsAfter, versionsBefore);
-
-                checkObjMdAndUpdate(objMDBefore, objMDAfter,
-                    ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
-                    'x-amz-restore', 'archive', 'dataStoreName']);
-                assert.deepStrictEqual(objMDAfter, objMDBefore);
-                return done();
-            });
-        });
-
-        it('should overwrite the current version if empty version id header', done => {
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            const params = { Bucket: bucketName, Key: objectName };
-            let objMDBefore;
-            let objMDAfter;
-            let versionsBefore;
-            let versionsAfter;
-            let vId;
-
-            async.series([
-                next => s3.putBucketVersioning(vParams, next),
-                next => s3.putObject(params, (err, res) => {
-                    vId = res.VersionId;
-                    return next(err);
-                }),
-                next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsBefore = res.Versions;
-                    return next(err);
-                }),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDBefore = objMD;
-                    return next(err);
-                }),
-                next => putMPUVersion(s3, bucketName, objectName, '', next),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDAfter = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsAfter = res.Versions;
-                    return next(err);
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-
-                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
-                assert.deepStrictEqual(versionsAfter, versionsBefore);
-
-                checkObjMdAndUpdate(objMDBefore, objMDAfter,
-                    ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
-                    'x-amz-restore', 'archive', 'dataStoreName']);
-                assert.deepStrictEqual(objMDAfter, objMDBefore);
-                return done();
-            });
-        });
-
-
-        it('should fail if version is invalid', done => {
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            const params = { Bucket: bucketName, Key: objectName };
-
-            async.series([
-                next => s3.putBucketVersioning(vParams, next),
-                next => s3.putObject(params, next),
-                next => putMPUVersion(s3, bucketName, objectName, 'aJLWKz4Ko9IjBBgXKj5KQT.G9UHv0g7P', err => {
-                    checkError(err, 'InvalidArgument', 400);
-                    return next();
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-                return done();
-            });
-        });
-
-        it('should fail if key does not exist', done => {
-            async.series([
-                next => putMPUVersion(s3, bucketName, objectName, '', err => {
-                    checkError(err, 'NoSuchKey', 404);
-                    return next();
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-                return done();
-            });
-        });
-
-        it('should fail if version does not exist', done => {
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            const params = { Bucket: bucketName, Key: objectName };
-
-            async.series([
-                next => s3.putBucketVersioning(vParams, next),
-                next => s3.putObject(params, next),
-                next => putMPUVersion(s3, bucketName, objectName,
-                '393833343735313131383832343239393939393952473030312020313031', err => {
-                    checkError(err, 'NoSuchVersion', 404);
-                    return next();
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-                return done();
-            });
-        });
-
-        it('should overwrite a non-current null version', done => {
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            const params = { Bucket: bucketName, Key: objectName };
-            let versionsBefore;
-            let versionsAfter;
-            let objMDBefore;
-            let objMDAfter;
-
-            async.series([
-                next => s3.putObject(params, next),
-                next => s3.putBucketVersioning(vParams, next),
-                next => s3.putObject(params, next),
-                next => fakeMetadataArchive(bucketName, objectName, 'null', archive, next),
-                next => getMetadata(bucketName, objectName, 'null', (err, objMD) => {
-                    objMDBefore = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsBefore = res.Versions;
-                    return next(err);
-                }),
-                next => putMPUVersion(s3, bucketName, objectName, 'null', next),
-                next => getMetadata(bucketName, objectName, 'null', (err, objMD) => {
-                    objMDAfter = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsAfter = res.Versions;
-                    return next(err);
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-
-                checkVersionsAndUpdate(versionsBefore, versionsAfter, [1]);
-                assert.deepStrictEqual(versionsAfter, versionsBefore);
-
-                checkObjMdAndUpdate(objMDBefore, objMDAfter,
-                    ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
-                    'x-amz-restore', 'archive', 'dataStoreName']);
-                assert.deepStrictEqual(objMDAfter, objMDBefore);
-                return done();
-            });
-        });
-
-        it('should overwrite the lastest version and keep nullVersionId', done => {
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            const params = { Bucket: bucketName, Key: objectName };
-            let versionsBefore;
-            let versionsAfter;
-            let objMDBefore;
-            let objMDAfter;
-            let vId;
-
-            async.series([
-                next => s3.putObject(params, next),
-                next => s3.putBucketVersioning(vParams, next),
-                next => s3.putObject(params, (err, res) => {
-                    vId = res.VersionId;
-                    return next(err);
-                }),
-                next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDBefore = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsBefore = res.Versions;
-                    next(err);
-                }),
-                next => putMPUVersion(s3, bucketName, objectName, vId, next),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDAfter = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsAfter = res.Versions;
-                    return next(err);
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-
-                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
-                assert.deepStrictEqual(versionsAfter, versionsBefore);
-
-                checkObjMdAndUpdate(objMDBefore, objMDAfter,
-                    ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
-                    'x-amz-restore', 'archive', 'dataStoreName']);
-                assert.deepStrictEqual(objMDAfter, objMDBefore);
-                return done();
-            });
-        });
-
-        it('should overwrite a current null version', done => {
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            const sParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Suspended',
-                }
-            };
-            const params = { Bucket: bucketName, Key: objectName };
-            let objMDBefore;
-            let objMDAfter;
-            let versionsBefore;
-            let versionsAfter;
-
-            async.series([
-                next => s3.putBucketVersioning(vParams, next),
-                next => s3.putObject(params, next),
-                next => s3.putBucketVersioning(sParams, next),
-                next => s3.putObject(params, next),
-                next => fakeMetadataArchive(bucketName, objectName, undefined, archive, next),
-                next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
-                    objMDBefore = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsBefore = res.Versions;
-                    next(err);
-                }),
-                next => putMPUVersion(s3, bucketName, objectName, '', next),
-                next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
-                    objMDAfter = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsAfter = res.Versions;
-                    return next(err);
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-
-                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
-                assert.deepStrictEqual(versionsAfter, versionsBefore);
-
-                checkObjMdAndUpdate(objMDBefore, objMDAfter,
-                    ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
-                    'x-amz-restore', 'archive', 'dataStoreName']);
-                assert.deepStrictEqual(objMDAfter, objMDBefore);
-                return done();
-            });
-        });
-
-        it('should overwrite a non-current version', done => {
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            const params = { Bucket: bucketName, Key: objectName };
-            let objMDBefore;
-            let objMDAfter;
-            let versionsBefore;
-            let versionsAfter;
-            let vId;
-
-            async.series([
-                next => s3.putBucketVersioning(vParams, next),
-                next => s3.putObject(params, next),
-                next => s3.putObject(params, (err, res) => {
-                    vId = res.VersionId;
-                    return next(err);
-                }),
-                next => s3.putObject(params, next),
-                next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDBefore = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsBefore = res.Versions;
-                    return next(err);
-                }),
-                next => putMPUVersion(s3, bucketName, objectName, vId, next),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDAfter = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsAfter = res.Versions;
-                    return next(err);
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-
-                checkVersionsAndUpdate(versionsBefore, versionsAfter, [1]);
-                assert.deepStrictEqual(versionsAfter, versionsBefore);
-
-                checkObjMdAndUpdate(objMDBefore, objMDAfter,
-                    ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
-                    'x-amz-restore', 'archive', 'dataStoreName']);
-                assert.deepStrictEqual(objMDAfter, objMDBefore);
-                return done();
-            });
-        });
-
-        it('should overwrite the current version', done => {
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            const params = { Bucket: bucketName, Key: objectName };
-            let objMDBefore;
-            let objMDAfter;
-            let versionsBefore;
-            let versionsAfter;
-            let vId;
-
-            async.series([
-                next => s3.putBucketVersioning(vParams, next),
-                next => s3.putObject(params, next),
-                next => s3.putObject(params, (err, res) => {
-                    vId = res.VersionId;
-                    return next(err);
-                }),
-                next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsBefore = res.Versions;
-                    return next(err);
-                }),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDBefore = objMD;
-                    return next(err);
-                }),
-                next => putMPUVersion(s3, bucketName, objectName, vId, next),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDAfter = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsAfter = res.Versions;
-                    return next(err);
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-
-                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
-                assert.deepStrictEqual(versionsAfter, versionsBefore);
-
-                checkObjMdAndUpdate(objMDBefore, objMDAfter,
-                    ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
-                    'x-amz-restore', 'archive', 'dataStoreName']);
-                assert.deepStrictEqual(objMDAfter, objMDBefore);
-                return done();
-            });
-        });
-
-        it('should overwrite the current version after bucket version suspended', done => {
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            const sParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Suspended',
-                }
-            };
-            const params = { Bucket: bucketName, Key: objectName };
-            let objMDBefore;
-            let objMDAfter;
-            let versionsBefore;
-            let versionsAfter;
-            let vId;
-
-            async.series([
-                next => s3.putBucketVersioning(vParams, next),
-                next => s3.putObject(params, next),
-                next => s3.putObject(params, (err, res) => {
-                    vId = res.VersionId;
-                    return next(err);
-                }),
-                next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsBefore = res.Versions;
-                    return next(err);
-                }),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDBefore = objMD;
-                    return next(err);
-                }),
-                next => s3.putBucketVersioning(sParams, next),
-                next => putMPUVersion(s3, bucketName, objectName, vId, next),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDAfter = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsAfter = res.Versions;
-                    return next(err);
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-
-                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
-                assert.deepStrictEqual(versionsAfter, versionsBefore);
-
-                checkObjMdAndUpdate(objMDBefore, objMDAfter,
-                    ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
-                    'x-amz-restore', 'archive', 'dataStoreName']);
-                assert.deepStrictEqual(objMDAfter, objMDBefore);
-                return done();
-            });
-        });
-
-        it('should overwrite the current null version after bucket version enabled', done => {
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            const params = { Bucket: bucketName, Key: objectName };
-            let objMDBefore;
-            let objMDAfter;
-            let versionsBefore;
-            let versionsAfter;
-
-            async.series([
-                next => s3.putObject(params, next),
-                next => fakeMetadataArchive(bucketName, objectName, undefined, archive, next),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsBefore = res.Versions;
-                    return next(err);
-                }),
-                next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
-                    objMDBefore = objMD;
-                    return next(err);
-                }),
-                next => s3.putBucketVersioning(vParams, next),
-                next => putMPUVersion(s3, bucketName, objectName, 'null', next),
-                next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
-                    objMDAfter = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsAfter = res.Versions;
-                    return next(err);
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-
-                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
-                assert.deepStrictEqual(versionsAfter, versionsBefore);
-
-                checkObjMdAndUpdate(objMDBefore, objMDAfter,
-                    ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
-                    'x-amz-restore', 'archive', 'dataStoreName']);
-
-                assert.deepStrictEqual(objMDAfter, objMDBefore);
-                return done();
-            });
-        });
-
-        it('should fail if archiving is not in progress', done => {
-            const params = { Bucket: bucketName, Key: objectName };
-
-            async.series([
-                next => s3.putObject(params, next),
-                next => putMPUVersion(s3, bucketName, objectName, '', err => {
-                    checkError(err, 'InvalidObjectState', 403);
-                    return next();
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-                return done();
-            });
-        });
-
-        it('should fail if trying to overwrite a delete marker', done => {
-            const params = { Bucket: bucketName, Key: objectName };
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            let vId;
-
-            async.series([
-                next => s3.putBucketVersioning(vParams, next),
-                next => s3.putObject(params, next),
-                next => s3.deleteObject(params, (err, res) => {
-                    vId = res.VersionId;
-                    return next(err);
-                }),
-                next => putMPUVersion(s3, bucketName, objectName, vId, err => {
-                    checkError(err, 'MethodNotAllowed', 405);
-                    return next();
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-                return done();
-            });
-        });
-
-        it('should fail if restore is already completed', done => {
-            const params = { Bucket: bucketName, Key: objectName };
-            const archiveCompleted = {
-                archiveInfo: {},
-                restoreRequestedAt: new Date(0),
-                restoreRequestedDays: 5,
-                restoreCompletedAt: new Date(10),
-                restoreWillExpireAt: new Date(10 + (5 * 24 * 60 * 60 * 1000)),
-            };
-
-            async.series([
-                next => s3.putObject(params, next),
-                next => fakeMetadataArchive(bucketName, objectName, undefined, archiveCompleted, next),
-                next => putMPUVersion(s3, bucketName, objectName, '', err => {
-                    checkError(err, 'InvalidObjectState', 403);
-                    return next();
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-                return done();
-            });
-        });
-
-        [
-            'non versioned',
-            'versioned',
-            'suspended'
-        ].forEach(versioning => {
-            it(`should update restore metadata while keeping storage class (${versioning})`, done => {
+            it('should overwrite an object', done => {
                 const params = { Bucket: bucketName, Key: objectName };
                 let objMDBefore;
                 let objMDAfter;
+                let versionsBefore;
+                let versionsAfter;
 
                 async.series([
-                    next => {
-                        if (versioning === 'versioned') {
-                            return s3.putBucketVersioning({
-                                Bucket: bucketName,
-                                VersioningConfiguration: { Status: 'Enabled' }
-                            }, next);
-                        } else if (versioning === 'suspended') {
-                            return s3.putBucketVersioning({
-                                Bucket: bucketName,
-                                VersioningConfiguration: { Status: 'Suspended' }
-                            }, next);
-                        }
-                        return next();
-                    },
                     next => s3.putObject(params, next),
                     next => fakeMetadataArchive(bucketName, objectName, undefined, archive, next),
                     next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
                         objMDBefore = objMD;
                         return next(err);
                     }),
-                    next => metadata.listObject(bucketName, mdListingParams, log, next),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsBefore = res.Versions;
+                        return next(err);
+                    }),
                     next => putMPUVersion(s3, bucketName, objectName, '', next),
                     next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
                         objMDAfter = objMD;
                         return next(err);
                     }),
-                    next => s3.listObjects({ Bucket: bucketName }, (err, res) => {
-                        assert.ifError(err);
-                        assert.strictEqual(res.Contents.length, 1);
-                        assert.strictEqual(res.Contents[0].StorageClass, 'location-dmf-v1');
-                        return next();
-                    }),
-                    next => s3.headObject(params, (err, res) => {
-                        assert.ifError(err);
-                        assert.strictEqual(res.StorageClass, 'location-dmf-v1');
-                        return next();
-                    }),
-                    next => s3.getObject(params, (err, res) => {
-                        assert.ifError(err);
-                        assert.strictEqual(res.StorageClass, 'location-dmf-v1');
-                        return next();
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsAfter = res.Versions;
+                        return next(err);
                     }),
                 ], err => {
                     assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
 
-                    // Make sure object data location is set back to its bucket data location.
-                    assert.deepStrictEqual(objMDAfter.dataStoreName, 'us-east-1');
+                    checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                    assert.deepStrictEqual(versionsAfter, versionsBefore);
 
-                    assert.deepStrictEqual(objMDAfter.archive.archiveInfo, objMDBefore.archive.archiveInfo);
-                    assert.deepStrictEqual(objMDAfter.archive.restoreRequestedAt,
-                        objMDBefore.archive.restoreRequestedAt);
-                    assert.deepStrictEqual(objMDAfter.archive.restoreRequestedDays,
-                        objMDBefore.archive.restoreRequestedDays);
-                    assert.deepStrictEqual(objMDAfter['x-amz-restore']['ongoing-request'], false);
+                    checkObjMdAndUpdate(objMDBefore, objMDAfter,
+                        ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
+                        'x-amz-restore', 'archive', 'dataStoreName']);
 
-                    assert(objMDAfter.archive.restoreCompletedAt);
-                    assert(objMDAfter.archive.restoreWillExpireAt);
-                    assert(objMDAfter['x-amz-restore']['expiry-date']);
+                    assert.deepStrictEqual(objMDAfter, objMDBefore);
                     return done();
                 });
             });
-        });
 
-        it('should "copy" all but non data-related metadata (data encryption, data size...)', done => {
-            const params = {
-                Bucket: bucketNameMD,
-                Key: objectName
-            };
-            const putParams = {
-                ...params,
-                Metadata: {
-                    'custom-user-md': 'custom-md',
-                },
-                WebsiteRedirectLocation: 'http://custom-redirect'
-            };
-            const aclParams = {
-                ...params,
-                // email of user Bart defined in authdata.json
-                GrantFullControl: 'emailaddress=sampleaccount1@sampling.com',
-            };
-            const tagParams = {
-                ...params,
-                Tagging: {
-                    TagSet: [{
-                      Key: 'tag1',
-                      Value: 'value1'
-                    }, {
-                        Key: 'tag2',
-                        Value: 'value2'
-                    }]
-                }
-            };
-            const legalHoldParams = {
-                ...params,
-                LegalHold: {
-                    Status: 'ON'
-                  },
-            };
-            const acl = {
-                'Canned': '',
-                'FULL_CONTROL': [
-                    // canonicalID of user Bart
-                    '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be',
-                ],
-                'WRITE_ACP': [],
-                'READ': [],
-                'READ_ACP': [],
-            };
-            const tags = { tag1: 'value1', tag2: 'value2' };
-            const replicationInfo = {
-                'status': 'COMPLETED',
-                'backends': [
-                        {
-                                'site': 'azure-normal',
-                                'status': 'COMPLETED',
-                                'dataStoreVersionId': '',
+            it('should overwrite a version', done => {
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                const params = { Bucket: bucketName, Key: objectName };
+                let objMDBefore;
+                let objMDAfter;
+                let versionsBefore;
+                let versionsAfter;
+                let vId;
+
+                async.series([
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => s3.putObject(params, (err, res) => {
+                        vId = res.VersionId;
+                        return next(err);
+                    }),
+                    next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsBefore = res.Versions;
+                        return next(err);
+                    }),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDBefore = objMD;
+                        return next(err);
+                    }),
+                    next => putMPUVersion(s3, bucketName, objectName, vId, next),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDAfter = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsAfter = res.Versions;
+                        return next(err);
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                    checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                    assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                    checkObjMdAndUpdate(objMDBefore, objMDAfter,
+                        ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
+                        'x-amz-restore', 'archive', 'dataStoreName']);
+                    assert.deepStrictEqual(objMDAfter, objMDBefore);
+                    return done();
+                });
+            });
+
+            it('should overwrite the current version if empty version id header', done => {
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                const params = { Bucket: bucketName, Key: objectName };
+                let objMDBefore;
+                let objMDAfter;
+                let versionsBefore;
+                let versionsAfter;
+                let vId;
+
+                async.series([
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => s3.putObject(params, (err, res) => {
+                        vId = res.VersionId;
+                        return next(err);
+                    }),
+                    next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsBefore = res.Versions;
+                        return next(err);
+                    }),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDBefore = objMD;
+                        return next(err);
+                    }),
+                    next => putMPUVersion(s3, bucketName, objectName, '', next),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDAfter = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsAfter = res.Versions;
+                        return next(err);
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                    checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                    assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                    checkObjMdAndUpdate(objMDBefore, objMDAfter,
+                        ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
+                        'x-amz-restore', 'archive', 'dataStoreName']);
+                    assert.deepStrictEqual(objMDAfter, objMDBefore);
+                    return done();
+                });
+            });
+
+            it('should overwrite a non-current null version', done => {
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                const params = { Bucket: bucketName, Key: objectName };
+                let versionsBefore;
+                let versionsAfter;
+                let objMDBefore;
+                let objMDAfter;
+
+                async.series([
+                    next => s3.putObject(params, next),
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => s3.putObject(params, next),
+                    next => fakeMetadataArchive(bucketName, objectName, 'null', archive, next),
+                    next => getMetadata(bucketName, objectName, 'null', (err, objMD) => {
+                        objMDBefore = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsBefore = res.Versions;
+                        return next(err);
+                    }),
+                    next => putMPUVersion(s3, bucketName, objectName, 'null', next),
+                    next => getMetadata(bucketName, objectName, 'null', (err, objMD) => {
+                        objMDAfter = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsAfter = res.Versions;
+                        return next(err);
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                    checkVersionsAndUpdate(versionsBefore, versionsAfter, [1]);
+                    assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                    checkObjMdAndUpdate(objMDBefore, objMDAfter,
+                        ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
+                        'x-amz-restore', 'archive', 'dataStoreName']);
+                    assert.deepStrictEqual(objMDAfter, objMDBefore);
+                    return done();
+                });
+            });
+
+            it('should overwrite the lastest version and keep nullVersionId', done => {
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                const params = { Bucket: bucketName, Key: objectName };
+                let versionsBefore;
+                let versionsAfter;
+                let objMDBefore;
+                let objMDAfter;
+                let vId;
+
+                async.series([
+                    next => s3.putObject(params, next),
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => s3.putObject(params, (err, res) => {
+                        vId = res.VersionId;
+                        return next(err);
+                    }),
+                    next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDBefore = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsBefore = res.Versions;
+                        next(err);
+                    }),
+                    next => putMPUVersion(s3, bucketName, objectName, vId, next),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDAfter = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsAfter = res.Versions;
+                        return next(err);
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                    checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                    assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                    checkObjMdAndUpdate(objMDBefore, objMDAfter,
+                        ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
+                        'x-amz-restore', 'archive', 'dataStoreName']);
+                    assert.deepStrictEqual(objMDAfter, objMDBefore);
+                    return done();
+                });
+            });
+
+            it('should overwrite a current null version', done => {
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                const sParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Suspended',
+                    }
+                };
+                const params = { Bucket: bucketName, Key: objectName };
+                let objMDBefore;
+                let objMDAfter;
+                let versionsBefore;
+                let versionsAfter;
+
+                async.series([
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => s3.putObject(params, next),
+                    next => s3.putBucketVersioning(sParams, next),
+                    next => s3.putObject(params, next),
+                    next => fakeMetadataArchive(bucketName, objectName, undefined, archive, next),
+                    next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                        objMDBefore = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsBefore = res.Versions;
+                        next(err);
+                    }),
+                    next => putMPUVersion(s3, bucketName, objectName, '', next),
+                    next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                        objMDAfter = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsAfter = res.Versions;
+                        return next(err);
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                    checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                    assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                    checkObjMdAndUpdate(objMDBefore, objMDAfter,
+                        ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
+                        'x-amz-restore', 'archive', 'dataStoreName']);
+                    assert.deepStrictEqual(objMDAfter, objMDBefore);
+                    return done();
+                });
+            });
+
+            it('should overwrite a non-current version', done => {
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                const params = { Bucket: bucketName, Key: objectName };
+                let objMDBefore;
+                let objMDAfter;
+                let versionsBefore;
+                let versionsAfter;
+                let vId;
+
+                async.series([
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => s3.putObject(params, next),
+                    next => s3.putObject(params, (err, res) => {
+                        vId = res.VersionId;
+                        return next(err);
+                    }),
+                    next => s3.putObject(params, next),
+                    next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDBefore = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsBefore = res.Versions;
+                        return next(err);
+                    }),
+                    next => putMPUVersion(s3, bucketName, objectName, vId, next),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDAfter = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsAfter = res.Versions;
+                        return next(err);
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                    checkVersionsAndUpdate(versionsBefore, versionsAfter, [1]);
+                    assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                    checkObjMdAndUpdate(objMDBefore, objMDAfter,
+                        ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
+                        'x-amz-restore', 'archive', 'dataStoreName']);
+                    assert.deepStrictEqual(objMDAfter, objMDBefore);
+                    return done();
+                });
+            });
+
+            it('should overwrite the current version', done => {
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                const params = { Bucket: bucketName, Key: objectName };
+                let objMDBefore;
+                let objMDAfter;
+                let versionsBefore;
+                let versionsAfter;
+                let vId;
+
+                async.series([
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => s3.putObject(params, next),
+                    next => s3.putObject(params, (err, res) => {
+                        vId = res.VersionId;
+                        return next(err);
+                    }),
+                    next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsBefore = res.Versions;
+                        return next(err);
+                    }),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDBefore = objMD;
+                        return next(err);
+                    }),
+                    next => putMPUVersion(s3, bucketName, objectName, vId, next),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDAfter = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsAfter = res.Versions;
+                        return next(err);
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                    checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                    assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                    checkObjMdAndUpdate(objMDBefore, objMDAfter,
+                        ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
+                        'x-amz-restore', 'archive', 'dataStoreName']);
+                    assert.deepStrictEqual(objMDAfter, objMDBefore);
+                    return done();
+                });
+            });
+
+            it('should overwrite the current version after bucket version suspended', done => {
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                const sParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Suspended',
+                    }
+                };
+                const params = { Bucket: bucketName, Key: objectName };
+                let objMDBefore;
+                let objMDAfter;
+                let versionsBefore;
+                let versionsAfter;
+                let vId;
+
+                async.series([
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => s3.putObject(params, next),
+                    next => s3.putObject(params, (err, res) => {
+                        vId = res.VersionId;
+                        return next(err);
+                    }),
+                    next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsBefore = res.Versions;
+                        return next(err);
+                    }),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDBefore = objMD;
+                        return next(err);
+                    }),
+                    next => s3.putBucketVersioning(sParams, next),
+                    next => putMPUVersion(s3, bucketName, objectName, vId, next),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDAfter = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsAfter = res.Versions;
+                        return next(err);
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                    checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                    assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                    checkObjMdAndUpdate(objMDBefore, objMDAfter,
+                        ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
+                        'x-amz-restore', 'archive', 'dataStoreName']);
+                    assert.deepStrictEqual(objMDAfter, objMDBefore);
+                    return done();
+                });
+            });
+
+            it('should overwrite the current null version after bucket version enabled', done => {
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                const params = { Bucket: bucketName, Key: objectName };
+                let objMDBefore;
+                let objMDAfter;
+                let versionsBefore;
+                let versionsAfter;
+
+                async.series([
+                    next => s3.putObject(params, next),
+                    next => fakeMetadataArchive(bucketName, objectName, undefined, archive, next),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsBefore = res.Versions;
+                        return next(err);
+                    }),
+                    next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                        objMDBefore = objMD;
+                        return next(err);
+                    }),
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => putMPUVersion(s3, bucketName, objectName, 'null', next),
+                    next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                        objMDAfter = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsAfter = res.Versions;
+                        return next(err);
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                    checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                    assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                    checkObjMdAndUpdate(objMDBefore, objMDAfter,
+                        ['location', 'content-length', 'originOp', 'uploadId', 'microVersionId',
+                        'x-amz-restore', 'archive', 'dataStoreName']);
+
+                    assert.deepStrictEqual(objMDAfter, objMDBefore);
+                    return done();
+                });
+            });
+
+            it('should fail if restore is already completed', done => {
+                const params = { Bucket: bucketName, Key: objectName };
+                const archiveCompleted = {
+                    archiveInfo: {},
+                    restoreRequestedAt: new Date(0),
+                    restoreRequestedDays: 5,
+                    restoreCompletedAt: new Date(10),
+                    restoreWillExpireAt: new Date(10 + (5 * 24 * 60 * 60 * 1000)),
+                };
+
+                async.series([
+                    next => s3.putObject(params, next),
+                    next => fakeMetadataArchive(bucketName, objectName, undefined, archiveCompleted, next),
+                    next => putMPUVersion(s3, bucketName, objectName, '', err => {
+                        checkError(err, 'InvalidObjectState', 403);
+                        return next();
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+                    return done();
+                });
+            });
+
+            [
+                'non versioned',
+                'versioned',
+                'suspended'
+            ].forEach(versioning => {
+                it(`should update restore metadata while keeping storage class (${versioning})`, done => {
+                    const params = { Bucket: bucketName, Key: objectName };
+                    let objMDBefore;
+                    let objMDAfter;
+
+                    async.series([
+                        next => {
+                            if (versioning === 'versioned') {
+                                return s3.putBucketVersioning({
+                                    Bucket: bucketName,
+                                    VersioningConfiguration: { Status: 'Enabled' }
+                                }, next);
+                            } else if (versioning === 'suspended') {
+                                return s3.putBucketVersioning({
+                                    Bucket: bucketName,
+                                    VersioningConfiguration: { Status: 'Suspended' }
+                                }, next);
+                            }
+                            return next();
                         },
-                ],
-                'content': [
-                        'DATA',
-                        'METADATA',
-                ],
-                'destination': 'arn:aws:s3:::versioned',
-                'storageClass': 'azure-normal',
-                'role': 'arn:aws:iam::root:role/s3-replication-role',
-                'storageType': 'azure',
-                'dataStoreVersionId': '',
-                'isNFS': null,
-            };
-            async.series([
-                next => s3.putObject(putParams, next),
-                next => s3.putObjectAcl(aclParams, next),
-                next => s3.putObjectTagging(tagParams, next),
-                next => s3.putObjectLegalHold(legalHoldParams, next),
-                next => getMetadata(bucketNameMD, objectName, undefined, (err, objMD) => {
-                    if (err) {
-                        return next(err);
+                        next => s3.putObject(params, next),
+                        next => fakeMetadataArchive(bucketName, objectName, undefined, archive, next),
+                        next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                            objMDBefore = objMD;
+                            return next(err);
+                        }),
+                        next => metadata.listObject(bucketName, mdListingParams, log, next),
+                        next => putMPUVersion(s3, bucketName, objectName, '', next),
+                        next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                            objMDAfter = objMD;
+                            return next(err);
+                        }),
+                        next => s3.listObjects({ Bucket: bucketName }, (err, res) => {
+                            assert.ifError(err);
+                            assert.strictEqual(res.Contents.length, 1);
+                            assert.strictEqual(res.Contents[0].StorageClass, 'location-dmf-v1');
+                            return next();
+                        }),
+                        next => s3.headObject(params, (err, res) => {
+                            assert.ifError(err);
+                            assert.strictEqual(res.StorageClass, 'location-dmf-v1');
+                            return next();
+                        }),
+                        next => s3.getObject(params, (err, res) => {
+                            assert.ifError(err);
+                            assert.strictEqual(res.StorageClass, 'location-dmf-v1');
+                            return next();
+                        }),
+                    ], err => {
+                        assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                        // Make sure object data location is set back to its bucket data location.
+                        assert.deepStrictEqual(objMDAfter.dataStoreName, 'us-east-1');
+
+                        assert.deepStrictEqual(objMDAfter.archive.archiveInfo, objMDBefore.archive.archiveInfo);
+                        assert.deepStrictEqual(objMDAfter.archive.restoreRequestedAt,
+                            objMDBefore.archive.restoreRequestedAt);
+                        assert.deepStrictEqual(objMDAfter.archive.restoreRequestedDays,
+                            objMDBefore.archive.restoreRequestedDays);
+                        assert.deepStrictEqual(objMDAfter['x-amz-restore']['ongoing-request'], false);
+
+                        assert(objMDAfter.archive.restoreCompletedAt);
+                        assert(objMDAfter.archive.restoreWillExpireAt);
+                        assert(objMDAfter['x-amz-restore']['expiry-date']);
+                        return done();
+                    });
+                });
+            });
+
+            it('should "copy" all but non data-related metadata (data encryption, data size...)', done => {
+                const params = {
+                    Bucket: bucketNameMD,
+                    Key: objectName
+                };
+                const putParams = {
+                    ...params,
+                    Metadata: {
+                        'custom-user-md': 'custom-md',
+                    },
+                    WebsiteRedirectLocation: 'http://custom-redirect'
+                };
+                const aclParams = {
+                    ...params,
+                    // email of user Bart defined in authdata.json
+                    GrantFullControl: 'emailaddress=sampleaccount1@sampling.com',
+                };
+                const tagParams = {
+                    ...params,
+                    Tagging: {
+                        TagSet: [{
+                        Key: 'tag1',
+                        Value: 'value1'
+                        }, {
+                            Key: 'tag2',
+                            Value: 'value2'
+                        }]
                     }
-                    /* eslint-disable no-param-reassign */
-                    objMD.dataStoreName = 'location-dmf-v1';
-                    objMD.archive = archive;
-                    objMD.replicationInfo = replicationInfo;
-                    // data related
-                    objMD['content-length'] = 99;
-                    objMD['content-type'] = 'testtype';
-                    objMD['content-md5'] = 'testmd5';
-                    objMD['content-encoding'] = 'testencoding';
-                    objMD['x-amz-server-side-encryption'] = 'aws:kms';
-                    /* eslint-enable no-param-reassign */
-                    return metadata.putObjectMD(bucketNameMD, objectName, objMD, undefined, log, next);
-                }),
-                next => putMPUVersion(s3, bucketNameMD, objectName, '', next),
-                next => getMetadata(bucketNameMD, objectName, undefined, (err, objMD) => {
-                    if (err) {
-                        return next(err);
-                    }
-                    assert.deepStrictEqual(objMD.acl, acl);
-                    assert.deepStrictEqual(objMD.tags, tags);
-                    assert.deepStrictEqual(objMD.replicationInfo, replicationInfo);
-                    assert.deepStrictEqual(objMD.legalHold, true);
-                    assert.strictEqual(objMD['x-amz-meta-custom-user-md'], 'custom-md');
-                    assert.strictEqual(objMD['x-amz-website-redirect-location'], 'http://custom-redirect');
-                    // make sure data related metadatas ar not the same before and after
-                    assert.notStrictEqual(objMD['x-amz-server-side-encryption'], 'aws:kms');
-                    assert.notStrictEqual(objMD['content-length'], 99);
-                    assert.notStrictEqual(objMD['content-encoding'], 'testencoding');
-                    assert.notStrictEqual(objMD['content-type'], 'testtype');
-                    // make sure we keep the same etag and add the new restored
-                    // data's etag inside x-amz-restore
-                    assert.strictEqual(objMD['content-md5'], 'testmd5');
-                    assert.strictEqual(typeof objMD['x-amz-restore']['content-md5'], 'string');
-                    return next();
-                }),
-                // removing legal hold to be able to clean the bucket after the test
-                next => {
-                    legalHoldParams.LegalHold.Status = 'OFF';
-                    return s3.putObjectLegalHold(legalHoldParams, next);
-                },
-            ], done);
+                };
+                const legalHoldParams = {
+                    ...params,
+                    LegalHold: {
+                        Status: 'ON'
+                    },
+                };
+                const acl = {
+                    'Canned': '',
+                    'FULL_CONTROL': [
+                        // canonicalID of user Bart
+                        '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be',
+                    ],
+                    'WRITE_ACP': [],
+                    'READ': [],
+                    'READ_ACP': [],
+                };
+                const tags = { tag1: 'value1', tag2: 'value2' };
+                const replicationInfo = {
+                    'status': 'COMPLETED',
+                    'backends': [
+                            {
+                                    'site': 'azure-normal',
+                                    'status': 'COMPLETED',
+                                    'dataStoreVersionId': '',
+                            },
+                    ],
+                    'content': [
+                            'DATA',
+                            'METADATA',
+                    ],
+                    'destination': 'arn:aws:s3:::versioned',
+                    'storageClass': 'azure-normal',
+                    'role': 'arn:aws:iam::root:role/s3-replication-role',
+                    'storageType': 'azure',
+                    'dataStoreVersionId': '',
+                    'isNFS': null,
+                };
+                async.series([
+                    next => s3.putObject(putParams, next),
+                    next => s3.putObjectAcl(aclParams, next),
+                    next => s3.putObjectTagging(tagParams, next),
+                    next => s3.putObjectLegalHold(legalHoldParams, next),
+                    next => getMetadata(bucketNameMD, objectName, undefined, (err, objMD) => {
+                        if (err) {
+                            return next(err);
+                        }
+                        /* eslint-disable no-param-reassign */
+                        objMD.dataStoreName = 'location-dmf-v1';
+                        objMD.archive = archive;
+                        objMD.replicationInfo = replicationInfo;
+                        // data related
+                        objMD['content-length'] = 99;
+                        objMD['content-type'] = 'testtype';
+                        objMD['content-md5'] = 'testmd5';
+                        objMD['content-encoding'] = 'testencoding';
+                        objMD['x-amz-server-side-encryption'] = 'aws:kms';
+                        /* eslint-enable no-param-reassign */
+                        return metadata.putObjectMD(bucketNameMD, objectName, objMD, undefined, log, next);
+                    }),
+                    next => putMPUVersion(s3, bucketNameMD, objectName, '', next),
+                    next => getMetadata(bucketNameMD, objectName, undefined, (err, objMD) => {
+                        if (err) {
+                            return next(err);
+                        }
+                        assert.deepStrictEqual(objMD.acl, acl);
+                        assert.deepStrictEqual(objMD.tags, tags);
+                        assert.deepStrictEqual(objMD.replicationInfo, replicationInfo);
+                        assert.deepStrictEqual(objMD.legalHold, true);
+                        assert.strictEqual(objMD['x-amz-meta-custom-user-md'], 'custom-md');
+                        assert.strictEqual(objMD['x-amz-website-redirect-location'], 'http://custom-redirect');
+                        // make sure data related metadatas ar not the same before and after
+                        assert.notStrictEqual(objMD['x-amz-server-side-encryption'], 'aws:kms');
+                        assert.notStrictEqual(objMD['content-length'], 99);
+                        assert.notStrictEqual(objMD['content-encoding'], 'testencoding');
+                        assert.notStrictEqual(objMD['content-type'], 'testtype');
+                        // make sure we keep the same etag and add the new restored
+                        // data's etag inside x-amz-restore
+                        assert.strictEqual(objMD['content-md5'], 'testmd5');
+                        assert.strictEqual(typeof objMD['x-amz-restore']['content-md5'], 'string');
+                        return next();
+                    }),
+                    // removing legal hold to be able to clean the bucket after the test
+                    next => {
+                        legalHoldParams.LegalHold.Status = 'OFF';
+                        return s3.putObjectLegalHold(legalHoldParams, next);
+                    },
+                ], done);
+            });
         });
     });
 });

--- a/tests/functional/aws-node-sdk/test/object/putVersion.js
+++ b/tests/functional/aws-node-sdk/test/object/putVersion.js
@@ -7,6 +7,7 @@ const metadata = require('../../../../../lib/metadata/wrapper');
 const { DummyRequestLogger } = require('../../../../unit/helpers');
 const checkError = require('../../lib/utility/checkError');
 const { getMetadata, fakeMetadataArchive, isNullKeyMetadataV1 } = require('../utils/init');
+const { hasColdStorage } = require('../../lib/utility/test-utils');
 
 const log = new DummyRequestLogger();
 
@@ -48,10 +49,10 @@ function checkObjMdAndUpdate(objMDBefore, objMDAfter, props) {
 }
 
 // TODO: CLDSRV-721 RING 10 Support ObjectRestore (cold storage) with MD v1
-// The whole test suite is skipped as bad versionId breaks after each bucket cleanup
-const describeSkipNullMdV1 = isNullKeyMetadataV1 || process.env.S3_END_TO_END ? describe.skip : describe;
+// The cold storage test suite is skipped as bad versionId while faking archive breaks after each bucket cleanup
+const describeSkipNullMdV1 = isNullKeyMetadataV1 || !hasColdStorage ? describe.skip : describe;
 
-describeSkipNullMdV1('PUT object with x-scal-s3-version-id header', () => {
+describe('PUT object with x-scal-s3-version-id header', () => {
     withV4(sigCfg => {
         let bucketUtil;
         let s3;
@@ -79,837 +80,835 @@ describeSkipNullMdV1('PUT object with x-scal-s3-version-id header', () => {
             });
         });
 
-        it('should overwrite an object', done => {
-            const params = { Bucket: bucketName, Key: objectName };
-            let objMDBefore;
-            let objMDAfter;
-            let versionsBefore;
-            let versionsAfter;
+        describe('error handling validation (without cold storage location)', () => {
+            it('should fail if version id is invalid', done => {
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                const params = { Bucket: bucketName, Key: objectName };
 
-            async.series([
-                next => s3.putObject(params, next),
-                next => fakeMetadataArchive(bucketName, objectName, undefined, archive, next),
-                next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
-                    objMDBefore = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsBefore = res.Versions;
-                    return next(err);
-                }),
-                next => putObjectVersion(s3, params, '', next),
-                next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
-                    objMDAfter = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsAfter = res.Versions;
-                    return next(err);
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+                async.series([
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => s3.putObject(params, next),
+                    next => putObjectVersion(s3, params, 'aJLWKz4Ko9IjBBgXKj5KQT.G9UHv0g7P', err => {
+                        checkError(err, 'InvalidArgument', 400);
+                        return next();
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+                    return done();
+                });
+            });
 
-                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
-                assert.deepStrictEqual(versionsAfter, versionsBefore);
+            it('should fail if key does not exist', done => {
+                const params = { Bucket: bucketName, Key: objectName };
 
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length',
-                'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName', 'originOp']);
-                assert.deepStrictEqual(objMDAfter, objMDBefore);
-                return done();
+                async.series([
+                    next => putObjectVersion(s3, params, '', err => {
+                        checkError(err, 'NoSuchKey', 404);
+                        return next();
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+                    return done();
+                });
+            });
+
+            it('should fail if version does not exist', done => {
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                const params = { Bucket: bucketName, Key: objectName };
+
+                async.series([
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => s3.putObject(params, next),
+                    next => putObjectVersion(s3, params,
+                    '393833343735313131383832343239393939393952473030312020313031', err => {
+                        checkError(err, 'NoSuchVersion', 404);
+                        return next();
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+                    return done();
+                });
+            });
+
+            it('should fail if archiving is not in progress', done => {
+                const params = { Bucket: bucketName, Key: objectName };
+
+                async.series([
+                    next => s3.putObject(params, next),
+                    next => putObjectVersion(s3, params, '', err => {
+                        checkError(err, 'InvalidObjectState', 403);
+                        return next();
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+                    return done();
+                });
+            });
+
+            it('should fail if trying to overwrite a delete marker', done => {
+                const params = { Bucket: bucketName, Key: objectName };
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                let vId;
+
+                async.series([
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => s3.putObject(params, next),
+                    next => s3.deleteObject(params, (err, res) => {
+                        vId = res.VersionId;
+                        return next(err);
+                    }),
+                    next => putObjectVersion(s3, params, vId, err => {
+                        checkError(err, 'MethodNotAllowed', 405);
+                        return next();
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+                    return done();
+                });
             });
         });
 
-        it('should overwrite a version', done => {
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            const params = { Bucket: bucketName, Key: objectName };
-            let objMDBefore;
-            let objMDAfter;
-            let versionsBefore;
-            let versionsAfter;
-            let vId;
-
-            async.series([
-                next => s3.putBucketVersioning(vParams, next),
-                next => s3.putObject(params, (err, res) => {
-                    vId = res.VersionId;
-                    return next(err);
-                }),
-                next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsBefore = res.Versions;
-                    return next(err);
-                }),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDBefore = objMD;
-                    return next(err);
-                }),
-                next => putObjectVersion(s3, params, vId, next),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDAfter = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsAfter = res.Versions;
-                    return next(err);
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-
-                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
-                assert.deepStrictEqual(versionsAfter, versionsBefore);
-
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
-                'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
-                assert.deepStrictEqual(objMDAfter, objMDBefore);
-                return done();
-            });
-        });
-
-        it('should overwrite the current version if empty version id header', done => {
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            const params = { Bucket: bucketName, Key: objectName };
-            let objMDBefore;
-            let objMDAfter;
-            let versionsBefore;
-            let versionsAfter;
-            let vId;
-
-            async.series([
-                next => s3.putBucketVersioning(vParams, next),
-                next => s3.putObject(params, (err, res) => {
-                    vId = res.VersionId;
-                    return next(err);
-                }),
-                next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsBefore = res.Versions;
-                    return next(err);
-                }),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDBefore = objMD;
-                    return next(err);
-                }),
-                next => putObjectVersion(s3, params, '', next),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDAfter = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsAfter = res.Versions;
-                    return next(err);
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-
-                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
-                assert.deepStrictEqual(versionsAfter, versionsBefore);
-
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
-                'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
-                assert.deepStrictEqual(objMDAfter, objMDBefore);
-                return done();
-            });
-        });
-
-
-        it('should fail if version id is invalid', done => {
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            const params = { Bucket: bucketName, Key: objectName };
-            let vId;
-
-            async.series([
-                next => s3.putBucketVersioning(vParams, next),
-                next => s3.putObject(params, (err, res) => {
-                    vId = res.VersionId;
-                    return next(err);
-                }),
-                next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
-                next => putObjectVersion(s3, params, 'aJLWKz4Ko9IjBBgXKj5KQT.G9UHv0g7P', err => {
-                    checkError(err, 'InvalidArgument', 400);
-                    return next();
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-                return done();
-            });
-        });
-
-        it('should fail if key does not exist', done => {
-            const params = { Bucket: bucketName, Key: objectName };
-
-            async.series([
-                next => putObjectVersion(s3, params, '', err => {
-                    checkError(err, 'NoSuchKey', 404);
-                    return next();
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-                return done();
-            });
-        });
-
-        it('should fail if version does not exist', done => {
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            const params = { Bucket: bucketName, Key: objectName };
-
-            async.series([
-                next => s3.putBucketVersioning(vParams, next),
-                next => s3.putObject(params, next),
-                next => putObjectVersion(s3, params,
-                '393833343735313131383832343239393939393952473030312020313031', err => {
-                    checkError(err, 'NoSuchVersion', 404);
-                    return next();
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-                return done();
-            });
-        });
-
-        it('should overwrite a non-current null version', done => {
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            const params = { Bucket: bucketName, Key: objectName };
-            let versionsBefore;
-            let versionsAfter;
-            let objMDBefore;
-            let objMDAfter;
-
-            async.series([
-                next => s3.putObject(params, next),
-                next => s3.putBucketVersioning(vParams, next),
-                next => s3.putObject(params, next),
-                next => fakeMetadataArchive(bucketName, objectName, 'null', archive, next),
-                next => getMetadata(bucketName, objectName, 'null', (err, objMD) => {
-                    objMDBefore = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsBefore = res.Versions;
-                    next(err);
-                }),
-                next => putObjectVersion(s3, params, 'null', next),
-                next => getMetadata(bucketName, objectName, 'null', (err, objMD) => {
-                    objMDAfter = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsAfter = res.Versions;
-                    return next(err);
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-
-                checkVersionsAndUpdate(versionsBefore, versionsAfter, [1]);
-                assert.deepStrictEqual(versionsAfter, versionsBefore);
-
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
-                'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
-                assert.deepStrictEqual(objMDAfter, objMDBefore);
-                return done();
-            });
-        });
-
-        it('should overwrite the lastest version and keep nullVersionId', done => {
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            const params = { Bucket: bucketName, Key: objectName };
-            let versionsBefore;
-            let versionsAfter;
-            let objMDBefore;
-            let objMDAfter;
-            let vId;
-
-            async.series([
-                next => s3.putObject(params, next),
-                next => s3.putBucketVersioning(vParams, next),
-                next => s3.putObject(params, (err, res) => {
-                    vId = res.VersionId;
-                    return next(err);
-                }),
-                next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDBefore = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsBefore = res.Versions;
-                    return next(err);
-                }),
-                next => putObjectVersion(s3, params, vId, next),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDAfter = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsAfter = res.Versions;
-                    return next(err);
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-
-                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
-                assert.deepStrictEqual(versionsAfter, versionsBefore);
-
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
-                'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
-                assert.deepStrictEqual(objMDAfter, objMDBefore);
-                return done();
-            });
-        });
-
-        it('should overwrite a current null version', done => {
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            const sParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Suspended',
-                }
-            };
-            const params = { Bucket: bucketName, Key: objectName };
-            let objMDBefore;
-            let objMDAfter;
-            let versionsBefore;
-            let versionsAfter;
-
-            async.series([
-                next => s3.putBucketVersioning(vParams, next),
-                next => s3.putObject(params, next),
-                next => s3.putBucketVersioning(sParams, next),
-                next => s3.putObject(params, next),
-                next => fakeMetadataArchive(bucketName, objectName, undefined, archive, next),
-                next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
-                    objMDBefore = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsBefore = res.Versions;
-                    return next(err);
-                }),
-                next => putObjectVersion(s3, params, '', next),
-                next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
-                    objMDAfter = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsAfter = res.Versions;
-                    return next(err);
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-
-                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
-                assert.deepStrictEqual(versionsAfter, versionsBefore);
-
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
-                'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
-                assert.deepStrictEqual(objMDAfter, objMDBefore);
-                return done();
-            });
-        });
-
-        it('should overwrite a non-current version', done => {
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            const params = { Bucket: bucketName, Key: objectName };
-            let objMDBefore;
-            let objMDAfter;
-            let versionsBefore;
-            let versionsAfter;
-            let vId;
-
-            async.series([
-                next => s3.putBucketVersioning(vParams, next),
-                next => s3.putObject(params, next),
-                next => s3.putObject(params, (err, res) => {
-                    vId = res.VersionId;
-                    return next(err);
-                }),
-                next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
-                next => s3.putObject(params, next),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsBefore = res.Versions;
-                    return next(err);
-                }),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDBefore = objMD;
-                    return next(err);
-                }),
-                next => putObjectVersion(s3, params, vId, next),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDAfter = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsAfter = res.Versions;
-                    return next(err);
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-
-                checkVersionsAndUpdate(versionsBefore, versionsAfter, [1]);
-                assert.deepStrictEqual(versionsAfter, versionsBefore);
-
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
-                'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
-                assert.deepStrictEqual(objMDAfter, objMDBefore);
-                return done();
-            });
-        });
-
-        it('should overwrite the current version', done => {
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            const params = { Bucket: bucketName, Key: objectName };
-            let objMDBefore;
-            let objMDAfter;
-            let versionsBefore;
-            let versionsAfter;
-            let vId;
-
-            async.series([
-                next => s3.putBucketVersioning(vParams, next),
-                next => s3.putObject(params, next),
-                next => s3.putObject(params, (err, res) => {
-                    vId = res.VersionId;
-                    return next(err);
-                }),
-                next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsBefore = res.Versions;
-                    return next(err);
-                }),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDBefore = objMD;
-                    return next(err);
-                }),
-                next => putObjectVersion(s3, params, vId, next),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDAfter = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsAfter = res.Versions;
-                    return next(err);
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-
-                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
-                assert.deepStrictEqual(versionsAfter, versionsBefore);
-
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
-                'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
-                assert.deepStrictEqual(objMDAfter, objMDBefore);
-                return done();
-            });
-        });
-
-        it('should overwrite the current version after bucket version suspended', done => {
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            const sParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Suspended',
-                }
-            };
-            const params = { Bucket: bucketName, Key: objectName };
-            let objMDBefore;
-            let objMDAfter;
-            let versionsBefore;
-            let versionsAfter;
-            let vId;
-
-            async.series([
-                next => s3.putBucketVersioning(vParams, next),
-                next => s3.putObject(params, next),
-                next => s3.putObject(params, (err, res) => {
-                    vId = res.VersionId;
-                    return next(err);
-                }),
-                next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsBefore = res.Versions;
-                    return next(err);
-                }),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDBefore = objMD;
-                    return next(err);
-                }),
-                next => s3.putBucketVersioning(sParams, next),
-                next => putObjectVersion(s3, params, vId, next),
-                next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
-                    objMDAfter = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsAfter = res.Versions;
-                    return next(err);
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-
-                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
-                assert.deepStrictEqual(versionsAfter, versionsBefore);
-
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
-                'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
-                assert.deepStrictEqual(objMDAfter, objMDBefore);
-                return done();
-            });
-        });
-
-        it('should overwrite the current null version after bucket version enabled', done => {
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            const params = { Bucket: bucketName, Key: objectName };
-            let objMDBefore;
-            let objMDAfter;
-            let versionsBefore;
-            let versionsAfter;
-
-            async.series([
-                next => s3.putObject(params, next),
-                next => fakeMetadataArchive(bucketName, objectName, undefined, archive, next),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsBefore = res.Versions;
-                    return next(err);
-                }),
-                next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
-                    objMDBefore = objMD;
-                    return next(err);
-                }),
-                next => s3.putBucketVersioning(vParams, next),
-                next => putObjectVersion(s3, params, 'null', next),
-                next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
-                    objMDAfter = objMD;
-                    return next(err);
-                }),
-                next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
-                    versionsAfter = res.Versions;
-                    return next(err);
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-
-                checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
-                assert.deepStrictEqual(versionsAfter, versionsBefore);
-
-                checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
-                'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
-                assert.deepStrictEqual(objMDAfter, objMDBefore);
-                return done();
-            });
-        });
-
-        it('should fail if archiving is not in progress', done => {
-            const params = { Bucket: bucketName, Key: objectName };
-
-            async.series([
-                next => s3.putObject(params, next),
-                next => putObjectVersion(s3, params, '', err => {
-                    checkError(err, 'InvalidObjectState', 403);
-                    return next();
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-                return done();
-            });
-        });
-
-        it('should fail if trying to overwrite a delete marker', done => {
-            const params = { Bucket: bucketName, Key: objectName };
-            const vParams = {
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                }
-            };
-            let vId;
-
-            async.series([
-                next => s3.putBucketVersioning(vParams, next),
-                next => s3.putObject(params, next),
-                next => s3.deleteObject(params, (err, res) => {
-                    vId = res.VersionId;
-                    return next(err);
-                }),
-                next => putObjectVersion(s3, params, vId, err => {
-                    checkError(err, 'MethodNotAllowed', 405);
-                    return next();
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-                return done();
-            });
-        });
-
-        it('should fail if restore is already completed', done => {
-            const params = { Bucket: bucketName, Key: objectName };
-            const archiveCompleted = {
-                archiveInfo: {},
-                restoreRequestedAt: new Date(0),
-                restoreRequestedDays: 5,
-                restoreCompletedAt: new Date(10),
-                restoreWillExpireAt: new Date(10 + (5 * 24 * 60 * 60 * 1000)),
-            };
-
-            async.series([
-                next => s3.putObject(params, next),
-                next => fakeMetadataArchive(bucketName, objectName, undefined, archiveCompleted, next),
-                next => putObjectVersion(s3, params, '', err => {
-                    checkError(err, 'InvalidObjectState', 403);
-                    return next();
-                }),
-            ], err => {
-                assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
-                return done();
-            });
-        });
-
-        [
-            'non versioned',
-            'versioned',
-            'suspended'
-        ].forEach(versioning => {
-            it(`should update restore metadata while keeping storage class (${versioning})`, done => {
+        describeSkipNullMdV1('with cold storage location', () => {
+            it('should overwrite an object', done => {
                 const params = { Bucket: bucketName, Key: objectName };
                 let objMDBefore;
                 let objMDAfter;
+                let versionsBefore;
+                let versionsAfter;
 
                 async.series([
-                    next => {
-                        if (versioning === 'versioned') {
-                            return s3.putBucketVersioning({
-                                Bucket: bucketName,
-                                VersioningConfiguration: { Status: 'Enabled' }
-                            }, next);
-                        } else if (versioning === 'suspended') {
-                            return s3.putBucketVersioning({
-                                Bucket: bucketName,
-                                VersioningConfiguration: { Status: 'Suspended' }
-                            }, next);
-                        }
-                        return next();
-                    },
                     next => s3.putObject(params, next),
                     next => fakeMetadataArchive(bucketName, objectName, undefined, archive, next),
                     next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
                         objMDBefore = objMD;
                         return next(err);
                     }),
-                    next => metadata.listObject(bucketName, mdListingParams, log, next),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsBefore = res.Versions;
+                        return next(err);
+                    }),
                     next => putObjectVersion(s3, params, '', next),
                     next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
                         objMDAfter = objMD;
                         return next(err);
                     }),
-                    next => s3.listObjects({ Bucket: bucketName }, (err, res) => {
-                        assert.ifError(err);
-                        assert.strictEqual(res.Contents.length, 1);
-                        assert.strictEqual(res.Contents[0].StorageClass, 'location-dmf-v1');
-                        return next();
-                    }),
-                    next => s3.headObject(params, (err, res) => {
-                        assert.ifError(err);
-                        assert.strictEqual(res.StorageClass, 'location-dmf-v1');
-                        return next();
-                    }),
-                    next => s3.getObject(params, (err, res) => {
-                        assert.ifError(err);
-                        assert.strictEqual(res.StorageClass, 'location-dmf-v1');
-                        return next();
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsAfter = res.Versions;
+                        return next(err);
                     }),
                 ], err => {
                     assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
 
-                    // storage class must stay as the cold location
-                    assert.deepStrictEqual(objMDAfter['x-amz-storage-class'], 'location-dmf-v1');
+                    checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                    assert.deepStrictEqual(versionsAfter, versionsBefore);
 
-                    /// Make sure object data location is set back to its bucket data location.
-                    assert.deepStrictEqual(objMDAfter.dataStoreName, 'us-east-1');
-
-                    assert.deepStrictEqual(objMDAfter.archive.archiveInfo, objMDBefore.archive.archiveInfo);
-                    assert.deepStrictEqual(objMDAfter.archive.restoreRequestedAt,
-                        objMDBefore.archive.restoreRequestedAt);
-                    assert.deepStrictEqual(objMDAfter.archive.restoreRequestedDays,
-                        objMDBefore.archive.restoreRequestedDays);
-                    assert.deepStrictEqual(objMDAfter['x-amz-restore']['ongoing-request'], false);
-
-                    assert(objMDAfter.archive.restoreCompletedAt);
-                    assert(objMDAfter.archive.restoreWillExpireAt);
-                    assert(objMDAfter['x-amz-restore']['expiry-date']);
+                    checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length',
+                    'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName', 'originOp']);
+                    assert.deepStrictEqual(objMDAfter, objMDBefore);
                     return done();
                 });
             });
-        });
 
-        it('should "copy" all but non data-related metadata (data encryption, data size...)', done => {
-            const params = {
-                Bucket: bucketNameMD,
-                Key: objectName
-            };
-            const putParams = {
-                ...params,
-                Metadata: {
-                    'custom-user-md': 'custom-md',
-                },
-                WebsiteRedirectLocation: 'http://custom-redirect'
-            };
-            const aclParams = {
-                ...params,
-                // email of user Bart defined in authdata.json
-                GrantFullControl: 'emailaddress=sampleaccount1@sampling.com',
-            };
-            const tagParams = {
-                ...params,
-                Tagging: {
-                    TagSet: [{
-                      Key: 'tag1',
-                      Value: 'value1'
-                    }, {
-                        Key: 'tag2',
-                        Value: 'value2'
-                    }]
-                }
-            };
-            const legalHoldParams = {
-                ...params,
-                LegalHold: {
-                    Status: 'ON'
-                  },
-            };
-            const acl = {
-                'Canned': '',
-                'FULL_CONTROL': [
-                    // canonicalID of user Bart
-                    '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be',
-                ],
-                'WRITE_ACP': [],
-                'READ': [],
-                'READ_ACP': [],
-            };
-            const tags = { tag1: 'value1', tag2: 'value2' };
-            const replicationInfo = {
-                'status': 'COMPLETED',
-                'backends': [
-                        {
-                                'site': 'azure-normal',
-                                'status': 'COMPLETED',
-                                'dataStoreVersionId': '',
+            it('should overwrite a version', done => {
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                const params = { Bucket: bucketName, Key: objectName };
+                let objMDBefore;
+                let objMDAfter;
+                let versionsBefore;
+                let versionsAfter;
+                let vId;
+
+                async.series([
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => s3.putObject(params, (err, res) => {
+                        vId = res.VersionId;
+                        return next(err);
+                    }),
+                    next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsBefore = res.Versions;
+                        return next(err);
+                    }),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDBefore = objMD;
+                        return next(err);
+                    }),
+                    next => putObjectVersion(s3, params, vId, next),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDAfter = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsAfter = res.Versions;
+                        return next(err);
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                    checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                    assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                    checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
+                    'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
+                    assert.deepStrictEqual(objMDAfter, objMDBefore);
+                    return done();
+                });
+            });
+
+            it('should overwrite the current version if empty version id header', done => {
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                const params = { Bucket: bucketName, Key: objectName };
+                let objMDBefore;
+                let objMDAfter;
+                let versionsBefore;
+                let versionsAfter;
+                let vId;
+
+                async.series([
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => s3.putObject(params, (err, res) => {
+                        vId = res.VersionId;
+                        return next(err);
+                    }),
+                    next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsBefore = res.Versions;
+                        return next(err);
+                    }),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDBefore = objMD;
+                        return next(err);
+                    }),
+                    next => putObjectVersion(s3, params, '', next),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDAfter = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsAfter = res.Versions;
+                        return next(err);
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                    checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                    assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                    checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
+                    'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
+                    assert.deepStrictEqual(objMDAfter, objMDBefore);
+                    return done();
+                });
+            });
+
+            it('should overwrite a non-current null version', done => {
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                const params = { Bucket: bucketName, Key: objectName };
+                let versionsBefore;
+                let versionsAfter;
+                let objMDBefore;
+                let objMDAfter;
+
+                async.series([
+                    next => s3.putObject(params, next),
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => s3.putObject(params, next),
+                    next => fakeMetadataArchive(bucketName, objectName, 'null', archive, next),
+                    next => getMetadata(bucketName, objectName, 'null', (err, objMD) => {
+                        objMDBefore = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsBefore = res.Versions;
+                        next(err);
+                    }),
+                    next => putObjectVersion(s3, params, 'null', next),
+                    next => getMetadata(bucketName, objectName, 'null', (err, objMD) => {
+                        objMDAfter = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsAfter = res.Versions;
+                        return next(err);
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                    checkVersionsAndUpdate(versionsBefore, versionsAfter, [1]);
+                    assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                    checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
+                    'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
+                    assert.deepStrictEqual(objMDAfter, objMDBefore);
+                    return done();
+                });
+            });
+
+            it('should overwrite the lastest version and keep nullVersionId', done => {
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                const params = { Bucket: bucketName, Key: objectName };
+                let versionsBefore;
+                let versionsAfter;
+                let objMDBefore;
+                let objMDAfter;
+                let vId;
+
+                async.series([
+                    next => s3.putObject(params, next),
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => s3.putObject(params, (err, res) => {
+                        vId = res.VersionId;
+                        return next(err);
+                    }),
+                    next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDBefore = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsBefore = res.Versions;
+                        return next(err);
+                    }),
+                    next => putObjectVersion(s3, params, vId, next),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDAfter = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsAfter = res.Versions;
+                        return next(err);
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                    checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                    assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                    checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
+                    'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
+                    assert.deepStrictEqual(objMDAfter, objMDBefore);
+                    return done();
+                });
+            });
+
+            it('should overwrite a current null version', done => {
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                const sParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Suspended',
+                    }
+                };
+                const params = { Bucket: bucketName, Key: objectName };
+                let objMDBefore;
+                let objMDAfter;
+                let versionsBefore;
+                let versionsAfter;
+
+                async.series([
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => s3.putObject(params, next),
+                    next => s3.putBucketVersioning(sParams, next),
+                    next => s3.putObject(params, next),
+                    next => fakeMetadataArchive(bucketName, objectName, undefined, archive, next),
+                    next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                        objMDBefore = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsBefore = res.Versions;
+                        return next(err);
+                    }),
+                    next => putObjectVersion(s3, params, '', next),
+                    next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                        objMDAfter = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsAfter = res.Versions;
+                        return next(err);
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                    checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                    assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                    checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
+                    'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
+                    assert.deepStrictEqual(objMDAfter, objMDBefore);
+                    return done();
+                });
+            });
+
+            it('should overwrite a non-current version', done => {
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                const params = { Bucket: bucketName, Key: objectName };
+                let objMDBefore;
+                let objMDAfter;
+                let versionsBefore;
+                let versionsAfter;
+                let vId;
+
+                async.series([
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => s3.putObject(params, next),
+                    next => s3.putObject(params, (err, res) => {
+                        vId = res.VersionId;
+                        return next(err);
+                    }),
+                    next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
+                    next => s3.putObject(params, next),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsBefore = res.Versions;
+                        return next(err);
+                    }),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDBefore = objMD;
+                        return next(err);
+                    }),
+                    next => putObjectVersion(s3, params, vId, next),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDAfter = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsAfter = res.Versions;
+                        return next(err);
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                    checkVersionsAndUpdate(versionsBefore, versionsAfter, [1]);
+                    assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                    checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
+                    'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
+                    assert.deepStrictEqual(objMDAfter, objMDBefore);
+                    return done();
+                });
+            });
+
+            it('should overwrite the current version', done => {
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                const params = { Bucket: bucketName, Key: objectName };
+                let objMDBefore;
+                let objMDAfter;
+                let versionsBefore;
+                let versionsAfter;
+                let vId;
+
+                async.series([
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => s3.putObject(params, next),
+                    next => s3.putObject(params, (err, res) => {
+                        vId = res.VersionId;
+                        return next(err);
+                    }),
+                    next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsBefore = res.Versions;
+                        return next(err);
+                    }),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDBefore = objMD;
+                        return next(err);
+                    }),
+                    next => putObjectVersion(s3, params, vId, next),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDAfter = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsAfter = res.Versions;
+                        return next(err);
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                    checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                    assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                    checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
+                    'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
+                    assert.deepStrictEqual(objMDAfter, objMDBefore);
+                    return done();
+                });
+            });
+
+            it('should overwrite the current version after bucket version suspended', done => {
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                const sParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Suspended',
+                    }
+                };
+                const params = { Bucket: bucketName, Key: objectName };
+                let objMDBefore;
+                let objMDAfter;
+                let versionsBefore;
+                let versionsAfter;
+                let vId;
+
+                async.series([
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => s3.putObject(params, next),
+                    next => s3.putObject(params, (err, res) => {
+                        vId = res.VersionId;
+                        return next(err);
+                    }),
+                    next => fakeMetadataArchive(bucketName, objectName, vId, archive, next),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsBefore = res.Versions;
+                        return next(err);
+                    }),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDBefore = objMD;
+                        return next(err);
+                    }),
+                    next => s3.putBucketVersioning(sParams, next),
+                    next => putObjectVersion(s3, params, vId, next),
+                    next => getMetadata(bucketName, objectName, vId, (err, objMD) => {
+                        objMDAfter = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsAfter = res.Versions;
+                        return next(err);
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                    checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                    assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                    checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
+                    'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
+                    assert.deepStrictEqual(objMDAfter, objMDBefore);
+                    return done();
+                });
+            });
+
+            it('should overwrite the current null version after bucket version enabled', done => {
+                const vParams = {
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    }
+                };
+                const params = { Bucket: bucketName, Key: objectName };
+                let objMDBefore;
+                let objMDAfter;
+                let versionsBefore;
+                let versionsAfter;
+
+                async.series([
+                    next => s3.putObject(params, next),
+                    next => fakeMetadataArchive(bucketName, objectName, undefined, archive, next),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsBefore = res.Versions;
+                        return next(err);
+                    }),
+                    next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                        objMDBefore = objMD;
+                        return next(err);
+                    }),
+                    next => s3.putBucketVersioning(vParams, next),
+                    next => putObjectVersion(s3, params, 'null', next),
+                    next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                        objMDAfter = objMD;
+                        return next(err);
+                    }),
+                    next => metadata.listObject(bucketName, mdListingParams, log, (err, res) => {
+                        versionsAfter = res.Versions;
+                        return next(err);
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                    checkVersionsAndUpdate(versionsBefore, versionsAfter, [0]);
+                    assert.deepStrictEqual(versionsAfter, versionsBefore);
+
+                    checkObjMdAndUpdate(objMDBefore, objMDAfter, ['location', 'content-length', 'originOp',
+                    'microVersionId', 'x-amz-restore', 'archive', 'dataStoreName']);
+                    assert.deepStrictEqual(objMDAfter, objMDBefore);
+                    return done();
+                });
+            });
+
+            it('should fail if restore is already completed', done => {
+                const params = { Bucket: bucketName, Key: objectName };
+                const archiveCompleted = {
+                    archiveInfo: {},
+                    restoreRequestedAt: new Date(0),
+                    restoreRequestedDays: 5,
+                    restoreCompletedAt: new Date(10),
+                    restoreWillExpireAt: new Date(10 + (5 * 24 * 60 * 60 * 1000)),
+                };
+
+                async.series([
+                    next => s3.putObject(params, next),
+                    next => fakeMetadataArchive(bucketName, objectName, undefined, archiveCompleted, next),
+                    next => putObjectVersion(s3, params, '', err => {
+                        checkError(err, 'InvalidObjectState', 403);
+                        return next();
+                    }),
+                ], err => {
+                    assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+                    return done();
+                });
+            });
+
+            [
+                'non versioned',
+                'versioned',
+                'suspended'
+            ].forEach(versioning => {
+                it(`should update restore metadata while keeping storage class (${versioning})`, done => {
+                    const params = { Bucket: bucketName, Key: objectName };
+                    let objMDBefore;
+                    let objMDAfter;
+
+                    async.series([
+                        next => {
+                            if (versioning === 'versioned') {
+                                return s3.putBucketVersioning({
+                                    Bucket: bucketName,
+                                    VersioningConfiguration: { Status: 'Enabled' }
+                                }, next);
+                            } else if (versioning === 'suspended') {
+                                return s3.putBucketVersioning({
+                                    Bucket: bucketName,
+                                    VersioningConfiguration: { Status: 'Suspended' }
+                                }, next);
+                            }
+                            return next();
                         },
-                ],
-                'content': [
-                        'DATA',
-                        'METADATA',
-                ],
-                'destination': 'arn:aws:s3:::versioned',
-                'storageClass': 'azure-normal',
-                'role': 'arn:aws:iam::root:role/s3-replication-role',
-                'storageType': 'azure',
-                'dataStoreVersionId': '',
-                'isNFS': null,
-            };
-            async.series([
-                next => s3.putObject(putParams, next),
-                next => s3.putObjectAcl(aclParams, next),
-                next => s3.putObjectTagging(tagParams, next),
-                next => s3.putObjectLegalHold(legalHoldParams, next),
-                next => getMetadata(bucketNameMD, objectName, undefined, (err, objMD) => {
-                    if (err) {
-                        return next(err);
+                        next => s3.putObject(params, next),
+                        next => fakeMetadataArchive(bucketName, objectName, undefined, archive, next),
+                        next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                            objMDBefore = objMD;
+                            return next(err);
+                        }),
+                        next => metadata.listObject(bucketName, mdListingParams, log, next),
+                        next => putObjectVersion(s3, params, '', next),
+                        next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                            objMDAfter = objMD;
+                            return next(err);
+                        }),
+                        next => s3.listObjects({ Bucket: bucketName }, (err, res) => {
+                            assert.ifError(err);
+                            assert.strictEqual(res.Contents.length, 1);
+                            assert.strictEqual(res.Contents[0].StorageClass, 'location-dmf-v1');
+                            return next();
+                        }),
+                        next => s3.headObject(params, (err, res) => {
+                            assert.ifError(err);
+                            assert.strictEqual(res.StorageClass, 'location-dmf-v1');
+                            return next();
+                        }),
+                        next => s3.getObject(params, (err, res) => {
+                            assert.ifError(err);
+                            assert.strictEqual(res.StorageClass, 'location-dmf-v1');
+                            return next();
+                        }),
+                    ], err => {
+                        assert.strictEqual(err, null, `Expected success got error ${JSON.stringify(err)}`);
+
+                        // storage class must stay as the cold location
+                        assert.deepStrictEqual(objMDAfter['x-amz-storage-class'], 'location-dmf-v1');
+
+                        /// Make sure object data location is set back to its bucket data location.
+                        assert.deepStrictEqual(objMDAfter.dataStoreName, 'us-east-1');
+
+                        assert.deepStrictEqual(objMDAfter.archive.archiveInfo, objMDBefore.archive.archiveInfo);
+                        assert.deepStrictEqual(objMDAfter.archive.restoreRequestedAt,
+                            objMDBefore.archive.restoreRequestedAt);
+                        assert.deepStrictEqual(objMDAfter.archive.restoreRequestedDays,
+                            objMDBefore.archive.restoreRequestedDays);
+                        assert.deepStrictEqual(objMDAfter['x-amz-restore']['ongoing-request'], false);
+
+                        assert(objMDAfter.archive.restoreCompletedAt);
+                        assert(objMDAfter.archive.restoreWillExpireAt);
+                        assert(objMDAfter['x-amz-restore']['expiry-date']);
+                        return done();
+                    });
+                });
+            });
+
+            it('should "copy" all but non data-related metadata (data encryption, data size...)', done => {
+                const params = {
+                    Bucket: bucketNameMD,
+                    Key: objectName
+                };
+                const putParams = {
+                    ...params,
+                    Metadata: {
+                        'custom-user-md': 'custom-md',
+                    },
+                    WebsiteRedirectLocation: 'http://custom-redirect'
+                };
+                const aclParams = {
+                    ...params,
+                    // email of user Bart defined in authdata.json
+                    GrantFullControl: 'emailaddress=sampleaccount1@sampling.com',
+                };
+                const tagParams = {
+                    ...params,
+                    Tagging: {
+                        TagSet: [{
+                        Key: 'tag1',
+                        Value: 'value1'
+                        }, {
+                            Key: 'tag2',
+                            Value: 'value2'
+                        }]
                     }
-                    /* eslint-disable no-param-reassign */
-                    objMD.dataStoreName = 'location-dmf-v1';
-                    objMD.archive = archive;
-                    objMD.replicationInfo = replicationInfo;
-                    // data related
-                    objMD['content-length'] = 99;
-                    objMD['content-type'] = 'testtype';
-                    objMD['content-md5'] = 'testmd5';
-                    objMD['content-encoding'] = 'testencoding';
-                    objMD['x-amz-server-side-encryption'] = 'aws:kms';
-                    /* eslint-enable no-param-reassign */
-                    return metadata.putObjectMD(bucketNameMD, objectName, objMD, undefined, log, next);
-                }),
-                next => putObjectVersion(s3, params, '', next),
-                next => getMetadata(bucketNameMD, objectName, undefined, (err, objMD) => {
-                    if (err) {
-                        return next(err);
-                    }
-                    assert.deepStrictEqual(objMD.acl, acl);
-                    assert.deepStrictEqual(objMD.tags, tags);
-                    assert.deepStrictEqual(objMD.replicationInfo, replicationInfo);
-                    assert.deepStrictEqual(objMD.legalHold, true);
-                    assert.strictEqual(objMD['x-amz-meta-custom-user-md'], 'custom-md');
-                    assert.strictEqual(objMD['x-amz-website-redirect-location'], 'http://custom-redirect');
-                    // make sure data related metadatas ar not the same before and after
-                    assert.notStrictEqual(objMD['x-amz-server-side-encryption'], 'aws:kms');
-                    assert.notStrictEqual(objMD['content-length'], 99);
-                    assert.notStrictEqual(objMD['content-encoding'], 'testencoding');
-                    assert.notStrictEqual(objMD['content-type'], 'testtype');
-                    // make sure we keep the same etag and add the new restored
-                    // data's etag inside x-amz-restore
-                    assert.strictEqual(objMD['content-md5'], 'testmd5');
-                    assert.strictEqual(typeof objMD['x-amz-restore']['content-md5'], 'string');
-                    return next();
-                }),
-                // removing legal hold to be able to clean the bucket after the test
-                next => {
-                    legalHoldParams.LegalHold.Status = 'OFF';
-                    return s3.putObjectLegalHold(legalHoldParams, next);
-                },
-            ], done);
+                };
+                const legalHoldParams = {
+                    ...params,
+                    LegalHold: {
+                        Status: 'ON'
+                    },
+                };
+                const acl = {
+                    'Canned': '',
+                    'FULL_CONTROL': [
+                        // canonicalID of user Bart
+                        '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be',
+                    ],
+                    'WRITE_ACP': [],
+                    'READ': [],
+                    'READ_ACP': [],
+                };
+                const tags = { tag1: 'value1', tag2: 'value2' };
+                const replicationInfo = {
+                    'status': 'COMPLETED',
+                    'backends': [
+                            {
+                                    'site': 'azure-normal',
+                                    'status': 'COMPLETED',
+                                    'dataStoreVersionId': '',
+                            },
+                    ],
+                    'content': [
+                            'DATA',
+                            'METADATA',
+                    ],
+                    'destination': 'arn:aws:s3:::versioned',
+                    'storageClass': 'azure-normal',
+                    'role': 'arn:aws:iam::root:role/s3-replication-role',
+                    'storageType': 'azure',
+                    'dataStoreVersionId': '',
+                    'isNFS': null,
+                };
+                async.series([
+                    next => s3.putObject(putParams, next),
+                    next => s3.putObjectAcl(aclParams, next),
+                    next => s3.putObjectTagging(tagParams, next),
+                    next => s3.putObjectLegalHold(legalHoldParams, next),
+                    next => getMetadata(bucketNameMD, objectName, undefined, (err, objMD) => {
+                        if (err) {
+                            return next(err);
+                        }
+                        /* eslint-disable no-param-reassign */
+                        objMD.dataStoreName = 'location-dmf-v1';
+                        objMD.archive = archive;
+                        objMD.replicationInfo = replicationInfo;
+                        // data related
+                        objMD['content-length'] = 99;
+                        objMD['content-type'] = 'testtype';
+                        objMD['content-md5'] = 'testmd5';
+                        objMD['content-encoding'] = 'testencoding';
+                        objMD['x-amz-server-side-encryption'] = 'aws:kms';
+                        /* eslint-enable no-param-reassign */
+                        return metadata.putObjectMD(bucketNameMD, objectName, objMD, undefined, log, next);
+                    }),
+                    next => putObjectVersion(s3, params, '', next),
+                    next => getMetadata(bucketNameMD, objectName, undefined, (err, objMD) => {
+                        if (err) {
+                            return next(err);
+                        }
+                        assert.deepStrictEqual(objMD.acl, acl);
+                        assert.deepStrictEqual(objMD.tags, tags);
+                        assert.deepStrictEqual(objMD.replicationInfo, replicationInfo);
+                        assert.deepStrictEqual(objMD.legalHold, true);
+                        assert.strictEqual(objMD['x-amz-meta-custom-user-md'], 'custom-md');
+                        assert.strictEqual(objMD['x-amz-website-redirect-location'], 'http://custom-redirect');
+                        // make sure data related metadatas ar not the same before and after
+                        assert.notStrictEqual(objMD['x-amz-server-side-encryption'], 'aws:kms');
+                        assert.notStrictEqual(objMD['content-length'], 99);
+                        assert.notStrictEqual(objMD['content-encoding'], 'testencoding');
+                        assert.notStrictEqual(objMD['content-type'], 'testtype');
+                        // make sure we keep the same etag and add the new restored
+                        // data's etag inside x-amz-restore
+                        assert.strictEqual(objMD['content-md5'], 'testmd5');
+                        assert.strictEqual(typeof objMD['x-amz-restore']['content-md5'], 'string');
+                        return next();
+                    }),
+                    // removing legal hold to be able to clean the bucket after the test
+                    next => {
+                        legalHoldParams.LegalHold.Status = 'OFF';
+                        return s3.putObjectLegalHold(legalHoldParams, next);
+                    },
+                ], done);
+            });
         });
     });
 });


### PR DESCRIPTION
To replace condition on S3_END_TO_END with by cold storage feature presence

To run header validation tests even in S3C

No new tests, just reorganization

Test `should fail if version id is invalid` doesn't need to `fakeMetadataArchive`, it's been simplified.

The big diff is indentation