### PR TITLE
CLDSRV-896: Emit IAM ARN in access log Requester field for IAM users

### DIFF
--- a/lib/utilities/serverAccessLogger.js
+++ b/lib/utilities/serverAccessLogger.js
@@ -334,10 +334,10 @@ function getRequester(authInfo) {
         } else if (arn && assumedRoleArnRegex.test(arn)) {
             return arn;
         } else if (authInfo.isRequesterAnIAMUser && authInfo.isRequesterAnIAMUser()) {
-            // IAM user: include IAM user name and account
-            const iamUserName = authInfo.getIAMdisplayName ? authInfo.getIAMdisplayName() : '';
-            const accountName = authInfo.getAccountDisplayName ? authInfo.getAccountDisplayName() : '';
-            return iamUserName && accountName ? `${iamUserName}:${accountName}` : authInfo.getCanonicalID();
+            // IAM user: emit the IAM ARN (arn:aws:iam::<accountId>:user/<userName>)
+            // to match the AWS S3 server access log format. Fall back to the
+            // canonical ID if the ARN is unexpectedly absent.
+            return arn || authInfo.getCanonicalID();
         } else if (authInfo.getCanonicalID) {
             // Regular user: canonical user ID
             return authInfo.getCanonicalID();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "9.2.35",
+  "version": "9.2.36",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {

--- a/tests/unit/utils/serverAccessLogger.js
+++ b/tests/unit/utils/serverAccessLogger.js
@@ -287,24 +287,23 @@ describe('serverAccessLogger utility functions', () => {
             assert.strictEqual(result, null);
         });
 
-        it('should return IAM user name with account for IAM user', () => {
+        it('should return IAM ARN for IAM user', () => {
+            const arn = 'arn:aws:iam::123456789012:user/myuser';
             const authInfo = {
                 isRequesterPublicUser: () => false,
                 isRequesterAnIAMUser: () => true,
-                getIAMdisplayName: () => 'iamUser',
-                getAccountDisplayName: () => 'accountName',
+                getArn: () => arn,
                 getCanonicalID: () => 'canonicalID123',
             };
             const result = getRequester(authInfo);
-            assert.strictEqual(result, 'iamUser:accountName');
+            assert.strictEqual(result, arn);
         });
 
-        it('should return canonical ID for IAM user if display names are missing', () => {
+        it('should fall back to canonical ID for IAM user when ARN is missing', () => {
             const authInfo = {
                 isRequesterPublicUser: () => false,
                 isRequesterAnIAMUser: () => true,
-                getIAMdisplayName: () => '',
-                getAccountDisplayName: () => 'accountName',
+                getArn: () => undefined,
                 getCanonicalID: () => 'canonicalID123',
             };
             const result = getRequester(authInfo);
@@ -321,19 +320,6 @@ describe('serverAccessLogger utility functions', () => {
             };
             const result = getRequester(authInfo);
             assert.strictEqual(result, arn);
-        });
-
-        it('should fall through to IAM user path for non-assumed-role ARN', () => {
-            const authInfo = {
-                isRequesterPublicUser: () => false,
-                isRequesterAnIAMUser: () => true,
-                getArn: () => 'arn:aws:iam::123456789012:user/myuser',
-                getIAMdisplayName: () => 'myuser',
-                getAccountDisplayName: () => 'myaccount',
-                getCanonicalID: () => 'canonicalID789',
-            };
-            const result = getRequester(authInfo);
-            assert.strictEqual(result, 'myuser:myaccount');
         });
 
         it('should return canonical ID for regular user', () => {


### PR DESCRIPTION
When an IAM user makes a request, the Requester field in the bucket server access log was emitted as `userName:accountName`.
AWS emits an ARN of the form `arn:aws:iam::<accountId>:user/<userName>.`
Use the IAM ARN that Vault already provides via authInfo to match the AWS S3 server access log format.