### PR TITLE
CLDSRV-835: Fix flaky kmip cluster test

### DIFF
--- a/tests/functional/sse-kms-migration/countPacketsByIp.sh
+++ b/tests/functional/sse-kms-migration/countPacketsByIp.sh
@@ -14,8 +14,10 @@ PACKETS_COUNT=${2:-1000}
 # -n: don't resolve hostnames
 # -t: don't print a timestamp
 # -q: quiet mode, less verbose output
-# -c $PACKETS_COUNT: capture $PACKETS_COUNT packets
-# 'tcp dst port $PORT': filter for TCP packets destined for port $PORT
+# -c $PACKETS_COUNT: capture exactly $PACKETS_COUNT packets then exit naturally,
+#   allowing the pipeline (awk | sort | uniq-c) to drain and output results.
+# 'tcp dst port $PORT and (tcp[tcpflags] & tcp-push != 0)': PSH-only filter
+#   so pure ACKs are excluded, keeping counts 1:1 with KMIP requests.
 
 # Output of tcpdump will look like this:
 # IP 127.0.0.1.33428 > 127.0.0.3.5696: tcp 341
@@ -29,7 +31,7 @@ PACKETS_COUNT=${2:-1000}
 # 323 127.0.0.2
 # 345 127.0.0.3
 
-tcpdump -i lo -n -t -q -c $PACKETS_COUNT "tcp dst port ${PORT}" | \
+tcpdump -i lo -n -t -q -c $PACKETS_COUNT "tcp dst port ${PORT} and (tcp[tcpflags] & tcp-push != 0)" | \
   awk '{print $4}' | \
   sed 's/\.[^.]*$//' | \
   sort | \

--- a/tests/functional/sse-kms-migration/load.js
+++ b/tests/functional/sse-kms-migration/load.js
@@ -124,9 +124,9 @@ describe(`KMS load (kmip cluster ${KMS_NODES} nodes): ${OBJECT_NUMBER
     });
 
     beforeEach(async () => {
-        // tcpdump can catch more than TOTAL_OBJECTS packets because there are PSH and ACK packets
-        // but we need to ensure it actually stops before there is no more packets
-        // to count packets by IP
+        // tcpdump captures exactly TOTAL_OBJECTS PSH packets then exits naturally,
+        // allowing the pipeline to drain and output results.
+        // Consider sending a little more request in case a packet is missed.
         tcpdumpProcess = await spawnTcpdump(5696, TOTAL_OBJECTS);
         stdout = '';
         stderr = '';
@@ -185,7 +185,8 @@ describe(`KMS load (kmip cluster ${KMS_NODES} nodes): ${OBJECT_NUMBER
     it(`should encrypt ${TOTAL_OBJECTS} times in parallel, ~${TOTAL_OBJECTS_PER_NODE} per node`, async () => {
         await (Promise.all(
             buckets.map(async ({ Bucket }) => Promise.all(
-                new Array(OBJECT_NUMBER).fill(0).map(async (_, i) =>
+                // Send little more request in case a packet is missed.
+                new Array(OBJECT_NUMBER + 1).fill(0).map(async (_, i) =>
                     helpers.s3.putObject({ Bucket, Key: `obj-${i}`, Body: `body-${i}` }).promise())
             ))
         ));
@@ -195,7 +196,8 @@ describe(`KMS load (kmip cluster ${KMS_NODES} nodes): ${OBJECT_NUMBER
     it(`should decrypt ${TOTAL_OBJECTS} times in parallel, ~${TOTAL_OBJECTS_PER_NODE} per node`, async () => {
         await Promise.all(
             buckets.map(async ({ Bucket }) => Promise.all(
-                new Array(OBJECT_NUMBER).fill(0).map(async (_, i) =>
+                // Send little more request in case a packet is missed.
+                new Array(OBJECT_NUMBER + 1).fill(0).map(async (_, i) =>
                     helpers.s3.getObject({ Bucket, Key: `obj-${i}` }).promise())
             ))
         );


### PR DESCRIPTION
Filter out ACK to count only PSH packets.
Otherwise distribution is messed by counting empty ACK packets.

Now repartition should be closer to expected.

___

Flakiness appear in branch `development/9.3` but I fix in lowest branch possible where test was introduced to avoid future backport.

___
Expected: ~500
Before:
```js
  repartition: [
    { count: 513, ip: '127.0.0.1' },
    { count: 467, ip: '127.0.0.2' },
    { count: 506, ip: '127.0.0.3' },
    { count: 514, ip: '127.0.0.4' }
  ]
```
Now:
```js
  repartition: [
    { count: 502, ip: '127.0.0.1' },
    { count: 498, ip: '127.0.0.2' },
    { count: 500, ip: '127.0.0.3' },
    { count: 500, ip: '127.0.0.4' }
  ]
```