### PR TITLE
Improvement/cldsrv 561 add tests for create and store object

### DIFF
--- a/tests/functional/aws-node-sdk/test/object/objectOverwrite.js
+++ b/tests/functional/aws-node-sdk/test/object/objectOverwrite.js
@@ -1,12 +1,49 @@
 const assert = require('assert');
 const {
     PutObjectCommand,
+    PutBucketVersioningCommand,
     HeadObjectCommand,
     GetObjectCommand,
 } = require('@aws-sdk/client-s3');
 
 const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
+const { fakeMetadataArchive, fakeMetadataTransition, getMetadata, initMetadata } = require('../utils/init');
+
+const coldStateScenarios = [
+    {
+        name: 'transition in progress',
+        transitionInProgress: true,
+    },
+    {
+        name: 'archived',
+        archiveState: {
+            archiveInfo: { archiveId: 'archive-1' },
+            restoreRequestedAt: new Date(0).toISOString(),
+            restoreRequestedDays: 5,
+        },
+    },
+    {
+        name: 'restored (not expired)',
+        archiveState: {
+            archiveInfo: { archiveId: 'archive-restored' },
+            restoreRequestedAt: new Date(0).toISOString(),
+            restoreRequestedDays: 5,
+            restoreCompletedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+            restoreWillExpireAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        },
+    },
+    {
+        name: 'restored (expired)',
+        archiveState: {
+            archiveInfo: { archiveId: 'archive-expired' },
+            restoreRequestedAt: new Date(0).toISOString(),
+            restoreRequestedDays: 5,
+            restoreCompletedAt: new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString(),
+            restoreWillExpireAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+        },
+    },
+];
 
 const objectName = 'someObject';
 const firstPutMetadata = {
@@ -30,6 +67,7 @@ describe('Put object with same key as prior object', () => {
             bucketUtil = new BucketUtility('default', sigCfg);
             s3 = bucketUtil.s3;
             bucketName = await bucketUtil.createRandom(1);
+            await initMetadata();
         });
 
         beforeEach(async () => {
@@ -66,5 +104,109 @@ describe('Put object with same key as prior object', () => {
                 const bodyText = await res.Body.transformToString();
                 assert.deepStrictEqual(bodyText, 'Much different');
             });
+
+        coldStateScenarios.forEach(({ name, transitionInProgress, archiveState }) => {
+            it(`should replace object with cold-state metadata (${name}) in non-versioned bucket`, async () => {
+                if (transitionInProgress) {
+                    await fakeMetadataTransition(bucketName, objectName, undefined);
+                } else {
+                    await fakeMetadataArchive(bucketName, objectName, undefined, archiveState);
+                }
+
+                await s3.send(new PutObjectCommand({
+                    Bucket: bucketName,
+                    Key: objectName,
+                    Body: `overwrite cold state ${name}`,
+                    Metadata: secondPutMetadata,
+                }));
+
+                const currentMD = await getMetadata(bucketName, objectName, undefined);
+                assert.strictEqual(currentMD.archive, undefined);
+                assert.strictEqual(currentMD['x-amz-scal-transition-in-progress'], undefined);
+            });
+        });
+
+        it('should create a new version when replacing archived current object in versioned bucket', async () => {
+            await bucketUtil.empty(bucketName);
+
+            await s3.send(new PutBucketVersioningCommand({
+                Bucket: bucketName,
+                VersioningConfiguration: { Status: 'Enabled' },
+            }));
+
+            const firstPutRes = await s3.send(new PutObjectCommand({
+                Bucket: bucketName,
+                Key: objectName,
+                Body: 'versioned first payload',
+                Metadata: firstPutMetadata,
+            }));
+            assert(firstPutRes.VersionId);
+
+            await fakeMetadataArchive(bucketName, objectName, undefined, {
+                archiveInfo: { archiveId: 'archive-versioned-current' },
+                restoreRequestedAt: new Date(0).toISOString(),
+                restoreRequestedDays: 5,
+            });
+
+            const secondPutRes = await s3.send(new PutObjectCommand({
+                Bucket: bucketName,
+                Key: objectName,
+                Body: 'versioned second payload',
+                Metadata: secondPutMetadata,
+            }));
+            assert(secondPutRes.VersionId);
+            assert.notStrictEqual(secondPutRes.VersionId, firstPutRes.VersionId);
+
+            const headRes = await s3.send(new HeadObjectCommand({
+                Bucket: bucketName,
+                Key: objectName,
+            }));
+            assert.deepStrictEqual(headRes.Metadata, secondPutMetadata);
+
+            const currentMD = await getMetadata(bucketName, objectName, undefined);
+            assert.strictEqual(currentMD.archive, undefined);
+        });
+
+        it('should replace archived current null version in version-suspended bucket', async () => {
+            await bucketUtil.empty(bucketName);
+
+            await s3.send(new PutBucketVersioningCommand({
+                Bucket: bucketName,
+                VersioningConfiguration: { Status: 'Enabled' },
+            }));
+            await s3.send(new PutObjectCommand({
+                Bucket: bucketName,
+                Key: objectName,
+                Body: 'enabled-version-payload',
+            }));
+            await s3.send(new PutBucketVersioningCommand({
+                Bucket: bucketName,
+                VersioningConfiguration: { Status: 'Suspended' },
+            }));
+
+            await s3.send(new PutObjectCommand({
+                Bucket: bucketName,
+                Key: objectName,
+                Body: 'null-current-before-archive',
+            }));
+
+            await fakeMetadataArchive(bucketName, objectName, undefined, {
+                archiveInfo: { archiveId: 'archive-null-current' },
+                restoreRequestedAt: new Date(0).toISOString(),
+                restoreRequestedDays: 5,
+            });
+
+            await s3.send(new PutObjectCommand({
+                Bucket: bucketName,
+                Key: objectName,
+                Body: 'replace archived null current',
+                Metadata: secondPutMetadata,
+            }));
+
+            const currentMD = await getMetadata(bucketName, objectName, undefined);
+            assert.strictEqual(currentMD.archive, undefined);
+            assert.deepStrictEqual(currentMD['x-amz-meta-secondput'], secondPutMetadata.secondput);
+        });
+
     });
 });

--- a/tests/functional/aws-node-sdk/test/object/putVersion.js
+++ b/tests/functional/aws-node-sdk/test/object/putVersion.js
@@ -34,7 +34,7 @@ const archive = {
     restoreRequestedDays: 5,
 };
 
-async function putObjectVersion(s3, params, vid, next) {
+function putObjectVersion(s3, params, vid, cb) {
     const paramsWithBody = { ...params, Body: '123' };
     const command = new PutObjectCommand(paramsWithBody);
     command.middlewareStack.add(
@@ -48,13 +48,9 @@ async function putObjectVersion(s3, params, vid, next) {
             name: 'addVersionIdHeader', // Add a name to identify the middleware
         }
     );
-    
-    try {
-        const res = await s3.send(command);
-        next(null, res);
-    } catch (err) {
-        next(err);
-    }
+
+    const promise = s3.send(command);
+    return cb ? promise.then(res => cb(null, res), cb) : promise;
 }
 
 function clearRestoreStatus(versions) {
@@ -955,6 +951,68 @@ describe('PUT object with x-scal-s3-version-id header', () => {
                         return s3.send(new PutObjectLegalHoldCommand(legalHoldParams)).then(() => next());
                     },
                 ], done);
+            });
+
+            it('should set restore originOp and drop restore-attempt metadata', done => {
+                const params = { Bucket: bucketName, Key: objectName };
+
+                async.series([
+                    next => s3.send(new PutObjectCommand({
+                        ...params,
+                        Metadata: {
+                            'custom-md': 'preserved-value',
+                        },
+                    })).then(() => next()).catch(next),
+                    next => fakeMetadataArchive(bucketName, objectName, undefined, archive, next),
+                    next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                        if (err) {
+                            return next(err);
+                        }
+                        /* eslint-disable no-param-reassign */
+                        objMD['x-amz-meta-scal-s3-restore-attempt'] = '3';
+                        /* eslint-enable no-param-reassign */
+                        return metadata.putObjectMD(bucketName, objectName, objMD, undefined, log, next);
+                    }),
+                    next => putObjectVersion(s3, params, '', next),
+                    next => getMetadata(bucketName, objectName, undefined, (err, objMD) => {
+                        if (err) {
+                            return next(err);
+                        }
+                        assert.strictEqual(objMD.originOp, 's3:ObjectRestore:Completed');
+                        assert.strictEqual(objMD['x-amz-meta-custom-md'], 'preserved-value');
+                        assert.strictEqual(objMD['x-amz-meta-scal-s3-restore-attempt'], undefined);
+                        return next();
+                    }),
+                ], done);
+            });
+
+            it('should keep x-amz-meta-scal-version-id when restoring on ingestion bucket', async () => {
+                const ingestionBucketName = `ingestion-restore-${Date.now()}`;
+                const params = { Bucket: ingestionBucketName, Key: objectName };
+                let putVersionId;
+                try {
+                    await s3.send(new CreateBucketCommand({
+                        Bucket: ingestionBucketName,
+                        CreateBucketConfiguration: {
+                            LocationConstraint: 'us-east-2:ingest',
+                        },
+                    }));
+
+                    const putRes = await s3.send(new PutObjectCommand(params));
+                    putVersionId = putRes.VersionId;
+
+                    await fakeMetadataArchive(ingestionBucketName, objectName, putVersionId, archive);
+
+                    await putObjectVersion(s3, params, putVersionId);
+
+                    const restoredObjMD = await getMetadata(
+                        ingestionBucketName, objectName, putVersionId);
+
+                    assert.strictEqual(restoredObjMD['x-amz-meta-scal-version-id'], putVersionId);
+                } finally {
+                    await bucketUtil.emptyMany([ingestionBucketName]).catch(() => {});
+                    await bucketUtil.deleteMany([ingestionBucketName]).catch(() => {});
+                }
             });
         });
     });

--- a/tests/functional/aws-node-sdk/test/utils/init.js
+++ b/tests/functional/aws-node-sdk/test/utils/init.js
@@ -38,22 +38,33 @@ function decodeVersionId(versionId) {
 
 let metadataInit = false;
 
-function initMetadata(done) {
-    if (metadataInit === true) {
-        return done();
-    }
-    return metadata.setup(err => {
-        if (err) {
-            return done(err);
+function initMetadata(cb) {
+    const promise = (async () => {
+        if (metadataInit) {
+            return;
         }
-        metadataInit = true;
-        return done();
-    });
+        await new Promise((resolve, reject) => {
+            metadata.setup(err => {
+                if (err) {
+                    return reject(err);
+                }
+                metadataInit = true;
+                return resolve();
+            });
+        });
+    })();
+    return cb ? promise.then(() => cb(), cb) : promise;
 }
 
 function getMetadata(bucketName, objectName, versionId, cb) {
-    return metadata.getObjectMD(bucketName, objectName, { versionId: decodeVersionId(versionId) },
-        log, cb);
+    const promise = new Promise((resolve, reject) => metadata.getObjectMD(
+        bucketName,
+        objectName,
+        { versionId: decodeVersionId(versionId) },
+        log,
+        (err, data) => (err ? reject(err) : resolve(data)),
+    ));
+    return cb ? promise.then(res => cb(null, res), cb) : promise;
 }
 
 /**
@@ -66,16 +77,19 @@ function getMetadata(bucketName, objectName, versionId, cb) {
  * @returns {undefined}
  */
 function fakeMetadataTransition(bucketName, objectName, versionId, cb) {
-    return getMetadata(bucketName, objectName, versionId, (err, objMD) => {
-        if (err) {
-            return cb(err);
-        }
-        /* eslint-disable no-param-reassign */
+    const promise = (async () => {
+        const objMD = await getMetadata(bucketName, objectName, versionId);
         objMD['x-amz-scal-transition-in-progress'] = true;
-        /* eslint-enable no-param-reassign */
-        return metadata.putObjectMD(bucketName, objectName, objMD, { versionId: decodeVersionId(versionId) },
-            log, err => cb(err));
-    });
+        await new Promise((resolve, reject) => metadata.putObjectMD(
+            bucketName,
+            objectName,
+            objMD,
+            { versionId: decodeVersionId(versionId) },
+            log,
+            err => (err ? reject(err) : resolve()),
+        ));
+    })();
+    return cb ? promise.then(() => cb(), cb) : promise;
 }
 
 /**
@@ -89,18 +103,21 @@ function fakeMetadataTransition(bucketName, objectName, versionId, cb) {
  * @returns {undefined}
  */
 function fakeMetadataArchive(bucketName, objectName, versionId, archive, cb) {
-    return getMetadata(bucketName, objectName, versionId, (err, objMD) => {
-        if (err) {
-            return cb(err);
-        }
-        /* eslint-disable no-param-reassign */
+    const promise = (async () => {
+        const objMD = await getMetadata(bucketName, objectName, versionId);
         objMD['x-amz-storage-class'] = LOCATION_NAME_DMF;
         objMD.dataStoreName = LOCATION_NAME_DMF;
         objMD.archive = archive;
-        /* eslint-enable no-param-reassign */
-        return metadata.putObjectMD(bucketName, objectName, objMD, { versionId: decodeVersionId(versionId) },
-            log, err => cb(err));
-    });
+        await new Promise((resolve, reject) => metadata.putObjectMD(
+            bucketName,
+            objectName,
+            objMD,
+            { versionId: decodeVersionId(versionId) },
+            log,
+            err => (err ? reject(err) : resolve()),
+        ));
+    })();
+    return cb ? promise.then(() => cb(), cb) : promise;
 }
 
 module.exports = {

--- a/tests/unit/api/createAndStoreObject.js
+++ b/tests/unit/api/createAndStoreObject.js
@@ -1,0 +1,581 @@
+/**
+ * Unit tests for createAndStoreObject function
+ * Tests cold storage restoration, versioning, and corner cases
+ */
+
+const assert = require('assert');
+const { promisify } = require('util');
+const { storage } = require('arsenal');
+const sinon = require('sinon');
+
+const { bucketPut } = require('../../../lib/api/bucketPut');
+const { cleanup, DummyRequestLogger, makeAuthInfo } = require('../helpers');
+const metadata = require('../metadataswitch');
+const rawCreateAndStoreObject = require('../../../lib/api/apiUtils/object/createAndStoreObject');
+const DummyRequest = require('../DummyRequest');
+
+const createAndStoreObject = promisify(rawCreateAndStoreObject);
+
+const { ds } = storage.data.inMemory.datastore;
+const log = new DummyRequestLogger();
+const authInfo = makeAuthInfo('accessKey1');
+const canonicalID = authInfo.getCanonicalID();
+const bucketName = 'test-bucket';
+const objectKey = 'test-object';
+
+const getObjectMDAsync = (bucket, key, params = {}) => new Promise((resolve, reject) => {
+    metadata.getObjectMD(bucket, key, params, log, (err, data) => {
+        if (err) {
+            reject(err);
+        } else {
+            resolve(data);
+        }
+    });
+});
+
+describe('createAndStoreObject', () => {
+    let testBucket;
+    const getStoredObjectData = () => metadata.putObjectMD.lastCall.args[2].getValue();
+    const getStoredOptions = () => metadata.putObjectMD.lastCall.args[3];
+
+    beforeEach(done => {
+        cleanup();
+        const bucketRequest = new DummyRequest({
+            bucketName,
+            namespace: 'default',
+            headers: { host: `${bucketName}.s3.amazonaws.com` },
+            url: '/',
+        });
+        bucketPut(authInfo, bucketRequest, log, err => {
+            if (err) {
+                return done(err);
+            }
+            return metadata.getBucket(bucketName, log, (err, bucket) => {
+                testBucket = bucket;
+                done(err);
+            });
+        });
+    });
+
+    afterEach(() => {
+        cleanup();
+        sinon.restore();
+    });
+
+    describe('Regular object creation', () => {
+        it('should create object successfully', async () => {
+            const request = new DummyRequest({
+                bucketName,
+                namespace: 'default',
+                objectKey,
+                headers: { 'content-type': 'text/plain' },
+                url: `/${bucketName}/${objectKey}`,
+            }, Buffer.from('test data', 'utf8'));
+
+            const result = await createAndStoreObject(bucketName, testBucket, objectKey, null,
+                authInfo, canonicalID, null, request, false, null,
+                ['overhead'], log, 's3:ObjectCreated:Put');
+
+            assert(result.contentMD5);
+
+            const objMD = await getObjectMDAsync(bucketName, objectKey, {});
+            assert.strictEqual(objMD['content-md5'], result.contentMD5);
+        });
+
+        it('should handle zero-byte object', async () => {
+            const request = new DummyRequest({
+                bucketName,
+                namespace: 'default',
+                objectKey,
+                headers: { 'content-type': 'text/plain' },
+                parsedContentLength: 0,
+                url: `/${bucketName}/${objectKey}`,
+            }, '');
+
+            const result = await createAndStoreObject(bucketName, testBucket, objectKey, null,
+                authInfo, canonicalID, null, request, false, null,
+                ['overhead'], log, 's3:ObjectCreated:Put');
+
+            assert(result.contentMD5);
+        });
+
+        it('should set bucketOwnerId when requester is not bucket owner', async () => {
+            const authInfo2 = makeAuthInfo('accessKey2');
+            sinon.spy(metadata, 'putObjectMD');
+
+            const request = new DummyRequest({
+                bucketName,
+                namespace: 'default',
+                objectKey,
+                headers: {},
+                url: `/${bucketName}/${objectKey}`,
+            }, Buffer.from('test', 'utf8'));
+
+            await createAndStoreObject(bucketName, testBucket, objectKey, null,
+                authInfo2, authInfo2.getCanonicalID(), null, request, false, null,
+                ['overhead'], log, 's3:ObjectCreated:Put');
+
+            const storedObjMD = getStoredObjectData();
+            assert.strictEqual(storedObjMD.bucketOwnerId, canonicalID);
+        });
+    });
+
+    describe('Delete marker creation', () => {
+        it('should create delete marker without storing data', async () => {
+            const request = new DummyRequest({
+                bucketName,
+                namespace: 'default',
+                objectKey,
+                headers: {},
+                url: `/${bucketName}/${objectKey}`,
+            });
+
+            await createAndStoreObject(bucketName, testBucket, objectKey, null,
+                authInfo, canonicalID, null, request, true, null,
+                ['overhead'], log, 's3:ObjectRemoved:DeleteMarkerCreated');
+
+            assert.deepStrictEqual(ds, []);
+
+            const objMD = await getObjectMDAsync(bucketName, objectKey, {});
+            assert(objMD.isDeleteMarker);
+        });
+    });
+
+    describe('Archived object replacement', () => {
+        it('should trigger oplog event when replacing archived object in non-versioned bucket', async () => {
+            const archivedObjMD = {
+                'content-md5': 'abc123',
+                'content-length': 100,
+                'archive': {
+                    'archiveInfo': { 'archiveID': 'archive-123' },
+                },
+            };
+
+            sinon.spy(metadata, 'putObjectMD');
+
+            const request = new DummyRequest({
+                bucketName,
+                namespace: 'default',
+                objectKey,
+                headers: {},
+                url: `/${bucketName}/${objectKey}`,
+            }, Buffer.from('new data', 'utf8'));
+
+            await createAndStoreObject(bucketName, testBucket, objectKey, archivedObjMD,
+                authInfo, canonicalID, null, request, false, null,
+                ['overhead'], log, 's3:ObjectCreated:Put');
+
+            const options = getStoredOptions();
+            assert.strictEqual(options.needOplogUpdate, true);
+            assert.strictEqual(options.originOp, 's3:ReplaceArchivedObject');
+        });
+
+        it('should not trigger oplog event for archived object in versioned bucket', async () => {
+            const archivedObjMD = {
+                'content-md5': 'abc123',
+                'content-length': 100,
+                'versionId': 'v1',
+                'archive': {
+                    'archiveInfo': { 'archiveID': 'archive-123' },
+                },
+            };
+
+            sinon.stub(testBucket, 'isVersioningEnabled').returns(true);
+            sinon.spy(metadata, 'putObjectMD');
+
+            const request = new DummyRequest({
+                bucketName,
+                namespace: 'default',
+                objectKey,
+                headers: {},
+                url: `/${bucketName}/${objectKey}`,
+            }, Buffer.from('new data', 'utf8'));
+
+            await createAndStoreObject(bucketName, testBucket, objectKey, archivedObjMD,
+                authInfo, canonicalID, null, request, false, null,
+                ['overhead'], log, 's3:ObjectCreated:Put');
+
+            const options = getStoredOptions();
+            assert.strictEqual(options.needOplogUpdate, undefined);
+            assert.strictEqual(options.originOp, undefined);
+        });
+
+        it('should trigger oplog event for archived object in version-suspended bucket', async () => {
+            const archivedObjMD = {
+                'content-md5': 'abc123',
+                'content-length': 100,
+                archive: {
+                    archiveInfo: { archiveID: 'archive-123' },
+                },
+            };
+
+            sinon.stub(testBucket, 'isVersioningEnabled').returns(false);
+            sinon.spy(metadata, 'putObjectMD');
+
+            const request = new DummyRequest({
+                bucketName,
+                namespace: 'default',
+                objectKey,
+                headers: {},
+                url: `/${bucketName}/${objectKey}`,
+            }, Buffer.from('new data', 'utf8'));
+
+            await createAndStoreObject(bucketName, testBucket, objectKey, archivedObjMD,
+                authInfo, canonicalID, null, request, false, null,
+                ['overhead'], log, 's3:ObjectCreated:Put');
+
+            const options = getStoredOptions();
+            assert.strictEqual(options.needOplogUpdate, true);
+            assert.strictEqual(options.originOp, 's3:ReplaceArchivedObject');
+        });
+
+        it('should not trigger oplog event when archiveInfo is absent', async () => {
+            const archivedObjMD = {
+                'content-md5': 'abc123',
+                'content-length': 100,
+                archive: {
+                    restoreRequestedAt: new Date().toISOString(),
+                },
+            };
+            sinon.spy(metadata, 'putObjectMD');
+
+            const request = new DummyRequest({
+                bucketName,
+                namespace: 'default',
+                objectKey,
+                headers: {},
+                url: `/${bucketName}/${objectKey}`,
+            }, Buffer.from('new data', 'utf8'));
+
+            await createAndStoreObject(bucketName, testBucket, objectKey, archivedObjMD,
+                authInfo, canonicalID, null, request, false, null,
+                ['overhead'], log, 's3:ObjectCreated:Put');
+
+            const options = getStoredOptions();
+            assert.strictEqual(options.needOplogUpdate, undefined);
+            assert.strictEqual(options.originOp, undefined);
+        });
+    });
+
+    describe('Cold storage restoration (putObjectVersion)', () => {
+        it('should restore object with x-scal-s3-version-id header', async () => {
+            const now = Date.now();
+            const archivedObjMD = {
+                'key': objectKey,
+                'versionId': 'v123',
+                'content-md5': 'original-hash',
+                'content-length': 100,
+                'x-amz-storage-class': 'cold-location',
+                'dataStoreName': 'cold-location',
+                'x-amz-meta-custom': 'preserved-value',
+                'tags': { 'tagkey': 'tagvalue' },
+                'archive': {
+                    'archiveInfo': { 'archiveID': 'archive-123' },
+                    'restoreRequestedAt': new Date(now).toISOString(),
+                    'restoreRequestedDays': 7,
+                },
+            };
+
+            sinon.spy(metadata, 'putObjectMD');
+
+            const request = new DummyRequest({
+                bucketName,
+                namespace: 'default',
+                objectKey,
+                headers: { 'x-scal-s3-version-id': 'v123' },
+                url: `/${bucketName}/${objectKey}`,
+            }, Buffer.from('restored data', 'utf8'));
+
+            await createAndStoreObject(bucketName, testBucket, objectKey, archivedObjMD,
+                authInfo, canonicalID, null, request, false, null,
+                ['overhead'], log, 's3:ObjectCreated:Put');
+
+            const storedObjMD = getStoredObjectData();
+            const options = getStoredOptions();
+            assert(storedObjMD.archive.restoreCompletedAt, 'restoreCompletedAt should be set');
+            assert(storedObjMD.archive.restoreWillExpireAt, 'restoreWillExpireAt should be set');
+            assert.strictEqual(storedObjMD.archive.restoreRequestedDays, 7);
+            assert.strictEqual(storedObjMD['x-amz-meta-custom'], 'preserved-value');
+            assert.deepStrictEqual(storedObjMD.tags, { 'tagkey': 'tagvalue' });
+            assert.strictEqual(storedObjMD.originOp, 's3:ObjectRestore:Completed');
+            assert.strictEqual(options.needOplogUpdate, undefined);
+            assert.strictEqual(options.originOp, undefined);
+        });
+
+        it('should preserve original etag for MPU restoration with different part count', async () => {
+            const archivedObjMD = {
+                'versionId': 'v123',
+                'content-md5': 'original-abc123-5', // Original had 5 parts
+                'archive': {
+                    'archiveInfo': { 'archiveID': 'archive-123' },
+                    'restoreRequestedAt': new Date().toISOString(),
+                    'restoreRequestedDays': 7,
+                },
+            };
+
+            sinon.spy(metadata, 'putObjectMD');
+
+            const request = new DummyRequest({
+                bucketName,
+                namespace: 'default',
+                objectKey,
+                headers: { 'x-scal-s3-version-id': 'v123' },
+                url: `/${bucketName}/${objectKey}`,
+                calculatedHash: 'restored-def456-3', // Restored with 3 parts
+            }, Buffer.from('restored data', 'utf8'));
+
+            await createAndStoreObject(bucketName, testBucket, objectKey, archivedObjMD,
+                authInfo, canonicalID, null, request, false, null,
+                ['overhead'], log, 's3:ObjectCreated:Put');
+
+            const storedObjMD = getStoredObjectData();
+            assert.strictEqual(storedObjMD['content-md5'], 'original-abc123-5',
+                'Original etag should be preserved');
+            assert(storedObjMD['x-amz-restore']['content-md5']);
+            assert.notStrictEqual(storedObjMD['x-amz-restore']['content-md5'],
+                storedObjMD['content-md5']);
+        });
+
+        it('should preserve replication info during restoration', async () => {
+            const replicationInfo = {
+                status: 'COMPLETED',
+                backends: [{ site: 'site1', status: 'COMPLETED' }],
+            };
+
+            const archivedObjMD = {
+                'versionId': 'v123',
+                replicationInfo,
+                'archive': {
+                    'archiveInfo': { 'archiveID': 'archive-123' },
+                    'restoreRequestedAt': new Date().toISOString(),
+                    'restoreRequestedDays': 7,
+                },
+            };
+
+            sinon.spy(metadata, 'putObjectMD');
+
+            const request = new DummyRequest({
+                bucketName,
+                namespace: 'default',
+                objectKey,
+                headers: { 'x-scal-s3-version-id': 'v123' },
+                url: `/${bucketName}/${objectKey}`,
+            }, Buffer.from('restored', 'utf8'));
+
+            await createAndStoreObject(bucketName, testBucket, objectKey, archivedObjMD,
+                authInfo, canonicalID, null, request, false, null,
+                ['overhead'], log, 's3:ObjectCreated:Put');
+
+            const storedObjMD = getStoredObjectData();
+            assert.strictEqual(storedObjMD.replicationInfo.status, replicationInfo.status,
+                'Replication status should be preserved');
+            assert.deepStrictEqual(storedObjMD.replicationInfo.backends, replicationInfo.backends,
+                'Replication backends should be preserved');
+        });
+
+        it('should preserve legal hold during restoration', async () => {
+            const archivedObjMD = {
+                'versionId': 'v123',
+                'legalHold': true,
+                'archive': {
+                    'archiveInfo': { 'archiveID': 'archive-123' },
+                    'restoreRequestedAt': new Date().toISOString(),
+                    'restoreRequestedDays': 7,
+                },
+            };
+
+            sinon.spy(metadata, 'putObjectMD');
+
+            const request = new DummyRequest({
+                bucketName,
+                namespace: 'default',
+                objectKey,
+                headers: { 'x-scal-s3-version-id': 'v123' },
+                url: `/${bucketName}/${objectKey}`,
+            }, Buffer.from('restored', 'utf8'));
+
+            await createAndStoreObject(bucketName, testBucket, objectKey, archivedObjMD,
+                authInfo, canonicalID, null, request, false, null,
+                ['overhead'], log, 's3:ObjectCreated:Put');
+
+            const storedObjMD = getStoredObjectData();
+            assert.strictEqual(storedObjMD.legalHold, true,
+                'Legal hold should be preserved');
+        });
+
+        it('should preserve ACLs during restoration', async () => {
+            const acl = {
+                'Canned': '',
+                'FULL_CONTROL': ['canonical-id-1'],
+                'READ': ['canonical-id-2'],
+            };
+
+            const archivedObjMD = {
+                'versionId': 'v123',
+                acl,
+                'archive': {
+                    'archiveInfo': { 'archiveID': 'archive-123' },
+                    'restoreRequestedAt': new Date().toISOString(),
+                    'restoreRequestedDays': 7,
+                },
+            };
+
+            sinon.spy(metadata, 'putObjectMD');
+
+            const request = new DummyRequest({
+                bucketName,
+                namespace: 'default',
+                objectKey,
+                headers: { 'x-scal-s3-version-id': 'v123' },
+                url: `/${bucketName}/${objectKey}`,
+            }, Buffer.from('restored', 'utf8'));
+
+            await createAndStoreObject(bucketName, testBucket, objectKey, archivedObjMD,
+                authInfo, canonicalID, null, request, false, null,
+                ['overhead'], log, 's3:ObjectCreated:Put');
+
+            const storedObjMD = getStoredObjectData();
+            assert.deepStrictEqual(storedObjMD.acl, acl,
+                'ACLs should be preserved');
+        });
+
+        it('should not preserve x-amz-meta-scal-s3-restore-attempt metadata', async () => {
+            const archivedObjMD = {
+                'versionId': 'v123',
+                'x-amz-meta-custom': 'keep-this',
+                'x-amz-meta-scal-s3-restore-attempt': '3',
+                'archive': {
+                    'archiveInfo': { 'archiveID': 'archive-123' },
+                    'restoreRequestedAt': new Date().toISOString(),
+                    'restoreRequestedDays': 7,
+                },
+            };
+
+            sinon.spy(metadata, 'putObjectMD');
+
+            const request = new DummyRequest({
+                bucketName,
+                namespace: 'default',
+                objectKey,
+                headers: { 'x-scal-s3-version-id': 'v123' },
+                url: `/${bucketName}/${objectKey}`,
+            }, Buffer.from('restored', 'utf8'));
+
+            await createAndStoreObject(bucketName, testBucket, objectKey, archivedObjMD,
+                authInfo, canonicalID, null, request, false, null,
+                ['overhead'], log, 's3:ObjectCreated:Put');
+
+            const storedObjMD = getStoredObjectData();
+            assert.strictEqual(storedObjMD['x-amz-meta-custom'], 'keep-this',
+                'Custom metadata should be preserved');
+            assert.strictEqual(storedObjMD['x-amz-meta-scal-s3-restore-attempt'], undefined,
+                'Restore attempt metadata should NOT be preserved');
+        });
+    });
+
+    describe('MPU scenarios', () => {
+        it('should set oldReplayId when overwriting MPU object', async () => {
+            const mpuObjMD = {
+                'uploadId': 'mpu-upload-123',
+                'content-md5': 'abc123',
+            };
+
+            sinon.spy(metadata, 'putObjectMD');
+
+            const request = new DummyRequest({
+                bucketName,
+                namespace: 'default',
+                objectKey,
+                headers: {},
+                url: `/${bucketName}/${objectKey}`,
+            }, Buffer.from('new data', 'utf8'));
+
+            await createAndStoreObject(bucketName, testBucket, objectKey, mpuObjMD,
+                authInfo, canonicalID, null, request, false, null,
+                ['overhead'], log, 's3:ObjectCreated:Put');
+
+            const options = getStoredOptions();
+            assert.strictEqual(options.oldReplayId, 'mpu-upload-123');
+        });
+    });
+
+    describe('Azure compatibility', () => {
+        it('should preserve creation-time from existing object', async () => {
+            const existingObjMD = {
+                'creation-time': '2024-01-01T00:00:00.000Z',
+                'last-modified': '2024-02-01T00:00:00.000Z',
+            };
+
+            sinon.spy(metadata, 'putObjectMD');
+
+            const request = new DummyRequest({
+                bucketName,
+                namespace: 'default',
+                objectKey,
+                headers: {},
+                url: `/${bucketName}/${objectKey}`,
+            }, Buffer.from('new data', 'utf8'));
+
+            await createAndStoreObject(bucketName, testBucket, objectKey, existingObjMD,
+                authInfo, canonicalID, null, request, false, null,
+                ['overhead'], log, 's3:ObjectCreated:Put');
+
+            const storedObjMD = getStoredObjectData();
+            assert.strictEqual(storedObjMD['creation-time'], '2024-01-01T00:00:00.000Z');
+        });
+
+        it('should fall back to last-modified if creation-time missing', async () => {
+            const existingObjMD = {
+                'last-modified': '2024-02-01T00:00:00.000Z',
+            };
+
+            sinon.spy(metadata, 'putObjectMD');
+
+            const request = new DummyRequest({
+                bucketName,
+                namespace: 'default',
+                objectKey,
+                headers: {},
+                url: `/${bucketName}/${objectKey}`,
+            }, Buffer.from('new data', 'utf8'));
+
+            await createAndStoreObject(bucketName, testBucket, objectKey, existingObjMD,
+                authInfo, canonicalID, null, request, false, null,
+                ['overhead'], log, 's3:ObjectCreated:Put');
+
+            const storedObjMD = getStoredObjectData();
+            assert.strictEqual(storedObjMD['creation-time'], '2024-02-01T00:00:00.000Z');
+        });
+    });
+
+    describe('Integration-sensitive restore behavior', () => {
+        it('should keep x-amz-meta-scal-version-id when restoring to ingestion location', async () => {
+            sinon.stub(testBucket, 'isIngestionBucket').returns(true);
+            sinon.spy(metadata, 'putObjectMD');
+            const putVersionId = 'restore-version-id';
+            const archivedObjMD = {
+                versionId: putVersionId,
+                archive: {
+                    archiveInfo: { archiveID: 'archive-123' },
+                    restoreRequestedAt: new Date().toISOString(),
+                    restoreRequestedDays: 7,
+                },
+            };
+
+            const request = new DummyRequest({
+                bucketName,
+                namespace: 'default',
+                objectKey,
+                headers: { 'x-scal-s3-version-id': putVersionId },
+                url: `/${bucketName}/${objectKey}`,
+            }, Buffer.from('restored', 'utf8'));
+
+            await createAndStoreObject(bucketName, testBucket, objectKey, archivedObjMD,
+                authInfo, canonicalID, null, request, false, null,
+                ['overhead'], log, 's3:ObjectCreated:Put');
+
+            const storedObjMD = getStoredObjectData();
+            assert.strictEqual(storedObjMD['x-amz-meta-scal-version-id'], putVersionId);
+        });
+    });
+});


### PR DESCRIPTION
This PR strengthens coverage around createAndStoreObject, the core path used by putObject, putRestoredObject, and putObjectVersion, with emphasis on cold-storage restore and archived-object edge cases.
The goal is to improve confidence in behavior-heavy flows
Issue: CLDSRV-561