### PR TITLE
CLDSRV-839: Reduce warning, add cors preflight, rename website

### DIFF
--- a/lib/api/apiUtils/object/corsResponse.js
+++ b/lib/api/apiUtils/object/corsResponse.js
@@ -125,7 +125,7 @@ isPreflight) {
             rule.exposeHeaders.join(', ');
     }
     if (isPreflight) {
-        resHeaders['content-length'] = '0';
+        resHeaders['content-length'] = 0;
         resHeaders.date = new Date().toUTCString();
     }
     return resHeaders;

--- a/lib/utilities/serverAccessLogger.js
+++ b/lib/utilities/serverAccessLogger.js
@@ -295,6 +295,13 @@ function getOperation(req) {
     if (req.apiMethod === 'objectPutCopyPart') {
         return 'REST.COPY.PART';
     }
+    // Special handling for website operations
+    if (req.apiMethod === 'websiteGet') {
+        return 'WEBSITE.GET.OBJECT';
+    }
+    if (req.apiMethod === 'websiteHead') {
+        return 'WEBSITE.HEAD.OBJECT';
+    }
 
     if (!resourceType) {
         // Only emit a warning if apiMethod is not undefined, meaning request is valid.

--- a/lib/utilities/serverAccessLogger.js
+++ b/lib/utilities/serverAccessLogger.js
@@ -251,7 +251,7 @@ const methodToResType = Object.freeze({
     'bucketPutEncryption': 'ENCRYPTION',
     'bucketPutLogging': 'LOGGING_STATUS',
     'bucketGetLogging': 'LOGGING_STATUS',
-    // 'corsPreflight': '',
+    'corsPreflight': 'PREFLIGHT',
     'completeMultipartUpload': 'UPLOAD',
     'initiateMultipartUpload': 'UPLOADS',
     'listMultipartUploads': 'UPLOADS',

--- a/lib/utilities/serverAccessLogger.js
+++ b/lib/utilities/serverAccessLogger.js
@@ -297,11 +297,16 @@ function getOperation(req) {
     }
 
     if (!resourceType) {
-        process.emitWarning('Unknown apiMethod for server access log', {
-            type: 'ServerAccessLogWarning',
-            code: 'UNKNOWN_API_METHOD',
-            detail: `apiMethod=${req.apiMethod}, method=${req.method}, url=${req.url}`
-        });
+        // Only emit a warning if apiMethod is not undefined, meaning request is valid.
+        // Otherwise we could get spam by invalid or broken requests.
+        // To help catch missing valid operation.
+        if (req.apiMethod) {
+            process.emitWarning('Unknown apiMethod for server access log', {
+                type: 'ServerAccessLogWarning',
+                code: 'UNKNOWN_API_METHOD',
+                detail: `apiMethod=${req.apiMethod}, method=${req.method}, url=${req.url}`
+            });
+        }
         return `REST.${req.method}.UNKNOWN`;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "9.2.22",
+  "version": "9.2.23",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
see commits

Not simple to have tests running on those because they are http request outside the SDK.

It seems that website and corsPreflight requests have no `analyticsAction` name (no monitoring action), they might leave an empty action in S3 monitoring