### PR TITLE
fix: Update commander API to v12 compatibility

### DIFF
--- a/bin/search_bucket.js
+++ b/bin/search_bucket.js
@@ -78,7 +78,8 @@ function _performSearch(host,
  */
 function searchBucket() {
     // TODO: Include other bucket listing possible query params?
-    commander
+    const program = new commander.Command();
+    program
         .version('0.0.1')
         .option('-a, --access-key <accessKey>', 'Access key id')
         .option('-k, --secret-key <secretKey>', 'Secret access key')
@@ -93,11 +94,11 @@ function searchBucket() {
         .option('-v, --verbose')
         .parse(process.argv);
     const { host, port, accessKey, secretKey, sessionToken, bucket, query, listVersions, verbose, ssl } =
-        commander;
+        program.opts();
 
     if (!host || !port || !accessKey || !secretKey || !bucket || !query) {
         logger.error('missing parameter');
-        commander.outputHelp();
+        program.outputHelp();
         process.exit(1);
     }
 

--- a/lib/kms/utilities.js
+++ b/lib/kms/utilities.js
@@ -72,7 +72,8 @@ function _createEncryptedBucket(host,
  * @return {undefined}
  */
 function createEncryptedBucket() {
-    commander
+    const program = new commander.Command();
+    program
         .version('0.0.1')
         .option('-a, --access-key <accessKey>', 'Access key id')
         .option('-k, --secret-key <secretKey>', 'Secret access key')
@@ -86,11 +87,11 @@ function createEncryptedBucket() {
         .parse(process.argv);
 
     const { host, port, accessKey, secretKey, bucket, verbose, ssl,
-    locationConstraint } = commander;
+    locationConstraint } = program.opts();
 
     if (!host || !port || !accessKey || !secretKey || !bucket) {
         logger.error('missing parameter');
-        commander.outputHelp();
+        program.outputHelp();
         process.exit(1);
     }
     _createEncryptedBucket(host, port, bucket, accessKey, secretKey, verbose,

--- a/lib/nfs/utilities.js
+++ b/lib/nfs/utilities.js
@@ -64,7 +64,8 @@ function _createBucketWithNFSEnabled(host, port, bucketName, accessKey,
  * @return {undefined}
  */
 function createBucketWithNFSEnabled() {
-    commander
+    const program = new commander.Command();
+    program
         .version('0.0.1')
         .option('-a, --access-key <accessKey>', 'Access key id')
         .option('-k, --secret-key <secretKey>', 'Secret access key')
@@ -78,11 +79,11 @@ function createBucketWithNFSEnabled() {
         .parse(process.argv);
 
     const { host, port, accessKey, secretKey, bucket, verbose,
-        ssl, locationConstraint } = commander;
+        ssl, locationConstraint } = program.opts();
 
     if (!host || !port || !accessKey || !secretKey || !bucket) {
         logger.error('missing parameter');
-        commander.outputHelp();
+        program.outputHelp();
         process.exit(1);
     }
     _createBucketWithNFSEnabled(host, port, bucket, accessKey, secretKey,

--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -123,7 +123,8 @@ function _listMetrics(host,
  * @return {undefined}
  */
 function listMetrics(metricType) {
-    commander
+    const program = new commander.Command();
+    program
         .version('0.0.1')
         .option('-a, --access-key <accessKey>', 'Access key id')
         .option('-k, --secret-key <secretKey>', 'Secret access key');
@@ -132,11 +133,11 @@ function listMetrics(metricType) {
     // bin/list_bucket_metrics.js when prior method of listing bucket metrics is
     // no longer supported.
     if (metricType === 'buckets') {
-        commander
+        program
             .option('-b, --buckets <buckets>', 'Name of bucket(s) with ' +
                 'a comma separator if more than one');
     } else {
-        commander
+        program
             .option('-m, --metric <metric>', 'Metric type')
             .option('--buckets <buckets>', 'Name of bucket(s) with a comma ' +
                 'separator if more than one')
@@ -146,7 +147,7 @@ function listMetrics(metricType) {
                 'more than one')
             .option('--service <service>', 'Name of service');
     }
-    commander
+    program
         .option('-s, --start <start>', 'Start of time range')
         .option('-r, --recent', 'List metrics including the previous and ' +
             'current 15 minute interval')
@@ -159,7 +160,7 @@ function listMetrics(metricType) {
 
     const { host, port, accessKey, secretKey, start, end, verbose, recent,
         ssl } =
-        commander;
+        program.opts();
     const requiredOptions = { host, port, accessKey, secretKey };
     // If not old style bucket metrics, we require usage of the metric option
     if (metricType !== 'buckets') {
@@ -174,24 +175,25 @@ function listMetrics(metricType) {
         }
     }
     // If old style bucket metrics, `metricType` will be 'buckets'. Otherwise,
-    // `commander.metric` should be defined.
-    const metric = metricType === 'buckets' ? 'buckets' : commander.metric;
-    requiredOptions[metric] = commander[metric];
+    // `program.opts().metric` should be defined.
+    const opts = program.opts();
+    const metric = metricType === 'buckets' ? 'buckets' : opts.metric;
+    requiredOptions[metric] = opts[metric];
     // If not recent listing, the start option must be provided
     if (!recent) {
-        requiredOptions.start = commander.start;
+        requiredOptions.start = opts.start;
     }
     Object.keys(requiredOptions).forEach(option => {
         if (!requiredOptions[option]) {
             logger.error(`missing required option: ${option}`);
-            commander.outputHelp();
+            program.outputHelp();
             process.exit(1);
         }
     });
 
-    // The string `commander[metric]` is a comma-separated list of resources
+    // The string `opts[metric]` is a comma-separated list of resources
     // given by the user.
-    const resources = commander[metric].split(',');
+    const resources = opts[metric].split(',');
 
     // Validate passed accounts to remove any canonicalIDs
     if (metric === 'accounts') {
@@ -208,7 +210,7 @@ function listMetrics(metricType) {
         const numStart = Number.parseInt(start, 10);
         if (!numStart) {
             logger.error('start must be a number');
-            commander.outputHelp();
+            program.outputHelp();
             process.exit(1);
             return;
         }
@@ -217,7 +219,7 @@ function listMetrics(metricType) {
             const numEnd = Number.parseInt(end, 10);
             if (!numEnd) {
                 logger.error('end must be a number');
-                commander.outputHelp();
+                program.outputHelp();
                 process.exit(1);
                 return;
             }


### PR DESCRIPTION
# Pull request template

## Description

- Migrated from deprecated commander API to v12 Command() pattern
- Fixed lib/kms/utilities.js createEncryptedBucket() function
- Fixed lib/nfs/utilities.js createBucketWithNFSEnabled() function
- Fixed lib/utapi/utilities.js listMetrics() function
- Fixed bin/search_bucket.js searchBucket() function

Changes:
- Replace 'commander.version().option()' with 'new commander.Command()'
- Replace direct commander property access with 'program.opts()'
- Update all commander.xyz references to program.opts().xyz

### Motivation and context

This fixes TypeError: commander.version is not a function when using create_encrypted_bucket.js and other utilities with commander v12.