### PR TITLE
CLDSRV-836 Fix deep healthcheck fail status

### DIFF
--- a/lib/utilities/healthcheckHandler.js
+++ b/lib/utilities/healthcheckHandler.js
@@ -56,20 +56,30 @@ function clientCheck(flightCheckOnStartUp, log, cb) {
         }
     });
     async.parallel(clientTasks, (err, results) => {
-        let fail = false;
         // obj will be an object of the healthcheck results of
         // every backends. No errors were returned directly to
         // async.parallel in order to complete the check, so a
         // manual check makes S3 return 500 error if any backend failed
         // other than aws_s3 or azure
-        const obj = results.reduce((obj, item) => Object.assign(obj, item), {});
-        // fail only if *all* backend fail, so that we can still serve the ones which are working
-        fail = Object.keys(obj).every(k =>
-            // if there is an error from an external backend,
-            // only return a 500 if it is on startup
-            // (flightCheckOnStartUp set to true)
-            obj[k].error && (flightCheckOnStartUp || !obj[k].external)
-        );
+        // Check if any client has ALL its backends/locations failing.
+        // Each result in the array represents one client (data, metadata, vault, kms)
+        // with its backend locations as keys.
+        // If ALL backend/locations of ANY client have errors, the overall check fails.
+        const { obj, fail } = results.reduce((acc, clientResult) => {
+            Object.assign(acc.obj, clientResult);
+
+            // Check if ALL backends/locations of this client have errors
+            const keys = Object.keys(clientResult);
+            // eslint-disable-next-line no-param-reassign
+            acc.fail ||= keys.length > 0 && keys.every(k =>
+                // if there is an error from an external backend,
+                // only return a 500 if it is on startup
+                // (flightCheckOnStartUp set to true)
+                clientResult[k].error && (flightCheckOnStartUp || !clientResult[k].external)
+            );
+
+            return acc;
+        }, { obj: {}, fail: false });
         if (fail) {
             return cb(errors.InternalError, obj);
         }

--- a/tests/unit/healthchecks/clientCheck.js
+++ b/tests/unit/healthchecks/clientCheck.js
@@ -1,0 +1,235 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const { errors } = require('arsenal');
+
+const { clientCheck } = require('../../../lib/utilities/healthcheckHandler');
+const { DummyRequestLogger } = require('../helpers');
+const { data } = require('../../../lib/data/wrapper');
+const metadata = require('../../../lib/metadata/wrapper');
+const vault = require('../../../lib/auth/vault');
+const kms = require('../../../lib/kms/wrapper');
+
+const log = new DummyRequestLogger();
+
+describe('clientCheck - failure detection logic', () => {
+    let dataStub;
+    let metadataStub;
+    let vaultStub;
+    let kmsStub;
+
+    beforeEach(() => {
+        // Create stubs for all client checkHealth methods
+        dataStub = sinon.stub(data, 'checkHealth');
+        metadataStub = sinon.stub(metadata, 'checkHealth');
+        vaultStub = sinon.stub(vault, 'checkHealth');
+        kmsStub = sinon.stub(kms, 'checkHealth');
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('should succeed when all backends are healthy', done => {
+        dataStub.callsFake((log, cb) => cb(null, {
+            'sproxyd-loc1': { code: 200, message: 'OK' },
+            'sproxyd-loc2': { code: 200, message: 'OK' },
+        }));
+        metadataStub.callsFake((log, cb) => cb(null, {
+            metadata: { code: 200, message: 'OK' },
+        }));
+        vaultStub.callsFake((log, cb) => cb(null, {
+            vault: { code: 200, message: 'OK' },
+        }));
+        kmsStub.callsFake((log, cb) => cb(null, {
+            kms: { code: 200, message: 'OK' },
+        }));
+
+        clientCheck(false, log, (err, result) => {
+            assert.ifError(err);
+            assert.deepStrictEqual(result, {
+                'sproxyd-loc1': { code: 200, message: 'OK' },
+                'sproxyd-loc2': { code: 200, message: 'OK' },
+                metadata: { code: 200, message: 'OK' },
+                vault: { code: 200, message: 'OK' },
+                kms: { code: 200, message: 'OK' },
+            });
+            done();
+        });
+    });
+
+    it('should fail when ALL backends of data client fail while metadata is healthy', done => {
+        dataStub.callsFake((log, cb) => cb(null, {
+            'sproxyd-loc1': { error: errors.InternalError, code: 500 },
+            'sproxyd-loc2': { error: errors.InternalError, code: 500 },
+        }));
+        metadataStub.callsFake((log, cb) => cb(null, {
+            metadata: { code: 200, message: 'OK' },
+        }));
+        vaultStub.callsFake((log, cb) => cb(null, {
+            vault: { code: 200, message: 'OK' },
+        }));
+        kmsStub.callsFake((log, cb) => cb(null, {
+            kms: { code: 200, message: 'OK' },
+        }));
+
+        clientCheck(false, log, (err, result) => {
+            assert(err);
+            assert.strictEqual(err.InternalError, true);
+            assert.deepStrictEqual(result, {
+                'sproxyd-loc1': { error: errors.InternalError, code: 500 },
+                'sproxyd-loc2': { error: errors.InternalError, code: 500 },
+                metadata: { code: 200, message: 'OK' },
+                vault: { code: 200, message: 'OK' },
+                kms: { code: 200, message: 'OK' },
+            });
+            done();
+        });
+    });
+
+    it('should succeed when ONE data location fails but another is healthy', done => {
+        dataStub.callsFake((log, cb) => cb(null, {
+            'sproxyd-loc1': { error: errors.InternalError, code: 500 },
+            'sproxyd-loc2': { code: 200, message: 'OK' },
+        }));
+        metadataStub.callsFake((log, cb) => cb(null, {
+            metadata: { code: 200, message: 'OK' },
+        }));
+        vaultStub.callsFake((log, cb) => cb(null, {
+            vault: { code: 200, message: 'OK' },
+        }));
+        kmsStub.callsFake((log, cb) => cb(null, {
+            kms: { code: 200, message: 'OK' },
+        }));
+
+        clientCheck(false, log, (err, result) => {
+            assert.ifError(err);
+            assert.deepStrictEqual(result, {
+                'sproxyd-loc1': { error: errors.InternalError, code: 500 },
+                'sproxyd-loc2': { code: 200, message: 'OK' },
+                metadata: { code: 200, message: 'OK' },
+                vault: { code: 200, message: 'OK' },
+                kms: { code: 200, message: 'OK' },
+            });
+            done();
+        });
+    });
+
+    it('should fail when ALL backends of multiple clients fail', done => {
+        dataStub.callsFake((log, cb) => cb(null, {
+            'sproxyd-loc1': { error: errors.InternalError, code: 500 },
+            'sproxyd-loc2': { error: errors.InternalError, code: 500 },
+        }));
+        metadataStub.callsFake((log, cb) => cb(null, {
+            metadata: { error: errors.InternalError, code: 500 },
+        }));
+        vaultStub.callsFake((log, cb) => cb(null, {
+            vault: { code: 200, message: 'OK' },
+        }));
+        kmsStub.callsFake((log, cb) => cb(null, {
+            kms: { code: 200, message: 'OK' },
+        }));
+
+        clientCheck(false, log, (err, result) => {
+            assert(err);
+            assert.strictEqual(err.InternalError, true);
+            assert.deepStrictEqual(result, {
+                'sproxyd-loc1': { error: errors.InternalError, code: 500 },
+                'sproxyd-loc2': { error: errors.InternalError, code: 500 },
+                metadata: { error: errors.InternalError, code: 500 },
+                vault: { code: 200, message: 'OK' },
+                kms: { code: 200, message: 'OK' },
+            });
+            done();
+        });
+    });
+
+    it('should succeed when client returns empty result', done => {
+        dataStub.callsFake((log, cb) => cb(null, {}));
+        metadataStub.callsFake((log, cb) => cb(null, {
+            metadata: { code: 200, message: 'OK' },
+        }));
+        vaultStub.callsFake((log, cb) => cb(null, {
+            vault: { code: 200, message: 'OK' },
+        }));
+        kmsStub.callsFake((log, cb) => cb(null, {
+            kms: { code: 200, message: 'OK' },
+        }));
+
+        clientCheck(false, log, (err, result) => {
+            assert.ifError(err);
+            assert.deepStrictEqual(result, {
+                metadata: { code: 200, message: 'OK' },
+                vault: { code: 200, message: 'OK' },
+                kms: { code: 200, message: 'OK' },
+            });
+            done();
+        });
+    });
+
+    describe('external backend error handling', () => {
+        it('should NOT fail on external backend errors during normal operation ' +
+            '(flightCheckOnStartUp=false)', done => {
+            dataStub.callsFake((log, cb) => cb(null, {
+                's3-backend': { error: errors.InternalError, code: 500, external: true },
+            }));
+            metadataStub.callsFake((log, cb) => cb(null, {
+                metadata: { code: 200, message: 'OK' },
+            }));
+            vaultStub.callsFake((log, cb) => cb(null, {}));
+            kmsStub.callsFake((log, cb) => cb(null, {}));
+
+            clientCheck(false, log, (err, result) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(result, {
+                    's3-backend': { error: errors.InternalError, code: 500, external: true },
+                    metadata: { code: 200, message: 'OK' },
+                });
+                done();
+            });
+        });
+
+        it('should fail on external backend errors during startup (flightCheckOnStartUp=true)', done => {
+            dataStub.callsFake((log, cb) => cb(null, {
+                's3-backend': { error: errors.InternalError, code: 500, external: true },
+            }));
+            metadataStub.callsFake((log, cb) => cb(null, {
+                metadata: { code: 200, message: 'OK' },
+            }));
+            vaultStub.callsFake((log, cb) => cb(null, {}));
+            kmsStub.callsFake((log, cb) => cb(null, {}));
+
+            clientCheck(true, log, (err, result) => {
+                assert(err);
+                assert.strictEqual(err.InternalError, true);
+                assert.deepStrictEqual(result, {
+                    's3-backend': { error: errors.InternalError, code: 500, external: true },
+                    metadata: { code: 200, message: 'OK' },
+                });
+                done();
+            });
+        });
+
+        it('should succeed when external backend fails but internal backend is healthy ' +
+            '(flightCheckOnStartUp=false)', done => {
+            dataStub.callsFake((log, cb) => cb(null, {
+                'sproxyd-loc1': { code: 200, message: 'OK' },
+                's3-backend': { error: errors.InternalError, code: 500, external: true },
+            }));
+            metadataStub.callsFake((log, cb) => cb(null, {
+                metadata: { code: 200, message: 'OK' },
+            }));
+            vaultStub.callsFake((log, cb) => cb(null, {}));
+            kmsStub.callsFake((log, cb) => cb(null, {}));
+
+            clientCheck(false, log, (err, result) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(result, {
+                    'sproxyd-loc1': { code: 200, message: 'OK' },
+                    's3-backend': { error: errors.InternalError, code: 500, external: true },
+                    metadata: { code: 200, message: 'OK' },
+                });
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Now fail if ALL backends of only one client fails.

Previously, the deep healthcheck would fail if ALL backends/locations
failed globally across all clients (data, metadata, vault, kms).

This change modifies the logic to fail if ANY client has ALL its
backends/locations failing. This ensures:

1. For data backend with multiple sproxyd location constraints:
   - Returns HTTP 200 if at least ONE location is healthy
   - Returns HTTP 500 only if ALL locations fail

2. Each client (data, metadata, vault, kms) is evaluated independently
   - If ALL locations of the data client fail, overall check fails
   - If ALL locations of metadata fail, overall check fails
   - etc.

The new logic uses:
- `results.some()` to check across clients
- `keys.every()` within each client to check all its locations