### PR TITLE
CLDSRV-843: Rename versionID to versionId in server access logs

### DIFF
--- a/lib/utilities/serverAccessLogger.js
+++ b/lib/utilities/serverAccessLogger.js
@@ -482,7 +482,7 @@ function buildLogEntry(req, params, options) {
         turnAroundTime: options.turnAroundTime ?? undefined,
         referer: options.referer ?? undefined,
         userAgent: options.userAgent ?? undefined,
-        versionID: options.versionID ?? undefined,
+        versionId: options.versionId ?? undefined,
         signatureVersion: authInfo?.getAuthVersion() ?? undefined,
         cipherSuite: req.socket?.encrypted ? req.socket.getCipher()['standardName'] : undefined,
         authenticationType: authInfo?.getAuthType() ?? undefined,
@@ -581,7 +581,7 @@ function logServerAccess(req, res) {
         objectSize: params.objectSize ?? getObjectSize(req, res),
         totalTime: calculateTotalTime(params.startTime, params.onFinishEndTime),
         turnAroundTime: calculateTurnAroundTime(params.startTurnAroundTime, endTurnAroundTime),
-        versionID: req.query?.versionId,
+        versionId: req.query?.versionId,
         aclRequired: undefined, // TODO: CLDSRV-774
         referer: req.headers?.referer,
         userAgent: req.headers?.['user-agent'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "9.2.23",
+  "version": "9.2.24",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {

--- a/tests/unit/utils/serverAccessLogger.js
+++ b/tests/unit/utils/serverAccessLogger.js
@@ -884,7 +884,7 @@ describe('serverAccessLogger utility functions', () => {
             assert.strictEqual(loggedData.turnAroundTime, '1');
             assert.strictEqual(loggedData.referer, 'https://example.com');
             assert.strictEqual(loggedData.userAgent, 'aws-cli/2.0.0');
-            assert.strictEqual(loggedData.versionID, 'version123');
+            assert.strictEqual(loggedData.versionId, 'version123');
             assert.strictEqual(loggedData.signatureVersion, 'AWS4-HMAC-SHA256');
             assert.strictEqual(loggedData.cipherSuite, 'TLS_AES_128_GCM_SHA256');
             assert.strictEqual(loggedData.authenticationType, 'REST-HEADER');
@@ -996,7 +996,7 @@ describe('serverAccessLogger utility functions', () => {
 
             assert.strictEqual(mockLogger.write.callCount, 1);
             const loggedData = JSON.parse(mockLogger.write.firstCall.args[0].trim());
-            assert.strictEqual('versionID' in loggedData, false);
+            assert.strictEqual('versionId' in loggedData, false);
         });
 
         it('should handle loggingEnabled without TargetBucket/TargetPrefix', () => {
@@ -1099,7 +1099,7 @@ describe('serverAccessLogger utility functions', () => {
             assert.strictEqual('bytesDeleted' in loggedData, false);
             assert.strictEqual('turnAroundTime' in loggedData, false);
             assert.strictEqual('referer' in loggedData, false);
-            assert.strictEqual('versionID' in loggedData, false);
+            assert.strictEqual('versionId' in loggedData, false);
             assert.strictEqual('cipherSuite' in loggedData, false);
             assert.strictEqual('tlsVersion' in loggedData, false);
             assert.strictEqual('aclRequired' in loggedData, false);


### PR DESCRIPTION
Rename the `versionID` field to `versionId` in server access logs to match the expected format of Fluentbit: 
```
Allowlist_key versionId
```
https://github.com/scality/Federation/blob/08f21d3bb003ca6f45082b6b2b39074313f2e149/roles/run-s3-analytics-fluentbit/templates/fluent-bit.conf.j2#L73
