### PR TITLE
Fix instance capabilities in report

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1813,7 +1813,7 @@ class Config extends EventEmitter {
 
         if (config.capabilities) {
             if (config.capabilities.locationTypes) {
-                config.capabilities.locationTypes = new Set(config.capabilities.locationTypes);
+                this.supportedLocationTypes = new Set(config.capabilities.locationTypes);
             }
             this.capabilities = config.capabilities;
         }

--- a/lib/utilities/reportHandler.js
+++ b/lib/utilities/reportHandler.js
@@ -66,15 +66,15 @@ function getCapabilities(cfg = config) {
     caps.lifecycleRules &&= cfg.supportedLifecycleRules;
 
     // Map locationTypes entries to the respective "legacy" capability flags
-    if (caps.locationTypes) {
-        caps.locationTypeAzure &&= caps.locationTypes.has('location-azure-v1');
-        caps.locationTypeGCP &&= caps.locationTypes.has('location-gcp-v1');
-        caps.locationTypeDigitalOcean &&= caps.locationTypes.has('location-do-spaces-v1');
-        caps.locationTypeSproxyd &&= caps.locationTypes.has('location-scality-sproxyd-v1');
-        caps.locationTypeNFS &&= caps.locationTypes.has('location-nfs-mount-v1');
-        caps.locationTypeCephRadosGW &&= caps.locationTypes.has('location-ceph-radosgw-s3-v1');
-        caps.locationTypeHyperdriveV2 &&= caps.locationTypes.has('location-scality-hdclient-v2');
-        caps.locationTypeLocal &&= caps.locationTypes.has('location-file-v1');
+    if (cfg.supportedLocationTypes) {
+        caps.locationTypeAzure &&= cfg.supportedLocationTypes.has('location-azure-v1');
+        caps.locationTypeGCP &&= cfg.supportedLocationTypes.has('location-gcp-v1');
+        caps.locationTypeDigitalOcean &&= cfg.supportedLocationTypes.has('location-do-spaces-v1');
+        caps.locationTypeSproxyd &&= cfg.supportedLocationTypes.has('location-scality-sproxyd-v1');
+        caps.locationTypeNFS &&= cfg.supportedLocationTypes.has('location-nfs-mount-v1');
+        caps.locationTypeCephRadosGW &&= cfg.supportedLocationTypes.has('location-ceph-radosgw-s3-v1');
+        caps.locationTypeHyperdriveV2 &&= cfg.supportedLocationTypes.has('location-scality-hdclient-v2');
+        caps.locationTypeLocal &&= cfg.supportedLocationTypes.has('location-file-v1');
     }
 
     return caps;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "9.1.12",
+  "version": "9.1.13",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {

--- a/tests/unit/utils/reportHandler.js
+++ b/tests/unit/utils/reportHandler.js
@@ -214,6 +214,13 @@ describe('reportHandler.getCapabilities', () => {
         });
 
         it('should update locationTypes capabilities based on locationTypes map', () => {
+            const locationTypes = [
+                'location-gcp-v1',
+                'location-scality-sproxyd-v1',
+                'location-ceph-radosgw-s3-v1',
+                'location-file-v1',
+                'location-scality-artesca-s3-v1',
+            ];
             const cfg = {
                 capabilities: {
                     locationTypeAzure: true,
@@ -225,15 +232,10 @@ describe('reportHandler.getCapabilities', () => {
                     locationTypeCephRadosGW: true,
                     locationTypeHyperdriveV2: true,
                     locationTypeLocal: true,
-                    locationTypes: new Set([
-                        'location-gcp-v1',
-                        'location-scality-sproxyd-v1',
-                        'location-ceph-radosgw-s3-v1',
-                        'location-file-v1',
-                        'location-scality-artesca-s3-v1',
-                    ]),
+                    locationTypes,
                 },
                 supportedLifecycleRules: ['Expiration'],
+                supportedLocationTypes: new Set(locationTypes),
             };
             const caps = getCapabilities(cfg);
 
@@ -250,6 +252,7 @@ describe('reportHandler.getCapabilities', () => {
 
         it('should handle multiple consistency checks together', () => {
             process.env.LOCAL_VOLUME_CAPABILITY = '0';
+            const locationTypes = ['location-azure-v1'];
             const cfg = {
                 capabilities: {
                     locationTypeLocal: true,
@@ -258,9 +261,10 @@ describe('reportHandler.getCapabilities', () => {
                     managedLifecycleTransition: true,
                     locationTypeAzure: true,
                     locationTypeGCP: true,
-                    locationTypes: new Set(['location-azure-v1']),
+                    locationTypes,
                 },
                 supportedLifecycleRules: ['Expiration'], // Missing Transition
+                supportedLocationTypes: new Set(locationTypes),
             };
             const caps = getCapabilities(cfg);
 


### PR DESCRIPTION
We create a `Set` when loading the config (to avoid costly looking),
but this must not modify the capabilities which are returned by
reportHandler.

Issue: CLDSRV-850
