### PR TITLE
CLDSRV-746: Adding log fields to the backbeat routes in order to fill the analytics dashboard

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -475,7 +475,7 @@ function putData(request, response, bucketInfo, objMd, log, callback) {
  */
 
 /**
- * 
+ *
  * @param {string} accountId - account ID
  * @param {Log} log - logger instance
  * @param {CanonicalIdCallback} cb - callback function
@@ -1466,6 +1466,7 @@ function routeBackbeat(clientIP, request, response, log) {
     const contentLength = request.headers['x-amz-decoded-content-length'] || request.headers['content-length'];
     // eslint-disable-next-line no-param-reassign
     request.parsedContentLength = Number.parseInt(contentLength?.toString() ?? '', 10);
+    _normalizeBackbeatRequest(request);
     log.addDefaultFields({
         clientIP,
         url: request.url,
@@ -1478,7 +1479,7 @@ function routeBackbeat(clientIP, request, response, log) {
     });
 
     log.debug('routing request');
-    _normalizeBackbeatRequest(request);
+
     const requestContexts = prepareRequestContexts('objectReplicate', request);
 
     if (request.resourceType === 'expiration' || request.resourceType === 'batchdelete') {
@@ -1521,6 +1522,12 @@ function routeBackbeat(clientIP, request, response, log) {
             }
             // eslint-disable-next-line no-param-reassign
             request.accountQuotas = infos?.accountQuota;
+
+            // Add authentication info to logs for consistency with regular S3 routes
+            if (userInfo) {
+                log.addDefaultFields(getAuthLogFields(userInfo));
+            }
+
             // FIXME for now, any authenticated user can access API
             // routes. We should introduce admin accounts or accounts
             // with admin privileges, and restrict access to those
@@ -1570,9 +1577,20 @@ function routeBackbeat(clientIP, request, response, log) {
             }
             // eslint-disable-next-line no-param-reassign
             request.accountQuotas = infos?.accountQuota;
+
+            // Add authentication info to logs for consistency with regular S3 routes
+            if (!err && userInfo) {
+                log.addDefaultFields(getAuthLogFields(userInfo));
+            }
+
             return next(err, userInfo);
         }, 's3', requestContexts),
         (userInfo, next) => {
+            // Add action to logs for consistency with regular S3 routes
+            const routeName = actionFromRequest(request);
+            if (routeName) {
+                log.addDefaultFields({ action: routeName });
+            }
             // TODO: understand why non-object requests (batchdelete) were not authenticated
             if (!_isObjectRequest(request)) {
                 if (userInfo.getCanonicalID() === constants.publicId) {
@@ -1657,5 +1675,50 @@ function routeBackbeat(clientIP, request, response, log) {
         ));
 }
 
+function getAuthLogFields(userInfo) {
+    const authNames = {};
+    if (typeof userInfo.getAccountDisplayName === 'function') {
+        authNames.accountName = userInfo.getAccountDisplayName();
+        authNames.accountDisplayName = userInfo.getAccountDisplayName();
+    }
+    if (typeof userInfo.isRequesterAnIAMUser === 'function' && userInfo.isRequesterAnIAMUser()) {
+        if (typeof userInfo.getIAMdisplayName === 'function') {
+            authNames.userName = userInfo.getIAMdisplayName();
+            authNames.IAMdisplayName = userInfo.getIAMdisplayName();
+        }
+    }
+    if (typeof userInfo.isRequesterASessionUser === 'function' && userInfo.isRequesterASessionUser()) {
+        authNames.sessionName = userInfo.getShortid().split(':')[1];
+    }
+    return authNames;
+}
+
+function actionFromRequest(request) {
+    const methodRoutes = backbeatRoutes[request.method];
+    if (!methodRoutes) {
+        return null;
+    }
+
+    let route = methodRoutes[request.resourceType];
+    if (!route) {
+        return null;
+    }
+
+    // For multiplebackenddata and index, we need to get the operation one layer deeper
+    if (typeof route !== 'function') {
+        const operation = request.query.operation;
+        if (!operation || !route[operation]) {
+            return null;
+        }
+        route = route[operation];
+    }
+
+    // Final check that we have a function with a name
+    if (typeof route !== 'function' || !route.name) {
+        return null;
+    }
+
+    return route.name.charAt(0).toUpperCase() + route.name.slice(1);
+}
 
 module.exports = routeBackbeat;

--- a/tests/unit/routes/routeBackbeat.js
+++ b/tests/unit/routes/routeBackbeat.js
@@ -550,6 +550,9 @@ describe('routeBackbeat', () => {
                 cb(null, {
                     canonicalID: 'id',
                     getCanonicalID: () => 'id',
+                    getAccountDisplayName: () => 'my-account',
+                    getIAMdisplayName: () => '[assumedRole] service-backbeat-lifecycle-1:backbeat-lifecycle',
+                    isRequesterAnIAMUser: () => true,
                 });
             });
 


### PR DESCRIPTION
Adding action, account and userName fields to the backbeat routes. 

`_normalizeBackbeatRequest` was executed too late as it is the one filling in the `bucketName` in the `request` (among other things) and that must happen before this field is used to customize the logger. 