### PR TITLE
CLDSRV-781: add pre and post MD fetch rate limit

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -82,6 +82,10 @@ const checkHttpHeadersSize = require('./apiUtils/object/checkHttpHeadersSize');
 const constants = require('../../constants');
 const { config } = require('../Config.js');
 const { validateMethodChecksumNoChunking } = require('./apiUtils/integrity/validateChecksums');
+const {
+    getRateLimitFromCache,
+    checkRateLimitWithConfig,
+} = require('./apiUtils/rateLimit/helpers');
 
 const monitoringMap = policies.actionMaps.actionMonitoringMapS3;
 
@@ -178,7 +182,12 @@ const api = {
         }
         let returnTagCount = true;
 
-        const validationRes = validateQueryAndHeaders(request, log);
+        // Initialize rate limit tracker flag
+        request.rateLimitAlreadyChecked = false;
+
+        // Process the request with validation, authentication, and execution
+        const processRequest = () => {
+            const validationRes = validateQueryAndHeaders(request, log);
         if (validationRes.error) {
             log.debug('request query / header validation failed', {
                 error: validationRes.error,
@@ -335,6 +344,48 @@ const api = {
             }
             return this[apiMethod](userInfo, request, log, methodCallback);
         });
+        }; // End of processRequest helper function
+
+        // Cache-only rate limit check (fast path, no metadata fetch)
+        // If config is cached, apply rate limiting now
+        // If not cached, metadata validation functions will handle it
+        if (request.bucketName && config.rateLimiting?.enabled) {
+            const cachedConfig = getRateLimitFromCache(request.bucketName);
+
+            if (cachedConfig !== undefined) {
+                // Cache hit - apply rate limiting NOW (fast path)
+                return checkRateLimitWithConfig(
+                    request.bucketName,
+                    cachedConfig,
+                    log,
+                    (rateLimitErr, rateLimited) => {
+                        if (rateLimitErr) {
+                            log.error('Rate limit check error in api.js', {
+                                error: rateLimitErr,
+                            });
+                        }
+
+                        if (rateLimited) {
+                            log.addDefaultFields({
+                                rateLimited: true,
+                                rateLimitSource: cachedConfig.source,
+                            });
+                            return callback(config.rateLimiting.error);
+                        }
+
+                        // Set tracker - rate limiting already applied
+                        request.rateLimitAlreadyChecked = true;
+
+                        // Continue with normal flow
+                        return processRequest();
+                    }
+                );
+            }
+        }
+
+        // Cache miss or no bucket name - continue to metadata validation
+        // Rate limiting will happen there after metadata fetch
+        return processRequest();
     },
     bucketDelete,
     bucketDeleteCors,

--- a/lib/api/apiUtils/rateLimit/helpers.js
+++ b/lib/api/apiUtils/rateLimit/helpers.js
@@ -1,0 +1,145 @@
+const { config } = require('../../../Config');
+const cache = require('./cache');
+const { evaluate, calculateInterval } = require('./gcra');
+const constants = require('../../../../constants');
+
+/**
+ * Get rate limit configuration from cache only (no metadata fetch)
+ *
+ * @param {string} bucketName - Bucket name
+ * @returns {object|null|undefined} Rate limit config, null (no limit), or undefined (not cached)
+ */
+function getRateLimitFromCache(bucketName) {
+    const cacheKey = `bucket:${bucketName}`;
+    return cache.getCachedConfig(cacheKey);
+}
+
+/**
+ * Extract rate limit configuration from bucket metadata and cache it
+ *
+ * Resolves in priority order:
+ * 1. Per-bucket configuration (from bucket metadata)
+ * 2. Global default configuration
+ * 3. No rate limiting (null)
+ *
+ * @param {object} bucket - Bucket metadata object
+ * @param {string} bucketName - Bucket name
+ * @param {object} log - Logger instance
+ * @returns {object|null} Rate limit config or null if no limit
+ */
+function extractAndCacheRateLimitConfig(bucket, bucketName, log) {
+    const cacheKey = `bucket:${bucketName}`;
+    const cacheTTL = config.rateLimiting.bucket?.configCacheTTL ||
+                     constants.rateLimitDefaultConfigCacheTTL;
+
+    // Try per-bucket config first
+    const bucketConfig = bucket.getRateLimitConfiguration();
+    if (bucketConfig) {
+        const data = bucketConfig.getData();
+        const limitConfig = {
+            limit: data.RequestsPerSecond.Limit,
+            source: 'bucket',
+        };
+
+        cache.setCachedConfig(cacheKey, limitConfig, cacheTTL);
+        log.debug('Extracted per-bucket rate limit config', {
+            bucketName,
+            limit: limitConfig.limit,
+        });
+
+        return limitConfig;
+    }
+
+    // Fall back to global default config
+    const globalLimit = config.rateLimiting.bucket?.defaultConfig?.limit;
+    if (globalLimit !== undefined && globalLimit > 0) {
+        const limitConfig = {
+            limit: globalLimit,
+            source: 'global',
+        };
+
+        cache.setCachedConfig(cacheKey, limitConfig, cacheTTL);
+        log.debug('Using global default rate limit config', {
+            bucketName,
+            limit: limitConfig.limit,
+        });
+
+        return limitConfig;
+    }
+
+    // No rate limiting configured - cache null to avoid repeated lookups
+    cache.setCachedConfig(cacheKey, null, cacheTTL);
+    log.trace('No rate limit configured for bucket', { bucketName });
+
+    return null;
+}
+
+/**
+ * Check rate limit with pre-resolved configuration
+ *
+ * Uses GCRA algorithm to determine if request should be rate limited.
+ * Updates counter if request is allowed.
+ *
+ * @param {string} bucketName - Bucket name
+ * @param {object|null} limitConfig - Pre-resolved rate limit config
+ * @param {object} log - Logger instance
+ * @param {function} callback - Callback(err, rateLimited boolean)
+ * @returns {undefined}
+ */
+function checkRateLimitWithConfig(bucketName, limitConfig, log, callback) {
+    // No rate limiting configured
+    if (!limitConfig || limitConfig.limit === 0) {
+        return callback(null, false);
+    }
+
+    // Calculate interval for this limit
+    const nodes = config.rateLimiting.nodes || 1;
+    const workers = config.clusters || 1;
+    const interval = calculateInterval(limitConfig.limit, nodes, workers);
+
+    // Get burst capacity (default to 1 if not configured)
+    const burstCapacity = config.rateLimiting.bucket?.defaultBurstCapacity ||
+                          constants.rateLimitDefaultBurstCapacity;
+    const bucketSize = burstCapacity * 1000;
+
+    // Get counter (in-memory only, no sync with other workers)
+    const counterKey = `bucket:${bucketName}:rps`;
+    const emptyAt = cache.getCounter(counterKey) || 0;
+    const arrivedAt = Date.now();
+
+    log.debug('Checking rate limit with GCRA', {
+        bucketName,
+        limit: limitConfig.limit,
+        source: limitConfig.source,
+        interval,
+        emptyAt,
+        arrivedAt,
+    });
+
+    // Evaluate GCRA
+    const result = evaluate(emptyAt, arrivedAt, interval, bucketSize);
+
+    // Update counter if allowed
+    if (result.allowed) {
+        cache.setCounter(counterKey, result.newEmptyAt);
+        log.debug('Rate limit check: allowed', {
+            bucketName,
+            newEmptyAt: result.newEmptyAt,
+        });
+    } else {
+        log.debug('Rate limit check: denied', {
+            bucketName,
+            limit: limitConfig.limit,
+            allowAt: result.newEmptyAt,
+            retryAfterMs: result.newEmptyAt - arrivedAt,
+        });
+    }
+
+    return callback(null, !result.allowed);
+}
+
+module.exports = {
+    getRateLimitFromCache,
+    extractAndCacheRateLimitConfig,
+    checkRateLimitWithConfig,
+};

--- a/lib/metadata/metadataUtils.js
+++ b/lib/metadata/metadataUtils.js
@@ -9,6 +9,11 @@ const bucketShield = require('../api/apiUtils/bucket/bucketShield');
 const { onlyOwnerAllowed } = require('../../constants');
 const { actionNeedQuotaCheck, actionWithDataDeletion } = require('arsenal/build/lib/policyEvaluator/RequestContext');
 const { processBytesToWrite, validateQuotas } = require('../api/apiUtils/quotas/quotaUtils');
+const { config } = require('../Config');
+const {
+    extractAndCacheRateLimitConfig,
+    checkRateLimitWithConfig,
+} = require('../api/apiUtils/rateLimit/helpers');
 
 /** getNullVersionFromMaster - retrieves the null version
  * metadata via retrieving the master key
@@ -169,6 +174,65 @@ function validateBucket(bucket, params, log, actionImplicitDenies = {}) {
     }
     return null;
 }
+
+/**
+ * Check rate limiting if not already checked
+ *
+ * Extracts rate limit config from bucket metadata, caches it, and enforces limit.
+ * Calls callback with error if rate limited, null if allowed or no rate limiting.
+ *
+ * @param {object} bucket - Bucket metadata object
+ * @param {string} bucketName - Bucket name
+ * @param {object} request - Request object with rateLimitAlreadyChecked tracker
+ * @param {object} log - Logger instance
+ * @param {function} callback - Callback(err) - err if rate limited, null if allowed
+ * @returns {undefined}
+ */
+function checkRateLimitIfNeeded(bucket, bucketName, request, log, callback) {
+    // Skip if already checked or not enabled
+    if (request.rateLimitAlreadyChecked || !config.rateLimiting?.enabled) {
+        return process.nextTick(callback, null);
+    }
+
+    // Extract rate limit config from bucket metadata and cache it
+    const rateLimitConfig = extractAndCacheRateLimitConfig(bucket, bucketName, log);
+
+    // No rate limiting configured
+    if (!rateLimitConfig) {
+        // eslint-disable-next-line no-param-reassign
+        request.rateLimitAlreadyChecked = true;
+        return process.nextTick(callback, null);
+    }
+
+    // Check rate limit with GCRA
+    return checkRateLimitWithConfig(
+        bucketName,
+        rateLimitConfig,
+        log,
+        (rateLimitErr, rateLimited) => {
+            if (rateLimitErr) {
+                log.error('Rate limit check error in metadata validation', {
+                    error: rateLimitErr,
+                });
+            }
+
+            if (rateLimited) {
+                log.addDefaultFields({
+                    rateLimited: true,
+                    rateLimitSource: rateLimitConfig.source,
+                });
+                // eslint-disable-next-line no-param-reassign
+                request.rateLimitAlreadyChecked = true;
+                return callback(config.rateLimiting.error);
+            }
+
+            // Allowed - set tracker and continue
+            // eslint-disable-next-line no-param-reassign
+            request.rateLimitAlreadyChecked = true;
+            return callback(null);
+        }
+    );
+}
 /** standardMetadataValidateBucketAndObj - retrieve bucket and object md from metadata
  * and check if user is authorized to access them.
  * @param {object} params - function parameters
@@ -222,12 +286,21 @@ function standardMetadataValidateBucketAndObj(params, actionImplicitDenies, log,
             if (validationError) {
                 return next(validationError, bucket);
             }
-            const objMD = getResult.obj ? JSON.parse(getResult.obj) : undefined;
-            if (!objMD && versionId === 'null') {
-                return getNullVersionFromMaster(bucketName, objectKey, log,
-                     (err, nullVer) => next(err, bucket, nullVer));
-            }
-            return next(null, bucket, objMD);
+
+            // Rate limiting check if not already done in api.js
+            return checkRateLimitIfNeeded(bucket, bucketName, request, log, err => {
+                if (err) {
+                    return next(err, bucket);
+                }
+
+                // Continue with object metadata processing
+                const objMD = getResult.obj ? JSON.parse(getResult.obj) : undefined;
+                if (!objMD && versionId === 'null') {
+                    return getNullVersionFromMaster(bucketName, objectKey, log,
+                         (err, nullVer) => next(err, bucket, nullVer));
+                }
+                return next(null, bucket, objMD);
+            });
         },
         (bucket, objMD, next) => {
             const objMetadata = objMD;
@@ -294,7 +367,7 @@ function standardMetadataValidateBucketAndObj(params, actionImplicitDenies, log,
  * @return {undefined} - and call callback with params err, bucket md
  */
 function standardMetadataValidateBucket(params, actionImplicitDenies, log, callback) {
-    const { bucketName } = params;
+    const { bucketName, request } = params;
     return metadata.getBucket(bucketName, log, (err, bucket) => {
         if (err) {
             // if some implicit actionImplicitDenies, return AccessDenied before
@@ -305,8 +378,17 @@ function standardMetadataValidateBucket(params, actionImplicitDenies, log, callb
             log.debug('metadata getbucket failed', { error: err });
             return callback(err);
         }
-        const validationError = validateBucket(bucket, params, log, actionImplicitDenies);
-        return callback(validationError, bucket);
+
+        // Rate limiting check if not already done in api.js
+        return checkRateLimitIfNeeded(bucket, bucketName, request, log, err => {
+            if (err) {
+                return callback(err);
+            }
+
+            // Continue with validation
+            const validationError = validateBucket(bucket, params, log, actionImplicitDenies);
+            return callback(validationError, bucket);
+        });
     });
 }
 

--- a/tests/unit/api/apiUtils/rateLimit/helpers.js
+++ b/tests/unit/api/apiUtils/rateLimit/helpers.js
@@ -1,0 +1,370 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const { config } = require('../../../../../lib/Config');
+const cache = require('../../../../../lib/api/apiUtils/rateLimit/cache');
+const helpers = require('../../../../../lib/api/apiUtils/rateLimit/helpers');
+const constants = require('../../../../../constants');
+
+describe('Rate limit helpers', () => {
+    let sandbox;
+    let mockLog;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        mockLog = {
+            trace: sinon.stub(),
+            debug: sinon.stub(),
+            info: sinon.stub(),
+            error: sinon.stub(),
+        };
+        // Clear cache before each test
+        cache.counters.clear();
+        cache.configCache.clear();
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe('getRateLimitFromCache', () => {
+        it('should return cached config on cache hit', () => {
+            const bucketName = 'test-bucket';
+            const limitConfig = { limit: 100, source: 'bucket' };
+            cache.setCachedConfig(`bucket:${bucketName}`, limitConfig, 60000);
+
+            const result = helpers.getRateLimitFromCache(bucketName);
+
+            assert.strictEqual(result, limitConfig);
+        });
+
+        it('should return undefined on cache miss', () => {
+            const bucketName = 'test-bucket';
+
+            const result = helpers.getRateLimitFromCache(bucketName);
+
+            assert.strictEqual(result, undefined);
+        });
+
+        it('should return null when null is cached', () => {
+            const bucketName = 'test-bucket';
+            cache.setCachedConfig(`bucket:${bucketName}`, null, 60000);
+
+            const result = helpers.getRateLimitFromCache(bucketName);
+
+            assert.strictEqual(result, null);
+        });
+    });
+
+    describe('extractAndCacheRateLimitConfig', () => {
+        let configStub;
+
+        beforeEach(() => {
+            configStub = sandbox.stub(config, 'rateLimiting').value({
+                enabled: true,
+                bucket: {
+                    configCacheTTL: 30000,
+                },
+            });
+        });
+
+        it('should extract and cache per-bucket config', () => {
+            const bucketName = 'test-bucket';
+            const mockBucket = {
+                getRateLimitConfiguration: () => ({
+                    getData: () => ({
+                        RequestsPerSecond: { Limit: 200 },
+                    }),
+                }),
+            };
+
+            const result = helpers.extractAndCacheRateLimitConfig(mockBucket, bucketName, mockLog);
+
+            assert.deepStrictEqual(result, { limit: 200, source: 'bucket' });
+            // Verify it was cached
+            const cached = cache.getCachedConfig(`bucket:${bucketName}`);
+            assert.deepStrictEqual(cached, { limit: 200, source: 'bucket' });
+        });
+
+        it('should fall back to global config when no bucket config', () => {
+            const bucketName = 'test-bucket';
+            const mockBucket = {
+                getRateLimitConfiguration: () => null,
+            };
+
+            configStub.value({
+                enabled: true,
+                bucket: {
+                    defaultConfig: { limit: 100 },
+                    configCacheTTL: 30000,
+                },
+            });
+
+            const result = helpers.extractAndCacheRateLimitConfig(mockBucket, bucketName, mockLog);
+
+            assert.deepStrictEqual(result, { limit: 100, source: 'global' });
+            // Verify it was cached
+            const cached = cache.getCachedConfig(`bucket:${bucketName}`);
+            assert.deepStrictEqual(cached, { limit: 100, source: 'global' });
+        });
+
+        it('should return null when no config exists', () => {
+            const bucketName = 'test-bucket';
+            const mockBucket = {
+                getRateLimitConfiguration: () => null,
+            };
+
+            configStub.value({
+                enabled: true,
+                bucket: {
+                    configCacheTTL: 30000,
+                },
+            });
+
+            const result = helpers.extractAndCacheRateLimitConfig(mockBucket, bucketName, mockLog);
+
+            assert.strictEqual(result, null);
+            // Verify null was cached
+            const cached = cache.getCachedConfig(`bucket:${bucketName}`);
+            assert.strictEqual(cached, null);
+        });
+
+        it('should skip global default if limit is 0', () => {
+            const bucketName = 'test-bucket';
+            const mockBucket = {
+                getRateLimitConfiguration: () => null,
+            };
+
+            configStub.value({
+                enabled: true,
+                bucket: {
+                    defaultConfig: { limit: 0 },
+                    configCacheTTL: 30000,
+                },
+            });
+
+            const result = helpers.extractAndCacheRateLimitConfig(mockBucket, bucketName, mockLog);
+
+            assert.strictEqual(result, null);
+        });
+
+        it('should use default TTL when not configured', () => {
+            const bucketName = 'test-bucket';
+            const mockBucket = {
+                getRateLimitConfiguration: () => ({
+                    getData: () => ({
+                        RequestsPerSecond: { Limit: 200 },
+                    }),
+                }),
+            };
+
+            configStub.value({
+                enabled: true,
+                bucket: {},
+            });
+
+            sandbox.stub(constants, 'rateLimitDefaultConfigCacheTTL').value(60000);
+
+            helpers.extractAndCacheRateLimitConfig(mockBucket, bucketName, mockLog);
+
+            // Verify it was cached with default TTL
+            const cached = cache.getCachedConfig(`bucket:${bucketName}`);
+            assert.deepStrictEqual(cached, { limit: 200, source: 'bucket' });
+        });
+    });
+
+    describe('checkRateLimitWithConfig', () => {
+        let configStub;
+
+        beforeEach(() => {
+            configStub = sandbox.stub(config, 'rateLimiting').value({
+                enabled: true,
+                nodes: 1,
+                bucket: {
+                    defaultBurstCapacity: 1,
+                },
+            });
+            sandbox.stub(config, 'clusters').value(1);
+        });
+
+        it('should allow request when no limit configured', done => {
+            const bucketName = 'test-bucket';
+            const limitConfig = null;
+
+            helpers.checkRateLimitWithConfig(bucketName, limitConfig, mockLog, (err, rateLimited) => {
+                assert.strictEqual(err, null);
+                assert.strictEqual(rateLimited, false);
+                done();
+            });
+        });
+
+        it('should allow request when limit is 0', done => {
+            const bucketName = 'test-bucket';
+            const limitConfig = { limit: 0, source: 'global' };
+
+            helpers.checkRateLimitWithConfig(bucketName, limitConfig, mockLog, (err, rateLimited) => {
+                assert.strictEqual(err, null);
+                assert.strictEqual(rateLimited, false);
+                done();
+            });
+        });
+
+        it('should allow request when bucket has capacity', done => {
+            const bucketName = 'test-bucket';
+            const limitConfig = { limit: 100, source: 'bucket' };
+
+            helpers.checkRateLimitWithConfig(bucketName, limitConfig, mockLog, (err, rateLimited) => {
+                assert.strictEqual(err, null);
+                assert.strictEqual(rateLimited, false);
+                // Verify counter was updated
+                const counter = cache.getCounter(`bucket:${bucketName}:rps`);
+                assert(counter > 0);
+                done();
+            });
+        });
+
+        it('should deny request when bucket is full', done => {
+            const bucketName = 'test-bucket';
+            const limitConfig = { limit: 100, source: 'bucket' };
+
+            // Pre-fill the bucket by setting counter to future
+            const now = Date.now();
+            cache.setCounter(`bucket:${bucketName}:rps`, now + 10000);
+
+            helpers.checkRateLimitWithConfig(bucketName, limitConfig, mockLog, (err, rateLimited) => {
+                assert.strictEqual(err, null);
+                assert.strictEqual(rateLimited, true);
+                done();
+            });
+        });
+
+        it('should use configured burst capacity', done => {
+            const bucketName = 'test-bucket';
+            const limitConfig = { limit: 100, source: 'bucket' };
+
+            configStub.value({
+                enabled: true,
+                nodes: 1,
+                bucket: {
+                    defaultBurstCapacity: 2,
+                },
+            });
+
+            helpers.checkRateLimitWithConfig(bucketName, limitConfig, mockLog, (err, rateLimited) => {
+                assert.strictEqual(err, null);
+                assert.strictEqual(rateLimited, false);
+                done();
+            });
+        });
+
+        it('should use default burst capacity when not configured', done => {
+            const bucketName = 'test-bucket';
+            const limitConfig = { limit: 100, source: 'bucket' };
+
+            configStub.value({
+                enabled: true,
+                nodes: 1,
+                bucket: {},
+            });
+
+            sandbox.stub(constants, 'rateLimitDefaultBurstCapacity').value(1);
+
+            helpers.checkRateLimitWithConfig(bucketName, limitConfig, mockLog, (err, rateLimited) => {
+                assert.strictEqual(err, null);
+                assert.strictEqual(rateLimited, false);
+                done();
+            });
+        });
+
+        it('should calculate interval for distributed setup', done => {
+            const bucketName = 'test-bucket';
+            const limitConfig = { limit: 1000, source: 'global' };
+
+            configStub.value({
+                enabled: true,
+                nodes: 10,
+                bucket: {
+                    defaultBurstCapacity: 1,
+                },
+            });
+            sandbox.stub(config, 'clusters').value(5);
+
+            helpers.checkRateLimitWithConfig(bucketName, limitConfig, mockLog, err => {
+                assert.strictEqual(err, null);
+                // Should work correctly with distributed calculation
+                done();
+            });
+        });
+
+        it('should log debug info before GCRA evaluation', done => {
+            const bucketName = 'test-bucket';
+            const limitConfig = { limit: 100, source: 'bucket' };
+
+            helpers.checkRateLimitWithConfig(bucketName, limitConfig, mockLog, () => {
+                assert(mockLog.debug.calledWith('Checking rate limit with GCRA'));
+                const logArgs = mockLog.debug.firstCall.args[1];
+                assert.strictEqual(logArgs.bucketName, bucketName);
+                assert.strictEqual(logArgs.limit, 100);
+                assert.strictEqual(logArgs.source, 'bucket');
+                done();
+            });
+        });
+
+        it('should log debug info when request allowed', done => {
+            const bucketName = 'test-bucket';
+            const limitConfig = { limit: 100, source: 'bucket' };
+
+            helpers.checkRateLimitWithConfig(bucketName, limitConfig, mockLog, (err, rateLimited) => {
+                assert.strictEqual(rateLimited, false);
+                // Find the "allowed" log call
+                const allowedCall = mockLog.debug.getCalls().find(
+                    call => call.args[0] === 'Rate limit check: allowed'
+                );
+                assert(allowedCall, 'Should have logged allowed message');
+                assert.strictEqual(allowedCall.args[1].bucketName, bucketName);
+                assert(allowedCall.args[1].newEmptyAt > 0);
+                done();
+            });
+        });
+
+        it('should log debug info when request denied with retry info', done => {
+            const bucketName = 'test-bucket';
+            const limitConfig = { limit: 100, source: 'bucket' };
+
+            // Pre-fill the bucket
+            const now = Date.now();
+            cache.setCounter(`bucket:${bucketName}:rps`, now + 10000);
+
+            helpers.checkRateLimitWithConfig(bucketName, limitConfig, mockLog, (err, rateLimited) => {
+                assert.strictEqual(rateLimited, true);
+                // Find the "denied" log call
+                const deniedCall = mockLog.debug.getCalls().find(
+                    call => call.args[0] === 'Rate limit check: denied'
+                );
+                assert(deniedCall, 'Should have logged denied message');
+                assert.strictEqual(deniedCall.args[1].bucketName, bucketName);
+                assert.strictEqual(deniedCall.args[1].limit, 100);
+                assert(deniedCall.args[1].allowAt > now);
+                assert(deniedCall.args[1].retryAfterMs > 0);
+                done();
+            });
+        });
+
+        it('should handle multiple sequential requests correctly', done => {
+            const bucketName = 'test-bucket';
+            const limitConfig = { limit: 100, source: 'bucket' };
+
+            // First request should be allowed
+            helpers.checkRateLimitWithConfig(bucketName, limitConfig, mockLog, (err, rateLimited) => {
+                assert.strictEqual(err, null);
+                assert.strictEqual(rateLimited, false);
+
+                // Second request should also be allowed (has capacity)
+                helpers.checkRateLimitWithConfig(bucketName, limitConfig, mockLog, (err2, rateLimited2) => {
+                    assert.strictEqual(err2, null);
+                    assert.strictEqual(rateLimited2, false);
+                    done();
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Add helpers for rate limit and pre and post MD fetch rate limit.
First request will be after MD check, but after that we have internal memory cache.
