### PR TITLE
CLDSRV-894: Report turn-around time for PutObject and UploadPart

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -263,6 +263,19 @@ const api = {
                     request.serverAccessLog.analyticsUserName    = authNames.userName;
                 }
                 if (apiMethod === 'objectPut' || apiMethod === 'objectPutPart') {
+                    const setStartTurnAroundTime = () => {
+                        if (request.serverAccessLog) {
+                            request.serverAccessLog.startTurnAroundTime = process.hrtime.bigint();
+                        }
+                    };
+                    // For 0-byte uploads, downstream handlers do not consume
+                    // the request stream, so 'end' never fires. Set
+                    // startTurnAroundTime synchronously in that case.
+                    if (request.headers['content-length'] === '0') {
+                        setStartTurnAroundTime();
+                    } else {
+                        request.on('end', setStartTurnAroundTime);
+                    }
                     return next(null, userInfo, authorizationResults, streamingV4Params, infos);
                 }
                 // issue 100 Continue to the client

--- a/tests/unit/api/api.js
+++ b/tests/unit/api/api.js
@@ -115,6 +115,40 @@ describe('api.callApiMethod', () => {
         api.callApiMethod('multipartDelete', request, response, log);
     });
 
+    ['objectPut', 'objectPutPart'].forEach(method => {
+        it(`should set startTurnAroundTime on request end for ${method}`, done => {
+            sandbox.stub(api, method).callsFake(
+                (userInfo, _request, streamingV4Params, _log, cb) => {
+                    request.on('end', () => {
+                        assert.strictEqual(typeof request.serverAccessLog.startTurnAroundTime, 'bigint');
+                        cb();
+                    });
+                    request.resume();
+                });
+            request.objectKey = 'testobject';
+            request.serverAccessLog = {};
+            api.callApiMethod(method, request, response, log, err => {
+                assert.ifError(err);
+                done();
+            });
+        });
+
+        it(`should set startTurnAroundTime synchronously for 0-byte ${method}`, done => {
+            sandbox.stub(api, method).callsFake(
+                (userInfo, _request, streamingV4Params, _log, cb) => {
+                    assert.strictEqual(typeof request.serverAccessLog.startTurnAroundTime, 'bigint');
+                    cb();
+                });
+            request.objectKey = 'testobject';
+            request.serverAccessLog = {};
+            request.headers = Object.assign({}, request.headers, { 'content-length': '0' });
+            api.callApiMethod(method, request, response, log, err => {
+                assert.ifError(err);
+                done();
+            });
+        });
+    });
+
     describe('MD5 checksum validation', () => {
         const methodsWithChecksumValidation = [
             'bucketPutACL',


### PR DESCRIPTION
Turn-around time was initially left unreported for PutObject and UploadPart because these operations stream the request body to the storage backend as it arrives. For large objects, receiving and processing overlap, so the measured turn-around time only captures the tail-end confirmation latency rather than the full processing duration. We decided this was misleading and chose to report '-' instead.

However, testing against AWS shows that it does report turn-around time for these operations regardless of object size. This PR aligns our behavior with AWS.