### PR TITLE
CLDSRV-886: pass configurable Server response header to Arsenal

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -972,6 +972,8 @@ class Config extends EventEmitter {
                 'bad config: internalPort must be a positive integer');
         }
 
+        this.serverHeader = config.serverHeader || 'S3 Server';
+
         this.port = config.port;
         this.listenOn = this._parseEndpoints(config.listenOn, 'listenOn');
         this.internalPort = config.internalPort;

--- a/lib/server.js
+++ b/lib/server.js
@@ -3,6 +3,7 @@ const https = require('https');
 const cluster = require('cluster');
 const { series } = require('async');
 const arsenal = require('arsenal');
+const { setServerHeader } = arsenal.s3routes.routesUtils;
 const { RedisClient, StatsClient } = arsenal.metrics;
 const monitoringClient = require('./utilities/monitoringHandler');
 
@@ -33,6 +34,8 @@ const { parseLC, MultipleBackendGateway } = arsenal.storage.data;
 const websiteEndpoints = _config.websiteEndpoints;
 let client = dataWrapper.client;
 const implName = dataWrapper.implName;
+
+setServerHeader(_config.serverHeader);
 
 let allEndpoints;
 function updateAllEndpoints() {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@azure/storage-blob": "^12.28.0",
     "@hapi/joi": "^17.1.1",
-    "arsenal": "git+https://github.com/scality/arsenal#8.2.48",
+    "arsenal": "git+https://github.com/scality/arsenal#8.2.50",
     "async": "2.6.4",
     "aws-sdk": "^2.1692.0",
     "bucketclient": "scality/bucketclient#8.2.7",

--- a/tests/functional/healthchecks/test/checkRoutes.js
+++ b/tests/functional/healthchecks/test/checkRoutes.js
@@ -131,6 +131,22 @@ if (config.healthChecks.enableInternalRoute) {
     });
 }
 
+describe('Server response header', () => {
+    it('should return the configured serverHeader value on S3 API responses', done => {
+        const getOptions = deepCopy(options);
+        getOptions.method = 'GET';
+        getOptions.path = '/';
+        getOptions.port = config.port || 8000;
+        getOptions.agent = makeAgent();
+        const req = transport.request(getOptions, res => {
+            assert.strictEqual(res.headers['server'], config.serverHeader);
+            done();
+        });
+        req.on('error', done);
+        req.end();
+    });
+});
+
 describe('Healthcheck stats', () => {
     const totalReqs = 5;
     beforeEach(done => {

--- a/tests/unit/Config.js
+++ b/tests/unit/Config.js
@@ -983,4 +983,31 @@ describe('Config', () => {
             assert.throws(() => new ConfigObject());
         });
     });
+
+    describe('serverHeader', () => {
+        let sandbox;
+        let readFileStub;
+
+        beforeEach(() => {
+            sandbox = sinon.createSandbox();
+            readFileStub = sandbox.stub(fs, 'readFileSync');
+            readFileStub.callThrough();
+        });
+
+        afterEach(() => {
+            sandbox.restore();
+        });
+
+        it('should default to "S3 Server" when not configured', () => {
+            const config = new ConfigObject();
+            assert.strictEqual(config.serverHeader, 'S3 Server');
+        });
+
+        it('should use the configured value when set', () => {
+            const modifiedConfig = { ...defaultConfig, serverHeader: 'ScalityS3' };
+            readFileStub.withArgs(sinon.match(/config.json$/)).returns(JSON.stringify(modifiedConfig));
+            const config = new ConfigObject();
+            assert.strictEqual(config.serverHeader, 'ScalityS3');
+        });
+    });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1527,9 +1527,9 @@ arraybuffer.prototype.slice@^1.0.4:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#8.2.48":
-  version "8.2.48"
-  resolved "git+https://github.com/scality/arsenal#362f7908b6126709add96ee981d5235d96bab58c"
+"arsenal@git+https://github.com/scality/arsenal#8.2.50":
+  version "8.2.50"
+  resolved "git+https://github.com/scality/arsenal#2b0a8026cb62e0f6a621738e78f5e9fcc977275e"
   dependencies:
     "@azure/identity" "^4.13.0"
     "@azure/storage-blob" "^12.28.0"


### PR DESCRIPTION
Read `serverHeader` from config and call Arsenal's `setServerHeader()` at startup. Allows deployments to configure the HTTP Server response header value. Default remains `'S3 Server'`.

Depends on: scality/Arsenal#2606