### PR TITLE
CLDSRV-827: Fix contentLength and objectSize in access logs 

### DIFF
--- a/lib/api/objectGet.js
+++ b/lib/api/objectGet.js
@@ -139,6 +139,11 @@ function objectGet(authInfo, request, returnTagCount, log, callback) {
 
         const objLength = (objMD.location === null ?
                            0 : parseInt(objMD['content-length'], 10));
+        // Store full object size for server access logs
+        if (request.serverAccessLog) {
+            // eslint-disable-next-line no-param-reassign
+            request.serverAccessLog.objectSize = objLength;
+        }
         let byteRange;
         const streamingParams = {};
         if (request.headers.range) {

--- a/lib/utilities/serverAccessLogger.js
+++ b/lib/utilities/serverAccessLogger.js
@@ -420,7 +420,7 @@ function logServerAccess(req, res) {
         bodyLength: req.headers['content-length'] !== undefined
             ? parseInt(req.headers['content-length'], 10)
             : undefined,
-        contentLength: Number.isInteger(req.parsedContentLength) ? req.parsedContentLength : undefined,
+        contentLength: getObjectSize(req, res) ?? undefined,
         // eslint-disable-next-line camelcase
         elapsed_ms: calculateElapsedMS(params.startTime, params.onCloseEndTime) ?? undefined,
 
@@ -430,7 +430,7 @@ function logServerAccess(req, res) {
         operation: getOperation(req),
         requestURI: getURI(req) ?? undefined,
         errorCode: errorCode ?? undefined,
-        objectSize: getObjectSize(req, res) ?? undefined,
+        objectSize: params.objectSize ?? getObjectSize(req, res) ?? undefined,
         totalTime: calculateTotalTime(params.startTime, params.onFinishEndTime) ?? undefined,
         turnAroundTime: calculateTurnAroundTime(params.startTurnAroundTime, endTurnAroundTime) ?? undefined,
         referer: req.headers.referer ?? undefined,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "9.2.15",
+  "version": "9.2.16",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {

--- a/tests/unit/utils/serverAccessLogger.js
+++ b/tests/unit/utils/serverAccessLogger.js
@@ -808,7 +808,7 @@ describe('serverAccessLogger utility functions', () => {
             assert.strictEqual(loggedData.bytesDeleted, 0);
             assert.strictEqual(loggedData.bytesReceived, 1024);
             assert.strictEqual(loggedData.bodyLength, 1024);
-            assert.strictEqual(loggedData.contentLength, 1024);
+            assert.strictEqual(loggedData.contentLength, 2048);
             assert.strictEqual(loggedData.elapsed_ms, 20.5);
 
             // Verify AWS access server log fields
@@ -1054,6 +1054,7 @@ describe('serverAccessLogger utility functions', () => {
                 serverAccessLog: {
                     analyticsBytesDeleted: 0,
                 },
+                apiMethod: 'objectPut',
                 headers: { 'content-length': '0' },
                 parsedContentLength: 0,
                 socket: {},


### PR DESCRIPTION
The `contentLength` field in S3 analytics captures egress (response size) for `GetObject` operations and ingress (request size) for `PutObject`.

In server access logs, `contentLength` was the HTTP request body size (bytes received from client).
This broke backwards compatibility with S3 analytics, and caused an Integration test to fail.

---

The fix is to update `contentLength` to capture transfer size (egress for GET, ingress for PUT).

This PR includes a second fix for `objectSize` to always reflect full object size (and not  sizes in range get operations).

---

Intregration bulid with this fix: https://github.com/scality/Integration/actions/runs/21141099093