### PR TITLE
CLDSRV-830: Fix NaN serialization as null in access logs

### DIFF
--- a/lib/utilities/serverAccessLogger.js
+++ b/lib/utilities/serverAccessLogger.js
@@ -416,11 +416,11 @@ function logServerAccess(req, res) {
         userName: params.analyticsUserName ?? undefined,
         httpMethod: req.method ?? undefined,
         bytesDeleted: params.analyticsBytesDeleted ?? undefined,
-        bytesReceived: req.parsedContentLength ?? undefined,
+        bytesReceived: Number.isInteger(req.parsedContentLength) ? req.parsedContentLength : undefined,
         bodyLength: req.headers['content-length'] !== undefined
             ? parseInt(req.headers['content-length'], 10)
             : undefined,
-        contentLength: req.parsedContentLength ?? undefined,
+        contentLength: Number.isInteger(req.parsedContentLength) ? req.parsedContentLength : undefined,
         // eslint-disable-next-line camelcase
         elapsed_ms: calculateElapsedMS(params.startTime, params.onCloseEndTime) ?? undefined,
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "9.2.14",
+  "version": "9.2.15",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {

--- a/tests/unit/utils/serverAccessLogger.js
+++ b/tests/unit/utils/serverAccessLogger.js
@@ -1122,6 +1122,29 @@ describe('serverAccessLogger utility functions', () => {
             assert.strictEqual(loggedData.errorCode, 'NoSuchKey');
             assert.strictEqual('errorCode' in loggedData, true);
         });
+
+        it('should omit NaN fields from log output', () => {
+            setServerAccessLogger(mockLogger);
+            const req = {
+                serverAccessLog: {},
+                headers: {},
+                parsedContentLength: NaN, // Simulates Number.parseInt('', 10)
+                socket: {},
+            };
+            const res = {
+                serverAccessLog: {},
+                getHeader: () => null,
+            };
+
+            logServerAccess(req, res);
+
+            assert.strictEqual(mockLogger.write.callCount, 1);
+            const loggedData = JSON.parse(mockLogger.write.firstCall.args[0].trim());
+
+            // NaN values should be omitted from the log output
+            assert.strictEqual('bytesReceived' in loggedData, false);
+            assert.strictEqual('contentLength' in loggedData, false);
+        });
     });
 });
 


### PR DESCRIPTION
Server access logs contain explicit `null` values for `bytesReceived` and `contentLength` when `parsedContentLength` is `NaN`.
Example seen in lab:
```
{
  "time": 1768576073,
  "hostname": "dvasilas-L06-store-5",
  "pid": 83,
  "action": "GetObject",
  "accountName": "dimitrios1",
  "httpMethod": "GET",
  "bytesReceived": null,
  "contentLength": null,
  "elapsed_ms": 21.807304,
  "startTime": "1768576073.554",
  "requester": "8b387b04a1e78cc47adb274f2d72aba9251fd508d8bd013eb10e70929833b4d6",
  "operation": "REST.GET.OBJECT",
  "requestURI": "GET /dest-bucket/test-bucket/2026-01-16-15-07-07-4910BC5BA5CFB61C HTTP/1.1",
  "objectSize": 509,
  "totalTime": "21",
  "turnAroundTime": "14",
  "userAgent": "aws-cli/1.29.62 md/Botocore#1.31.62 ua/2.0 os/linux#5.14.0-570.17.1.el9_6.x86_64 md/arch#x86_64 lang/python#3.9.25 md/pyimpl#CPython cfg/retry-mode#legacy botocore/1.31.62",
  "signatureVersion": "SigV4",
  "authenticationType": "AuthHeader",
  "hostHeader": "127.0.0.1:8080",
  "bucketOwner": "8b387b04a1e78cc47adb274f2d72aba9251fd508d8bd013eb10e70929833b4d6",
  "bucketName": "dest-bucket",
  "req_id": "95657259fa46b201d0cd",
  "bytesSent": 509,
  "clientIP": "10.160.120.10",
  "httpCode": 200,
  "objectKey": "test-bucket/2026-01-16-15-07-07-4910BC5BA5CFB61C",
  "logFormatVersion": "0",
  "loggingEnabled": false,
  "awsAccessKeyID": "1J1U8SORZL163A7MNPPC",
  "raftSessionID": 5
}
```

This happens when `Number.parseInt('', 10)` returns `NaN`, which `JSON.stringify` then serializes as null instead of omitting the field.