### PR TITLE
 CLDSRV-792: Split bucket logging API control from writing server-access.logs file

### DIFF
--- a/.github/docker/config.s3c.json
+++ b/.github/docker/config.s3c.json
@@ -63,7 +63,7 @@
     ],
     "enableVeeamRoute": false,
     "serverAccessLogs": {
-        "enabled": true,
+        "mode": "ENABLED",
         "outputFile": "/logs/server-access.log"
     }
 }

--- a/.github/docker/docker-compose.yaml
+++ b/.github/docker/docker-compose.yaml
@@ -46,7 +46,7 @@ services:
       - S3QUOTA
       - QUOTA_ENABLE_INFLIGHTS
       - S3_VERSION_ID_ENCODING_TYPE
-      - S3_ENABLE_SERVER_ACCESS_LOGS=true
+      - S3_SERVER_ACCESS_LOGS_MODE=ENABLED
     env_file:
       - creds.env
     depends_on:

--- a/config.json
+++ b/config.json
@@ -151,7 +151,7 @@
         "objectPutRetention": true
     },
     "serverAccessLogs": {
-        "enabled": false,
+        "mode": "DISABLED",
         "outputFile": "/logs/server-access.log",
         "highWaterMarkBytes": 10485760,
         "retryReopenDelayMS": 1000,

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -574,9 +574,16 @@ function parseIntegrityChecks(config) {
     return integrityChecks;
 }
 
+const serverAccessLogsModes = {
+    DISABLED: 'DISABLED',
+    LOG_ONLY: 'LOG_ONLY',
+    ENABLED: 'ENABLED',
+};
+
 function parseServerAccessLogs(config) {
+    const validModes = Object.values(serverAccessLogsModes);
     const res = {
-        enabled: false,
+        mode: serverAccessLogsModes.DISABLED,
         outputFile: '/logs/server-access.log',
         highWaterMarkBytes: 10485760,
         retryReopenDelayMS: 1000,
@@ -585,7 +592,7 @@ function parseServerAccessLogs(config) {
 
     if (config && config.serverAccessLogs) {
         const settings = [
-            { key: 'enabled', type: 'boolean' },
+            { key: 'mode', type: 'string' },
             { key: 'outputFile', type: 'string' },
             { key: 'highWaterMarkBytes', type: 'number' },
             { key: 'retryReopenDelayMS', type: 'number' },
@@ -599,10 +606,17 @@ function parseServerAccessLogs(config) {
                 res[setting.key] = config.serverAccessLogs[setting.key];
             }
         });
+
+        if ('mode' in config.serverAccessLogs) {
+            assert(validModes.includes(config.serverAccessLogs.mode),
+                `bad config: serverAccessLogs.mode must be one of: ${validModes.join(', ')}`);
+        }
     }
 
-    if (process.env.S3_ENABLE_SERVER_ACCESS_LOGS === 'true') {
-        res.enabled = true;
+    if (process.env.S3_SERVER_ACCESS_LOGS_MODE) {
+        assert(validModes.includes(process.env.S3_SERVER_ACCESS_LOGS_MODE),
+            `bad config: S3_SERVER_ACCESS_LOGS_MODE must be one of: ${validModes.join(', ')}`);
+        res.mode = process.env.S3_SERVER_ACCESS_LOGS_MODE;
     }
 
     return res;
@@ -2171,6 +2185,7 @@ module.exports = {
     locationConstraintAssert,
     ConfigObject: Config,
     config: new Config(),
+    serverAccessLogsModes,
     requestsConfigAssert,
     bucketNotifAssert,
     azureGetStorageAccountName,

--- a/lib/api/bucketGetLogging.js
+++ b/lib/api/bucketGetLogging.js
@@ -2,7 +2,7 @@ const { standardMetadataValidateBucket } = require('../metadata/metadataUtils');
 const { checkExpectedBucketOwner } = require('./apiUtils/authorization/bucketOwner');
 const monitoring = require('../utilities/monitoringHandler');
 const { waterfall } = require('async');
-const { config } = require('../Config');
+const { config, serverAccessLogsModes } = require('../Config');
 const { errorInstances } = require('arsenal');
 
 const BucketLoggingStatusNotFoundBody = '<?xml version="1.0" encoding="UTF-8"?>\n' +
@@ -11,7 +11,7 @@ const BucketLoggingStatusNotFoundBody = '<?xml version="1.0" encoding="UTF-8"?>\
 function bucketGetLogging(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'bucketGetLogging' });
 
-    if (!config.serverAccessLogs || !config.serverAccessLogs.enabled) {
+    if (!config.serverAccessLogs || config.serverAccessLogs.mode !== serverAccessLogsModes.ENABLED) {
         return callback(errorInstances.NotImplemented);
     }
 

--- a/lib/api/bucketPutLogging.js
+++ b/lib/api/bucketPutLogging.js
@@ -5,12 +5,12 @@ const BucketLoggingStatus = require('arsenal').models.BucketLoggingStatus;
 const metadata = require('../metadata/wrapper');
 const monitoring = require('../utilities/monitoringHandler');
 const { errorInstances } = require('arsenal');
-const { config } = require('../Config');
+const { config, serverAccessLogsModes } = require('../Config');
 
 function bucketPutLogging(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'bucketPutLogging' });
 
-    if (!config.serverAccessLogs || !config.serverAccessLogs.enabled) {
+    if (!config.serverAccessLogs || config.serverAccessLogs.mode !== serverAccessLogsModes.ENABLED) {
         return callback(errorInstances.NotImplemented);
     }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -9,7 +9,7 @@ const monitoringClient = require('./utilities/monitoringHandler');
 const logger = require('./utilities/logger');
 const { internalHandlers } = require('./utilities/internalHandlers');
 const { clientCheck, healthcheckHandler } = require('./utilities/healthcheckHandler');
-const _config = require('./Config').config;
+const { config: _config, serverAccessLogsModes } = require('./Config');
 const { blacklistedPrefixes } = require('../constants');
 const api = require('./api/api');
 const dataWrapper = require('./data/wrapper');
@@ -124,7 +124,10 @@ class S3Server {
         const requestStartTime = process.hrtime.bigint();
 
         // Skip server access logs for heartbeat and backbeat.
-        if (_config.serverAccessLogs && _config.serverAccessLogs.enabled && !req.url.startsWith('/_/')) {
+        const isLoggingEnabled = _config.serverAccessLogs
+            && (_config.serverAccessLogs.mode === serverAccessLogsModes.LOG_ONLY
+                || _config.serverAccessLogs.mode === serverAccessLogsModes.ENABLED);
+        if (isLoggingEnabled && !req.url.startsWith('/_/')) {
             // eslint-disable-next-line no-param-reassign
             req.serverAccessLog = {
                 enabled: false,
@@ -394,7 +397,8 @@ class S3Server {
             }
 
            try {
-                if (_config.serverAccessLogs.enabled) {
+                if (_config.serverAccessLogs.mode === serverAccessLogsModes.LOG_ONLY
+                    || _config.serverAccessLogs.mode === serverAccessLogsModes.ENABLED) {
                     var serverAccessLogger = new ServerAccessLogger(
                         _config.serverAccessLogs.outputFile,
                         _config.serverAccessLogs.highWaterMarkBytes,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "9.2.3",
+  "version": "9.2.4",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {

--- a/tests/functional/config.json
+++ b/tests/functional/config.json
@@ -8,7 +8,7 @@
         "port": 6379
     },
     "serverAccessLogs": {
-        "enabled": true,
+        "mode": "ENABLED",
         "outputFile": "/logs/server-access.log"
     }
 }

--- a/tests/unit/api/bucketGetLogging.js
+++ b/tests/unit/api/bucketGetLogging.js
@@ -11,9 +11,9 @@ const otherAuthInfo = makeAuthInfo('accessKey2');
 const bucketName = 'bucketgetloggingtest';
 const targetBucket = 'loggingbucket';
 const namespace = 'default';
-const { config } = require('../../../lib/Config');
+const { config, serverAccessLogsModes } = require('../../../lib/Config');
 
-config.serverAccessLogs.enabled = true;
+config.serverAccessLogs.mode = serverAccessLogsModes.ENABLED;
 
 const testBucketPutRequest = {
     bucketName,

--- a/tests/unit/api/bucketPutLogging.js
+++ b/tests/unit/api/bucketPutLogging.js
@@ -10,9 +10,9 @@ const otherAuthInfo = makeAuthInfo('accessKey2');
 const bucketName = 'bucketputloggingtest';
 const targetBucket = 'loggingbucket';
 const namespace = 'default';
-const { config } = require('../../../lib/Config');
+const { config, serverAccessLogsModes } = require('../../../lib/Config');
 
-config.serverAccessLogs.enabled = true;
+config.serverAccessLogs.mode = serverAccessLogsModes.ENABLED;
 
 const testBucketPutRequest = {
     bucketName,


### PR DESCRIPTION
Adds independent control over bucket logging API availability, separate from server access logging using an enum.