### PR TITLE
CLDSRV-769: Add raftSessionId to BucketInfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@azure/storage-blob": "^12.28.0",
     "@hapi/joi": "^17.1.1",
-    "arsenal": "git+https://github.com/scality/Arsenal#8.2.34",
+    "arsenal": "git+https://github.com/scality/Arsenal#8.2.35",
     "async": "2.6.4",
     "aws-sdk": "^2.1692.0",
     "bucketclient": "scality/bucketclient#8.2.7",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "arsenal": "git+https://github.com/scality/Arsenal#8.2.34",
     "async": "2.6.4",
     "aws-sdk": "^2.1692.0",
-    "bucketclient": "scality/bucketclient#8.2.5",
+    "bucketclient": "scality/bucketclient#8.2.7",
     "bufferutil": "^4.0.8",
     "commander": "^12.1.0",
     "cron-parser": "^4.9.0",

--- a/tests/unit/api/bucketDeleteLifecycle.js
+++ b/tests/unit/api/bucketDeleteLifecycle.js
@@ -47,7 +47,8 @@ describe('deleteBucketLifecycle API', () => {
         async.series([
             next => bucketPutLifecycle(authInfo, _makeRequest(true), log, next),
             next => bucketDeleteLifecycle(authInfo, _makeRequest(), log, next),
-            next => metadata.getBucket(bucketName, log, next),
+            // eslint-disable-next-line no-unused-vars
+            next => metadata.getBucket(bucketName, log, (err, bucket, raftSessionId) => next(err, bucket)),
         ], (err, results) => {
             assert.equal(err, null, `Expected success, got error: ${err}`);
             const bucket = results[2];

--- a/tests/unit/api/bucketDeletePolicy.js
+++ b/tests/unit/api/bucketDeletePolicy.js
@@ -53,7 +53,8 @@ describe('deleteBucketPolicy API', () => {
         async.series([
             next => bucketPutPolicy(authInfo, _makeRequest(true), log, next),
             next => bucketDeletePolicy(authInfo, _makeRequest(), log, next),
-            next => metadata.getBucket(bucketName, log, next),
+            // eslint-disable-next-line no-unused-vars
+            next => metadata.getBucket(bucketName, log, (err, bucket, raftSessionId) => next(err, bucket)),
         ], (err, results) => {
             assert.equal(err, null, `Expected success, got error: ${err}`);
             const bucket = results[2];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1451,9 +1451,9 @@ arraybuffer.prototype.slice@^1.0.4:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/Arsenal#8.2.34":
-  version "8.2.34"
-  resolved "git+https://github.com/scality/Arsenal#7b9db2473a69ef4da6cc9971ac71141422b5d98e"
+"arsenal@git+https://github.com/scality/Arsenal#8.2.35":
+  version "8.2.35"
+  resolved "git+https://github.com/scality/Arsenal#51640ec484e521925e2d3a8b7ce5912f61590b8d"
   dependencies:
     "@azure/identity" "^4.13.0"
     "@azure/storage-blob" "^12.28.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1759,6 +1759,14 @@ bucketclient@scality/bucketclient#8.2.5:
     httpagent "git+https://github.com/scality/httpagent#1.1.0"
     werelogs scality/werelogs#8.2.2
 
+bucketclient@scality/bucketclient#8.2.7:
+  version "8.2.7"
+  resolved "https://codeload.github.com/scality/bucketclient/tar.gz/3f6cd94ef0100bfdd5c640ac21e38228de855457"
+  dependencies:
+    arsenal "git+https://github.com/scality/Arsenal#8.2.4"
+    httpagent "git+https://github.com/scality/httpagent#1.1.0"
+    werelogs scality/werelogs#8.2.2
+
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"


### PR DESCRIPTION
`raftSessionId` needs to be logged for the bucket logging feature.