### PR TITLE
CLDSRV-853: Account rate limit config

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1870,8 +1870,7 @@ class Config extends EventEmitter {
         if (config.rateLimiting?.enabled) {
             // rate limiting uses the same localCache config defined for S3 to avoid
             // config duplication.
-            assert(this.localCache, 'missing required property of rateLimit ' +
-                'configuration: localCache');
+            assert(this.localCache, 'localCache must be defined when rate limiting is enabled');
 
             // Parse and validate all rate limiting configuration
             this.rateLimiting = parseRateLimitConfig(config.rateLimiting, this.clusters = this.clusters || 1);

--- a/lib/api/apiUtils/rateLimit/config.js
+++ b/lib/api/apiUtils/rateLimit/config.js
@@ -25,7 +25,7 @@ const { calculateInterval } = require('./gcra');
  *     // Optional: Bucket-level rate limiting configuration
  *     "bucket": {
  *       // Optional: Global default rate limit for all buckets
- *       // Can be overridden per-bucket via PutBucketRateLimit API
+ *       // Limit can be overridden per-bucket via PutBucketRateLimit API
  *       "defaultConfig": {
  *         "requestsPerSecond": {
  *           // Required: Requests per second limit (0 = unlimited)
@@ -44,6 +44,32 @@ const { calculateInterval } = require('./gcra');
  *       "configCacheTTL": 30000,
  *
  *       // Optional: Default burst capacity for per-bucket configs
+ *       // Default: 1
+ *       "defaultBurstCapacity": 1
+ *     },
+ *
+ *     // Optional: Account-level rate limiting configuration
+ *     "account": {
+ *       // Optional: Global default rate limit for all accounts
+ *       // Limit can be overridden per-account via UpdateAccountLimits API
+ *       "defaultConfig": {
+ *         "requestsPerSecond": {
+ *           // Required: Requests per second limit (0 = unlimited)
+ *           "limit": 100,
+ *
+ *           // Optional: Burst capacity (allows temporary spikes)
+ *           // Default: 1 (no burst allowed)
+ *           // Higher values allow more requests in quick succession
+ *           "burstCapacity": 2
+ *         }
+ *       },
+ *
+ *       // Optional: How long to cache rate limit configs (milliseconds)
+ *       // Default: 30000 (30 seconds)
+ *       // Higher values = better performance, slower config updates
+ *       "configCacheTTL": 30000,
+ *
+ *       // Optional: Default burst capacity for per-account configs
  *       // Default: 1
  *       "defaultBurstCapacity": 1
  *     },
@@ -155,6 +181,7 @@ const rateLimitConfigSchema = Joi.object({
     tokenBucketBufferSize: Joi.number().integer().positive().default(50),
     tokenBucketRefillThreshold: Joi.number().integer().positive().default(20),
     bucket: rateLimitClassConfigSchema,
+    account: rateLimitClassConfigSchema,
     error: Joi.object({
         statusCode: Joi.number().integer().min(400).max(599).default(503),
         code: Joi.string().default(errors.SlowDown.message),
@@ -256,6 +283,7 @@ function parseRateLimitConfig(rateLimitingConfig, clusters) {
     };
 
     parsed.bucket = transformClassConfig('bucket', validated.bucket, clusters, parsed.nodes);
+    parsed.account = transformClassConfig('account', validated.account, clusters, parsed.nodes);
 
     return parsed;
 }

--- a/lib/api/apiUtils/rateLimit/config.js
+++ b/lib/api/apiUtils/rateLimit/config.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const Joi = require('@hapi/joi');
 const { errors, ArsenalError } = require('arsenal');
 
 const { rateLimitDefaultConfigCacheTTL, rateLimitDefaultBurstCapacity } = require('../../../../constants');
@@ -126,6 +126,98 @@ const { calculateInterval } = require('./gcra');
  */
 
 /**
+ * RateLimitClassConfig
+ * @typedef {Object} RateLimitClassConfig
+ * @property {object} defaultConfig - Default config applied if no resource specific configuration is found.
+ * @property {number} configCacheTTL - Number of milliseconds to cache per resource configs
+ * @property {number} defaultBurstCapacity - Default used if resource does not specify a burst capacity.
+*/
+
+const rateLimitClassConfigSchema = Joi.object({
+    defaultConfig: Joi.object({
+        requestsPerSecond: Joi.object({
+            limit: Joi.number().integer().min(0).required(),
+            burstCapacity: Joi.number().positive(),
+        }),
+    }),
+    configCacheTTL: Joi.number().integer().positive().default(rateLimitDefaultConfigCacheTTL),
+    defaultBurstCapacity: Joi.number().positive().default(rateLimitDefaultBurstCapacity),
+}).default({
+    defaultConfig: undefined,
+    configCacheTTL: rateLimitDefaultConfigCacheTTL,
+    defaultBurstCapacity: rateLimitDefaultBurstCapacity,
+});
+
+const rateLimitConfigSchema = Joi.object({
+    enabled: Joi.boolean().default(false),
+    serviceUserArn: Joi.string().required(),
+    nodes: Joi.number().integer().positive().default(1),
+    tokenBucketBufferSize: Joi.number().integer().positive().default(50),
+    tokenBucketRefillThreshold: Joi.number().integer().positive().default(20),
+    bucket: rateLimitClassConfigSchema,
+    error: Joi.object({
+        statusCode: Joi.number().integer().min(400).max(599).default(503),
+        code: Joi.string().default(errors.SlowDown.message),
+        message: Joi.string().default(errors.SlowDown.description),
+    }).default({
+        statusCode: 503,
+        code: errors.SlowDown.message,
+        message: errors.SlowDown.description,
+    }),
+});
+
+/**
+ * Transform validated class config (bucket or account) by calculating intervals
+ * and applying business logic
+ *
+ * @param {string} resourceClass - Rate limit class name ('bucket' or 'account')
+ * @param {object} validatedCfg - Already validated config from Joi
+ * @param {number} clusters - Number of worker processes spawned per instance
+ * @param {number} nodes - Number of instances that requests will be load balanced across
+ * @returns {RateLimitClassConfig} Transformed rate limit config
+ */
+function transformClassConfig(resourceClass, validatedCfg, clusters, nodes) {
+    const transformed = {
+        defaultConfig: undefined,
+        configCacheTTL: validatedCfg.configCacheTTL,
+        defaultBurstCapacity: validatedCfg.defaultBurstCapacity,
+    };
+
+    if (validatedCfg.defaultConfig?.requestsPerSecond) {
+        const { limit, burstCapacity } = validatedCfg.defaultConfig.requestsPerSecond;
+
+        // Validate limit against nodes AND workers (business rule)
+        const minLimit = nodes * clusters;
+        if (limit > 0 && limit < minLimit) {
+            throw new Error(
+                `rateLimiting.${resourceClass}.defaultConfig.` +
+                `requestsPerSecond.limit (${limit}) must be >= ` +
+                `(nodes x workers = ${nodes} x ${clusters} = ${minLimit}) ` +
+                'or 0 (unlimited). Each worker enforces limit/nodes/workers locally. ' +
+                `With limit < ${minLimit}, per-worker rate would be < 1 req/s, effectively blocking traffic.`
+            );
+        }
+
+        // Use provided burstCapacity or fall back to default
+        const effectiveBurstCapacity = burstCapacity || transformed.defaultBurstCapacity;
+
+        // Calculate per-worker interval using distributed architecture
+        const interval = calculateInterval(limit, nodes, clusters);
+
+        // Store both the original limit and the calculated values
+        transformed.defaultConfig = {
+            limit,
+            requestsPerSecond: {
+                interval,
+                bucketSize: effectiveBurstCapacity * 1000,
+            },
+        };
+    }
+
+    return transformed;
+}
+
+/**
  * Parse and validate the complete rate limiting configuration
  *
  * @param {Object} rateLimitingConfig - config.rateLimiting object from config.json
@@ -134,196 +226,36 @@ const { calculateInterval } = require('./gcra');
  * @throws {Error} If configuration is invalid
  */
 function parseRateLimitConfig(rateLimitingConfig, clusters) {
-    const parsed = {
-        enabled: true,
-    };
-
-    // Validate and set serviceUserArn
-    assert.strictEqual(
-        typeof rateLimitingConfig.serviceUserArn, 'string',
-        'rateLimiting.serviceUserArn must be a string'
+    // Validate configuration using Joi schema
+    const { error: validationError, value: validated } = rateLimitConfigSchema.validate(
+        rateLimitingConfig,
+        {
+            abortEarly: false,   // Return all validation errors at once
+            allowUnknown: false, // Don't allow key not present in schema
+            convert: false,      // Don't do type coercion (e.g. "1" -> 1)
+        }
     );
-    parsed.serviceUserArn = rateLimitingConfig.serviceUserArn;
 
-    // Parse and validate node count
-    if (rateLimitingConfig.nodes !== undefined) {
-        assert(
-            typeof rateLimitingConfig.nodes === 'number' &&
-            Number.isInteger(rateLimitingConfig.nodes) &&
-            rateLimitingConfig.nodes > 0,
-            'rateLimiting.nodes must be a positive integer'
-        );
-        parsed.nodes = rateLimitingConfig.nodes;
-    } else {
-        parsed.nodes = 1; // Default to 1 node
+    if (validationError) {
+        const details = validationError.details.map(d => d.message).join('; ');
+        throw new Error(`rateLimiting configuration is invalid: ${details}`);
     }
 
-    if (rateLimitingConfig.tokenBucketBufferSize !== undefined) {
-        assert(
-            typeof rateLimitingConfig.tokenBucketBufferSize === 'number' &&
-            Number.isInteger(rateLimitingConfig.tokenBucketBufferSize) &&
-            rateLimitingConfig.tokenBucketBufferSize > 0,
-            'rateLimiting.tokenBucketBufferSize must be a positive integer'
-        );
-        parsed.tokenBucketBufferSize = rateLimitingConfig.tokenBucketBufferSize;
-    } else {
-        parsed.tokenBucketBufferSize = 50; // (5 seconds @ 10 req/s)
-    }
-
-    if (rateLimitingConfig.tokenBucketRefillThreshold !== undefined) {
-        assert(
-            typeof rateLimitingConfig.tokenBucketRefillThreshold === 'number' &&
-            Number.isInteger(rateLimitingConfig.tokenBucketRefillThreshold) &&
-            rateLimitingConfig.tokenBucketRefillThreshold > 0,
-            'rateLimiting.tokenBucketRefillThreshold must be a positive integer'
-        );
-        parsed.tokenBucketRefillThreshold = rateLimitingConfig.tokenBucketRefillThreshold;
-    } else {
-        parsed.tokenBucketRefillThreshold = 20;
-    }
-
-    // Parse bucket configuration
-    // Always initialize bucket config to support per-bucket rate limits set via API
-    // This ensures caching and default values work even when no global default is configured
-    parsed.bucket = {
-        defaultConfig: undefined,  // No global default unless specified
-        configCacheTTL: rateLimitDefaultConfigCacheTTL,  // Default cache TTL
-        defaultBurstCapacity: rateLimitDefaultBurstCapacity,  // Default burst capacity for per-bucket configs
+    // Initialize parsed config with validated values (including defaults)
+    const parsed = {
+        enabled: validated.enabled,
+        serviceUserArn: validated.serviceUserArn,
+        nodes: validated.nodes,
+        tokenBucketBufferSize: validated.tokenBucketBufferSize,
+        tokenBucketRefillThreshold: validated.tokenBucketRefillThreshold,
+        error: new ArsenalError(
+            validated.error.code,
+            validated.error.statusCode,
+            validated.error.message,
+        ),
     };
 
-    // Override with user-provided bucket configuration
-    if (rateLimitingConfig.bucket) {
-        assert.strictEqual(
-            typeof rateLimitingConfig.bucket, 'object',
-            'rateLimiting.bucket must be an object'
-        );
-
-        // Parse default config for buckets (global default applied to all buckets)
-        // If defaultConfig is specified: Parse and validate the bucket rate limit settings
-        if (rateLimitingConfig.bucket.defaultConfig) {
-            const bucketConfig = rateLimitingConfig.bucket.defaultConfig;
-
-            // Validate config structure
-            assert.strictEqual(
-                typeof bucketConfig, 'object',
-                'rate limit config must be an object'
-            );
-
-            const limitConfig = {};
-
-            if (bucketConfig.requestsPerSecond) {
-                assert.strictEqual(
-                    typeof bucketConfig.requestsPerSecond, 'object',
-                    'requestsPerSecond must be an object'
-                );
-
-                const { limit } = bucketConfig.requestsPerSecond;
-
-                // Validate limit
-                assert(
-                    typeof limit === 'number' && Number.isInteger(limit) && limit >= 0,
-                    'requestsPerSecond.limit must be a non-negative integer'
-                );
-
-                // Validate limit against nodes AND workers
-                const minLimit = parsed.nodes * clusters;
-                if (limit > 0 && limit < minLimit) {
-                    throw new Error(
-                        `requestsPerSecond.limit (${limit}) must be >= ` +
-                        `(nodes × workers = ${parsed.nodes} × ${clusters} = ${minLimit}) ` +
-                        'or 0 (unlimited). Each worker enforces limit/nodes/workers locally. ' +
-                        `With limit < ${minLimit}, per-worker rate would be < 1 req/s, effectively blocking traffic.`
-                    );
-                }
-
-                // Default to global default burst capacity
-                let burstCapacity = parsed.bucket.defaultBurstCapacity;
-
-                // Override if provided in config
-                if (bucketConfig.requestsPerSecond.burstCapacity !== undefined) {
-                    burstCapacity = bucketConfig.requestsPerSecond.burstCapacity;
-                    assert(
-                        typeof burstCapacity === 'number' && Number.isInteger(burstCapacity) && burstCapacity > 0,
-                        'requestsPerSecond.burstCapacity must be a positive integer'
-                    );
-                }
-
-                // Calculate per-worker interval using distributed architecture
-                const interval = calculateInterval(limit, parsed.nodes, clusters);
-
-                // Store both the original limit and the calculated values
-                limitConfig.limit = limit;
-                limitConfig.requestsPerSecond = {
-                    interval,
-                    bucketSize: burstCapacity * 1000,
-                };
-            }
-
-            parsed.bucket.defaultConfig = limitConfig;
-        }
-
-        // Parse config cache TTL
-        // If configCacheTTL is specified: Override the default cache TTL
-        if (rateLimitingConfig.bucket.configCacheTTL !== undefined) {
-            const configCacheTTL = rateLimitingConfig.bucket.configCacheTTL;
-            assert(
-                typeof configCacheTTL === 'number' &&
-                Number.isInteger(configCacheTTL) &&
-                configCacheTTL > 0,
-                'rateLimiting.bucket.configCacheTTL must be a positive integer'
-            );
-            parsed.bucket.configCacheTTL = configCacheTTL;
-        }
-    }
-
-    // Parse error configuration (supports any HTTP 4xx/5xx status code)
-    // Default to SlowDown error
-    parsed.error = errors.SlowDown;
-
-    // Override with custom error if specified
-    if (rateLimitingConfig.error !== undefined) {
-        // Validate error is an object
-        assert.strictEqual(
-            typeof rateLimitingConfig.error, 'object',
-            'rateLimiting.error must be an object'
-        );
-
-        // If statusCode is specified, validate and create custom error
-        if (rateLimitingConfig.error.statusCode !== undefined) {
-            assert(
-                typeof rateLimitingConfig.error.statusCode === 'number' &&
-                Number.isInteger(rateLimitingConfig.error.statusCode) &&
-                rateLimitingConfig.error.statusCode >= 400 &&
-                rateLimitingConfig.error.statusCode < 600,
-                'rateLimiting.error.statusCode must be a valid HTTP status code (400-599)'
-            );
-
-            // Validate error code if provided
-            const errorCode = rateLimitingConfig.error.code || 'SlowDown';
-            if (rateLimitingConfig.error.code !== undefined) {
-                assert.strictEqual(
-                    typeof rateLimitingConfig.error.code, 'string',
-                    'rateLimiting.error.code must be a string'
-                );
-            }
-
-            // Validate error message if provided
-            const errorMessage = rateLimitingConfig.error.message || errors.SlowDown.description;
-            if (rateLimitingConfig.error.message !== undefined) {
-                assert.strictEqual(
-                    typeof rateLimitingConfig.error.message, 'string',
-                    'rateLimiting.error.message must be a string'
-                );
-            }
-
-            // Override default with custom Arsenal error
-            parsed.error = new ArsenalError(
-                errorCode,
-                rateLimitingConfig.error.statusCode,
-                errorMessage
-            );
-        }
-    }
+    parsed.bucket = transformClassConfig('bucket', validated.bucket, clusters, parsed.nodes);
 
     return parsed;
 }

--- a/tests/unit/api/apiUtils/rateLimit/config.js
+++ b/tests/unit/api/apiUtils/rateLimit/config.js
@@ -510,6 +510,24 @@ describe('parseRateLimitConfig', () => {
                 /requestsPerSecond.burstCapacity must be a positive integer/
             );
         });
+
+        it('should accept float burstCapacity', () => {
+            const config = {
+                serviceUserArn: 'arn:aws:iam::123456789012:user/rate-limit-service',
+                bucket: {
+                    defaultConfig: {
+                        requestsPerSecond: {
+                            limit: 100,
+                            burstCapacity: 1.5,
+                        },
+                    },
+                },
+            };
+
+            const result = parseRateLimitConfig(config, 1);
+            const bucketSize = result.bucket.defaultConfig.requestsPerSecond.bucketSize;
+            assert.strictEqual(bucketSize, 1.5 * 1000);
+        });
     });
 
     describe('bucket.configCacheTTL validation', () => {

--- a/tests/unit/api/apiUtils/rateLimit/config.js
+++ b/tests/unit/api/apiUtils/rateLimit/config.js
@@ -28,7 +28,7 @@ describe('parseRateLimitConfig', () => {
         it('should parse complete valid configuration', () => {
             const result = parseRateLimitConfig(validConfig, 10);
 
-            assert.strictEqual(result.enabled, true);
+            assert.strictEqual(result.enabled, false); // Default when not specified
             assert.strictEqual(result.serviceUserArn, validConfig.serviceUserArn);
             assert.strictEqual(result.nodes, 2);
             assert.strictEqual(result.bucket.configCacheTTL, 300);
@@ -46,9 +46,11 @@ describe('parseRateLimitConfig', () => {
 
             const result = parseRateLimitConfig(minimalConfig, 5);
 
-            assert.strictEqual(result.enabled, true);
+            assert.strictEqual(result.enabled, false); // Default
             assert.strictEqual(result.serviceUserArn, minimalConfig.serviceUserArn);
             assert.strictEqual(result.nodes, 1); // Default
+            assert.strictEqual(result.tokenBucketBufferSize, 50); // Default
+            assert.strictEqual(result.tokenBucketRefillThreshold, 20); // Default
             // Bucket config is always initialized for per-bucket rate limiting via API
             assert(result.bucket);
             assert.strictEqual(result.bucket.defaultConfig, undefined); // No global default
@@ -96,13 +98,56 @@ describe('parseRateLimitConfig', () => {
         });
     });
 
+    describe('enabled field validation', () => {
+        it('should default enabled to false when not specified', () => {
+            const config = {
+                serviceUserArn: 'arn:aws:iam::123456789012:user/rate-limit-service',
+            };
+
+            const result = parseRateLimitConfig(config, 1);
+            assert.strictEqual(result.enabled, false);
+        });
+
+        it('should accept enabled: true', () => {
+            const config = {
+                enabled: true,
+                serviceUserArn: 'arn:aws:iam::123456789012:user/rate-limit-service',
+            };
+
+            const result = parseRateLimitConfig(config, 1);
+            assert.strictEqual(result.enabled, true);
+        });
+
+        it('should accept enabled: false', () => {
+            const config = {
+                enabled: false,
+                serviceUserArn: 'arn:aws:iam::123456789012:user/rate-limit-service',
+            };
+
+            const result = parseRateLimitConfig(config, 1);
+            assert.strictEqual(result.enabled, false);
+        });
+
+        it('should throw if enabled is not a boolean', () => {
+            const config = {
+                enabled: 'yes',
+                serviceUserArn: 'arn:aws:iam::123456789012:user/rate-limit-service',
+            };
+
+            assert.throws(
+                () => parseRateLimitConfig(config, 1),
+                /rateLimiting configuration is invalid/
+            );
+        });
+    });
+
     describe('serviceUserArn validation', () => {
         it('should throw if serviceUserArn is missing', () => {
             const config = { nodes: 1 };
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.serviceUserArn must be a string/
+                /rateLimiting configuration is invalid.*"serviceUserArn" is required/
             );
         });
 
@@ -113,7 +158,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.serviceUserArn must be a string/
+                /rateLimiting configuration is invalid.*"serviceUserArn" must be a string/
             );
         });
     });
@@ -146,7 +191,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.nodes must be a positive integer/
+                /rateLimiting configuration is invalid.*"nodes" must be a positive number/
             );
         });
 
@@ -158,7 +203,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.nodes must be a positive integer/
+                /rateLimiting configuration is invalid.*"nodes" must be a positive number/
             );
         });
 
@@ -170,7 +215,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.nodes must be a positive integer/
+                /rateLimiting configuration is invalid.*"nodes" must be an integer/
             );
         });
 
@@ -182,7 +227,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.nodes must be a positive integer/
+                /rateLimiting configuration is invalid.*"nodes" must be a number/
             );
         });
     });
@@ -215,7 +260,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.tokenBucketBufferSize must be a positive integer/
+                /rateLimiting configuration is invalid.*"tokenBucketBufferSize" must be a positive number/
             );
         });
 
@@ -227,7 +272,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.tokenBucketBufferSize must be a positive integer/
+                /rateLimiting configuration is invalid.*"tokenBucketBufferSize" must be a positive number/
             );
         });
 
@@ -239,7 +284,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.tokenBucketBufferSize must be a positive integer/
+                /rateLimiting configuration is invalid.*"tokenBucketBufferSize" must be an integer/
             );
         });
     });
@@ -272,7 +317,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.tokenBucketRefillThreshold must be a positive integer/
+                /rateLimiting configuration is invalid.*"tokenBucketRefillThreshold" must be a positive number/
             );
         });
 
@@ -284,7 +329,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.tokenBucketRefillThreshold must be a positive integer/
+                /rateLimiting configuration is invalid.*"tokenBucketRefillThreshold" must be a positive number/
             );
         });
 
@@ -296,7 +341,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.tokenBucketRefillThreshold must be a positive integer/
+                /rateLimiting configuration is invalid.*"tokenBucketRefillThreshold" must be an integer/
             );
         });
     });
@@ -310,7 +355,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.bucket must be an object/
+                /rateLimiting configuration is invalid.*"bucket" must be of type object/
             );
         });
 
@@ -342,7 +387,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rate limit config must be an object/
+                /rateLimiting configuration is invalid.*"bucket.defaultConfig" must be of type object/
             );
         });
 
@@ -358,7 +403,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /requestsPerSecond must be an object/
+                /rateLimiting configuration is invalid.*"bucket.defaultConfig.requestsPerSecond" must be of type object/
             );
         });
 
@@ -393,7 +438,26 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /requestsPerSecond.limit must be a non-negative integer/
+                // eslint-disable-next-line max-len
+                /rateLimiting configuration is invalid.*"bucket.defaultConfig.requestsPerSecond.limit" must be larger than or equal to 0/
+            );
+        });
+
+        it('should throw if limit is missing when requestsPerSecond is provided', () => {
+            const config = {
+                serviceUserArn: 'arn:aws:iam::123456789012:user/rate-limit-service',
+                bucket: {
+                    defaultConfig: {
+                        requestsPerSecond: {
+                            burstCapacity: 10,
+                        },
+                    },
+                },
+            };
+
+            assert.throws(
+                () => parseRateLimitConfig(config, 1),
+                /rateLimiting configuration is invalid.*"bucket.defaultConfig.requestsPerSecond.limit" is required/
             );
         });
     });
@@ -450,7 +514,8 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /requestsPerSecond.burstCapacity must be a positive integer/
+                // eslint-disable-next-line max-len
+                /rateLimiting configuration is invalid.*"bucket.defaultConfig.requestsPerSecond.burstCapacity" must be a positive number/
             );
         });
 
@@ -469,26 +534,8 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /requestsPerSecond.burstCapacity must be a positive integer/
-            );
-        });
-
-        it('should throw if burstCapacity is not an integer', () => {
-            const config = {
-                serviceUserArn: 'arn:aws:iam::123456789012:user/rate-limit-service',
-                bucket: {
-                    defaultConfig: {
-                        requestsPerSecond: {
-                            limit: 100,
-                            burstCapacity: 5.5,
-                        },
-                    },
-                },
-            };
-
-            assert.throws(
-                () => parseRateLimitConfig(config, 1),
-                /requestsPerSecond.burstCapacity must be a positive integer/
+                // eslint-disable-next-line max-len
+                /rateLimiting configuration is invalid.*"bucket.defaultConfig.requestsPerSecond.burstCapacity" must be a positive number/
             );
         });
 
@@ -507,7 +554,8 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /requestsPerSecond.burstCapacity must be a positive integer/
+                // eslint-disable-next-line max-len
+                /rateLimiting configuration is invalid.*"bucket.defaultConfig.requestsPerSecond.burstCapacity" must be a number/
             );
         });
 
@@ -553,7 +601,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.bucket.configCacheTTL must be a positive integer/
+                /rateLimiting configuration is invalid.*"bucket.configCacheTTL" must be a positive number/
             );
         });
 
@@ -567,7 +615,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.bucket.configCacheTTL must be a positive integer/
+                /rateLimiting configuration is invalid.*"bucket.configCacheTTL" must be a positive number/
             );
         });
 
@@ -581,7 +629,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.bucket.configCacheTTL must be a positive integer/
+                /rateLimiting configuration is invalid.*"bucket.configCacheTTL" must be an integer/
             );
         });
 
@@ -595,7 +643,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.bucket.configCacheTTL must be a positive integer/
+                /rateLimiting configuration is invalid.*"bucket.configCacheTTL" must be a number/
             );
         });
     });
@@ -609,7 +657,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.error must be an object/
+                /rateLimiting configuration is invalid.*"error" must be of type object/
             );
         });
 
@@ -652,7 +700,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.error.statusCode must be a valid HTTP status code \(400-599\)/
+                /rateLimiting configuration is invalid.*"error.statusCode" must be larger than or equal to 400/
             );
         });
 
@@ -667,7 +715,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.error.statusCode must be a valid HTTP status code \(400-599\)/
+                /rateLimiting configuration is invalid.*"error.statusCode" must be less than or equal to 599/
             );
         });
 
@@ -682,7 +730,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.error.statusCode must be a valid HTTP status code \(400-599\)/
+                /rateLimiting configuration is invalid.*"error.statusCode" must be an integer/
             );
         });
 
@@ -697,7 +745,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.error.statusCode must be a valid HTTP status code \(400-599\)/
+                /rateLimiting configuration is invalid.*"error.statusCode" must be a number/
             );
         });
 
@@ -726,7 +774,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.error.message must be a string/
+                /rateLimiting configuration is invalid.*"error.message" must be a string/
             );
         });
 
@@ -783,7 +831,7 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 1),
-                /rateLimiting.error.code must be a string/
+                /rateLimiting configuration is invalid.*"error.code" must be a string/
             );
         });
     });
@@ -796,7 +844,7 @@ describe('parseRateLimitConfig', () => {
                 bucket: {
                     defaultConfig: {
                         requestsPerSecond: {
-                            limit: 10, // Less than 5 nodes × 10 workers = 50
+                            limit: 10, // Less than 5 nodes x 10 workers = 50
                         },
                     },
                 },
@@ -804,8 +852,292 @@ describe('parseRateLimitConfig', () => {
 
             assert.throws(
                 () => parseRateLimitConfig(config, 10),
-                /requestsPerSecond\.limit \(10\) must be >= \(nodes × workers = 5 × 10 = 50\)/
+                /requestsPerSecond\.limit \(10\) must be >= \(nodes x workers = 5 x 10 = 50\)/
             );
+        });
+    });
+
+    describe('account-level rate limiting', () => {
+        it('should parse account configuration similar to bucket', () => {
+            const config = {
+                serviceUserArn: 'arn:aws:iam::123456789012:user/rate-limit-service',
+                account: {
+                    defaultConfig: {
+                        requestsPerSecond: {
+                            limit: 500,
+                            burstCapacity: 5,
+                        },
+                    },
+                    configCacheTTL: 60000,
+                    defaultBurstCapacity: 2,
+                },
+            };
+
+            const result = parseRateLimitConfig(config, 5);
+
+            assert(result.account);
+            assert(result.account.defaultConfig);
+            assert.strictEqual(result.account.defaultConfig.limit, 500);
+            assert.strictEqual(result.account.configCacheTTL, 60000);
+            assert.strictEqual(result.account.defaultBurstCapacity, 2);
+        });
+
+        it('should support both bucket and account rate limiting simultaneously', () => {
+            const config = {
+                serviceUserArn: 'arn:aws:iam::123456789012:user/rate-limit-service',
+                bucket: {
+                    defaultConfig: {
+                        requestsPerSecond: {
+                            limit: 1000,
+                        },
+                    },
+                },
+                account: {
+                    defaultConfig: {
+                        requestsPerSecond: {
+                            limit: 500,
+                        },
+                    },
+                },
+            };
+
+            const result = parseRateLimitConfig(config, 5);
+
+            assert(result.bucket.defaultConfig);
+            assert.strictEqual(result.bucket.defaultConfig.limit, 1000);
+            assert(result.account.defaultConfig);
+            assert.strictEqual(result.account.defaultConfig.limit, 500);
+        });
+
+        it('should validate account limit against nodes and workers', () => {
+            const config = {
+                serviceUserArn: 'arn:aws:iam::123456789012:user/rate-limit-service',
+                nodes: 10,
+                account: {
+                    defaultConfig: {
+                        requestsPerSecond: {
+                            limit: 20, // Less than 10 nodes x 5 workers = 50
+                        },
+                    },
+                },
+            };
+
+            assert.throws(
+                () => parseRateLimitConfig(config, 5),
+                /requestsPerSecond\.limit \(20\) must be >= \(nodes x workers = 10 x 5 = 50\)/
+            );
+        });
+
+        it('should throw if account is not an object', () => {
+            const config = {
+                serviceUserArn: 'arn:aws:iam::123456789012:user/rate-limit-service',
+                account: 'invalid',
+            };
+
+            assert.throws(
+                () => parseRateLimitConfig(config, 1),
+                /rateLimiting configuration is invalid.*"account" must be of type object/
+            );
+        });
+
+        it('should apply defaults to account config when fields are omitted', () => {
+            const config = {
+                serviceUserArn: 'arn:aws:iam::123456789012:user/rate-limit-service',
+                account: {
+                    defaultConfig: {
+                        requestsPerSecond: {
+                            limit: 100,
+                        },
+                    },
+                },
+            };
+
+            const result = parseRateLimitConfig(config, 1);
+
+            assert.strictEqual(result.account.configCacheTTL, constants.rateLimitDefaultConfigCacheTTL);
+            assert.strictEqual(result.account.defaultBurstCapacity, constants.rateLimitDefaultBurstCapacity);
+        });
+    });
+
+    describe('account burstCapacity validation', () => {
+        it('should use default burstCapacity when not provided', () => {
+            const config = {
+                serviceUserArn: 'arn:aws:iam::123456789012:user/rate-limit-service',
+                account: {
+                    defaultConfig: {
+                        requestsPerSecond: {
+                            limit: 100,
+                        },
+                    },
+                },
+            };
+
+            const result = parseRateLimitConfig(config, 1);
+            const bucketSize = result.account.defaultConfig.requestsPerSecond.bucketSize;
+            assert.strictEqual(bucketSize, constants.rateLimitDefaultBurstCapacity * 1000);
+        });
+
+        it('should use custom burstCapacity when provided', () => {
+            const config = {
+                serviceUserArn: 'arn:aws:iam::123456789012:user/rate-limit-service',
+                account: {
+                    defaultConfig: {
+                        requestsPerSecond: {
+                            limit: 100,
+                            burstCapacity: 20,
+                        },
+                    },
+                },
+            };
+
+            const result = parseRateLimitConfig(config, 1);
+            const bucketSize = result.account.defaultConfig.requestsPerSecond.bucketSize;
+            assert.strictEqual(bucketSize, 20 * 1000);
+        });
+
+        it('should accept float burstCapacity', () => {
+            const config = {
+                serviceUserArn: 'arn:aws:iam::123456789012:user/rate-limit-service',
+                account: {
+                    defaultConfig: {
+                        requestsPerSecond: {
+                            limit: 100,
+                            burstCapacity: 1.5,
+                        },
+                    },
+                },
+            };
+
+            const result = parseRateLimitConfig(config, 1);
+            const bucketSize = result.account.defaultConfig.requestsPerSecond.bucketSize;
+            assert.strictEqual(bucketSize, 1.5 * 1000);
+        });
+
+        it('should throw if burstCapacity is negative', () => {
+            const config = {
+                serviceUserArn: 'arn:aws:iam::123456789012:user/rate-limit-service',
+                account: {
+                    defaultConfig: {
+                        requestsPerSecond: {
+                            limit: 100,
+                            burstCapacity: -5,
+                        },
+                    },
+                },
+            };
+
+            assert.throws(
+                () => parseRateLimitConfig(config, 1),
+                // eslint-disable-next-line max-len
+                /rateLimiting configuration is invalid.*"account.defaultConfig.requestsPerSecond.burstCapacity" must be a positive number/
+            );
+        });
+
+        it('should throw if burstCapacity is zero', () => {
+            const config = {
+                serviceUserArn: 'arn:aws:iam::123456789012:user/rate-limit-service',
+                account: {
+                    defaultConfig: {
+                        requestsPerSecond: {
+                            limit: 100,
+                            burstCapacity: 0,
+                        },
+                    },
+                },
+            };
+
+            assert.throws(
+                () => parseRateLimitConfig(config, 1),
+                // eslint-disable-next-line max-len
+                /rateLimiting configuration is invalid.*"account.defaultConfig.requestsPerSecond.burstCapacity" must be a positive number/
+            );
+        });
+
+        it('should throw if burstCapacity is not a number', () => {
+            const config = {
+                serviceUserArn: 'arn:aws:iam::123456789012:user/rate-limit-service',
+                account: {
+                    defaultConfig: {
+                        requestsPerSecond: {
+                            limit: 100,
+                            burstCapacity: 'ten',
+                        },
+                    },
+                },
+            };
+
+            assert.throws(
+                () => parseRateLimitConfig(config, 1),
+                // eslint-disable-next-line max-len
+                /rateLimiting configuration is invalid.*"account.defaultConfig.requestsPerSecond.burstCapacity" must be a number/
+            );
+        });
+    });
+
+    describe('schema validation - unknown fields', () => {
+        it('should reject unknown top-level fields', () => {
+            const config = {
+                serviceUserArn: 'arn:aws:iam::123456789012:user/rate-limit-service',
+                unknownField: 'invalid',
+            };
+
+            assert.throws(
+                () => parseRateLimitConfig(config, 1),
+                /rateLimiting configuration is invalid.*"unknownField" is not allowed/
+            );
+        });
+
+        it('should reject unknown fields in bucket config', () => {
+            const config = {
+                serviceUserArn: 'arn:aws:iam::123456789012:user/rate-limit-service',
+                bucket: {
+                    unknownField: 'invalid',
+                },
+            };
+
+            assert.throws(
+                () => parseRateLimitConfig(config, 1),
+                /rateLimiting configuration is invalid.*"bucket.unknownField" is not allowed/
+            );
+        });
+
+        it('should reject unknown fields in error config', () => {
+            const config = {
+                serviceUserArn: 'arn:aws:iam::123456789012:user/rate-limit-service',
+                error: {
+                    statusCode: 503,
+                    unknownField: 'invalid',
+                },
+            };
+
+            assert.throws(
+                () => parseRateLimitConfig(config, 1),
+                /rateLimiting configuration is invalid.*"error.unknownField" is not allowed/
+            );
+        });
+    });
+
+    describe('schema validation - multiple errors', () => {
+        it('should report all validation errors at once', () => {
+            const config = {
+                // Missing serviceUserArn (required)
+                nodes: -5, // Invalid (must be positive)
+                tokenBucketBufferSize: 0, // Invalid (must be positive)
+                bucket: 'not an object', // Invalid type
+            };
+
+            assert.throws(() => {
+                try {
+                    parseRateLimitConfig(config, 1);
+                } catch (error) {
+                    // Should contain multiple errors
+                    assert(error.message.includes('serviceUserArn'));
+                    assert(error.message.includes('nodes'));
+                    assert(error.message.includes('tokenBucketBufferSize'));
+                    assert(error.message.includes('bucket'));
+                    throw error;
+                }
+            }, /rateLimiting configuration is invalid/);
         });
     });
 


### PR DESCRIPTION
This PR: 
- Refactors the rate limit config parsing to use joi to allow bucket and account configs to share code.
- Adds account level rate limiting config key

Note for reviewers: This PR is being merged into a feature branch so the code can remain "broken" between PRs as code is refactored without impacting the `development/*` branches.