### PR TITLE
Remove instanceID generation

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -919,25 +919,6 @@ class Config extends EventEmitter {
             assert(instanceId.length <= 6,
                 'bad config: instanceId must be at most 6 characters long');
             this.instanceId = instanceId;
-        } else if (process.env.HOSTNAME) {
-            // If running in Kubernetes, the pod name is set in the HOSTNAME env var
-            // and is of the form: cloudserver-7869f99955-nr984
-            // where:
-            // - cloudserver is the name of the pod
-            // - 7869f99955 is a long hash that guarantees uniqueness within the namespace
-            // - nr984 is a short hash that is unique only within the current ReplicaSet/Deployment
-            // We use the last part of the pod name as the instanceId, prefixed with 'i' for internal
-            // or 'e' for external cloudserver.
-            // This allows having a unique identifier that will be used when generating versionIds
-            const instanceType = process.env.HOSTNAME.includes('internal') ? 'i' : 'e';
-            const parts = process.env.HOSTNAME.split('-');
-            if (parts.length >= 2) {
-                const shortId = parts[parts.length - 1];
-                this.instanceId = instanceType + shortId;
-            } else {
-                // fallback: generate a random string if format is unexpected
-                this.instanceId = uuidv4().replace(/-/g, '').slice(0, 6);
-            }
         } else {
             this.instanceId = uuidv4().replace(/-/g, '').slice(0, 6);
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {

--- a/tests/unit/Config.js
+++ b/tests/unit/Config.js
@@ -869,23 +869,7 @@ describe('Config', () => {
             assert.throws(() => new ConfigObject());
         });
 
-        it('should generate a new instanceId for external cloudserver', () => {
-            setEnv('HOSTNAME', 'connector-cloudserver-69958b4697-bs5pn');
-            const config = new ConfigObject();
-            assert.strictEqual(config.instanceId, 'ebs5pn');
-        });
-
-        it('should generate a new instanceId for internal cloudserver', () => {
-            setEnv('HOSTNAME', 'internal-cloudserver-54dc76b796-48m2x');
-            const config = new ConfigObject();
-            assert.strictEqual(config.instanceId, 'i48m2x');
-        });
-        it('should generate a random instanceId if HOSTNAME has an unexpected format', () => {
-            setEnv('HOSTNAME', 'cldsrv1');
-            const config = new ConfigObject();
-            assert.strictEqual(config.instanceId.length, 6);
-        });
-        it('should generate a random instanceId if HOSTNAME is not set', () => {
+        it('should generate a random instanceId if not set', () => {
             const config = new ConfigObject();
             assert.strictEqual(config.instanceId.length, 6);
         });


### PR DESCRIPTION
Remove `InstanceID` generation from Cloudserver, logic moved to zkop as it's tightly close to the k8s implementation.
Relates to https://github.com/scality/zenko-operator/pull/570

Issue: CLDSRV-748