### PR TITLE
CLDSRV-849: don't crash if invalid Date header

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@azure/storage-blob": "^12.28.0",
     "@hapi/joi": "^17.1.1",
-    "arsenal": "git+https://github.com/scality/arsenal#8.2.45",
+    "arsenal": "git+https://github.com/scality/arsenal#8.2.46",
     "async": "2.6.4",
     "aws-sdk": "^2.1692.0",
     "bucketclient": "scality/bucketclient#8.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "9.2.27",
+  "version": "9.2.28",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {

--- a/tests/functional/raw-node/test/malformedDateHeader.js
+++ b/tests/functional/raw-node/test/malformedDateHeader.js
@@ -1,0 +1,80 @@
+const assert = require('assert');
+const http = require('http');
+
+const bucket = 'test-bucket';
+const objectKey = 'test-file.txt';
+
+describe('malformed Date header:', () => {
+    it('should return AccessDenied for bad date with x-amz-content-sha256 header', done => {
+        const options = {
+            hostname: 'localhost',
+            port: 8000,
+            path: `/${bucket}/${objectKey}`,
+            method: 'GET',
+            headers: {
+                'Date': 'BAD_DATE',
+                'Authorization': 'AWS4-HMAC-SHA256 Credential=accessKey1/20260211/us-east-1/s3/aws4_request, ' +
+                    'SignedHeaders=host, Signature=d459d5b2a2395b4c65d8f8aa2729b22c5abb04614fafbd93ab4fe203e76d21a3',
+                'X-Amz-Content-Sha256': 'fa8d015f89da2a769d1cea7e3bd77a5670d098d7844cda148a40c1304e5b778b',
+                'Host': 'localhost:8000'
+            }
+        };
+
+        const req = http.request(options, res => {
+            let body = '';
+            res.on('data', chunk => {
+                body += chunk;
+            });
+            res.on('end', () => {
+                assert.strictEqual(res.statusCode, 403, 'Server should return 403 AccessDenied for malformed Date');
+                assert(body.includes('AccessDenied'), 'Response should contain AccessDenied');
+                assert(body.includes('Authentication requires a valid Date or x-amz-date header'));
+                done();
+            });
+        });
+
+        req.on('error', err => {
+            // If we get ECONNRESET or similar, it means the server crashed
+            assert.fail(`Server crashed or connection error: ${err.message}`);
+        });
+
+        req.end();
+    });
+
+    it('should return AccessDenied for bad x-amz-date with x-amz-content-sha256 header', done => {
+        const options = {
+            hostname: 'localhost',
+            port: 8000,
+            path: `/${bucket}/${objectKey}`,
+            method: 'GET',
+            headers: {
+                'X-Amz-Date': 'BAD_DATE',
+                'Authorization': 'AWS4-HMAC-SHA256 Credential=accessKey1/20260211/us-east-1/s3/aws4_request, ' +
+                    'SignedHeaders=host;x-amz-date, ' +
+                    'Signature=d459d5b2a2395b4c65d8f8aa2729b22c5abb04614fafbd93ab4fe203e76d21a3',
+                'X-Amz-Content-Sha256': 'fa8d015f89da2a769d1cea7e3bd77a5670d098d7844cda148a40c1304e5b778b',
+                'Host': 'localhost:8000'
+            }
+        };
+
+        const req = http.request(options, res => {
+            let body = '';
+            res.on('data', chunk => {
+                body += chunk;
+            });
+            res.on('end', () => {
+                assert.strictEqual(res.statusCode, 403, 'Server should return 403 AccessDenied for malformed Date');
+                assert(body.includes('AccessDenied'), 'Response should contain AccessDenied');
+                assert(body.includes('Authentication requires a valid Date or x-amz-date header'));
+                done();
+            });
+        });
+
+        req.on('error', err => {
+            // If we get ECONNRESET or similar, it means the server crashed
+            assert.fail(`Server crashed or connection error: ${err.message}`);
+        });
+
+        req.end();
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1527,9 +1527,9 @@ arraybuffer.prototype.slice@^1.0.4:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#8.2.45":
-  version "8.2.45"
-  resolved "git+https://github.com/scality/arsenal#af610f2510084a6e12a7c4c38b85eeb24a0e468c"
+"arsenal@git+https://github.com/scality/arsenal#8.2.46":
+  version "8.2.46"
+  resolved "git+https://github.com/scality/arsenal#f241d4e2f292944d6bdb40789eec6085aa5fe7a2"
   dependencies:
     "@azure/identity" "^4.13.0"
     "@azure/storage-blob" "^12.28.0"


### PR DESCRIPTION
Test that the arsenal bump fixed the invalid Date header crash.

Repro code:
```
curl -v -H "Date: BAD_DATE" -H "Authorization: AWS4-HMAC-SHA256 Credential=accessKey1/20260211/us-east-1/s3/aws4_request, SignedHeaders=host, Signature=d459d5b2a2395b4c65d8f8aa2729b22c5abb04614fafbd93ab4fe203e76d21a3" -H "X-Amz-Content-Sha256: fa8d015f89da2a769d1cea7e3bd77a5670d098d7844cda148a40c1304e5b778b" localhost:8000/leif-us-east-1/test-file.txt
```

```
2026-02-11T09:33:06.467Z: uncaughtException:
RangeError: Invalid time value
    at Date.toISOString (<anonymous>)
    at convertUTCtoISO8601 (/app/node_modules/arsenal/build/lib/auth/v4/timeUtils.js:26:43)
    at Object.check [as headers] (/app/node_modules/arsenal/build/lib/auth/v4/headerAuthCheck.js:98:57)
    at extractParams (/app/node_modules/arsenal/build/lib/auth/auth.js:122:47)
    at Object.doAuth (/app/node_modules/arsenal/build/lib/auth/auth.js:140:17)
    at /app/lib/api/api.js:238:33
    at nextTask (/app/node_modules/async/dist/async.js:5327:14)
    at Object.waterfall (/app/node_modules/async/dist/async.js:5337:5)
    at processRequest (/app/lib/api/api.js:237:22)
    at Object.callApiMethod (/app/lib/api/api.js:418:16)
{"name":"S3","time":1770802386467,"error":"Invalid time value","stack":"RangeError: Invalid time value\n    at Date.toISOString (<anonymous>)\n    at convertUTCtoISO8601 (/app/node_modules/arsenal/build/lib/auth/v4/timeUtils.js:26:43)\n    at Object.check [as headers] (/app/node_modules/arsenal/build/lib/auth/v4/headerAuthCheck.js:98:57)\n    at extractParams (/app/node_modules/arsenal/build/lib/auth/auth.js:122:47)\n    at Object.doAuth (/app/node_modules/arsenal/build/lib/auth/auth.js:140:17)\n    at /app/lib/api/api.js:238:33\n    at nextTask (/app/node_modules/async/dist/async.js:5327:14)\n    at Object.waterfall (/app/node_modules/async/dist/async.js:5337:5)\n    at processRequest (/app/lib/api/api.js:237:22)\n    at Object.callApiMethod (/app/lib/api/api.js:418:16)","level":"fatal","message":"caught error","hostname":"xps","pid":886}
```