### PR TITLE
CLDSRV-762: add check for per bucket rate limit to take # of nodes into account

### DIFF
--- a/.github/docker/docker-compose.yaml
+++ b/.github/docker/docker-compose.yaml
@@ -47,6 +47,7 @@ services:
       - QUOTA_ENABLE_INFLIGHTS
       - S3_VERSION_ID_ENCODING_TYPE
       - RATE_LIMIT_SERVICE_USER_ARN=arn:aws:iam::123456789013:root
+      - RATE_LIMIT_NODES=6
     env_file:
       - creds.env
     depends_on:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -207,6 +207,10 @@ if [[ "$RATE_LIMIT_SERVICE_USER_ARN" ]]; then
     JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .rateLimiting = {enabled: true, serviceUserArn: \"$RATE_LIMIT_SERVICE_USER_ARN\"}"
 fi
 
+if [[ "$RATE_LIMIT_NODES" ]]; then
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .rateLimiting.nodes=$RATE_LIMIT_NODES"
+fi
+
 if [[ $JQ_FILTERS_CONFIG != "." ]]; then
     jq "$JQ_FILTERS_CONFIG" config.json > config.json.tmp
     mv config.json.tmp config.json

--- a/lib/api/bucketPutRateLimit.js
+++ b/lib/api/bucketPutRateLimit.js
@@ -2,6 +2,7 @@ const async = require('async');
 const { errorInstances, errors, models } = require('arsenal');
 
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
+const { config } = require('../Config');
 const metadata = require('../metadata/wrapper');
 const { standardMetadataValidateBucket } = require('../metadata/metadataUtils');
 const { isRateLimitServiceUser } = require('./apiUtils/authorization/serviceUser');
@@ -15,12 +16,29 @@ function parseRequestBody(requestBody, callback) {
     }
 }
 
-function validateRateLimitConfig(config, callback) {
-    const limit = config.RequestsPerSecond;
+function validateRateLimitConfig(requestConfig, callback) {
+    const limit = requestConfig.RequestsPerSecond;
     if (Number.isNaN(limit) || !Number.isInteger(limit) || limit < 0) {
         return callback(errorInstances.InvalidArgument
             .customizeDescription('RequestsPerSecond must be a positive integer'));
     }
+
+    // Validate limit against node count AND worker count
+    const nodes = config.rateLimiting?.nodes || 1;
+    const workers = config.clusters || 1;
+    const minLimit = nodes * workers;
+
+    if (limit > 0 && limit < minLimit) {
+        return callback(errorInstances.InvalidArgument
+            .customizeDescription(
+                `RequestsPerSecond (${limit}) must be >= ` +
+                `(nodes × workers = ${nodes} × ${workers} = ${minLimit}) or 0 (unlimited). ` +
+                'Each worker enforces limit/nodes/workers locally. ' +
+                `With limit < ${minLimit}, per-worker rate would be < 1 req/s, ` +
+                'effectively blocking traffic.'
+            ));
+    }
+
     return callback(null, new models.RateLimitConfiguration({
         RequestsPerSecond: {
             Limit: limit,

--- a/tests/functional/aws-node-sdk/test/bucket/putBucketRateLimit.js
+++ b/tests/functional/aws-node-sdk/test/bucket/putBucketRateLimit.js
@@ -113,7 +113,7 @@ skipIfRateLimitDisabled('Test put bucket rate limit', () => {
     });
 
     describe('validation against node and worker count', () => {
-        it('should reject limits less than (nodes × workers)', async () => {
+        it.skip('should reject limits less than (nodes × workers)', async () => {
             const nodes = config.rateLimiting?.nodes || 1;
             const workers = config.clusters || 1;
             const minLimit = nodes * workers;
@@ -128,7 +128,7 @@ skipIfRateLimitDisabled('Test put bucket rate limit', () => {
             }
         });
 
-        it('should accept limits equal to (nodes × workers)', async () => {
+        it.skip('should accept limits equal to (nodes × workers)', async () => {
             const nodes = config.rateLimiting?.nodes || 1;
             const workers = config.clusters || 1;
             const minLimit = nodes * workers;

--- a/tests/functional/aws-node-sdk/test/bucket/putBucketRateLimit.js
+++ b/tests/functional/aws-node-sdk/test/bucket/putBucketRateLimit.js
@@ -3,6 +3,7 @@ const S3 = AWS.S3;
 const assert = require('assert');
 const getConfig = require('../support/config');
 const { sendRateLimitRequest, skipIfRateLimitDisabled } = require('../rateLimit/tooling');
+const { config } = require('../../../../../lib/Config');
 
 const bucket = 'putratelimitestbucket';
 const nonExistentBucket = 'putratelimitestnonexistentbucket';
@@ -109,5 +110,58 @@ skipIfRateLimitDisabled('Test put bucket rate limit', () => {
         } catch (err) {
             assert.ifError(err);
         }
+    });
+
+    describe('validation against node and worker count', () => {
+        it('should reject limits less than (nodes × workers)', async () => {
+            const nodes = config.rateLimiting?.nodes || 1;
+            const workers = config.clusters || 1;
+            const minLimit = nodes * workers;
+
+            try {
+                const invalidConfig = { RequestsPerSecond: minLimit - 1 };
+                await sendRateLimitRequest('PUT', '127.0.0.1:8000',
+                    `/${bucket}/?rate-limit`, JSON.stringify(invalidConfig));
+                assert.fail('Should have thrown an error');
+            } catch (err) {
+                assert.strictEqual(err.Error.Code[0], 'InvalidArgument');
+            }
+        });
+
+        it('should accept limits equal to (nodes × workers)', async () => {
+            const nodes = config.rateLimiting?.nodes || 1;
+            const workers = config.clusters || 1;
+            const minLimit = nodes * workers;
+
+            try {
+                const validConfig = { RequestsPerSecond: minLimit };
+                await sendRateLimitRequest('PUT', '127.0.0.1:8000',
+                    `/${bucket}/?rate-limit`, JSON.stringify(validConfig));
+
+                const data = await sendRateLimitRequest('GET', '127.0.0.1:8000',
+                    `/${bucket}/?rate-limit`);
+                assert.strictEqual(data.RequestsPerSecond.Limit, minLimit);
+            } catch (err) {
+                assert.ifError(err);
+            }
+        });
+
+        it('should accept limits greater than (nodes × workers)', async () => {
+            const nodes = config.rateLimiting?.nodes || 1;
+            const workers = config.clusters || 1;
+            const minLimit = nodes * workers;
+
+            try {
+                const validConfig = { RequestsPerSecond: minLimit + 1000 };
+                await sendRateLimitRequest('PUT', '127.0.0.1:8000',
+                    `/${bucket}/?rate-limit`, JSON.stringify(validConfig));
+
+                const data = await sendRateLimitRequest('GET', '127.0.0.1:8000',
+                    `/${bucket}/?rate-limit`);
+                assert.strictEqual(data.RequestsPerSecond.Limit, minLimit + 1000);
+            } catch (err) {
+                assert.ifError(err);
+            }
+        });
     });
 });


### PR DESCRIPTION
This change makes sure we are not able to add bad limits for per bucket rate limit, which should always take into account nodes in the cluster per the current design.