### PR TITLE
CLDSRV-893: Return ARN for assumed-role requesters in access logs

### DIFF
--- a/lib/utilities/serverAccessLogger.js
+++ b/lib/utilities/serverAccessLogger.js
@@ -323,11 +323,16 @@ function getOperation(req) {
     return `REST.${req.method}.${resourceType}`;
 }
 
+const assumedRoleArnRegex = /^arn:aws:sts::[0-9]{12}:assumed-role\/\S+$/;
+
 function getRequester(authInfo) {
     const requester = null;
     if (authInfo) {
+        const arn = authInfo.getArn ? authInfo.getArn() : null;
         if (authInfo.isRequesterPublicUser && authInfo.isRequesterPublicUser()) {
             return requester; // Unauthenticated requests
+        } else if (arn && assumedRoleArnRegex.test(arn)) {
+            return arn;
         } else if (authInfo.isRequesterAnIAMUser && authInfo.isRequesterAnIAMUser()) {
             // IAM user: include IAM user name and account
             const iamUserName = authInfo.getIAMdisplayName ? authInfo.getIAMdisplayName() : '';

--- a/tests/unit/utils/serverAccessLogger.js
+++ b/tests/unit/utils/serverAccessLogger.js
@@ -311,6 +311,31 @@ describe('serverAccessLogger utility functions', () => {
             assert.strictEqual(result, 'canonicalID123');
         });
 
+        it('should return ARN for assumed-role session user', () => {
+            const arn = 'arn:aws:sts::123456789012:assumed-role/lifecycle-role/backbeat-lifecycle';
+            const authInfo = {
+                isRequesterPublicUser: () => false,
+                isRequesterAnIAMUser: () => false,
+                getArn: () => arn,
+                getCanonicalID: () => 'canonicalID789',
+            };
+            const result = getRequester(authInfo);
+            assert.strictEqual(result, arn);
+        });
+
+        it('should fall through to IAM user path for non-assumed-role ARN', () => {
+            const authInfo = {
+                isRequesterPublicUser: () => false,
+                isRequesterAnIAMUser: () => true,
+                getArn: () => 'arn:aws:iam::123456789012:user/myuser',
+                getIAMdisplayName: () => 'myuser',
+                getAccountDisplayName: () => 'myaccount',
+                getCanonicalID: () => 'canonicalID789',
+            };
+            const result = getRequester(authInfo);
+            assert.strictEqual(result, 'myuser:myaccount');
+        });
+
         it('should return canonical ID for regular user', () => {
             const authInfo = {
                 isRequesterPublicUser: () => false,


### PR DESCRIPTION
For assumed-role sessions, the requester field in server access logs currently contains spaces (e.g. `[assumedRole] lifecycle-role:backbeat-lifecycle:scality-internal-services`). Since the log format is space-delimited and this field is unquoted, the space shifts all subsequent fields for log parsers.

Per the [AWS S3 Server Access Log Format](https://docs.aws.amazon.com/AmazonS3/latest/userguide/LogFormat.html#log-record-fields), the Requester field for assumed-role sessions should be an ARN:
```
arn:aws:sts::123456789012:assumed-role/roleName/sessionName
```

Fixes: [S3C-11117](https://scality.atlassian.net/browse/S3C-11117)

[S3C-11117]: https://scality.atlassian.net/browse/S3C-11117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ