### PR TITLE
CLDSRV-809: allow tokens before redis interaction

### DIFF
--- a/lib/api/apiUtils/rateLimit/tokenBucket.js
+++ b/lib/api/apiUtils/rateLimit/tokenBucket.js
@@ -29,9 +29,9 @@ class WorkerTokenBucket {
         this.log = log;
 
         // Token buffer configuration
-        this.tokens = 0;
         this.bufferSize = config.tokenBucketBufferSize || 50; // Max tokens to hold
         this.refillThreshold = config.tokenBucketRefillThreshold || 20; // Trigger refill when below this
+        this.tokens = this.bufferSize; // Start with full buffer for fail-open at startup
 
         // Refill state
         this.refillInProgress = false;

--- a/tests/unit/api/apiUtils/rateLimit/helpers.js
+++ b/tests/unit/api/apiUtils/rateLimit/helpers.js
@@ -231,8 +231,9 @@ describe('Rate limit helpers', () => {
             const bucketName = 'test-bucket';
             const limitConfig = { limit: 100, source: 'bucket' };
 
-            // Token bucket starts with 0 tokens (no pre-population)
-            // This simulates exhausted quota
+            const bucket = tokenBucket.getTokenBucket(bucketName, limitConfig, mockLog);
+            // Explicitly set tokens to 0 to simulate exhausted quota
+            bucket.tokens = 0;
 
             helpers.checkRateLimitWithConfig(bucketName, limitConfig, mockLog, (err, rateLimited) => {
                 assert.strictEqual(err, null);
@@ -311,7 +312,10 @@ describe('Rate limit helpers', () => {
             const bucketName = 'test-bucket';
             const limitConfig = { limit: 100, source: 'bucket' };
 
-            // Token bucket with 0 tokens will log denial
+            const bucket = tokenBucket.getTokenBucket(bucketName, limitConfig, mockLog);
+            // Explicitly set tokens to 0 to trigger denial log
+            bucket.tokens = 0;
+
             helpers.checkRateLimitWithConfig(bucketName, limitConfig, mockLog, () => {
                 // Check for token bucket denial log
                 const deniedCall = mockLog.debug.getCalls().find(
@@ -351,7 +355,9 @@ describe('Rate limit helpers', () => {
             const bucketName = 'test-bucket';
             const limitConfig = { limit: 100, source: 'bucket' };
 
-            // Token bucket starts with 0 tokens
+            const bucket = tokenBucket.getTokenBucket(bucketName, limitConfig, mockLog);
+            // Explicitly set tokens to 0 to simulate exhausted quota
+            bucket.tokens = 0;
 
             helpers.checkRateLimitWithConfig(bucketName, limitConfig, mockLog, (err, rateLimited) => {
                 assert.strictEqual(rateLimited, true);

--- a/tests/unit/api/apiUtils/rateLimit/tokenBucket.js
+++ b/tests/unit/api/apiUtils/rateLimit/tokenBucket.js
@@ -45,9 +45,9 @@ describe('WorkerTokenBucket', () => {
 
             assert.strictEqual(bucket.bucketName, 'test-bucket');
             assert.deepStrictEqual(bucket.limitConfig, { limit: 100 });
-            assert.strictEqual(bucket.tokens, 0);
             assert.strictEqual(bucket.bufferSize, 50);
             assert.strictEqual(bucket.refillThreshold, 20);
+            assert.strictEqual(bucket.tokens, 50); // Starts with full buffer for fail-open
             assert.strictEqual(bucket.refillInProgress, false);
             assert.strictEqual(bucket.refillCount, 0);
         });


### PR DESCRIPTION
- Add rate limit fields to server access logs (optional fields for monitoring)
- Fix fail-open behavior at startup: workers now start with full token buffer (50 tokens) instead of 0, preventing request throttling before Redis connection is established

Note: this is default behaviour, which might be modified per strategy used for Redis unavailability which is out of scope of this PR and will be handled in another PR.