### PR TITLE
Override an unversioned object originOp when moving it to a version

### DIFF
--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -98,6 +98,7 @@ function _storeNullVersionMD(bucketName, objKey, nullVersionId, objMD, log, cb) 
             isNull2: true,
         });
     }
+    nullVersionMD.originOp = 's3:ObjectNullVersionStoredAsNewVersion';
     metadata.putObjectMD(bucketName, objKey, nullVersionMD, { versionId }, log, err => {
         if (err) {
             log.debug('error from metadata storing null version as new version',


### PR DESCRIPTION
This prevents triggering a possible s3:ObjectCreated:Put bucket notification when moving this object to a version, when deleting it (when creating a deletion marker).
