### PR TITLE
CLDSRV-776: Fix batchDelete route to handle raftSessionId parameter from Arsenal

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -1316,7 +1316,8 @@ function batchDelete(request, response, userInfo, log, callback) {
             }
 
             return async.waterfall([
-                next => metadata.getBucket(bucket, log, next),
+                // eslint-disable-next-line no-unused-vars
+                next => metadata.getBucket(bucket, log, (err, bucketMD, raftSessionId) => next(err, bucketMD)),
                 (bucketMD, next) => quotaUtils.validateQuotas(request, bucketMD, request.accountQuotas,
                     ['objectDelete'], 'objectDelete', -contentLength, false, log, next),
             ], err => {

--- a/tests/unit/api/multiObjectDelete.js
+++ b/tests/unit/api/multiObjectDelete.js
@@ -400,7 +400,7 @@ describe('multiObjectDelete function', () => {
                 'accountA',
                 new Date().toISOString(),
                 15,
-            )));
+            ), undefined));
 
         multiObjectDelete.multiObjectDelete(authInfo, request, log, (err, res) => {
             // Expected result is an access denied on the object, and no error, as the API was authorized
@@ -443,7 +443,7 @@ describe('multiObjectDelete function', () => {
                 'accountA',
                 new Date().toISOString(),
                 15,
-            )));
+            ), undefined));
 
         multiObjectDelete.multiObjectDelete(authInfo, request, log, (err, res) => {
             // Expected result is an access denied on the object, and no error, as the API was authorized

--- a/tests/unit/routes/routeBackbeat.js
+++ b/tests/unit/routes/routeBackbeat.js
@@ -671,7 +671,7 @@ describe('routeBackbeat', () => {
                 getName: () => 'bucket0',
                 getQuota: () => 0n,
             };
-            sandbox.stub(metadata, 'getBucket').callsFake((bucket, log, cb) => cb(null, bucketMD));
+            sandbox.stub(metadata, 'getBucket').callsFake((bucket, log, cb) => cb(null, bucketMD, undefined));
 
             routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
             await endPromise;
@@ -787,6 +787,39 @@ describe('routeBackbeat', () => {
 
         routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
         void await endPromise;
+
+        assert.strictEqual(mockResponse.statusCode, 200);
+        assert.deepStrictEqual(mockResponse.body, null);
+    });
+
+    it('should handle raftSessionId parameter from metadata.getBucket', async () => {
+        sandbox.stub(config, 'isQuotaEnabled').returns(true);
+        const testRaftSessionId = 12345;
+        const bucketMD = {
+            getName: () => 'bucket0',
+            getQuota: () => 0n,
+        };
+
+        const getBucketStub = sandbox.stub(metadata, 'getBucket')
+            .callsFake((bucket, log, cb) => cb(null, bucketMD, testRaftSessionId));
+
+        routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+        void await endPromise;
+
+        sinon.assert.calledOnce(getBucketStub);
+
+        sinon.assert.calledOnce(validateQuotasSpy);
+        sinon.assert.calledWith(validateQuotasSpy,
+            mockRequest,
+            bucketMD,
+            mockRequest.accountQuotas,
+            ['objectDelete'],
+            'objectDelete',
+            -100,
+            false,
+            log,
+            sinon.match.any,
+        );
 
         assert.strictEqual(mockResponse.statusCode, 200);
         assert.deepStrictEqual(mockResponse.body, null);

--- a/tests/unit/routes/veeam-routes.js
+++ b/tests/unit/routes/veeam-routes.js
@@ -48,7 +48,7 @@ describe('Veeam routes - comprehensive unit tests', () => {
         utilizationStub = sinon.stub(UtilizationService, 'getUtilizationMetrics');
         metadataStub = sinon.stub(metadata, 'getBucket');
         // By default, metadata.getBucket succeeds
-        metadataStub.callsArgWith(2, null, bucketMd);
+        metadataStub.callsArgWith(2, null, bucketMd, undefined);
     });
 
     afterEach(() => {
@@ -301,7 +301,7 @@ describe('Veeam routes - HEAD request UtilizationService error handling', () => 
         log.debug = sinon.stub();
 
         metadataStub = sinon.stub(metadata, 'getBucket');
-        metadataStub.callsArgWith(2, null, bucketMd);
+        metadataStub.callsArgWith(2, null, bucketMd, undefined);
     });
 
     afterEach(() => {
@@ -438,7 +438,7 @@ describe('Veeam routes - LIST request handling', () => {
         log.trace = sinon.stub();
 
         metadataStub = sinon.stub(metadata, 'getBucket');
-        metadataStub.callsArgWith(2, null, bucketMd);
+        metadataStub.callsArgWith(2, null, bucketMd, undefined);
     });
 
     afterEach(() => {


### PR DESCRIPTION
Fixes a bug in the `batchDelete` backbeat route that was missed when https://github.com/scality/Arsenal/pull/2560 upgraded  `metadata.getBucket()` callback signature to include a third parameter.