### PR TITLE
CLDSRV-814: prevent premature codecov results

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,10 @@
 ---
+codecov:
+  require_ci_to_pass: true
+  notify:
+    wait_for_ci: true
+    after_n_builds: 9
+
 parsers:
   javascript:
     enable_partials: yes


### PR DESCRIPTION
Prevent premature codecov results to be published on PR status before all tests successfully run and pass.

`development/9.0` contains 9 codecov uploads, `development/9.2` contains 10, should be fine to set it up as 9 starting from `9.0` and if needed we can bump it.