### PR TITLE
Update LastModified date format to ISO string in XML response

### DIFF
--- a/lib/routes/veeam/list.js
+++ b/lib/routes/veeam/list.js
@@ -38,7 +38,7 @@ function buildXMLResponse(request, arrayOfFiles, versioned = false) {
         value: {
             IsDeleteMarker: false,
             IsNull: true,
-            LastModified: file['Last-Modified'],
+            LastModified: new Date(file['Last-Modified']).toISOString(),
             // Generated ETag alrady contains quotes, removing them here
             ETag: file.ETag.substring(1, file.ETag.length - 1),
             Size: file['Content-Length'],

--- a/tests/unit/routes/veeam-routes.js
+++ b/tests/unit/routes/veeam-routes.js
@@ -493,6 +493,44 @@ describe('Veeam routes - LIST request handling', () => {
         });
     });
 
+    it('should emit LastModified in ISO 8601 format in XML body', done => {
+        const request = createRequest();
+        const response = createResponse();
+
+        const xmlChunks = [];
+        response.write.callsFake(chunk => {
+            xmlChunks.push(Buffer.isBuffer(chunk) ? chunk.toString() : String(chunk));
+            return true;
+        });
+
+        listVeeamFiles(request, response, bucketMd, log);
+
+        giveAsyncCallbackTimeToExecute(() => {
+            assert(response.writeHead.calledWith(200), 'should return 200');
+
+            const body = xmlChunks.join('');
+            assert(body.length > 0, 'response body should not be empty');
+
+            const lastModifiedRegex = /<LastModified>([^<]+)<\/LastModified>/g;
+            const matches = [];
+            let match;
+            while ((match = lastModifiedRegex.exec(body)) !== null) {
+                matches.push(match[1]);
+            }
+
+            assert.strictEqual(matches.length, 3,
+                'should have 3 LastModified entries (system.xml, capacity.xml, folder)');
+
+            const iso8601Regex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+            matches.forEach(value => {
+                assert(iso8601Regex.test(value),
+                    `LastModified "${value}" should be in ISO 8601 format`);
+            });
+
+            done();
+        });
+    });
+
     it('should handle versions query parameter', done => {
         const request = createRequest({ versions: '' });
         const response = createResponse();


### PR DESCRIPTION
Issue [CLDSRV-857](https://scality.atlassian.net/browse/CLDSRV-857)

When browsing objects created by Veeam SOSAPI, the UI shows "An error occurred while loading data" even though the API returns a 200 response with valid XML.

Root cause: The LastModified field in the response uses RFC 2822 format (Mon, 23 Feb 2026 08:24:20 GMT) instead of ISO 8601 (2026-02-23T08:24:20.000Z). AWS SDK v3 strictly expects RFC 3339/ISO 8601 and throws TypeError: Invalid RFC3339 timestamp format during deserialization, causing the entire response to fail.


[CLDSRV-857]: https://scality.atlassian.net/browse/CLDSRV-857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ