### PR TITLE
CLDSRV-770: parseRateLimitConfig unit tests

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1857,7 +1857,7 @@ class Config extends EventEmitter {
                         typeof config.rateLimiting.bucket.defaultConfig, 'object',
                         'rateLimiting.bucket.defaultConfig must be an object'
                     );
-                    defaultConfig = parseRateLimitConfig(config.rateLimiting.bucket);
+                    defaultConfig = parseRateLimitConfig(config.rateLimiting.bucket.defaultConfig);
                 }
 
                 let configCacheTTL = constants.rateLimitDefaultConfigCacheTTL;

--- a/lib/api/apiUtils/rateLimit/config.js
+++ b/lib/api/apiUtils/rateLimit/config.js
@@ -19,10 +19,12 @@ function parseRateLimitConfig(config) {
         }
 
         limitConfig.requestsPerSecond = {
-            interval: Math.ceil((1 / limit) * 1000),
+            interval: 1000 / limit,
             bucketSize: burstCapacity * 1000,
         };
     }
+
+    return limitConfig;
 }
 
 module.exports = {

--- a/tests/unit/api/apiUtils/rateLimit/config.js
+++ b/tests/unit/api/apiUtils/rateLimit/config.js
@@ -1,0 +1,84 @@
+const assert = require('assert');
+
+const { parseRateLimitConfig } = require('../../../../../lib/api/apiUtils/rateLimit/config');
+
+describe('test parseRateLimitConfig', () => {
+    const testCases = [
+        {
+            desc: 'should return an empty config if given one',
+            input: {},
+            expected: {},
+        },
+        {
+            desc: '[rps] should calculate the request interval',
+            input: {
+                requestsPerSecond: {
+                    limit: 500
+                },
+            },
+            expected: {
+                requestsPerSecond: {
+                    interval: 2,
+                    bucketSize: 1000,
+                }
+            },
+        },
+        {
+            desc: '[rps] should calculate bucket size',
+            input: {
+                requestsPerSecond: {
+                    limit: 500,
+                    burstCapacity: 5,
+                },
+            },
+            expected: {
+                requestsPerSecond: {
+                    interval: 2,
+                    bucketSize: 5000,
+                }
+            },
+        },
+        {
+            desc: '[rps] should throw an error if requestsPerSecond isn\'t an object',
+            input: {
+                requestsPerSecond: 'foo'
+            },
+            throws: true,
+        },
+        {
+            desc: '[rps] should throw an error if requestsPerSecond.limit isn\'t a number',
+            input: {
+                requestsPerSecond: {
+                    limit: 'foo',
+                },
+            },
+            throws: true,
+        },
+        {
+            desc: '[rps] should throw an error if requestsPerSecond.burstCapacity isn\'t a number',
+            input: {
+                requestsPerSecond: {
+                    limit: 500,
+                    burstCapacity: '5',
+                },
+            },
+            throws: true,
+        },
+    ];
+
+    testCases.forEach(testCase => {
+        it(testCase.desc, () => {
+            if (testCase.throws) {
+                let err;
+                try {
+                    parseRateLimitConfig(testCase.input);
+                } catch (e) {
+                    err = e;
+                }
+                assert(err instanceof Error);
+            } else {
+                assert.deepStrictEqual(parseRateLimitConfig(testCase.input), testCase.expected);
+            }
+        });
+    });
+});


### PR DESCRIPTION
Adds unit tests for the config loading code already in the feature branch.
Small deviation from the design to note: `burstCapacity` is optionally configurable at the cluster level rather than being a constant.
I thought this change was easy enough and would help us out when trying to determine the default value during testing. 