### PR TITLE
CLDSRV-865: Use correct input name for scality-kms release dispatch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,4 +109,4 @@ jobs:
           gh workflow run release.yaml \
             --repo scality/scality-kms \
             --ref main \
-            --field tag=${{ github.event.inputs.tag }}
+            --field cloudserver-version=${{ github.event.inputs.tag }}


### PR DESCRIPTION
The scality-kms release.yaml expects `cloudserver-version` but cloudserver was passing `tag`, causing HTTP 422 on release: https://github.com/scality/cloudserver/actions/runs/22727002512

See https://github.com/scality/scality-kms/blob/f7603506041e6afcbcae118d63fb0ee69483eba3/.github/workflows/release.yaml#L12