### PR TITLE
CLDSRV-839: Multi delete raftSession in logs

### DIFF
--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -31,6 +31,7 @@ const versionIdUtils = versioning.VersionID;
 const { data } = require('../data/wrapper');
 const logger = require('../utilities/logger');
 const { processBytesToWrite, validateQuotas } = require('./apiUtils/quotas/quotaUtils');
+const { logBatchDeleteObject } = require('../utilities/serverAccessLogger');
 
 /*
    Format of xml request:
@@ -371,14 +372,24 @@ function getObjMetadataAndDelete(authInfo, canonicalID, request,
                             callback(err, objMD, deleteInfo, result.versionId));
                 },
             ], (err, objMD, deleteInfo, versionId) => {
+                const requestID = log.getSerializedUids();
+
                 if (err === skipError) {
+                    // Object doesn't exist - log without object size (AWS behavior)
+                    logBatchDeleteObject(request, requestID, entry.key, null, null);
                     return moveOn();
                 } else if (err === objectLockedError) {
                     errorResults.push({ entry, error: errors.AccessDenied, objectLocked: true });
+                    // Log locked object with size if available
+                    const objectSize = objMD && objMD['content-length'] ? objMD['content-length'] : null;
+                    logBatchDeleteObject(request, requestID, entry.key, objectSize, errors.AccessDenied);
                     return moveOn();
                 } else if (err) {
                     log.error('error deleting object', { error: err, entry });
                     errorResults.push({ entry, error: err });
+                    // Log error case with size if available
+                    const objectSize = objMD && objMD['content-length'] ? objMD['content-length'] : null;
+                    logBatchDeleteObject(request, requestID, entry.key, objectSize, err);
                     return moveOn();
                 }
                 if (deleteInfo.deleted && objMD['content-length']) {
@@ -408,6 +419,9 @@ function getObjMetadataAndDelete(authInfo, canonicalID, request,
                     entry, isDeleteMarker,
                     deleteMarkerVersionId,
                 });
+                // Log successful deletion with object size
+                const objectSize = objMD && objMD['content-length'] ? objMD['content-length'] : null;
+                logBatchDeleteObject(request, requestID, entry.key, objectSize, null);
                 return moveOn();
             });
         },

--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -31,7 +31,7 @@ const versionIdUtils = versioning.VersionID;
 const { data } = require('../data/wrapper');
 const logger = require('../utilities/logger');
 const { processBytesToWrite, validateQuotas } = require('./apiUtils/quotas/quotaUtils');
-const { logBatchDeleteObject } = require('../utilities/serverAccessLogger');
+const { initializeInternalLogRequestQueue, queueInternalLogRequest } = require('../utilities/serverAccessLogger');
 
 /*
    Format of xml request:
@@ -257,6 +257,9 @@ function getObjMetadataAndDelete(authInfo, canonicalID, request,
     const objectLockedError = new Error('object locked');
     let deleteFromStorage = [];
 
+    // Initialize the queue for internal log request logging before concurrent execution
+    initializeInternalLogRequestQueue(request);
+
     return async.waterfall([
         callback => initializeMultiObjectDeleteWithBatchingSupport(bucketName, inPlay, log, callback),
         (cache, callback) => async.forEachLimit(inPlay, config.multiObjectDeleteConcurrency, (entry, moveOn) => {
@@ -372,24 +375,22 @@ function getObjMetadataAndDelete(authInfo, canonicalID, request,
                             callback(err, objMD, deleteInfo, result.versionId));
                 },
             ], (err, objMD, deleteInfo, versionId) => {
-                const requestID = log.getSerializedUids();
-
                 if (err === skipError) {
                     // Object doesn't exist - log without object size (AWS behavior)
-                    logBatchDeleteObject(request, requestID, entry.key, null, null);
+                    queueInternalLogRequest(request, { objectKey: entry.key, objectSize: null, error: null });
                     return moveOn();
                 } else if (err === objectLockedError) {
                     errorResults.push({ entry, error: errors.AccessDenied, objectLocked: true });
                     // Log locked object with size if available
                     const objectSize = objMD && objMD['content-length'] ? objMD['content-length'] : null;
-                    logBatchDeleteObject(request, requestID, entry.key, objectSize, errors.AccessDenied);
+                    queueInternalLogRequest(request, { objectKey: entry.key, objectSize, error: errors.AccessDenied });
                     return moveOn();
                 } else if (err) {
                     log.error('error deleting object', { error: err, entry });
                     errorResults.push({ entry, error: err });
                     // Log error case with size if available
                     const objectSize = objMD && objMD['content-length'] ? objMD['content-length'] : null;
-                    logBatchDeleteObject(request, requestID, entry.key, objectSize, err);
+                    queueInternalLogRequest(request, { objectKey: entry.key, objectSize, error: err });
                     return moveOn();
                 }
                 if (deleteInfo.deleted && objMD['content-length']) {
@@ -419,9 +420,9 @@ function getObjMetadataAndDelete(authInfo, canonicalID, request,
                     entry, isDeleteMarker,
                     deleteMarkerVersionId,
                 });
-                // Log successful deletion with object size
+                // Queue successful deletion with object size
                 const objectSize = objMD && objMD['content-length'] ? objMD['content-length'] : null;
-                logBatchDeleteObject(request, requestID, entry.key, objectSize, null);
+                queueInternalLogRequest(request, { objectKey: entry.key, objectSize, error: null });
                 return moveOn();
             });
         },

--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -492,7 +492,7 @@ function multiObjectDelete(authInfo, request, log, callback) {
         },
         function checkBucketMetadata(quietSetting, objects, next) {
             const errorResults = [];
-            return metadata.getBucket(bucketName, log, (err, bucketMD) => {
+            return metadata.getBucket(bucketName, log, (err, bucketMD, raftSessionId) => {
                 if (err) {
                     log.trace('error retrieving bucket metadata',
                         { error: err });
@@ -502,10 +502,7 @@ function multiObjectDelete(authInfo, request, log, callback) {
                 if (bucketShield(bucketMD, 'objectDelete')) {
                     return next(errors.NoSuchBucket);
                 }
-                if (request.serverAccessLog) {
-                    // eslint-disable-next-line no-param-reassign
-                    request.serverAccessLog.bucketOwner = bucketMD.getOwner();
-                }
+                metadataUtils.storeServerAccessLogInfo(request, bucketMD, raftSessionId);
                 // The implicit deny flag is ignored in the DeleteObjects API, as authorization only
                 // affects the objects.
                 if (!isBucketAuthorized(bucketMD, 'objectDelete', canonicalID, authInfo, log, request)) {

--- a/lib/metadata/metadataUtils.js
+++ b/lib/metadata/metadataUtils.js
@@ -445,4 +445,5 @@ module.exports = {
     processBytesToWrite,
     standardMetadataValidateBucketAndObj,
     standardMetadataValidateBucket,
+    storeServerAccessLogInfo,
 };

--- a/lib/utilities/serverAccessLogger.js
+++ b/lib/utilities/serverAccessLogger.js
@@ -584,7 +584,6 @@ function logServerAccess(req, res) {
 
 module.exports = {
     logServerAccess,
-    logBatchDeleteObject,
     setServerAccessLogger,
     ServerAccessLogger,
     initializeInternalLogRequestQueue,

--- a/lib/utilities/serverAccessLogger.js
+++ b/lib/utilities/serverAccessLogger.js
@@ -231,7 +231,7 @@ const methodToResType = Object.freeze({
     'listMultipartUploads': 'UPLOADS',
     'listParts': 'UPLOAD',
     'metadataSearch': 'OBJECT',
-    'multiObjectDelete': 'OBJECT',
+    'multiObjectDelete': 'MULTI_OBJECT_DELETE',
     'multipartDelete': 'UPLOAD',
     'objectDelete': 'OBJECT',
     'objectDeleteTagging': 'TAGGING',

--- a/lib/utilities/serverAccessLogger.js
+++ b/lib/utilities/serverAccessLogger.js
@@ -153,6 +153,32 @@ function setServerAccessLogger(logger) {
     serverAccessLogger = logger;
 }
 
+/**
+ * initializeInternalLogRequestQueue - Initialize the queue for internal log request logging
+ * @param {object} request - HTTP request object
+ * @return {undefined}
+ */
+function initializeInternalLogRequestQueue(request) {
+    if (!request.serverAccessLog) {
+        return;
+    }
+    // eslint-disable-next-line no-param-reassign
+    request.serverAccessLog.internalLogRequestQueue = [];
+}
+
+/**
+ * queueInternalLogRequest - Queue an internal log request entry for later processing
+ * @param {object} request - HTTP request object
+ * @param {object} entry - Log entry data
+ * @return {undefined}
+ */
+function queueInternalLogRequest(request, entry) {
+    if (!request.serverAccessLog || !request.serverAccessLog.internalLogRequestQueue) {
+        return;
+    }
+    request.serverAccessLog.internalLogRequestQueue.push(entry);
+}
+
 function getRemoteIPFromRequest(request) {
     let remoteIP = null;
     if (request.headers) {
@@ -544,6 +570,15 @@ function logServerAccess(req, res) {
         objectKey: params.objectKey,
     });
 
+
+    if (params.internalLogRequestQueue && params.internalLogRequestQueue.length > 0) {
+        if (logEntry.operation === 'REST.POST.MULTI_OBJECT_DELETE') {
+            for (const entry of params.internalLogRequestQueue) {
+                logBatchDeleteObject(req, requestID, entry.objectKey, entry.objectSize, entry.error);
+            }
+        }
+    }
+
     serverAccessLogger.write(`${JSON.stringify(logEntry)}\n`);
 }
 
@@ -552,6 +587,8 @@ module.exports = {
     logBatchDeleteObject,
     setServerAccessLogger,
     ServerAccessLogger,
+    initializeInternalLogRequestQueue,
+    queueInternalLogRequest,
 
     // Exported for testing.
     getRemoteIPFromRequest,

--- a/lib/utilities/serverAccessLogger.js
+++ b/lib/utilities/serverAccessLogger.js
@@ -395,19 +395,17 @@ function timestampToDateTime643(unixMS) {
     return (unixMS / 1000).toFixed(3);
 }
 
-function logServerAccess(req, res) {
-    if (!req.serverAccessLog || !res.serverAccessLog || !serverAccessLogger) {
-        return;
-    }
-
-    const params = req.serverAccessLog;
-    const errorCode = res.serverAccessLog.errorCode;
-    const endTurnAroundTime = res.serverAccessLog.endTurnAroundTime;
-    const requestID = res.serverAccessLog.requestID;
-    const bytesSent = res.serverAccessLog.bytesSent;
+/**
+ * Builds a log entry object with common fields
+ * @param {object} req - HTTP request object
+ * @param {object} params - Server access log parameters from req.serverAccessLog
+ * @param {object} options - Variable fields for the log entry
+ * @return {object} Log entry object
+ */
+function buildLogEntry(req, params, options) {
     const authInfo = params.authInfo;
 
-    serverAccessLogger.write(`${JSON.stringify({
+    return {
         // Werelog fields
         // logs.access_logs_ingest.timestamp in Clickhouse is of type DateTime so it expects seconds as an integer.
         time: Math.floor(Date.now() / 1000),
@@ -419,33 +417,31 @@ function logServerAccess(req, res) {
         accountName: params.analyticsAccountName ?? undefined,
         userName: params.analyticsUserName ?? undefined,
         httpMethod: req.method ?? undefined,
-        bytesDeleted: params.analyticsBytesDeleted ?? undefined,
-        bytesReceived: Number.isInteger(req.parsedContentLength) ? req.parsedContentLength : undefined,
-        bodyLength: req.headers['content-length'] !== undefined
-            ? parseInt(req.headers['content-length'], 10)
-            : undefined,
-        contentLength: getObjectSize(req, res) ?? undefined,
+        bytesDeleted: options.bytesDeleted ?? undefined,
+        bytesReceived: options.bytesReceived ?? undefined,
+        bodyLength: options.bodyLength ?? undefined,
+        contentLength: options.contentLength ?? undefined,
         // eslint-disable-next-line camelcase
-        elapsed_ms: calculateElapsedMS(params.startTime, params.onCloseEndTime) ?? undefined,
+        elapsed_ms: options.elapsed_ms ?? undefined,
 
         // AWS access server logs fields https://docs.aws.amazon.com/AmazonS3/latest/userguide/LogFormat.html
         startTime: timestampToDateTime643(params.startTimeUnixMS) ?? undefined, // AWS "Time" field
         requester: getRequester(authInfo) ?? undefined,
-        operation: getOperation(req),
-        requestURI: getURI(req) ?? undefined,
-        errorCode: errorCode ?? undefined,
-        objectSize: params.objectSize ?? getObjectSize(req, res) ?? undefined,
-        totalTime: calculateTotalTime(params.startTime, params.onFinishEndTime) ?? undefined,
-        turnAroundTime: calculateTurnAroundTime(params.startTurnAroundTime, endTurnAroundTime) ?? undefined,
-        referer: req.headers.referer ?? undefined,
-        userAgent: req.headers['user-agent'] ?? undefined,
-        versionID: req.query?.versionId ?? undefined,
+        operation: options.operation ?? undefined,
+        requestURI: options.requestURI ?? undefined,
+        errorCode: options.errorCode ?? undefined,
+        objectSize: options.objectSize ?? undefined,
+        totalTime: options.totalTime ?? undefined,
+        turnAroundTime: options.turnAroundTime ?? undefined,
+        referer: options.referer ?? undefined,
+        userAgent: options.userAgent ?? undefined,
+        versionID: options.versionID ?? undefined,
         signatureVersion: authInfo?.getAuthVersion() ?? undefined,
-        cipherSuite: req.socket.encrypted ? req.socket.getCipher()['standardName'] : undefined,
+        cipherSuite: req.socket?.encrypted ? req.socket.getCipher()['standardName'] : undefined,
         authenticationType: authInfo?.getAuthType() ?? undefined,
-        hostHeader: req.headers.host ?? undefined,
-        tlsVersion: req.socket.encrypted ? req.socket.getCipher()['version'] : undefined,
-        aclRequired: undefined,  // TODO: CLDSRV-774
+        hostHeader: req.headers?.host ?? undefined,
+        tlsVersion: req.socket?.encrypted ? req.socket.getCipher()['version'] : undefined,
+        aclRequired: options.aclRequired ?? undefined,  // TODO: CLDSRV-774
         // hostID: undefined,         // NOT IMPLEMENTED
         // accessPointARN: undefined, // NOT IMPLEMENTED
 
@@ -453,11 +449,11 @@ function logServerAccess(req, res) {
         bucketOwner: params.bucketOwner ?? undefined,
         bucketName: params.bucketName ?? undefined, // AWS "Bucket" field
         // eslint-disable-next-line camelcase
-        req_id: requestID ?? undefined, // AWS "Request ID" field
-        bytesSent: getBytesSent(res, bytesSent) ?? undefined,
+        req_id: options.requestID ?? undefined, // AWS "Request ID" field
+        bytesSent: options.bytesSent ?? undefined,
         clientIP: getRemoteIPFromRequest(req) ?? undefined,  // AWS 'Remote IP' field
-        httpCode: res.statusCode ?? undefined, // AWS "HTTP Status" field
-        objectKey: params.objectKey ?? undefined, // AWS "Key" field
+        httpCode: options.httpCode ?? undefined, // AWS "HTTP Status" field
+        objectKey: options.objectKey ?? undefined, // AWS "Key" field
 
         // Scality server access logs extra fields
         logFormatVersion: SERVER_ACCESS_LOG_FORMAT_VERSION,
@@ -472,11 +468,88 @@ function logServerAccess(req, res) {
         // Rate Limiting fields (only present when rate limited)
         rateLimited: params.rateLimited ?? undefined,
         rateLimitSource: params.rateLimitSource ?? undefined,
-    })}\n`);
+    };
+}
+
+/**
+ * Logs a BATCH.DELETE.OBJECT entry for individual object deletions in multi-object delete
+ * @param {object} req - HTTP request object
+ * @param {string} requestID - Request ID from the response
+ * @param {string} objectKey - Key of the object being deleted
+ * @param {number|null} objectSize - Size of the object, or null if object doesn't exist
+ * @param {Error|null} error - Error object if deletion failed, null if successful
+ * @return {undefined}
+ */
+function logBatchDeleteObject(req, requestID, objectKey, objectSize, error) {
+    if (!req.serverAccessLog || !serverAccessLogger) {
+        return;
+    }
+
+    const params = req.serverAccessLog;
+    let httpCode = 204;
+    let errorCode = undefined;
+
+    if (error) {
+        httpCode = error.code ? parseInt(error.code, 10) : 500;
+        errorCode = error.message || 'InternalError';
+    }
+
+    const logEntry = buildLogEntry(req, params, {
+        bytesDeleted: objectSize,
+        contentLength: objectSize,
+        operation: 'BATCH.DELETE.OBJECT',
+        objectSize,
+        httpCode,
+        errorCode,
+        objectKey,
+        requestID,
+    });
+
+    serverAccessLogger.write(`${JSON.stringify(logEntry)}\n`);
+}
+
+function logServerAccess(req, res) {
+    if (!req.serverAccessLog || !res.serverAccessLog || !serverAccessLogger) {
+        return;
+    }
+
+    const params = req.serverAccessLog;
+    const errorCode = res.serverAccessLog.errorCode;
+    const endTurnAroundTime = res.serverAccessLog.endTurnAroundTime;
+    const requestID = res.serverAccessLog.requestID;
+    const bytesSent = res.serverAccessLog.bytesSent;
+
+    const logEntry = buildLogEntry(req, params, {
+        bytesDeleted: params.analyticsBytesDeleted,
+        bytesReceived: Number.isInteger(req.parsedContentLength) ? req.parsedContentLength : undefined,
+        bodyLength: req.headers['content-length'] !== undefined
+            ? parseInt(req.headers['content-length'], 10)
+            : undefined,
+        contentLength: getObjectSize(req, res),
+        // eslint-disable-next-line camelcase
+        elapsed_ms: calculateElapsedMS(params.startTime, params.onCloseEndTime),
+        operation: getOperation(req),
+        requestURI: getURI(req),
+        errorCode,
+        objectSize: params.objectSize ?? getObjectSize(req, res),
+        totalTime: calculateTotalTime(params.startTime, params.onFinishEndTime),
+        turnAroundTime: calculateTurnAroundTime(params.startTurnAroundTime, endTurnAroundTime),
+        versionID: req.query?.versionId,
+        aclRequired: undefined, // TODO: CLDSRV-774
+        referer: req.headers?.referer,
+        userAgent: req.headers?.['user-agent'],
+        requestID,
+        bytesSent: getBytesSent(res, bytesSent),
+        httpCode: res.statusCode,
+        objectKey: params.objectKey,
+    });
+
+    serverAccessLogger.write(`${JSON.stringify(logEntry)}\n`);
 }
 
 module.exports = {
     logServerAccess,
+    logBatchDeleteObject,
     setServerAccessLogger,
     ServerAccessLogger,
 

--- a/schema/server_access_log.schema.json
+++ b/schema/server_access_log.schema.json
@@ -57,8 +57,8 @@
             "minimum": 0
         },
         "elapsed_ms": {
-            "description": "Total duration of the request in milliseconds. The timer starts when the server first routes the request and stops when the request completes or is closed prematurely.",
-            "type": "number",
+            "description": "Total duration of the request in milliseconds. The timer starts when the server first routes the request and stops when the request completes or is closed prematurely. Null for BATCH.DELETE.OBJECT operations logged during request processing.",
+            "type": ["number", "null"],
             "minimum": 0
         },
         "startTime": {
@@ -74,8 +74,8 @@
             "type": "string"
         },
         "requestURI": {
-            "description": "AWS server access log 'Request URI' field. From AWS 'The Request-URI part of the HTTP request message.'.",
-            "type": "string"
+            "description": "AWS server access log 'Request URI' field. From AWS 'The Request-URI part of the HTTP request message.'. Null for BATCH.DELETE.OBJECT operations logged during request processing.",
+            "type": ["string", "null"]
         },
         "errorCode": {
             "description": "AWS server access log 'Error Code' field. From AWS 'The Amazon S3 Error responses , or - if no error occurred.'. We use null to signal no error.",
@@ -86,8 +86,8 @@
             "type": ["integer", "null"]
         },
         "totalTime": {
-            "description": "AWS server access log 'Total Time' field. From AWS 'The number of milliseconds that the request was in flight from the server's perspective. This value is measured from the time that your request is received to the time that the last byte of the response is sent. Measurements made from the client's perspective might be longer because of network latency.'.",
-            "type": "string"
+            "description": "AWS server access log 'Total Time' field. From AWS 'The number of milliseconds that the request was in flight from the server's perspective. This value is measured from the time that your request is received to the time that the last byte of the response is sent. Measurements made from the client's perspective might be longer because of network latency.'. Null for BATCH.DELETE.OBJECT operations logged during request processing.",
+            "type": ["string", "null"]
         },
         "turnAroundTime": {
             "description": "AWS server access log 'Turn Around Time' field. From AWS 'The number of milliseconds that Amazon S3 spent processing your request. This value is measured from the time that the last byte of your request was received until the time that the first byte of the response was sent.'.",
@@ -201,9 +201,6 @@
         "logFormatVersion",
         "httpMethod",
         "startTime",
-        "elapsed_ms",
-        "totalTime",
-        "requestURI",
         "hostHeader",
         "req_id",
         "httpCode",

--- a/tests/functional/aws-node-sdk/test/serverAccessLogs/testServerAccessLogFile.js
+++ b/tests/functional/aws-node-sdk/test/serverAccessLogs/testServerAccessLogFile.js
@@ -1711,7 +1711,7 @@ describe('Server Access Logs - File Output', async () => {
                         },
                         {
                             ...commonProperties,
-                            operation: 'REST.POST.OBJECT',
+                            operation: 'REST.POST.MULTI_OBJECT_DELETE',
                             action: 'DeleteObjects',
                             httpMethod: 'POST',
                         }

--- a/tests/functional/aws-node-sdk/test/serverAccessLogs/testServerAccessLogFile.js
+++ b/tests/functional/aws-node-sdk/test/serverAccessLogs/testServerAccessLogFile.js
@@ -1669,7 +1669,7 @@ describe('Server Access Logs - File Output', async () => {
                 };
             })(),
             (() => {
-                // This operation tests deleting multiple objects.
+                // This operation tests deleting multiple objects including a non-existent one.
                 const method = async () => {
                     await s3.createBucket({ Bucket: bucketName }).promise();
                     await s3.putObject({ Bucket: bucketName, Key: objectKey, Body: 'test data' }).promise();
@@ -1679,7 +1679,8 @@ describe('Server Access Logs - File Output', async () => {
                         Delete: {
                             Objects: [
                                 { Key: objectKey },
-                                { Key: `${objectKey}2` }
+                                { Key: `${objectKey}2` },
+                                { Key: `${objectKey}-non-existent` }
                             ]
                         }
                     }).promise();
@@ -1711,9 +1712,34 @@ describe('Server Access Logs - File Output', async () => {
                         },
                         {
                             ...commonProperties,
+                            operation: 'BATCH.DELETE.OBJECT',
+                            action: 'DeleteObject',
+                            objectKey,
+                            httpCode: 204,
+                            httpMethod: 'POST',
+                        },
+                        {
+                            ...commonProperties,
+                            operation: 'BATCH.DELETE.OBJECT',
+                            action: 'DeleteObject',
+                            objectKey: `${objectKey}2`,
+                            httpCode: 204,
+                            httpMethod: 'POST',
+                        },
+                        {
+                            ...commonProperties,
+                            operation: 'BATCH.DELETE.OBJECT',
+                            action: 'DeleteObject',
+                            objectKey: `${objectKey}-non-existent`,
+                            httpCode: 204,
+                            httpMethod: 'POST',
+                        },
+                        {
+                            ...commonProperties,
                             operation: 'REST.POST.MULTI_OBJECT_DELETE',
                             action: 'DeleteObjects',
                             httpMethod: 'POST',
+                            objectKey: null,
                         }
                     ],
                 };

--- a/tests/functional/aws-node-sdk/test/serverAccessLogs/testServerAccessLogFile.js
+++ b/tests/functional/aws-node-sdk/test/serverAccessLogs/testServerAccessLogFile.js
@@ -2650,6 +2650,32 @@ describe('Server Access Logs - File Output', async () => {
             truncateLogFileIfExists(logFilePath);
         });
 
+        // Helper function to validate a log entry against expected properties
+        const validateLogEntry = (logEntry, properties) => {
+            const result = tv4.validateResult(logEntry, schema);
+            assert.strictEqual(result.valid, true,
+                `Log entry should match schema: ${JSON.stringify(result.error)}`);
+
+            for (const [key, val] of Object.entries(properties)) {
+                if (val === null) {
+                    assert.strictEqual(key in logEntry, false,
+                        `Field ${key} should be omitted when null, action ${properties.action}`);
+                } else {
+                    assert.strictEqual(logEntry[key], val,
+                        `Invalid value for ${key}, action ${properties.action}`);
+                }
+            }
+
+            if (config.backends.metadata === 'scality') {
+                assert.strictEqual('raftSessionID' in logEntry, true,
+                    `raftSessionID should be present for action ${properties.action}`);
+                assert.strictEqual(typeof logEntry.raftSessionID, 'string',
+                    `raftSessionID should be a string for action ${properties.action}`);
+                assert.strictEqual(logEntry.raftSessionID.length > 0, true,
+                    `raftSessionID should not be empty for action ${properties.action}`);
+            }
+        };
+
         for (const operation of operations) {
             it(`should log correct ${operation.methodName} operation with all required fields`, async () => {
                 await operation.method();
@@ -2658,34 +2684,8 @@ describe('Server Access Logs - File Output', async () => {
                 assert.strictEqual(logEntries.length, operation.expected.length,
                     `Expected ${operation.expected.length} log entries, got ${logEntries.length}`);
 
-                for (let logEntryIdx = 0, operationIdx = 0;
-                    operationIdx < operation.expected.length;
-                    logEntryIdx++, operationIdx++) {
-                    const result = tv4.validateResult(logEntries[logEntryIdx], schema);
-                    assert.strictEqual(result.valid, true,
-                        `Log entry should match schema: ${JSON.stringify(result.error)}`);
-
-                    const properties = operation.expected[operationIdx];
-                    for (const [key, val] of Object.entries(properties)) {
-                        if (val === null) {
-                            // Verify that null fields are omitted (not present in log)
-                            assert.strictEqual(key in logEntries[logEntryIdx], false,
-                                `Field ${key} should be omitted when null, action ${properties.action}`);
-                            continue;
-                        }
-                        assert.strictEqual(logEntries[logEntryIdx][key], val,
-                            `Invalid value for ${key}, action ${properties.action}`);
-                    }
-
-                    // Verify raftSessionID is present when using scality backend
-                    if (config.backends.metadata === 'scality') {
-                        assert.strictEqual('raftSessionID' in logEntries[logEntryIdx], true,
-                            `raftSessionID should be present for action ${properties.action}`);
-                        assert.strictEqual(typeof logEntries[logEntryIdx].raftSessionID, 'string',
-                            `raftSessionID should be a string for action ${properties.action}`);
-                        assert.strictEqual(logEntries[logEntryIdx].raftSessionID.length > 0, true,
-                            `raftSessionID should not be empty for action ${properties.action}`);
-                    }
+                for (let i = 0; i < operation.expected.length; i++) {
+                    validateLogEntry(logEntries[i], operation.expected[i]);
                 }
             });
         }

--- a/tests/functional/aws-node-sdk/test/serverAccessLogs/testServerAccessLogFile.js
+++ b/tests/functional/aws-node-sdk/test/serverAccessLogs/testServerAccessLogFile.js
@@ -156,7 +156,7 @@ describe('Server Access Logs - File Output', async () => {
             'loggingTargetBucket': null, // DYNAMIC
             'loggingTargetPrefix': null, // DYNAMIC
             'awsAccessKeyID': 'accessKey1', // STATIC
-            'raftSessionID': null, // UNKNOWN
+            'raftSessionID': null, // UNKNOWN but available with scality backend, null otherwise
         };
 
         const operations = [
@@ -2649,6 +2649,16 @@ describe('Server Access Logs - File Output', async () => {
                         }
                         assert.strictEqual(logEntries[logEntryIdx][key], val,
                             `Invalid value for ${key}, action ${properties.action}`);
+                    }
+
+                    // Verify raftSessionID is present when using scality backend
+                    if (config.backends.metadata === 'scality') {
+                        assert.strictEqual('raftSessionID' in logEntries[logEntryIdx], true,
+                            `raftSessionID should be present for action ${properties.action}`);
+                        assert.strictEqual(typeof logEntries[logEntryIdx].raftSessionID, 'string',
+                            `raftSessionID should be a string for action ${properties.action}`);
+                        assert.strictEqual(logEntries[logEntryIdx].raftSessionID.length > 0, true,
+                            `raftSessionID should not be empty for action ${properties.action}`);
                     }
                 }
             });

--- a/tests/functional/aws-node-sdk/test/serverAccessLogs/testServerAccessLogFile.js
+++ b/tests/functional/aws-node-sdk/test/serverAccessLogs/testServerAccessLogFile.js
@@ -1710,29 +1710,41 @@ describe('Server Access Logs - File Output', async () => {
                             objectKey: `${objectKey}2`,
                             httpMethod: 'PUT',
                         },
+                        // Objects are deleted concurrently, they might get logged in any order
+                        // for example errors or non-existent objects might get logged first
                         {
-                            ...commonProperties,
-                            operation: 'BATCH.DELETE.OBJECT',
-                            action: 'DeleteObject',
-                            objectKey,
-                            httpCode: 204,
-                            httpMethod: 'POST',
-                        },
-                        {
-                            ...commonProperties,
-                            operation: 'BATCH.DELETE.OBJECT',
-                            action: 'DeleteObject',
-                            objectKey: `${objectKey}2`,
-                            httpCode: 204,
-                            httpMethod: 'POST',
-                        },
-                        {
-                            ...commonProperties,
-                            operation: 'BATCH.DELETE.OBJECT',
-                            action: 'DeleteObject',
-                            objectKey: `${objectKey}-non-existent`,
-                            httpCode: 204,
-                            httpMethod: 'POST',
+                            unordered: [
+                                {
+                                    ...commonProperties,
+                                    operation: 'BATCH.DELETE.OBJECT',
+                                    action: 'DeleteObjects',
+                                    objectKey,
+                                    httpCode: 204,
+                                    httpMethod: 'POST',
+                                    referer: null,
+                                    userAgent: null,
+                                },
+                                {
+                                    ...commonProperties,
+                                    operation: 'BATCH.DELETE.OBJECT',
+                                    action: 'DeleteObjects',
+                                    objectKey: `${objectKey}2`,
+                                    httpCode: 204,
+                                    httpMethod: 'POST',
+                                    referer: null,
+                                    userAgent: null,
+                                },
+                                {
+                                    ...commonProperties,
+                                    operation: 'BATCH.DELETE.OBJECT',
+                                    action: 'DeleteObjects',
+                                    objectKey: `${objectKey}-non-existent`,
+                                    httpCode: 204,
+                                    httpMethod: 'POST',
+                                    referer: null,
+                                    userAgent: null,
+                                },
+                            ],
                         },
                         {
                             ...commonProperties,
@@ -2679,13 +2691,46 @@ describe('Server Access Logs - File Output', async () => {
         for (const operation of operations) {
             it(`should log correct ${operation.methodName} operation with all required fields`, async () => {
                 await operation.method();
-                const logEntries = await waitForLogs(logFilePath, operation.expected.length,
+                // Count total expected logs, including unordered entries
+                let totalExpected = 0;
+                for (const exp of operation.expected) {
+                    totalExpected += exp.unordered ? exp.unordered.length : 1;
+                }
+                const logEntries = await waitForLogs(logFilePath, totalExpected,
                     TEST_CONFIG.MAX_LOG_WAIT_RETRIES, TEST_CONFIG.LOG_POLL_DELAY_MS);
-                assert.strictEqual(logEntries.length, operation.expected.length,
-                    `Expected ${operation.expected.length} log entries, got ${logEntries.length}`);
+                assert.strictEqual(logEntries.length, totalExpected,
+                    `Expected ${totalExpected} log entries, got ${logEntries.length}`);
 
+                let logIdx = 0;
+
+                // Validate entries (ordered or unordered)
                 for (let i = 0; i < operation.expected.length; i++) {
-                    validateLogEntry(logEntries[i], operation.expected[i]);
+                    const expected = operation.expected[i];
+
+                    if (expected.unordered) {
+                        // Handle unordered entries
+                        const unorderedLogs = logEntries.slice(logIdx, logIdx + expected.unordered.length);
+                        const remaining = [...expected.unordered];
+
+                        for (const logEntry of unorderedLogs) {
+                            const matchIdx = remaining.findIndex(exp => exp.objectKey === logEntry.objectKey);
+
+                            assert.notStrictEqual(matchIdx, -1,
+                                `Unexpected log entry with objectKey: ${logEntry.objectKey}`);
+
+                            validateLogEntry(logEntry, remaining[matchIdx]);
+                            remaining.splice(matchIdx, 1);
+                        }
+
+                        assert.strictEqual(remaining.length, 0,
+                            `Missing expected entries: ${JSON.stringify(remaining)}`);
+
+                        logIdx += expected.unordered.length;
+                    } else {
+                        // Handle ordered entry
+                        validateLogEntry(logEntries[logIdx], expected);
+                        logIdx++;
+                    }
                 }
             });
         }


### PR DESCRIPTION
- Include raft in server access logs
- Replace `REST.POST.OBJECT` => `REST.POST.MULTI_OBJECT_DELETE`
- Add internal `BATCH.DELETE.OBJECT` lines for each key