### PR TITLE
INTEGRATION [PR#5970 > development/8.8] CLDSRV-764: backport install required version of typing-extensions

### DIFF
--- a/.github/pykmip/Dockerfile
+++ b/.github/pykmip/Dockerfile
@@ -13,6 +13,8 @@ RUN apk add --no-cache \
         build-base \
         curl \
         git && \
+    pip3 install --upgrade pip && \
+    pip3 install --upgrade typing-extensions>=4.13.2 && \
     git clone https://github.com/openkmip/pykmip.git && \
     cd pykmip && \
     python3 setup.py install && \


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #5970.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.8/bugfix/CLDSRV-764-backport-fix`, please follow this
procedure:

```bash
 git fetch
 git checkout w/8.8/bugfix/CLDSRV-764-backport-fix
 # <amend or cancel the changeset by _adding_ new commits>
 git push origin w/8.8/bugfix/CLDSRV-764-backport-fix
```

Please always comment pull request #5970 instead of this one.