### PR TITLE
CLDSRV-794: fix service user auth for bucket rate limit APIs + variable bug in lua scripts + arsenal update

### DIFF
--- a/bin/ensureServiceUser
+++ b/bin/ensureServiceUser
@@ -3,55 +3,39 @@
 // TODO
 // - deduplicate with Vault's seed script at https://github.com/scality/Vault/pull/1627
 // - add permission boundaries to user when https://scality.atlassian.net/browse/VAULT-4 is implemented
-const fs = require('fs');
-
-const { errors, errorUtils } = require('arsenal');
+process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE = '1';
+const { errors } = require('arsenal');
 const { program } = require('commander');
 const werelogs = require('werelogs');
-const version = require('../package.json').version;
 const async = require('async');
-const { IAM, STS } = require('aws-sdk');
+const { IAM } = require('aws-sdk');
+const { version } = require('../package.json');
 
 const systemPrefix = '/scality-internal/';
 
-function generateUserAssumeRolePolicyDocument(roleName, targetAccount) {
-    return {
-        Version: '2012-10-17',
-        Statement: {
-            Effect: 'Allow',
-            Action: 'sts:AssumeRole',
-            Resource: `arn:aws:iam::${targetAccount}:role${systemPrefix}${roleName}`,
-        }
-    };
-}
 
-function generateRoleTrustPolicyDocument(userArn) {
+function generateUserPolicyDocument() {
     return {
         Version: '2012-10-17',
         Statement: [
-          {
-            Effect: 'Allow',
-            Principal: {
-              AWS: userArn,
+            {
+                Sid: 'RateLimitAdminAPIs',
+                Effect: 'Allow',
+                Action: [
+                    'scality:GetBucketRateLimit',
+                    'scality:PutBucketRateLimit',
+                    'scality:DeleteBucketRateLimit',
+                ],
+                Resource: 'arn:aws:s3:::bucket/*',
             },
-            Action: 'sts:AssumeRole',
-            Condition: {}
-          }
-        ]
-     };
+        ],
+    };
 }
 
 function createIAMClient(opts) {
     return new IAM({
         endpoint: opts.iamEndpoint,
-        region: opts.region,
-    });
-}
-
-function createSTSClient(opts) {
-    return new STS({
-        endpoint: opts.stsEndpoint,
-        region: opts.region,
+        region: 'us-east-1',
     });
 }
 
@@ -64,68 +48,72 @@ function needsCreation(v) {
 }
 
 class BaseHandler {
-    constructor(serviceName, iamClient, log, options) {
+    resourceType;
+
+    constructor(serviceName, iamClient, log
+    ) {
         this.serviceName = serviceName;
         this.iamClient = iamClient;
         this.log = log;
-        this.options = options || {};
-        this.name = this.options.name;
-        this.resourceTypeSuffix = this.name ? `_${this.name}` : '';
-        this.resourceNameSuffix = this.name ? `-${this.name}` : '';
-        this.resourceName = `${this.serviceName}${this.resourceNameSuffix}`;
-        this.stsClient = this.options.stsClient;
     }
 
-    get fqResourceType() {
-        return `${this.resourceType}${this.resourceTypeSuffix}`;
-    }
+    collect() {};
+    create(values) {};
+    conflicts(v) {}
 
     applyWaterfall(values, done) {
-        this.log.debug('applyWaterfall', { values, type: this.fqResourceType });
+        this.log.debug('applyWaterfall', { values, type: this.resourceType });
 
-        const v = values[this.fqResourceType];
+        const v = values[this.resourceType];
 
         if (needsCreation(v)) {
-            this.log.debug('creating', { v, type: this.fqResourceType });
+            this.log.debug('creating', { v, type: this.resourceType });
             return this.create(values)
                 .then(res =>
-                    done(null, Object.assign(values, {
-                        [this.fqResourceType]: res,
-                    })))
+                    done(
+                        null,
+                        Object.assign(values, {
+                            [this.resourceType]: res,
+                        }),
+                    ),
+                )
                 .catch(done);
         }
 
-        this.log.debug('conflicts check', { v, type: this.fqResourceType });
+        this.log.debug('conflicts check', { v, type: this.resourceType });
         if (this.conflicts(v)) {
-            return done(errors.EntityAlreadyExists.customizeDescription(
-                `${this.fqResourceType} ${this.serviceName} already exists and conflicts with the expected value.`));
+            return done(
+                errors.EntityAlreadyExists.customizeDescription(
+                    `${this.resourceType} ${this.serviceName} already exists and conflicts with the expected value.`,
+                ),
+            );
         }
 
-        this.log.debug('nothing to do', { v, type: this.fqResourceType });
+        this.log.debug('nothing to do', { v, type: this.resourceType });
         return done(null, values);
     }
 }
 
 class UserHandler extends BaseHandler {
-    get resourceType() {
-        return 'user';
+    resourceType = 'user';
+
+    async collect() {
+        return this.iamClient
+            .getUser({
+                UserName: this.serviceName,
+            })
+            .promise()
+            .then(res => res.User);
     }
 
-    collect() {
-        return this.iamClient.getUser({
-            UserName: this.resourceName,
-        })
-        .promise()
-        .then(res => res.User);
-    }
-
-    create(allResources) {
-        return this.iamClient.createUser({
-            UserName: this.resourceName,
-            Path: systemPrefix,
-        })
-        .promise()
-        .then(res => res.User);
+    async create() {
+        return this.iamClient
+            .createUser({
+                UserName: this.serviceName,
+                Path: systemPrefix,
+            })
+            .promise()
+            .then(res => res.User);
     }
 
     conflicts(u) {
@@ -133,168 +121,62 @@ class UserHandler extends BaseHandler {
     }
 }
 
-class PolicyHandler extends BaseHandler {
-    get resourceType() {
-        return 'policy';
-    }
+class UserPolicyHandler extends BaseHandler {
+    resourceType = 'userPolicy';
 
-    collect() {
-        return this.iamClient.listPolicies({
-            MaxItems: 100,
-            OnlyAttached: false,
-            Scope: 'All',
-        })
-        .promise()
-        .then(res => res.Policies.find(p => p.PolicyName === this.resourceName));
-    }
-
-    create(allResources) {
-        return new Promise((resolve, reject) => {
-            if (!this.options.constrainToThisAccount) {
-                return resolve('*');
-            }
-
-            return this.stsClient.getCallerIdentity((err, res) => {
-                if (err) {
-                    // return reject(err);
-                    // Workaround a Vault issue on 8.3 branch
-                    // https://scality.atlassian.net/browse/VAULT-238
-                    return resolve('000000000000');
-                }
-
-                return resolve(res.Account);
-            });
-        })
-        .then(accountId => {
-            if (this.options.policy) {
-                return this.options.policy;
-            }
-
-            return generateUserAssumeRolePolicyDocument(this.serviceName, accountId);
-        })
-        .then(policyDocument =>
-            this.iamClient.createPolicy({
-                PolicyName: this.resourceName,
-                PolicyDocument: JSON.stringify(policyDocument),
-                Path: systemPrefix,
+    async collect() {
+        return this.iamClient
+            .getUserPolicy({
+                UserName: this.serviceName,
+                PolicyName: this.serviceName,
             })
             .promise()
-        )
-        .then(res => res.Policy);
+            .then(() => true);
     }
 
-    conflicts(p) {
-        return p.Path !== systemPrefix;
-    }
-}
+    async create() {
+        const doc = generateUserPolicyDocument();
 
-class RoleHandler extends BaseHandler {
-    get resourceType() {
-        return 'role';
-    }
-
-    collect() {
-        return this.iamClient.getRole({
-            RoleName: this.resourceName,
-        })
-        .promise()
-        .then(res => res.Role);
+        return this.iamClient
+            .putUserPolicy({
+                UserName: this.serviceName,
+                PolicyName: this.serviceName,
+                PolicyDocument: JSON.stringify(doc),
+            })
+            .promise()
+            .then(() => true);
     }
 
-    create(allResources) {
-        const trustPolicy = generateRoleTrustPolicyDocument(allResources.user.Arn);
-
-        return this.iamClient.createRole({
-            RoleName: this.resourceName,
-            Path: systemPrefix,
-            AssumeRolePolicyDocument: JSON.stringify(trustPolicy),
-        })
-        .promise()
-        .then(res => res.Role);
-    }
-
-    conflicts(p) {
-        return p.Path !== systemPrefix;
-    }
-}
-
-class PolicyUserAttachmentHandler extends BaseHandler {
-    get resourceType() {
-        return 'policyAttachment';
-    }
-
-    collect() {
-        return this.iamClient.listAttachedUserPolicies({
-            UserName: this.resourceName,
-            MaxItems: 100,
-        })
-        .promise()
-        .then(res => res.AttachedPolicies);
-    }
-
-    create(allResources) {
-        return this.iamClient.attachUserPolicy({
-            PolicyArn: allResources.policy_user.Arn,
-            UserName: this.resourceName,
-        })
-        .promise();
-    }
-
-    conflicts(p) {
-        return false;
-    }
-}
-
-class PolicyRoleAttachmentHandler extends BaseHandler {
-    get resourceType() {
-        return 'policyRoleAttachment';
-    }
-
-    collect() {
-        return this.iamClient.listAttachedRolePolicies({
-            RoleName: this.resourceName,
-            MaxItems: 100,
-        })
-        .promise()
-        .then(res => res.AttachedPolicies);
-    }
-
-    create(allResources) {
-        return this.iamClient.attachRolePolicy({
-            PolicyArn: allResources.policy_role.Arn,
-            RoleName: this.resourceName,
-        })
-        .promise();
-    }
-
-    conflicts(p) {
+    conflicts() {
         return false;
     }
 }
 
 class AccessKeyHandler extends BaseHandler {
-    get resourceType() {
-        return 'accessKey';
+    resourceType = 'accessKey';
+
+    async collect() {
+        // if at least one key already exists, the script won't create a new key
+        // and will display the list of existing keys
+        return this.iamClient
+            .listAccessKeys({
+                UserName: this.serviceName,
+                MaxItems: 100,
+            })
+            .promise()
+            .then(res => res.AccessKeyMetadata);
     }
 
-    collect() {
-        return this.iamClient.listAccessKeys({
-            UserName: this.resourceName,
-            MaxItems: 100,
-        })
-        .promise()
-        .then(res => res.AccessKeyMetadata);
+    async create() {
+        return this.iamClient
+            .createAccessKey({
+                UserName: this.serviceName,
+            })
+            .promise()
+            .then(res => res.AccessKey);
     }
 
-    create(allResources) {
-        return this.iamClient.createAccessKey({
-            UserName: this.resourceName,
-        })
-        .promise()
-        .then(res => res.AccessKey);
-    }
-
-    conflicts(a) {
+    conflicts() {
         return false;
     }
 }
@@ -302,91 +184,60 @@ class AccessKeyHandler extends BaseHandler {
 function collectResource(v, done) {
     v.collect()
         .then(res => done(null, res))
-        .catch(err => {
+        .catch((err) => {
             if (err.code === 'NoSuchEntity') {
-                return done(null, null);
+                return done();
             }
-            done(err);
+
+            return done(err);
         });
 }
 
 function collectResourcesFromHandlers(handlers, cb) {
-    const tasks = handlers.reduce((acc, v) => ({
-        [v.fqResourceType]: done => collectResource(v, done),
-        ...acc,
-    }), {});
+    const tasks = handlers.reduce(
+        (acc, v) => ({
+            [v.resourceType]: (done) => collectResource(v, done),
+            ...acc,
+        }),
+        {},
+    );
     async.parallel(tasks, cb);
 }
 
-function buildServiceUserForCrossAccountAssumeRoleHandlers(serviceName, client, log) {
-    return [
-        new UserHandler(serviceName, client, log),
-        new PolicyHandler(serviceName, client, log, {
-            name: 'user',
-            policy: generateUserAssumeRolePolicyDocument(serviceName, '*'),
-        }),
-        new PolicyUserAttachmentHandler(serviceName, client, log),
-        new AccessKeyHandler(serviceName, client, log),
-    ];
+function buildServiceUserHandlers(serviceName, client, log) {
+    return [UserHandler, UserPolicyHandler, AccessKeyHandler].map(Handler => new Handler(serviceName, client, log));
 }
 
-function buildServiceUserForInAccountAssumeRoleHandlers(serviceName, policy, iamClient, stsClient, log) {
-    return [
-        // try permission policy first so that the waterfall
-        // fails early if it contains forbidden actions
-        new PolicyHandler(serviceName, iamClient, log, {
-            policy,
-            name: 'role',
-        }),
-        new UserHandler(serviceName, iamClient, log),
-        new PolicyHandler(serviceName, iamClient, log, {
-            stsClient,
-            name: 'user',
-            constrainToThisAccount: true,
-        }),
-        new PolicyUserAttachmentHandler(serviceName, iamClient, log),
-        new RoleHandler(serviceName, iamClient, log),
-        new PolicyRoleAttachmentHandler(serviceName, iamClient, log),
-        new AccessKeyHandler(serviceName, iamClient, log),
-    ];
+function apply(client, serviceName, log, cb) {
+    const handlers = buildServiceUserHandlers(serviceName, client, log);
+
+    async.waterfall(
+        [
+            (done) => collectResourcesFromHandlers(handlers, done),
+            ...handlers.map(h => h.applyWaterfall.bind(h)),
+            (values, done) => done(null, values.accessKey),
+        ],
+        cb,
+    );
 }
 
-function apply(iamClient, stsClient, serviceName, policyFile, log, cb) {
-    let handlers;
-
-    if (policyFile) {
-        const policyStr = fs.readFileSync(policyFile);
-        const policy = JSON.parse(policyStr);
-        handlers = buildServiceUserForInAccountAssumeRoleHandlers(serviceName, policy, iamClient, stsClient, log);
-    } else {
-        handlers = buildServiceUserForCrossAccountAssumeRoleHandlers(serviceName, iamClient, log);
-    }
-
-    async.waterfall([
-        done => collectResourcesFromHandlers(handlers, done),
-        ...handlers.map(h => h.applyWaterfall.bind(h)),
-        (values, done) => done(null, values.accessKey),
-    ], cb);
-}
-
-function wrapAction(actionFunc, serviceName, _, cmd) {
-    const options = cmd.optsWithGlobals();
-
+function wrapAction(actionFunc, serviceName, options) {
     werelogs.configure({
         level: options.logLevel,
         dump: options.logDumpLevel,
     });
 
     const log = new werelogs.Logger(process.argv[1]).newRequestLogger();
-    const iamClient = createIAMClient(options);
-    const stsClient = createSTSClient(options);
-
-    actionFunc(iamClient, stsClient, serviceName, options.policy, log, (err, data) => {
+    const client = createIAMClient(options);
+    actionFunc(client, serviceName, log, (err, data) => {
         if (err) {
             log.error('failed', {
                 data,
-                error: errorUtils.reshapeExceptionError(err),
+                error: err,
             });
+            if (err.EntityAlreadyExists) {
+                log.error(`run "${process.argv[1]} purge ${serviceName}" to fix.`);
+            }
             process.exit(1);
         }
         log.info('success', { data });
@@ -396,19 +247,19 @@ function wrapAction(actionFunc, serviceName, _, cmd) {
 
 program.version(version);
 
-program
-    .option('--iam-endpoint <url>', 'IAM endpoint', 'http://localhost:8600')
-    .option('--sts-endpoint <url>', 'STS endpoint', 'http://localhost:8800')
-    .option('--region <region>', 'AWS region', 'us-east-1')
-    .option('--log-level <level>', 'log level', 'info')
-    .option('--log-dump-level <level>', 'log level that triggers a dump of the debug buffer', 'error');
-
-program
-    .command('apply <service-name>')
-    .option('-p, --policy <policy-file.json>', 'Create a policy using the provided document' +
-        ' and attach it to a role that the service user is allowed to assume, instead' +
-        ' of only allowing the user to assume one (seeded) role named <service-name> in all accounts.')
-    .action(wrapAction.bind(null, apply));
+[
+    {
+        name: 'apply <service-name>',
+        actionFunc: apply,
+    },
+].forEach(cmd => {
+    program
+        .command(cmd.name)
+        .option('--iam-endpoint <url>', 'IAM endpoint', 'http://localhost:8600')
+        .option('--log-level <level>', 'log level', 'info')
+        .option('--log-dump-level <level>', 'log level that triggers a dump of the debug buffer', 'error')
+        .action(wrapAction.bind(null, cmd.actionFunc));
+});
 
 const validCommands = program.commands.map(n => n._name);
 

--- a/constants.js
+++ b/constants.js
@@ -1,4 +1,10 @@
 const crypto = require('crypto');
+// HACK TODO: need to export this from arsenal actionMap.ts
+const actionMapBucketRateLimit = {
+    bucketGetRateLimit: 'scality:GetBucketRateLimit',
+    bucketPutRateLimit: 'scality:PutBucketRateLimit',
+    bucketDeleteRateLimit: 'scality:DeleteBucketRateLimit',
+};
 
 const constants = {
     /*
@@ -279,6 +285,7 @@ const constants = {
     rateLimitDefaultConfigCacheTTL: 30000, // 30 seconds
     rateLimitDefaultBurstCapacity: 1,
     rateLimitCleanupInterval: 10000, // 10 seconds
+    rateLimitApiActions: Object.keys(actionMapBucketRateLimit),
 };
 
 module.exports = constants;

--- a/constants.js
+++ b/constants.js
@@ -1,10 +1,4 @@
 const crypto = require('crypto');
-// HACK TODO: need to export this from arsenal actionMap.ts
-const actionMapBucketRateLimit = {
-    bucketGetRateLimit: 'scality:GetBucketRateLimit',
-    bucketPutRateLimit: 'scality:PutBucketRateLimit',
-    bucketDeleteRateLimit: 'scality:DeleteBucketRateLimit',
-};
 
 const constants = {
     /*
@@ -285,7 +279,6 @@ const constants = {
     rateLimitDefaultConfigCacheTTL: 30000, // 30 seconds
     rateLimitDefaultBurstCapacity: 1,
     rateLimitCleanupInterval: 10000, // 10 seconds
-    rateLimitApiActions: Object.keys(actionMapBucketRateLimit),
 };
 
 module.exports = constants;

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -364,7 +364,7 @@ const api = {
         // Cache-only rate limit check (fast path, no metadata fetch)
         // If config is cached, apply rate limiting now
         // If not cached, metadata validation functions will handle it
-        if (request.bucketName && config.rateLimiting?.enabled) {
+        if (request.bucketName && config.rateLimiting?.enabled && !constants.rateLimitApiActions.includes(apiMethod)) {
             const cachedConfig = getRateLimitFromCache(request.bucketName);
 
             if (cachedConfig !== undefined) {

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -85,6 +85,7 @@ const { validateMethodChecksumNoChunking } = require('./apiUtils/integrity/valid
 const {
     getRateLimitFromCache,
     checkRateLimitWithConfig,
+    rateLimitApiActions,
 } = require('./apiUtils/rateLimit/helpers');
 
 const monitoringMap = policies.actionMaps.actionMonitoringMapS3;
@@ -364,7 +365,7 @@ const api = {
         // Cache-only rate limit check (fast path, no metadata fetch)
         // If config is cached, apply rate limiting now
         // If not cached, metadata validation functions will handle it
-        if (request.bucketName && config.rateLimiting?.enabled && !constants.rateLimitApiActions.includes(apiMethod)) {
+        if (request.bucketName && config.rateLimiting?.enabled && !rateLimitApiActions.includes(apiMethod)) {
             const cachedConfig = getRateLimitFromCache(request.bucketName);
 
             if (cachedConfig !== undefined) {

--- a/lib/api/apiUtils/rateLimit/grantTokens.lua
+++ b/lib/api/apiUtils/rateLimit/grantTokens.lua
@@ -47,7 +47,7 @@ else
         local grantedTokens = math.floor(availableCapacity / interval)
 
         if grantedTokens > 0 then
-            local grantedCost = granted * interval
+            local grantedCost = grantedTokens * interval
             local newEmptyAt = expectedTime + grantedCost
             redis.call('SET', key, newEmptyAt, 'PX', burstCapacity + 10000)
             return grantedTokens

--- a/lib/api/apiUtils/rateLimit/helpers.js
+++ b/lib/api/apiUtils/rateLimit/helpers.js
@@ -2,6 +2,9 @@ const { config } = require('../../../Config');
 const cache = require('./cache');
 const constants = require('../../../../constants');
 const { getTokenBucket } = require('./tokenBucket');
+const { policies: { actionMaps: { actionMapBucketRateLimit } } } = require('arsenal');
+
+const rateLimitApiActions = Object.keys(actionMapBucketRateLimit);
 
 /**
  * Get rate limit configuration from cache only (no metadata fetch)
@@ -121,4 +124,5 @@ module.exports = {
     getRateLimitFromCache,
     extractAndCacheRateLimitConfig,
     checkRateLimitWithConfig,
+    rateLimitApiActions,
 };

--- a/lib/metadata/metadataUtils.js
+++ b/lib/metadata/metadataUtils.js
@@ -5,8 +5,9 @@ const metadata = require('./wrapper');
 const BucketInfo = require('arsenal').models.BucketInfo;
 const { isBucketAuthorized, isObjAuthorized } =
     require('../api/apiUtils/authorization/permissionChecks');
+const { isRateLimitServiceUser } = require('../api/apiUtils/authorization/serviceUser');
 const bucketShield = require('../api/apiUtils/bucket/bucketShield');
-const { onlyOwnerAllowed } = require('../../constants');
+const { onlyOwnerAllowed, rateLimitApiActions } = require('../../constants');
 const { actionNeedQuotaCheck, actionWithDataDeletion } = require('arsenal/build/lib/policyEvaluator/RequestContext');
 const { processBytesToWrite, validateQuotas } = require('../api/apiUtils/quotas/quotaUtils');
 const { config } = require('../Config');
@@ -212,7 +213,9 @@ function validateBucket(bucket, params, log, actionImplicitDenies = {}) {
  */
 function checkRateLimitIfNeeded(bucket, bucketName, request, log, callback) {
     // Skip if already checked or not enabled
-    if (request.rateLimitAlreadyChecked || !config.rateLimiting?.enabled) {
+    if (request.rateLimitAlreadyChecked
+        || !config.rateLimiting?.enabled
+        || rateLimitApiActions.includes(request.apiMethod)) {
         return process.nextTick(callback, null);
     }
 

--- a/lib/metadata/metadataUtils.js
+++ b/lib/metadata/metadataUtils.js
@@ -183,10 +183,21 @@ function validateBucket(bucket, params, log, actionImplicitDenies = {}) {
         });
         return errors.NoSuchBucket;
     }
+
     const canonicalID = authInfo.getCanonicalID();
     if (!Array.isArray(requestType)) {
         requestType = [requestType];
     }
+
+    // Skip checking bucket ownership if the requesting user is the rate limit service user
+    // and the requestType is Get/Put/DeleteBucketRateLimit.
+    if (requestType.every(type => rateLimitApiActions.includes(type))
+        && config.rateLimiting.enabled
+        && isRateLimitServiceUser(authInfo)
+    ) {
+        return null;
+    }
+
     if (bucket.getOwner() !== canonicalID && requestType.some(type => onlyOwnerAllowed.includes(type))) {
         return errors.MethodNotAllowed;
     }

--- a/lib/metadata/metadataUtils.js
+++ b/lib/metadata/metadataUtils.js
@@ -7,13 +7,14 @@ const { isBucketAuthorized, isObjAuthorized } =
     require('../api/apiUtils/authorization/permissionChecks');
 const { isRateLimitServiceUser } = require('../api/apiUtils/authorization/serviceUser');
 const bucketShield = require('../api/apiUtils/bucket/bucketShield');
-const { onlyOwnerAllowed, rateLimitApiActions } = require('../../constants');
+const { onlyOwnerAllowed } = require('../../constants');
 const { actionNeedQuotaCheck, actionWithDataDeletion } = require('arsenal/build/lib/policyEvaluator/RequestContext');
 const { processBytesToWrite, validateQuotas } = require('../api/apiUtils/quotas/quotaUtils');
 const { config } = require('../Config');
 const {
     extractAndCacheRateLimitConfig,
     checkRateLimitWithConfig,
+    rateLimitApiActions,
 } = require('../api/apiUtils/rateLimit/helpers');
 
 function storeServerAccessLogInfo(request, bucket, raftSessionId) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@azure/storage-blob": "^12.28.0",
     "@hapi/joi": "^17.1.1",
-    "arsenal": "git+https://github.com/scality/Arsenal#8.2.40",
+    "arsenal": "git+https://github.com/scality/Arsenal#8.2.41",
     "async": "2.6.4",
     "aws-sdk": "^2.1692.0",
     "bucketclient": "scality/bucketclient#8.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1495,9 +1495,9 @@ arraybuffer.prototype.slice@^1.0.4:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/Arsenal#8.2.40":
-  version "8.2.40"
-  resolved "git+https://github.com/scality/Arsenal#0565be3a01c95b283eb8a3f2e0eb64e19fa5030a"
+"arsenal@git+https://github.com/scality/Arsenal#8.2.41":
+  version "8.2.41"
+  resolved "git+https://github.com/scality/Arsenal#0914598961fa2ca352a336a26b05b82ddc481749"
   dependencies:
     "@azure/identity" "^4.13.0"
     "@azure/storage-blob" "^12.28.0"


### PR DESCRIPTION
Authors: @tmacro and @anurag4DSB

This pull request introduces improvements to the rate limiting logic, especially for bucket rate limit API actions, and refines how service users are handled in authorization and validation flows. The main changes focus on ensuring rate-limiting checks are skipped for specific API actions and authorized service users, and fixing a variable name bug in the rate limit token grant logic(Lua script).

Per requirements, we should be able to call the bucket rate limit APIs without assuming role (like SUR admin APIs) using the normal credentials of a service user.

Dependency update:

Updated the arsenal dependency to version 8.2.41 in package.json. This update includes the exported bucket rate limit APIs' action map.