### PR TITLE
CLDSRV-864: add an error listener to TrailingChecksumTransform

### DIFF
--- a/lib/api/apiUtils/object/prepareStream.js
+++ b/lib/api/apiUtils/object/prepareStream.js
@@ -31,13 +31,14 @@ function prepareStream(stream, streamingV4Params, log, errCb) {
     return stream;
 }
 
-function stripTrailingChecksumStream(stream, log) {
+function stripTrailingChecksumStream(stream, log, errCb) {
     // don't do anything if we are not in the correct integrity check mode
     if (stream.headers['x-amz-content-sha256'] !== 'STREAMING-UNSIGNED-PAYLOAD-TRAILER') {
         return stream;
     }
 
     const trailingChecksumTransform = new TrailingChecksumTransform(log);
+    trailingChecksumTransform.on('error', errCb);
     stream.pipe(trailingChecksumTransform);
     trailingChecksumTransform.headers = stream.headers;
     return trailingChecksumTransform;

--- a/tests/unit/auth/TrailingChecksumTransform.js
+++ b/tests/unit/auth/TrailingChecksumTransform.js
@@ -4,6 +4,7 @@ const async = require('async');
 const { Readable } = require('stream');
 
 const TrailingChecksumTransform = require('../../../lib/auth/streamingV4/trailingChecksumTransform');
+const { stripTrailingChecksumStream } = require('../../../lib/api/apiUtils/object/prepareStream');
 const { DummyRequestLogger } = require('../helpers');
 
 const log = new DummyRequestLogger();
@@ -168,6 +169,28 @@ describe('TrailingChecksumTransform class', () => {
             done();
         });
         chunkedReader.pipe(trailingChecksumTransform);
+    });
+
+    it('should propagate _flush error via errCb when stream closes without chunked encoding', done => {
+        const incompleteData = '10\r\n01234\r6789abcd\r\n\r\n';
+        const source = new ChunkedReader([Buffer.from(incompleteData)]);
+        source.headers = { 'x-amz-content-sha256': 'STREAMING-UNSIGNED-PAYLOAD-TRAILER' };
+        const stream = stripTrailingChecksumStream(source, log, err => {
+            assert.deepStrictEqual(err, errors.InvalidArgument);
+            done();
+        });
+        stream.resume();
+    });
+
+    it('should propagate _transform error via errCb for invalid chunk size', done => {
+        const badData = '500000000000\r\n';
+        const source = new ChunkedReader([Buffer.from(badData)]);
+        source.headers = { 'x-amz-content-sha256': 'STREAMING-UNSIGNED-PAYLOAD-TRAILER' };
+        const stream = stripTrailingChecksumStream(source, log, err => {
+            assert.deepStrictEqual(err, errors.InvalidArgument);
+            done();
+        });
+        stream.resume();
     });
 
     it('should return early if supplied with an out of specification chunk size', done => {


### PR DESCRIPTION
Cloudserver crashes if TrailingChecksumTransform encounters an error because an exception is thrown. The fix is to add a error listener to the TrailingChecksumTransform.
 
Crash trace:
```
{"name":"S3","clientIP":"::1","clientPort":44180,"httpMethod":"PUT","httpURL":"/leif-us-east-1/raw_request.txt","bucketName":"leif-us-east-1","objectKey":"raw_request.txt","bodyLength":0,"bytesReceived":15,"service":"s3","action":"PutObject","accountDisplayName":"Bart","accountName":"Bart","time":1772711134918,"req_id":"d7b458e3494dbb61f876","level":"error","message":"stream ended without closing chunked encoding","hostname":"xps","pid":13612}
2026-03-05T11:45:34.919Z: uncaughtException:
Error: InvalidArgument
    at Object.get (/app/node_modules/arsenal/build/lib/errors/index.js:188:31)
    at TrailingChecksumTransform._flush (/app/lib/auth/streamingV4/trailingChecksumTransform.js:35:36)
    at TrailingChecksumTransform.final [as _final] (node:internal/streams/transform:128:10)
    at prefinish (node:internal/streams/writable:916:14)
    at finishMaybe (node:internal/streams/writable:930:5)
    at Writable.end (node:internal/streams/writable:845:5)
    at IncomingMessage.onend (node:internal/streams/readable:948:10)
    at Object.onceWrapper (node:events:632:28)
    at IncomingMessage.emit (node:events:518:28)
    at IncomingMessage.emit (node:domain:489:12)
{"name":"S3","time":1772711134919,"error":"InvalidArgument","stack":"Error: InvalidArgument\n    at Object.get (/app/node_modules/arsenal/build/lib/errors/index.js:188:31)\n    at TrailingChecksumTransform._flush (/app/lib/auth/streamingV4/trailingChecksumTransform.js:35:36)\n    at TrailingChecksumTransform.final [as _final] (node:internal/streams/transform:128:10)\n    at prefinish (node:internal/streams/writable:916:14)\n    at finishMaybe (node:internal/streams/writable:930:5)\n    at Writable.end (node:internal/streams/writable:845:5)\n    at IncomingMessage.onend (node:internal/streams/readable:948:10)\n    at Object.onceWrapper (node:events:632:28)\n    at IncomingMessage.emit (node:events:518:28)\n    at IncomingMessage.emit (node:domain:489:12)","level":"fatal","message":"caught error","hostname":"xps","pid":13612}
```