### PR TITLE
CLDSRV-764: backport install required version of typing-extensions

### DIFF
--- a/.github/pykmip/Dockerfile
+++ b/.github/pykmip/Dockerfile
@@ -13,6 +13,8 @@ RUN apk add --no-cache \
         build-base \
         curl \
         git && \
+    pip3 install --upgrade pip && \
+    pip3 install --upgrade typing-extensions>=4.13.2 && \
     git clone https://github.com/openkmip/pykmip.git && \
     cd pykmip && \
     python3 setup.py install && \


### PR DESCRIPTION
CLDSRV-757

(cherry picked from commit a8d567234ee0d1b6cfcf6c1eb1c75ff478ec054e)
