### PR TITLE
CLDSRV-741: Replace null with undefined in bucket

### DIFF
--- a/lib/api/apiUtils/bucket/bucketCreation.js
+++ b/lib/api/apiUtils/bucket/bucketCreation.js
@@ -165,20 +165,21 @@ function bucketLevelServerSideEncryption(bucket, headers, log, cb) {
  */
 function createBucket(authInfo, bucketName, headers,
     locationConstraint, log, cb) {
+    // Prefer using undefined instead of null for unused properties so they are not present in metadata payload
     log.trace('Creating bucket');
     assert.strictEqual(typeof bucketName, 'string');
     const canonicalID = authInfo.getCanonicalID();
     const ownerDisplayName =
         authInfo.getAccountDisplayName();
     const creationDate = new Date().toJSON();
-    const isNFSEnabled = headers['x-scal-nfs-enabled'] === 'true';
+    const isNFSEnabled = headers['x-scal-nfs-enabled'] === 'true' || undefined;
     const headerObjectLock = headers['x-amz-bucket-object-lock-enabled'];
     const objectLockEnabled
         = headerObjectLock && headerObjectLock.toLowerCase() === 'true';
     const bucket = new BucketInfo(bucketName, canonicalID, ownerDisplayName,
-        creationDate, BucketInfo.currentModelVersion(), null, null, null, null,
-        null, null, null, null, null, null, null, null, null, isNFSEnabled,
-        null, null, objectLockEnabled);
+        creationDate, BucketInfo.currentModelVersion(), undefined, undefined, undefined, undefined,
+        undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, isNFSEnabled,
+        undefined, undefined, objectLockEnabled);
     let locationConstraintVal = null;
 
     if (locationConstraint) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "9.0.27",
+  "version": "9.0.28",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
To make the bucket attributes payload smaller when features are not defined

Bucket payload any features looks like:

```json
{
  "name": "bkt9",
  "owner": "79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be",
  "ownerDisplayName": "Bart",
  "creationDate": "2025-09-29T10:33:41.359Z",
  "mdBucketModelVersion": 16,
  "transient": false,
  "deleted": false,
  "serverSideEncryption": null,
  "locationConstraint": "dc-1",
  "uid": "ce6dbe03-22b4-4354-8668-d6fecbd5dadd",
  "tags": [],
  "quotaMax": "0"
}
```

Dropped fields when null:
```diff
<   "versioningConfiguration": null,
<   "readLocationConstraint": null,
<   "cors": null,
<   "replicationConfiguration": null,
<   "lifecycleConfiguration": null,
<   "bucketPolicy": null,
<   "isNFS": false,
<   "ingestion": null,
<   "azureInfo": null,
```

___

Only sse remain null as it breaks many places if removed