### PR TITLE
CLDSRV-741: Block internal routes veeam & workflowEngineOperator

### DIFF
--- a/.github/docker/config.s3c.json
+++ b/.github/docker/config.s3c.json
@@ -60,5 +60,6 @@
             "type": "dummy",
             "host": "localhost:6000"
         }
-    ]
+    ],
+    "enableVeeamRoute": false
 }

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1797,6 +1797,10 @@ class Config extends EventEmitter {
                 'bad config: overrideObjectKeyByteLimit must be a positive integer');
         }
 
+        this.enableVeeamRoute = true;
+        if (config.enableVeeamRoute !== undefined && config.enableVeeamRoute !== null) {
+            this.enableVeeamRoute = config.enableVeeamRoute;
+        }
         return config;
     }
 

--- a/lib/routes/routeVeeam.js
+++ b/lib/routes/routeVeeam.js
@@ -146,8 +146,8 @@ function _normalizeVeeamRequest(req) {
     req.url = req.url.replace('/_/veeam', '');
     // Assign multiple common (extracted) parameters to the request object
     const parsedUrl = url.parse(req.url, true);
-    req.path = _decodeURI(parsedUrl.pathname);
-    const pathArr = req.path.split('/');
+    req.path = _decodeURI(parsedUrl.pathname || '');
+    const pathArr = (req.path || '').split('/');
     req.query = parsedUrl.query;
     req.bucketName = pathArr[1];
     req.objectKey = pathArr.slice(2).join('/');

--- a/lib/utilities/internalHandlers.js
+++ b/lib/utilities/internalHandlers.js
@@ -11,9 +11,15 @@ const internalHandlers = {
     backbeat: routeBackbeat,
     report: reportHandler,
     metadata: routeMetadata,
-    'workflow-engine-operator': routeWorkflowEngineOperator,
-    veeam: routeVeeam,
 };
+
+if (config.workflowEngineOperator) {
+    internalHandlers['workflow-engine-operator'] = routeWorkflowEngineOperator;
+}
+
+if (config.enableVeeamRoute) {
+    internalHandlers.veeam = routeVeeam;
+}
 
 if (config.healthChecks.enableInternalRoute) {
     // CLDSRV-740: S3C with the healthcheck on s3 port needs the internal route

--- a/tests/multipleBackend/routes/routeVeeam.js
+++ b/tests/multipleBackend/routes/routeVeeam.js
@@ -5,12 +5,15 @@ const async = require('async');
 const { makeRequest } = require('../../functional/raw-node/utils/makeRequest');
 const BucketUtility =
     require('../../functional/aws-node-sdk/lib/utility/bucket-util');
+const { getCredentials } = require('../../functional/aws-node-sdk/test/support/credentials');
 
 const ipAddress = process.env.IP ? process.env.IP : '127.0.0.1';
 
+const { accessKeyId, secretAccessKey } = getCredentials();
+
 const veeamAuthCredentials = {
-    accessKey: 'accessKey1',
-    secretKey: 'verySecretKey1',
+    accessKey: accessKeyId,
+    secretKey: secretAccessKey,
 };
 
 const badVeeamAuthCredentials = {
@@ -128,6 +131,24 @@ function makeVeeamRequest(params, callback) {
     };
     makeRequest(options, callback);
 }
+
+describe('veeam invalid requests:', () => {
+    it('should return MethodNotAllowed for invalid request', done => {
+        const options = {
+            authCredentials: veeamAuthCredentials,
+            hostname: ipAddress,
+            port: 8000,
+            method: 'GET',
+            path: '/_/veeam',
+            urlForSignature: '',
+            jsonResponse: false,
+        };
+        makeRequest(options, (err, response) => {
+            assert.strictEqual(response.statusCode, 405);
+            done();
+        });
+    });
+});
 
 describe('veeam PUT routes:', () => {
     before(done => {


### PR DESCRIPTION
For S3C those routes are not supported, we don't want to have them available to avoid unexpected behavior if used.

+ fix veeam route crash
