### PR TITLE
CLDSRV-877: Add dependabot for vault and metadata image bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: docker-compose
+    directory: /.github/docker
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "scality/vault"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "scality/metadata"
+        update-types: ["version-update:semver-major"]

--- a/.github/docker/docker-compose.sse.yaml
+++ b/.github/docker/docker-compose.sse.yaml
@@ -42,10 +42,3 @@ services:
     extends: cloudserver-sse-before-migration
     profiles: [sse-migration]
     command: sh -c "yarn start > /artifacts/s3.migration.log 2> /artifacts/s3-stderr.migration.log"
-  metadata-standalone:
-    image: ghcr.io/scality/metadata:8.11.0-standalone
-    profiles: ['metadata-standalone']
-    network_mode: 'host'
-    volumes:
-      - ./md-config.json:/mnt/standalone_workdir/config.json:ro
-      - /tmp/artifacts/${JOB_NAME}/md:/mnt/standalone_workdir/log

--- a/.github/docker/docker-compose.yaml
+++ b/.github/docker/docker-compose.yaml
@@ -106,3 +106,28 @@ services:
     privileged: yes # for setxattr on local filesystem
     volumes:
       - /tmp/artifacts/${JOB_NAME}/sproxyd:/logs
+  vault:
+    image: ghcr.io/scality/vault:7.76.0
+    profiles: ['vault']
+    user: root
+    command: sh -c "chmod 400 tests/utils/keyfile && yarn start > /artifacts/vault.log 2> /artifacts/vault-stderr.log"
+    network_mode: "host"
+    volumes:
+      - /tmp/artifacts/${JOB_NAME}:/artifacts
+      - ./vault-config.json:/conf/config.json:ro
+      - ./vault-db:/data
+    environment:
+      - VAULT_DB_BACKEND=LEVELDB
+      - CI=true
+      - ENABLE_LOCAL_CACHE=true
+      - REDIS_HOST=0.0.0.0
+      - REDIS_PORT=6379
+    depends_on:
+      - redis
+  metadata-standalone:
+    image: ghcr.io/scality/metadata:8.11.0-standalone
+    profiles: ['metadata-standalone']
+    network_mode: 'host'
+    volumes:
+      - ./md-config.json:/mnt/standalone_workdir/config.json:ro
+      - /tmp/artifacts/${JOB_NAME}/md:/mnt/standalone_workdir/log

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -520,7 +520,6 @@ jobs:
       COMPOSE_FILE: docker-compose.yaml:docker-compose.sse.yaml
       S3_VERSION_ID_ENCODING_TYPE: hex
       JOB_NAME: ${{ matrix.job-name }}
-      VAULT_IMAGE: ghcr.io/scality/vault:7.76.0
       S3_END_TO_END: true
       S3_TESTVAL_OWNERCANONICALID: 79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be
       S3_SERVER_ACCESS_LOGS_MODE: ENABLED
@@ -553,7 +552,7 @@ jobs:
     - name: Copy S3C config
       run: cp .github/docker/config.s3c.json tests/functional/sse-kms-migration/config.json
     - name: Setup CI services
-      run: docker compose up -d --quiet-pull redis sproxyd metadata-standalone vault-sse-before-migration cloudserver-sse-before-migration
+      run: docker compose up -d --quiet-pull redis sproxyd metadata-standalone vault cloudserver-sse-before-migration
       working-directory: .github/docker
     - name: Wait for services to be ready
       run: |-
@@ -597,7 +596,7 @@ jobs:
         set -o pipefail;
         yarn run ft_healthchecks | tee /tmp/artifacts/${{ matrix.job-name }}/ft_healthchecks.log
     - name: Teardown CI services
-      run: docker compose down redis sproxyd metadata-standalone vault-sse-before-migration cloudserver-sse-before-migration
+      run: docker compose down redis sproxyd metadata-standalone vault cloudserver-sse-before-migration
       working-directory: .github/docker
     - name: Cleanup and upload coverage
       uses: ./.github/actions/cleanup-and-coverage


### PR DESCRIPTION
Move vault and metadata into `docker-compose.yaml` so dependabot can detect and bump them.

SSE migration services remain in `docker-compose.sse.yaml` with pinned versions for migration testing.