### PR TITLE
CLDSRV-891 Update GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/actions/cleanup-and-coverage/action.yaml
+++ b/.github/actions/cleanup-and-coverage/action.yaml
@@ -32,7 +32,7 @@ runs:
       working-directory: .github/docker
     
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         token: ${{ inputs.codecov-token }}
         directory: /tmp/coverage/${{ github.job }}

--- a/.github/actions/setup-ci/action.yaml
+++ b/.github/actions/setup-ci/action.yaml
@@ -25,7 +25,7 @@ runs:
       run: |-
         set -exu;
         mkdir -p /tmp/coverage/${JOB_NAME}/;
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: '22'
         cache: 'yarn'
@@ -35,11 +35,11 @@ runs:
     - name: install dependencies
       shell: bash
       run: yarn install --ignore-engines --frozen-lockfile --network-concurrency 1
-    - uses: actions/cache@v3
+    - uses: actions/cache@v5
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v6
       with:
         python-version: 3.9
     - name: Setup python2 test environment

--- a/.github/workflows/alerts.yaml
+++ b/.github/workflows/alerts.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Render and test ${{ matrix.tests.name }}
         uses: scality/action-prom-render-test@1.0.3

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -17,9 +17,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: javascript, python, ruby
 
       - name: Build and analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,7 +95,7 @@ jobs:
     if: github.repository_owner == 'scality'
     steps:
       - name: Generate GitHub App Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.ACTIONS_APP_ID }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildk
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -44,7 +44,7 @@ jobs:
         working-directory: monitoring
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -54,7 +54,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push test coverage image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -64,7 +64,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push federation image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: images/federation
@@ -80,7 +80,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=federation
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -79,8 +79,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+      uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
         node-version: '22'
         cache: yarn
@@ -89,7 +89,7 @@ jobs:
       run: yarn global add typescript@4.9.5
     - name: install dependencies
       run: yarn install --frozen-lockfile --network-concurrency 1
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.9'
         cache: pip
@@ -108,8 +108,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+      uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
         node-version: '22'
         cache: yarn
@@ -133,7 +133,7 @@ jobs:
         files: '**/junit/*junit*.xml'
         flags: unit
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: ./coverage/test
@@ -161,20 +161,20 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ github.token }}
 
       - name: Build and push cloudserver image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: .
@@ -189,7 +189,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=cloudserver
 
       - name: Build and push cloudserver image test coverage
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: .
@@ -204,7 +204,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=cloudserver
 
       - name: Build and push federation image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: images/federation
@@ -220,7 +220,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=federation
 
       - name: Build and push pykmip image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: .github/pykmip
@@ -233,7 +233,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=pykmip
 
       - name: Build and push MongoDB
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: .github/docker/mongodb
@@ -255,9 +255,9 @@ jobs:
       JOB_NAME: ${{ github.job }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Login to Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
@@ -316,7 +316,7 @@ jobs:
       S3_SERVER_ACCESS_LOGS_MODE: ENABLED
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Setup CI environment
       uses: ./.github/actions/setup-ci
     - name: Setup server access logs file and directory
@@ -377,7 +377,7 @@ jobs:
       S3_SERVER_ACCESS_LOGS_MODE: ENABLED
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Setup CI environment
       uses: ./.github/actions/setup-ci
     - name: Setup server access logs file and directory
@@ -445,7 +445,7 @@ jobs:
       S3_SERVER_ACCESS_LOGS_MODE: ENABLED
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Setup CI environment
       uses: ./.github/actions/setup-ci
     - name: Setup matrix job artifacts directory
@@ -525,9 +525,9 @@ jobs:
       S3_SERVER_ACCESS_LOGS_MODE: ENABLED
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Login to Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
@@ -634,7 +634,7 @@ jobs:
       JOB_NAME: ${{ github.job }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Setup CI environment
       uses: ./.github/actions/setup-ci
     - name: Setup CI services
@@ -690,7 +690,7 @@ jobs:
       JOB_NAME: ${{ github.job }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Setup CI environment
       uses: ./.github/actions/setup-ci
     - name: Setup CI services
@@ -747,7 +747,7 @@ jobs:
       S3KMIP_CA: /tmp/ssl-kmip/kmip-ca.pem
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Setup CI environment
       uses: ./.github/actions/setup-ci
     - name: Copy KMIP certs
@@ -799,8 +799,8 @@ jobs:
       S3KMS: kmip
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+      uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
         python-version: 3.9
     - name: Setup CI environment
@@ -902,12 +902,12 @@ jobs:
       COMPOSE_FILE: docker-compose.yaml:docker-compose.sse.yaml
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+      uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
         python-version: 3.9
     - name: Login to GitHub Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
@@ -1036,8 +1036,8 @@ jobs:
     if: always()
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+      uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
         node-version: '22'
         cache: yarn


### PR DESCRIPTION
## Summary
Update GitHub Actions workflow files to use action versions that run on Node 24.

Closes CLDSRV-891

## Context
GitHub is deprecating Node 20 as the JavaScript runtime for GitHub Actions runners:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

**Timeline**:
- June 2, 2026: Runners will default to Node 24 (deprecation warnings for node20 actions)
- Fall 2026: Node 20 completely removed from runners

## Changes
Updated action versions in all workflow files:
- `actions/checkout@v4` → `@v6`
- `actions/setup-node@v4` → `@v6`
- `actions/setup-python@v5` → `@v6`
- `docker/build-push-action@v5` → `@v7`
- `docker/login-action@v3` → `@v4`
- `docker/setup-buildx-action@v3` → `@v4`
- `softprops/action-gh-release@v2` → `@v3`
- `codecov/codecov-action@v4/@v5` → `@v6`