### PR TITLE
CLDSRV-881: fix missing CORS headers on 403 responses

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -81,6 +81,8 @@ const { isRequesterASessionUser } = require('./apiUtils/authorization/permission
 const checkHttpHeadersSize = require('./apiUtils/object/checkHttpHeadersSize');
 const constants = require('../../constants');
 const { config } = require('../Config.js');
+const metadata = require('../metadata/wrapper');
+const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const { validateMethodChecksumNoChunking } = require('./apiUtils/integrity/validateChecksums');
 const {
     requestNeedsRateCheck,
@@ -92,6 +94,91 @@ const {
 const monitoringMap = policies.actionMaps.actionMonitoringMapS3;
 
 auth.setHandler(vault);
+
+// Detect CORS headers the handler already attached to its callback args.
+// Callback arity varies per route ((err, corsHeaders), (err, xml,
+// corsHeaders), (err, dataGetInfo, resMetaHeaders, range), ...) so we
+// scan the args instead of relying on a fixed position.
+function hasCorsHeaders(callbackArgs) {
+    for (const arg of callbackArgs) {
+        if (!arg || typeof arg !== 'object' || Array.isArray(arg)
+            || Buffer.isBuffer(arg)) {
+            continue;
+        }
+        if ('access-control-allow-origin' in arg) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Wrap the API callback so that, on error, we look up the bucket's CORS
+// configuration and set the matching Access-Control-* headers directly on
+// the HTTP response. This is needed because auth / pre-handler errors
+// return before the API handler retrieves the bucket (where the existing
+// collectCorsHeaders call lives), so the route-level error response path
+// otherwise sends no CORS headers - breaking cross-origin browser clients.
+// We only pay the extra metadata lookup when an Origin header is present,
+// matching AWS behavior and the existing contract of collectCorsHeaders.
+//
+// On the error path of a single request, this wrapper produces at most one
+// extra metadata.getBucket call - the fallback below. It only fires when:
+//   1. The handler ran and called metadata.getBucket itself (count = 1), AND
+//   2. It returned without surfacing CORS headers in its callback args
+//      (e.g. handler dropped the loaded bucket between waterfall steps,
+//      or the request did not match any CORS rule and the result was {}).
+// Combined with the handler's own call, total getBucket calls per failing
+// request stay capped at 2. Any future optimization must preserve or
+// improve that ceiling; the unit test in tests/unit/api/corsErrorHeaders.js
+// asserts it.
+function wrapCallbackWithErrorCorsHeaders(callback, request, response, log) {
+    function applyHeadersFromBucket(bucket) {
+        if (!bucket || response.headersSent) {
+            return;
+        }
+        const headers = collectCorsHeaders(
+            request.headers.origin, request.method, bucket);
+        Object.keys(headers).forEach(key => {
+            try {
+                response.setHeader(key, headers[key]);
+            } catch (e) {
+                log.debug('could not set CORS header on error', {
+                    header: key, error: e.message,
+                });
+            }
+        });
+    }
+
+    return (err, ...callbackArgs) => {
+        if (!err || !request.headers || !request.headers.origin
+            || !request.bucketName) {
+            return callback(err, ...callbackArgs);
+        }
+        // Fast path: most post-auth failures come back with corsHeaders
+        // already computed by the handler. The route will forward them
+        // to responseXMLBody/responseNoBody, so no extra lookup is needed.
+        if (hasCorsHeaders(callbackArgs)) {
+            return callback(err, ...callbackArgs);
+        }
+        // Fallback: either the bucket was never loaded (pre-handler
+        // failure like auth.server.doAuth denial, header-size check,
+        // copy-source parse error) or the handler returned without
+        // surfacing CORS headers. Re-fetch the bucket using the
+        // request's bucketName (the destination on copy operations) so
+        // we evaluate CORS against the right bucket.
+        return metadata.getBucket(request.bucketName, log, (mdErr, bucket) => {
+            if (mdErr) {
+                log.warn('could not fetch bucket CORS config for error response', {
+                    bucketName: request.bucketName,
+                    error: mdErr.code || mdErr.message,
+                });
+                return callback(err, ...callbackArgs);
+            }
+            applyHeadersFromBucket(bucket);
+            return callback(err, ...callbackArgs);
+        });
+    };
+}
 
 function checkAuthResults(authResults, apiMethod, log) {
     let returnTagCount = true;
@@ -346,6 +433,8 @@ const api = {
     callApiMethod(apiMethod, request, response, log, callback) {
         // Attach the apiMethod method to the request, so it can used by monitoring in the server
         request.apiMethod = apiMethod;
+        callback = wrapCallbackWithErrorCorsHeaders(
+            callback, request, response, log);
         // Array of end of API callbacks, used to perform some logic
         // at the end of an API.
         request.finalizerHooks = [];

--- a/lib/api/bucketGetCors.js
+++ b/lib/api/bucketGetCors.js
@@ -29,10 +29,7 @@ function bucketGetCors(authInfo, request, log, callback) {
         const corsHeaders = collectCorsHeaders(request.headers.origin, request.method, bucket);
         if (err) {
             monitoring.promMetrics('GET', bucketName, err.code, METRICS_ACTION);
-            if (err?.is?.AccessDenied) {
-                return callback(err, corsHeaders);
-            }
-            return callback(err);
+            return callback(err, null, corsHeaders);
         }
 
         const cors = bucket.getCors();

--- a/lib/api/bucketGetLocation.js
+++ b/lib/api/bucketGetLocation.js
@@ -29,10 +29,7 @@ function bucketGetLocation(authInfo, request, log, callback) {
         const corsHeaders = collectCorsHeaders(request.headers.origin, request.method, bucket);
         if (err) {
             monitoring.promMetrics('GET', bucketName, err.code, METRICS_ACTION);
-            if (err?.is?.AccessDenied) {
-                return callback(err, corsHeaders);
-            }
-            return callback(err);
+            return callback(err, null, corsHeaders);
         }
 
         let locationConstraint = bucket.getLocationConstraint();

--- a/lib/api/bucketGetWebsite.js
+++ b/lib/api/bucketGetWebsite.js
@@ -30,10 +30,7 @@ function bucketGetWebsite(authInfo, request, log, callback) {
         const corsHeaders = collectCorsHeaders(request.headers.origin, request.method, bucket);
         if (err) {
             monitoring.promMetrics('GET', bucketName, err.code, METRICS_ACTION);
-            if (err?.is?.AccessDenied) {
-                return callback(err, corsHeaders);
-            }
-            return callback(err);
+            return callback(err, null, corsHeaders);
         }
 
         const websiteConfig = bucket.getWebsiteConfiguration();

--- a/lib/utilities/collectCorsHeaders.js
+++ b/lib/utilities/collectCorsHeaders.js
@@ -9,15 +9,11 @@ const { findCorsRule, generateCorsResHeaders } =
  * @return {object} - object containing CORS headers
  */
 function collectCorsHeaders(origin, httpMethod, bucket) {
-    // NOTE: Because collecting CORS headers requires making a call to
-    // metadata to retrieve the bucket's CORS configuration, we opt not to
-    // return the CORS headers if the request encounters an error before
-    // the api method retrieves the bucket from metadata (an example
-    // being if a request is not properly authenticated). This is a slight
-    // deviation from AWS compatibility, but has the benefit of avoiding
-    // additional backend calls for an invalid request. Also, we anticipate
-    // that the preflight OPTIONS route will serve most client needs regarding
-    // CORS.
+    // Returns {} when no bucket is supplied; this function does not itself
+    // fetch metadata. Callers that only have a bucketName (e.g. auth
+    // failures that happen before the API handler loads the bucket) should
+    // look it up themselves - see wrapCallbackWithErrorCorsHeaders in
+    // lib/api/api.js.
     if (!origin || !bucket) {
         return {};
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "9.2.38",
+  "version": "9.2.39",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {

--- a/tests/functional/aws-node-sdk/test/object/corsErrorHeaders.js
+++ b/tests/functional/aws-node-sdk/test/object/corsErrorHeaders.js
@@ -1,0 +1,152 @@
+const { S3 } = require('aws-sdk');
+const assert = require('assert');
+const async = require('async');
+
+const getConfig = require('../support/config');
+const { methodRequest, generateCorsParams } =
+    require('../../lib/utility/cors-util');
+
+const config = getConfig('default', { signatureVersion: 'v4' });
+const s3 = new S3(config);
+
+const bucket = 'corserrorheadertest';
+const objectKey = 'objectKey';
+const allowedOrigin = 'http://www.allowed.test';
+const vary = 'Origin, Access-Control-Request-Headers, '
+    + 'Access-Control-Request-Method';
+
+const expectedCorsHeaders = {
+    'access-control-allow-origin': allowedOrigin,
+    'access-control-allow-methods': 'GET, PUT, POST, DELETE, HEAD',
+    'access-control-allow-credentials': 'true',
+    vary,
+};
+
+const corsParams = generateCorsParams(bucket, {
+    allowedMethods: ['GET', 'PUT', 'POST', 'DELETE', 'HEAD'],
+    allowedOrigins: [allowedOrigin],
+    allowedHeaders: ['*'],
+});
+
+// Raw unauthenticated requests - they always return 403.
+// Each spec describes (method, path, query) against the bucket.
+const unauthenticatedRequests = [
+    { description: 'GET bucket (list objects)',
+        method: 'GET', query: null, objectKey: null },
+    { description: 'HEAD bucket',
+        method: 'HEAD', query: null, objectKey: null },
+    { description: 'DELETE bucket',
+        method: 'DELETE', query: null, objectKey: null },
+    { description: 'GET bucket ACL',
+        method: 'GET', query: 'acl', objectKey: null },
+    { description: 'GET bucket CORS',
+        method: 'GET', query: 'cors', objectKey: null },
+    { description: 'GET bucket versioning',
+        method: 'GET', query: 'versioning', objectKey: null },
+    { description: 'GET bucket website',
+        method: 'GET', query: 'website', objectKey: null },
+    { description: 'GET bucket tagging',
+        method: 'GET', query: 'tagging', objectKey: null },
+    { description: 'GET object',
+        method: 'GET', query: null, objectKey },
+    { description: 'HEAD object',
+        method: 'HEAD', query: null, objectKey },
+    { description: 'PUT object',
+        method: 'PUT', query: null, objectKey },
+    { description: 'DELETE object',
+        method: 'DELETE', query: null, objectKey },
+    { description: 'GET bucket uploads (list multipart uploads)',
+        method: 'GET', query: 'uploads', objectKey: null },
+    // GET bucket policy and POST multi-delete are not covered here: the
+    // first returns 405 (method rejected pre-auth), the second returns 400
+    // (missing XML body fails validation pre-auth). Neither reaches the
+    // 403 path. Both are exercised via the unit test that stubs auth
+    // failure directly.
+];
+
+function _waitForAWS(callback, err) {
+    if (err) {
+        return setTimeout(() => callback(err), 500);
+    }
+    return setTimeout(() => callback(), 500);
+}
+
+describe('CORS headers on 403 responses when bucket has CORS configured', () => {
+    before(done => async.series([
+        cb => s3.createBucket({ Bucket: bucket }, err => _waitForAWS(cb, err)),
+        cb => s3.putBucketCors(corsParams, err => _waitForAWS(cb, err)),
+    ], done));
+
+    after(done => s3.deleteBucket({ Bucket: bucket },
+        err => _waitForAWS(done, err)));
+
+    unauthenticatedRequests.forEach(spec => {
+        it(`returns CORS headers on 403 for ${spec.description} `
+            + 'when Origin matches a rule', done => {
+            methodRequest({
+                method: spec.method,
+                bucket,
+                objectKey: spec.objectKey,
+                query: spec.query,
+                headers: { origin: allowedOrigin },
+                // Use numeric status: HEAD responses have no body, and some
+                // endpoints (bucket policy, multi-delete) can fail with a
+                // non-AccessDenied body before auth even runs. We only care
+                // about the 403 status and the CORS headers here.
+                code: 403,
+                headersResponse: expectedCorsHeaders,
+            }, done);
+        });
+    });
+
+    it('omits CORS headers on 403 when Origin does not match any rule',
+        done => {
+            methodRequest({
+                method: 'GET',
+                bucket,
+                query: null,
+                objectKey: null,
+                headers: { origin: 'http://not-allowed.test' },
+                code: 403,
+                // headersResponse unset -> cors-util asserts CORS headers
+                // are NOT present.
+            }, done);
+        });
+
+    it('omits CORS headers on 403 when no Origin header is sent',
+        done => {
+            methodRequest({
+                method: 'GET',
+                bucket,
+                query: null,
+                objectKey: null,
+                headers: {},
+                code: 403,
+            }, done);
+        });
+});
+
+describe('CORS headers on 200 responses (regression guard)', () => {
+    before(done => async.series([
+        cb => s3.createBucket({ Bucket: bucket }, err => _waitForAWS(cb, err)),
+        cb => s3.putBucketCors(corsParams, err => _waitForAWS(cb, err)),
+    ], done));
+
+    after(done => s3.deleteBucket({ Bucket: bucket },
+        err => _waitForAWS(done, err)));
+
+    it('returns CORS headers on a successful list objects (200)', done => {
+        const request = s3.listObjects({ Bucket: bucket });
+        request.on('build', () => {
+            request.httpRequest.headers.origin = allowedOrigin;
+        });
+        request.on('success', response => {
+            const h = response.httpResponse.headers;
+            assert.strictEqual(h['access-control-allow-origin'],
+                allowedOrigin);
+            done();
+        });
+        request.on('error', err => done(err));
+        request.send();
+    });
+});

--- a/tests/unit/api/corsErrorHeaders.js
+++ b/tests/unit/api/corsErrorHeaders.js
@@ -1,0 +1,429 @@
+const assert = require('assert');
+const async = require('async');
+const sinon = require('sinon');
+const { errors, auth } = require('arsenal');
+
+const api = require('../../../lib/api/api');
+const { bucketGet } = require('../../../lib/api/bucketGet');
+const bucketGetCors = require('../../../lib/api/bucketGetCors');
+const { bucketPut } = require('../../../lib/api/bucketPut');
+const bucketPutCors = require('../../../lib/api/bucketPutCors');
+const metadata = require('../../../lib/metadata/wrapper');
+const DummyRequest = require('../DummyRequest');
+const {
+    CorsConfigTester,
+    DummyRequestLogger,
+    cleanup,
+    makeAuthInfo,
+} = require('../helpers');
+
+const endpoints = [
+    { apiMethod: 'bucketGet', httpMethod: 'GET', url: '/', query: {} },
+    { apiMethod: 'bucketHead', httpMethod: 'HEAD', url: '/', query: {} },
+    { apiMethod: 'bucketDelete', httpMethod: 'DELETE', url: '/', query: {} },
+    { apiMethod: 'bucketGetACL', httpMethod: 'GET', url: '/?acl',
+        query: { acl: '' } },
+    { apiMethod: 'bucketGetCors', httpMethod: 'GET', url: '/?cors',
+        query: { cors: '' } },
+    { apiMethod: 'bucketGetLifecycle', httpMethod: 'GET', url: '/?lifecycle',
+        query: { lifecycle: '' } },
+    { apiMethod: 'bucketGetReplication', httpMethod: 'GET',
+        url: '/?replication', query: { replication: '' } },
+    { apiMethod: 'bucketGetPolicy', httpMethod: 'GET', url: '/?policy',
+        query: { policy: '' } },
+    { apiMethod: 'bucketGetVersioning', httpMethod: 'GET', url: '/?versioning',
+        query: { versioning: '' } },
+    { apiMethod: 'bucketGetWebsite', httpMethod: 'GET', url: '/?website',
+        query: { website: '' } },
+    { apiMethod: 'bucketGetTagging', httpMethod: 'GET', url: '/?tagging',
+        query: { tagging: '' } },
+    { apiMethod: 'bucketGetEncryption', httpMethod: 'GET', url: '/?encryption',
+        query: { encryption: '' } },
+    { apiMethod: 'bucketGetNotification', httpMethod: 'GET',
+        url: '/?notification', query: { notification: '' } },
+    { apiMethod: 'bucketGetObjectLock', httpMethod: 'GET',
+        url: '/?object-lock', query: { 'object-lock': '' } },
+    { apiMethod: 'bucketGetLocation', httpMethod: 'GET', url: '/?location',
+        query: { location: '' } },
+    { apiMethod: 'objectGet', httpMethod: 'GET', url: '/obj', query: {},
+        objectKey: 'obj' },
+    { apiMethod: 'objectHead', httpMethod: 'HEAD', url: '/obj', query: {},
+        objectKey: 'obj' },
+    { apiMethod: 'objectDelete', httpMethod: 'DELETE', url: '/obj', query: {},
+        objectKey: 'obj' },
+    { apiMethod: 'listMultipartUploads', httpMethod: 'GET', url: '/?uploads',
+        query: { uploads: '' } },
+];
+
+const bucketName = 'corserrorheaderstest';
+const authInfo = makeAuthInfo('accessKey1');
+const origin = 'http://foo.test';
+
+function setupBucketWithCors(done) {
+    cleanup();
+    const putBucketReq = {
+        bucketName,
+        headers: { host: `${bucketName}.s3.amazonaws.com` },
+        url: '/',
+        actionImplicitDenies: false,
+    };
+    // Single rule allowing all tested HTTP methods from the test Origin.
+    // Using CorsConfigTester's default rules would leave HEAD/DELETE
+    // uncovered for our origin and mask the thing we want to assert.
+    const corsUtil = new CorsConfigTester({
+        allowedMethods: ['GET', 'HEAD', 'PUT', 'POST', 'DELETE'],
+        allowedOrigins: [origin],
+        allowedHeaders: ['*'],
+    });
+    const putCorsReq = corsUtil.createBucketCorsRequest('PUT', bucketName);
+    const log = new DummyRequestLogger();
+    return bucketPut(authInfo, putBucketReq, log, err => {
+        if (err) {
+            return done(err);
+        }
+        return bucketPutCors(authInfo, putCorsReq, log, done);
+    });
+}
+
+function buildRequest(spec) {
+    // DummyRequest is an http.IncomingMessage stream that emits 'end'
+    // synchronously. We need that because callApiMethod's waterfall
+    // waits for the request body on non-objectPut paths.
+    return new DummyRequest({
+        bucketName,
+        objectKey: spec.objectKey,
+        headers: {
+            host: `${bucketName}.s3.amazonaws.com`,
+            origin,
+        },
+        url: spec.url,
+        query: spec.query,
+        method: spec.httpMethod,
+    }, Buffer.alloc(0));
+}
+
+function buildResponseSpy(sandbox) {
+    const headers = {};
+    return {
+        headers,
+        setHeader: sandbox.spy((k, v) => { headers[k.toLowerCase()] = v; }),
+        getHeader: k => headers[k.toLowerCase()],
+    };
+}
+
+function buildLog(sandbox) {
+    return {
+        addDefaultFields: sandbox.stub(),
+        trace: sandbox.stub(),
+        debug: sandbox.stub(),
+        info: sandbox.stub(),
+        warn: sandbox.stub(),
+        error: sandbox.stub(),
+        fatal: sandbox.stub(),
+        end() { return this; },
+    };
+}
+
+describe('CORS headers on 403 auth failures (api.callApiMethod)', () => {
+    let sandbox;
+
+    before(done => setupBucketWithCors(done));
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        const authServer = {
+            doAuth: sandbox.stub().callsArgWith(2, errors.AccessDenied),
+        };
+        sandbox.stub(auth, 'server').value(authServer);
+    });
+
+    afterEach(() => sandbox.restore());
+
+    endpoints.forEach(spec => {
+        it(`attaches CORS headers to 403 response for ${spec.apiMethod}`,
+            done => {
+                const request = buildRequest(spec);
+                const response = buildResponseSpy(sandbox);
+                const log = buildLog(sandbox);
+
+                api.callApiMethod(spec.apiMethod, request, response, log,
+                    err => {
+                        assert(err, 'expected an error');
+                        assert(err.is && err.is.AccessDenied,
+                            `expected AccessDenied, got ${err.code}`);
+                        // Either the callback surfaces CORS headers in one of
+                        // its trailing args OR they have been set directly on
+                        // the HTTP response. We assert on the response since
+                        // that is what the HTTP transport ultimately sends.
+                        const allowOrigin = response.getHeader(
+                            'access-control-allow-origin');
+                        assert(allowOrigin,
+                            'access-control-allow-origin missing from 403 '
+                            + `response for ${spec.apiMethod}`);
+                        assert(response.getHeader(
+                            'access-control-allow-methods'),
+                            'access-control-allow-methods missing');
+                        done();
+                    });
+            });
+    });
+
+    it('does not attach CORS headers when Origin header is absent',
+        done => {
+            const request = buildRequest({
+                apiMethod: 'bucketGet', httpMethod: 'GET',
+                url: '/', query: {},
+            });
+            delete request.headers.origin;
+            const response = buildResponseSpy(sandbox);
+            const log = buildLog(sandbox);
+
+            api.callApiMethod('bucketGet', request, response, log, err => {
+                assert(err && err.is.AccessDenied);
+                assert.strictEqual(
+                    response.getHeader('access-control-allow-origin'),
+                    undefined);
+                done();
+            });
+        });
+
+    it('does not attach CORS headers when origin does not match any rule',
+        done => {
+            const request = buildRequest({
+                apiMethod: 'bucketGet', httpMethod: 'GET',
+                url: '/', query: {},
+            });
+            request.headers.origin = 'http://not-allowed.test';
+            // The bucket's CORS config allows any method from foo.test
+            // plus GET from *. Use PUT from a different origin so neither
+            // condition matches.
+            request.method = 'PUT';
+            const response = buildResponseSpy(sandbox);
+            const log = buildLog(sandbox);
+
+            api.callApiMethod('bucketGet', request, response, log, err => {
+                assert(err && err.is.AccessDenied);
+                assert.strictEqual(
+                    response.getHeader('access-control-allow-origin'),
+                    undefined);
+                done();
+            });
+        });
+});
+
+describe('CORS headers on 403 via handler (fast path)', () => {
+    let sandbox;
+
+    before(done => setupBucketWithCors(done));
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        // Auth succeeds as accessKey2 so the handler runs and then
+        // denies at its own ACL check (bucket is owned by accessKey1).
+        const otherAuth = makeAuthInfo('accessKey2');
+        const authServer = {
+            doAuth: sandbox.stub().callsArgWith(2, null, otherAuth,
+                [{ isAllowed: true, isImplicit: false }], null, {}),
+        };
+        sandbox.stub(auth, 'server').value(authServer);
+    });
+
+    afterEach(() => sandbox.restore());
+
+    it('forwards handler-provided corsHeaders without setting headers '
+        + 'on the response directly', done => {
+        const request = buildRequest({
+            apiMethod: 'bucketGet', httpMethod: 'GET',
+            url: '/', query: {},
+        });
+        const response = buildResponseSpy(sandbox);
+        const log = buildLog(sandbox);
+
+        api.callApiMethod('bucketGet', request, response, log,
+            (err, xml, corsHeaders) => {
+                assert(err, 'expected an error');
+                assert(err.is && err.is.AccessDenied,
+                    `expected AccessDenied, got ${err.code}`);
+                assert(corsHeaders,
+                    'handler should have supplied corsHeaders');
+                assert.strictEqual(
+                    corsHeaders['access-control-allow-origin'], origin);
+                // Fast path: wrapper forwards corsHeaders via the callback
+                // instead of setting them on the response directly.
+                assert.strictEqual(
+                    response.getHeader('access-control-allow-origin'),
+                    undefined);
+                done();
+            });
+    });
+
+    it('makes at most 2 metadata.getBucket calls on the error path',
+        done => {
+            const getBucketSpy = sandbox.spy(metadata, 'getBucket');
+            const request = buildRequest({
+                apiMethod: 'bucketHead', httpMethod: 'HEAD',
+                url: '/', query: {},
+            });
+            // Origin that matches no CORS rule -> handler emits empty
+            // corsHeaders -> fast path misses -> wrapper falls back to a
+            // second getBucket. The handler's own call (1) + the wrapper
+            // fallback (1) is the documented ceiling - see the comment
+            // on wrapCallbackWithErrorCorsHeaders in lib/api/api.js. Use
+            // <= so this remains a future-proof ceiling: optimizations
+            // that reduce the count are welcome.
+            request.headers.origin = 'http://not-allowed.test';
+            const response = buildResponseSpy(sandbox);
+            const log = buildLog(sandbox);
+
+            api.callApiMethod('bucketHead', request, response, log, err => {
+                assert(err && err.is.AccessDenied);
+                assert(getBucketSpy.callCount <= 2,
+                    'expected at most 2 metadata.getBucket calls, got '
+                    + `${getBucketSpy.callCount}`);
+                done();
+            });
+        });
+});
+
+describe('CORS headers on copy operations', () => {
+    // objectCopy / objectPutCopyPart call standardMetadataValidateBucketAndObj
+    // twice (destination, then source). The wrapper must evaluate CORS
+    // against the request's actual bucket (destination), not the source -
+    // even though the source is loaded last. We exercise this by giving
+    // dest a config that does NOT match the request and source a config
+    // that DOES match, then asserting source headers don't leak.
+    const destBucket = 'cors-copy-dest';
+    const srcBucket = 'cors-copy-src';
+    const reqOrigin = 'http://foo.test';
+    let sandbox;
+
+    before(done => {
+        cleanup();
+        const log = new DummyRequestLogger();
+        const destPutReq = {
+            bucketName: destBucket,
+            headers: { host: `${destBucket}.s3.amazonaws.com` },
+            url: '/',
+            actionImplicitDenies: false,
+        };
+        const srcPutReq = {
+            bucketName: srcBucket,
+            headers: { host: `${srcBucket}.s3.amazonaws.com` },
+            url: '/',
+            actionImplicitDenies: false,
+        };
+        // Dest CORS: only GET from reqOrigin. The request is a PUT, so
+        // dest's collectCorsHeaders returns {} - no headers should be
+        // applied to the response.
+        const destCors = new CorsConfigTester({
+            allowedMethods: ['GET'],
+            allowedOrigins: [reqOrigin],
+        });
+        // Source CORS: PUT from reqOrigin. If the wrapper mistakenly
+        // evaluated against source, it would set real CORS headers.
+        const srcCors = new CorsConfigTester({
+            allowedMethods: ['PUT'],
+            allowedOrigins: [reqOrigin],
+        });
+        async.series([
+            cb => bucketPut(authInfo, destPutReq, log, cb),
+            cb => bucketPut(authInfo, srcPutReq, log, cb),
+            cb => bucketPutCors(authInfo,
+                destCors.createBucketCorsRequest('PUT', destBucket), log, cb),
+            cb => bucketPutCors(authInfo,
+                srcCors.createBucketCorsRequest('PUT', srcBucket), log, cb),
+        ], done);
+    });
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        const authServer = {
+            doAuth: sandbox.stub().callsArgWith(2, null, authInfo,
+                [{ isAllowed: true, isImplicit: false },
+                    { isAllowed: true, isImplicit: false }], null, {}),
+        };
+        sandbox.stub(auth, 'server').value(authServer);
+    });
+
+    afterEach(() => sandbox.restore());
+
+    it('does not leak source-bucket CORS headers on objectCopy errors',
+        done => {
+            const request = new DummyRequest({
+                bucketName: destBucket,
+                objectKey: 'destkey',
+                headers: {
+                    host: `${destBucket}.s3.amazonaws.com`,
+                    origin: reqOrigin,
+                    'x-amz-copy-source': `/${srcBucket}/missing-source-key`,
+                },
+                url: `/${destBucket}/destkey`,
+                query: {},
+                method: 'PUT',
+            }, Buffer.alloc(0));
+            const response = buildResponseSpy(sandbox);
+            const log = buildLog(sandbox);
+
+            api.callApiMethod('objectCopy', request, response, log, err => {
+                assert(err, 'expected an error');
+                // Dest does not allow PUT from reqOrigin, so no CORS
+                // headers should be set. If the wrapper used the source
+                // bucket (which DOES allow PUT from reqOrigin) we would
+                // see access-control-allow-origin: http://foo.test here.
+                assert.strictEqual(
+                    response.getHeader('access-control-allow-origin'),
+                    undefined,
+                    'wrapper must not apply source-bucket CORS headers');
+                done();
+            });
+        });
+});
+
+describe('CORS headers on 200 successful responses (per-handler)', () => {
+    before(done => setupBucketWithCors(done));
+
+    it('bucketGet returns corsHeaders to callback on 200', done => {
+        const log = new DummyRequestLogger();
+        const request = {
+            bucketName,
+            headers: {
+                host: `${bucketName}.s3.amazonaws.com`,
+                origin,
+            },
+            method: 'GET',
+            url: '/',
+            query: {},
+            actionImplicitDenies: false,
+        };
+        bucketGet(authInfo, request, log, (err, xml, corsHeaders) => {
+            assert.ifError(err);
+            assert(corsHeaders,
+                'expected corsHeaders to be set on successful bucketGet');
+            assert(corsHeaders['access-control-allow-origin'],
+                'expected access-control-allow-origin on 200');
+            done();
+        });
+    });
+
+    it('bucketGetCors returns corsHeaders to callback on 200', done => {
+        const log = new DummyRequestLogger();
+        const request = {
+            bucketName,
+            headers: {
+                host: `${bucketName}.s3.amazonaws.com`,
+                origin,
+            },
+            method: 'GET',
+            url: '/?cors',
+            query: { cors: '' },
+            actionImplicitDenies: false,
+        };
+        bucketGetCors(authInfo, request, log, (err, xml, corsHeaders) => {
+            assert.ifError(err);
+            assert(corsHeaders
+                && corsHeaders['access-control-allow-origin'],
+            'expected access-control-allow-origin on 200');
+            done();
+        });
+    });
+});


### PR DESCRIPTION
When a bucket has CORS configured, cloudserver was omitting `Access-Control-*` headers from 403 responses. Browsers treat such responses as opaque and block the error from the web app, even though AWS S3 returns CORS headers on error responses when a matching rule exists.

The existing `collectCorsHeaders` helper only runs inside an API handler, after bucket metadata has been loaded. Auth failures from Vault return before any handler runs, so the route-level error response path sent no CORS headers.

The fix wraps `callApiMethod`'s callback: on error, when the request has an `Origin` header and a known bucket, it fetches the bucket's CORS config and sets the matching `Access-Control-*` headers directly on the HTTP response before propagating the error. The extra metadata lookup only happens on failed requests with an `Origin` header - no cost for non-CORS traffic or successful requests.

Fixes: [CLDSRV-881](https://scality.atlassian.net/browse/CLDSRV-881)

[CLDSRV-881]: https://scality.atlassian.net/browse/CLDSRV-881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ