### PR TITLE
CLDSRV-859: trigger scality-kms release workflow on cloudserver release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,3 +88,25 @@ jobs:
           tag_name: ${{ github.event.inputs.tag }}
           generate_release_notes: true
           target_commitish: ${{ github.sha }}
+
+  trigger-kms-release:
+    runs-on: ubuntu-latest
+    needs: release
+    if: github.repository_owner == 'scality'
+    steps:
+      - name: Generate GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.ACTIONS_APP_ID }}
+          private-key: ${{ secrets.ACTIONS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Trigger scality-kms release workflow
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh workflow run release.yaml \
+            --repo scality/scality-kms \
+            --ref main \
+            --field tag=${{ github.event.inputs.tag }}


### PR DESCRIPTION
## Summary
- Add a new job to the release workflow that automatically triggers the scality-kms release workflow after a successful cloudserver release
- Use GitHub App authentication to trigger the cross-repository workflow
- Add repository owner check to prevent forks from attempting to trigger the workflow

This ensures the KMS server image is built with the latest cloudserver base image whenever a new cloudserver release is published.

Related to scality/scality-kms#79