### PR TITLE
CLDSRV-899: Log replication events in server access logs

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -536,6 +536,19 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
 
         const { headers, bucketName, objectKey } = request;
 
+        // Destination-side delete-marker replication.
+        // We need the REPLICA status to distinguish from
+        // source-side replication status updates that also carry isDeleteMarker=true.
+        if (omVal.isDeleteMarker
+            && omVal.replicationInfo
+            && omVal.replicationInfo.status === 'REPLICA'
+            && request.serverAccessLog) {
+            // eslint-disable-next-line no-param-reassign
+            request.serverAccessLog.replication = true;
+            // eslint-disable-next-line no-param-reassign
+            request.serverAccessLog.deleteMarker = true;
+        }
+
         if (headers['x-scal-replication-content'] === 'METADATA') {
             if (!objMd) {
                 return callback(errors.ObjNotFound);

--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -565,6 +565,23 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
             request.serverAccessLog.tagging = true;
         }
 
+        // Destination-side ACL-only replication.
+        // AWS uses REST.PUT.ACL on the destination with URI
+        // PUT /<bucket>/<key>?acl&versionId=<srcVersionId> and
+        // populates the aclRequired field.
+        // The REPLICA status excludes source-side replication-status updates.
+        if (omVal.replicationInfo
+            && omVal.replicationInfo.status === 'REPLICA'
+            && omVal.originOp === 's3:ObjectAcl:Put'
+            && request.serverAccessLog) {
+            // eslint-disable-next-line no-param-reassign
+            request.serverAccessLog.replication = true;
+            // eslint-disable-next-line no-param-reassign
+            request.serverAccessLog.acl = true;
+            // eslint-disable-next-line no-param-reassign
+            request.serverAccessLog.aclRequired = 'Yes';
+        }
+
         if (headers['x-scal-replication-content'] === 'METADATA') {
             if (!objMd) {
                 return callback(errors.ObjNotFound);

--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -408,6 +408,10 @@ function createCipherBundle(bucketInfo, isV2Request, log, cb) {
 }
 
 function putData(request, response, bucketInfo, objMd, log, callback) {
+    if (request.serverAccessLog) {
+        // eslint-disable-next-line no-param-reassign
+        request.serverAccessLog.replication = true;
+    }
     let errMessage;
     const canonicalID = request.headers['x-scal-canonical-id'];
     if (canonicalID === undefined) {

--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -549,6 +549,22 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
             request.serverAccessLog.deleteMarker = true;
         }
 
+        // Destination-side tag-only replication.
+        // AWS uses REST.PUT.OBJECT_TAGGING for both - a tag-delete
+        // is replicated as a PUT of an empty tag set with the same
+        // URI shape.
+        // The REPLICA status excludes source-side replication-status updates.
+        if (omVal.replicationInfo
+            && omVal.replicationInfo.status === 'REPLICA'
+            && (omVal.originOp === 's3:ObjectTagging:Put'
+                || omVal.originOp === 's3:ObjectTagging:Delete')
+            && request.serverAccessLog) {
+            // eslint-disable-next-line no-param-reassign
+            request.serverAccessLog.replication = true;
+            // eslint-disable-next-line no-param-reassign
+            request.serverAccessLog.tagging = true;
+        }
+
         if (headers['x-scal-replication-content'] === 'METADATA') {
             if (!objMd) {
                 return callback(errors.ObjNotFound);

--- a/lib/utilities/serverAccessLogger.js
+++ b/lib/utilities/serverAccessLogger.js
@@ -295,6 +295,9 @@ function getOperation(req) {
             if (req.serverAccessLog.deleteMarker) {
                 return 'REST.DELETE.OBJECT';
             }
+            if (req.serverAccessLog.tagging) {
+                return 'REST.PUT.OBJECT_TAGGING';
+            }
             return 'REST.PUT.OBJECT';
         }
         return `REST.${req.method}.BACKBEAT`;
@@ -651,10 +654,17 @@ function logServerAccess(req, res) {
         logEntry.clientIP = undefined;
         logEntry.userAgent = undefined;
         logEntry.referer = undefined;
-        const method = params.deleteMarker ? 'DELETE' : req.method;
+        let method = req.method;
+        let query = '';
+        if (params.deleteMarker) {
+            method = 'DELETE';
+        } else if (params.tagging) {
+            const versionId = req.query?.versionId;
+            query = versionId ? `?tagging&versionId=${versionId}` : '?tagging';
+        }
         const encodedKey = params.objectKey.split('/').map(encodeURIComponent).join('/');
         logEntry.requestURI =
-            `${method} /${params.bucketName}/${encodedKey} HTTP/${req.httpVersion ?? '1.1'}`;
+            `${method} /${params.bucketName}/${encodedKey}${query} HTTP/${req.httpVersion ?? '1.1'}`;
     }
 
     if (params.internalLogRequestQueue && params.internalLogRequestQueue.length > 0) {

--- a/lib/utilities/serverAccessLogger.js
+++ b/lib/utilities/serverAccessLogger.js
@@ -298,6 +298,9 @@ function getOperation(req) {
             if (req.serverAccessLog.tagging) {
                 return 'REST.PUT.OBJECT_TAGGING';
             }
+            if (req.serverAccessLog.acl) {
+                return 'REST.PUT.ACL';
+            }
             return 'REST.PUT.OBJECT';
         }
         return `REST.${req.method}.BACKBEAT`;
@@ -661,6 +664,9 @@ function logServerAccess(req, res) {
         } else if (params.tagging) {
             const versionId = req.query?.versionId;
             query = versionId ? `?tagging&versionId=${versionId}` : '?tagging';
+        } else if (params.acl) {
+            const versionId = req.query?.versionId;
+            query = versionId ? `?acl&versionId=${versionId}` : '?acl';
         }
         const encodedKey = params.objectKey.split('/').map(encodeURIComponent).join('/');
         logEntry.requestURI =

--- a/lib/utilities/serverAccessLogger.js
+++ b/lib/utilities/serverAccessLogger.js
@@ -292,6 +292,9 @@ function getOperation(req) {
             return 'S3.EXPIRE.OBJECT';
         }
         if (req.serverAccessLog.replication) {
+            if (req.serverAccessLog.deleteMarker) {
+                return 'REST.DELETE.OBJECT';
+            }
             return 'REST.PUT.OBJECT';
         }
         return `REST.${req.method}.BACKBEAT`;
@@ -632,6 +635,7 @@ function logServerAccess(req, res) {
         logEntry.awsAccessKeyID = undefined;
     }
 
+    // Match AWS log shape for replication entries: blank clientIP, userAgent
     // and referer, and rewrite requestURI from the internal /_/backbeat/{data,metadata}
     // endpoint to a standard verb on the destination bucket.
     // The synthesized requestURI matches the AWS requestURI for replication.
@@ -647,9 +651,10 @@ function logServerAccess(req, res) {
         logEntry.clientIP = undefined;
         logEntry.userAgent = undefined;
         logEntry.referer = undefined;
+        const method = params.deleteMarker ? 'DELETE' : req.method;
         const encodedKey = params.objectKey.split('/').map(encodeURIComponent).join('/');
         logEntry.requestURI =
-            `${req.method} /${params.bucketName}/${encodedKey} HTTP/${req.httpVersion ?? '1.1'}`;
+            `${method} /${params.bucketName}/${encodedKey} HTTP/${req.httpVersion ?? '1.1'}`;
     }
 
     if (params.internalLogRequestQueue && params.internalLogRequestQueue.length > 0) {

--- a/lib/utilities/serverAccessLogger.js
+++ b/lib/utilities/serverAccessLogger.js
@@ -291,6 +291,9 @@ function getOperation(req) {
         if (req.serverAccessLog.expiration) {
             return 'S3.EXPIRE.OBJECT';
         }
+        if (req.serverAccessLog.replication) {
+            return 'REST.PUT.OBJECT';
+        }
         return `REST.${req.method}.BACKBEAT`;
     }
 
@@ -519,9 +522,10 @@ function buildLogEntry(req, params, options) {
 
         // Scality server access logs extra fields
         logFormatVersion: SERVER_ACCESS_LOG_FORMAT_VERSION,
-        // For non-expiration backbeat requests, force loggingEnabled
-        // to false to prevent delivery to log courier.
-        loggingEnabled: (params.backbeat && !params.expiration) ? false : (params.enabled ?? undefined),
+        // For backbeat requests other than expiration and replication,
+        // force loggingEnabled to false to prevent delivery to log courier.
+        loggingEnabled: (params.backbeat && !params.expiration && !params.replication)
+            ? false : (params.enabled ?? undefined),
         loggingTargetBucket: params.loggingEnabled?.TargetBucket ?? undefined,
         loggingTargetPrefix: params.loggingEnabled?.TargetPrefix ?? undefined,
         awsAccessKeyID: authInfo?.getAccessKey() ?? undefined,
@@ -626,6 +630,26 @@ function logServerAccess(req, res) {
         logEntry.userAgent = undefined;
         logEntry.versionId = undefined;
         logEntry.awsAccessKeyID = undefined;
+    }
+
+    // and referer, and rewrite requestURI from the internal /_/backbeat/{data,metadata}
+    // endpoint to a standard verb on the destination bucket.
+    // The synthesized requestURI matches the AWS requestURI for replication.
+    // It is not an actual cloudserver endpoint (replication is delivered via /_/backbeat/...);
+    // the operation field is the authoritative signal that the entry is a replication event.
+    //   - Delete-marker replication arrives as a putMetadata (PUT) but is logged
+    //     as a DELETE.
+    //   - Tag-only replication appends ?tagging&versionId=<destVid> to match the
+    //     AWS PutObjectTagging URI.
+    //   - ACL-only replication appends ?acl&versionId=<destVid> to match the
+    //     AWS PutObjectAcl URI.
+    if (params.replication) {
+        logEntry.clientIP = undefined;
+        logEntry.userAgent = undefined;
+        logEntry.referer = undefined;
+        const encodedKey = params.objectKey.split('/').map(encodeURIComponent).join('/');
+        logEntry.requestURI =
+            `${req.method} /${params.bucketName}/${encodedKey} HTTP/${req.httpVersion ?? '1.1'}`;
     }
 
     if (params.internalLogRequestQueue && params.internalLogRequestQueue.length > 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "9.2.39",
+  "version": "9.2.40",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {

--- a/tests/multipleBackend/backendHealthcheckResponse.js
+++ b/tests/multipleBackend/backendHealthcheckResponse.js
@@ -20,7 +20,9 @@ const log = new DummyRequestLogger();
 const locConstraints = Object.keys(config.locationConstraints);
 const azureClient = getAzureClient();
 
-describe('Healthcheck response', () => {
+describe('Healthcheck response', function describeHealthcheck() {
+    this.timeout(60000);
+
     it('should return result for every location constraint in ' +
     'locationConfig and every external locations with flightCheckOnStartUp ' +
     'set to true', done => {

--- a/tests/unit/utils/serverAccessLogger.js
+++ b/tests/unit/utils/serverAccessLogger.js
@@ -286,6 +286,16 @@ describe('serverAccessLogger utility functions', () => {
             const result = getOperation(req);
             assert.strictEqual(result, 'S3.EXPIRE.OBJECT');
         });
+
+        it('should return REST.PUT.OBJECT for replication requests', () => {
+            const req = {
+                method: 'PUT',
+                apiMethod: 'routeBackbeat',
+                serverAccessLog: { backbeat: true, replication: true },
+            };
+            const result = getOperation(req);
+            assert.strictEqual(result, 'REST.PUT.OBJECT');
+        });
     });
 
     describe('getRequester', () => {
@@ -1638,6 +1648,209 @@ describe('serverAccessLogger utility functions', () => {
             assert.strictEqual(loggedData.requester, 'ScalityS3LifecycleService');
             assert.strictEqual(loggedData.errorCode, 'NoSuchKey');
             assert.strictEqual(loggedData.httpCode, undefined);
+        });
+
+        it('should pass through loggingEnabled for replication', () => {
+            setServerAccessLogger(mockLogger);
+            const req = {
+                serverAccessLog: {
+                    backbeat: true,
+                    replication: true,
+                    enabled: true,
+                    loggingEnabled: {
+                        TargetBucket: 'log-bucket',
+                        TargetPrefix: 'logs/',
+                    },
+                    bucketName: 'dest-bucket',
+                    objectKey: 'replicated.txt',
+                },
+                method: 'PUT',
+                apiMethod: 'routeBackbeat',
+                headers: {},
+                socket: {},
+            };
+            const res = {
+                serverAccessLog: {},
+                getHeader: () => null,
+            };
+
+            logServerAccess(req, res);
+
+            assert.strictEqual(mockLogger.write.callCount, 1);
+            const loggedData = JSON.parse(mockLogger.write.firstCall.args[0].trim());
+            assert.strictEqual(loggedData.loggingEnabled, true);
+            assert.strictEqual(loggedData.loggingTargetBucket, 'log-bucket');
+            assert.strictEqual(loggedData.loggingTargetPrefix, 'logs/');
+            assert.strictEqual(loggedData.operation, 'REST.PUT.OBJECT');
+        });
+
+        it('should not deliver replication log when bucket has no logging config', () => {
+            setServerAccessLogger(mockLogger);
+            const req = {
+                serverAccessLog: {
+                    backbeat: true,
+                    replication: true,
+                    enabled: false,
+                    bucketName: 'dest-bucket',
+                    objectKey: 'replicated.txt',
+                },
+                method: 'PUT',
+                apiMethod: 'routeBackbeat',
+                headers: {},
+                socket: {},
+            };
+            const res = {
+                serverAccessLog: {},
+                getHeader: () => null,
+            };
+
+            logServerAccess(req, res);
+
+            assert.strictEqual(mockLogger.write.callCount, 1);
+            const loggedData = JSON.parse(mockLogger.write.firstCall.args[0].trim());
+            assert.strictEqual(loggedData.loggingEnabled, false);
+        });
+
+        it('should produce a complete log entry for replication', () => {
+            setServerAccessLogger(mockLogger);
+            const authInfo = {
+                getAccountDisplayName: () => 'replicationAccount',
+                getCanonicalID: () => 'replication-canonical-id',
+                isRequesterPublicUser: () => false,
+                isRequesterAnIAMUser: () => false,
+                getArn: () =>
+                    'arn:aws:sts::123456789012:assumed-role/replication-role/backbeat-replication',
+                getAuthVersion: () => 'AWS4-HMAC-SHA256',
+                getAuthType: () => 'REST-HEADER',
+                getAccessKey: () => 'replication-access-key',
+            };
+            const startTime = process.hrtime.bigint();
+            const startTurnAroundTime = startTime + 1_000_000n;
+            const endTurnAroundTime = startTurnAroundTime + 13_000_000n;
+            const onFinishEndTime = startTime + 19_000_000n;
+            const onCloseEndTime = startTime + 20_000_000n;
+
+            const req = {
+                serverAccessLog: {
+                    backbeat: true,
+                    replication: true,
+                    enabled: true,
+                    loggingEnabled: {
+                        TargetBucket: 'log-bucket',
+                        TargetPrefix: 'access-logs/',
+                    },
+                    bucketOwner: 'bucket-owner-id',
+                    bucketName: 'dest-bucket',
+                    objectKey: 'replicated.txt',
+                    authInfo,
+                    analyticsAction: 'putData',
+                    analyticsAccountName: 'replicationAccount',
+                    analyticsUserName: '',
+                    startTime,
+                    startTimeUnixMS: Date.now(),
+                    startTurnAroundTime,
+                    onFinishEndTime,
+                    onCloseEndTime,
+                    objectSize: 43,
+                },
+                method: 'PUT',
+                apiMethod: 'routeBackbeat',
+                url: '/_/backbeat/data/dest-bucket/replicated.txt?v2',
+                httpVersion: '1.1',
+                headers: {
+                    host: '127.0.0.1:8000',
+                    referer: 'http://example.com',
+                    'user-agent': 'aws-sdk-nodejs/2.1692.0',
+                },
+                socket: {},
+            };
+            const res = {
+                serverAccessLog: {
+                    endTurnAroundTime,
+                    bytesSent: 75,
+                },
+                statusCode: 200,
+                getHeader: () => null,
+            };
+
+            logServerAccess(req, res);
+
+            assert.strictEqual(mockLogger.write.callCount, 1);
+            const loggedData = JSON.parse(mockLogger.write.firstCall.args[0].trim());
+
+            // Core replication fields
+            assert.strictEqual(loggedData.operation, 'REST.PUT.OBJECT');
+            assert.strictEqual(loggedData.loggingEnabled, true);
+            assert.strictEqual(loggedData.loggingTargetBucket, 'log-bucket');
+            assert.strictEqual(loggedData.loggingTargetPrefix, 'access-logs/');
+
+            // Bucket and object info
+            assert.strictEqual(loggedData.bucketOwner, 'bucket-owner-id');
+            assert.strictEqual(loggedData.bucketName, 'dest-bucket');
+            assert.strictEqual(loggedData.objectKey, 'replicated.txt');
+
+            // Requester is the assumed-role ARN from auth
+            assert.strictEqual(loggedData.requester,
+                'arn:aws:sts::123456789012:assumed-role/replication-role/backbeat-replication');
+
+            // requestURI is synthesized to look like a normal S3 PUT,
+            // not the internal /_/backbeat/data path
+            assert.strictEqual(loggedData.requestURI,
+                'PUT /dest-bucket/replicated.txt HTTP/1.1');
+
+            // HTTP-layer fields that AWS blanks for replication
+            assert.strictEqual(loggedData.clientIP, undefined);
+            assert.strictEqual(loggedData.userAgent, undefined);
+            assert.strictEqual(loggedData.referer, undefined);
+
+            // Real HTTP timing/status preserved
+            assert.strictEqual(loggedData.httpCode, 200);
+            assert.strictEqual(loggedData.bytesSent, 75);
+            assert.strictEqual(loggedData.objectSize, 43);
+            assert.strictEqual(loggedData.hostHeader, '127.0.0.1:8000');
+            assert.strictEqual(loggedData.signatureVersion, 'AWS4-HMAC-SHA256');
+            assert.strictEqual(loggedData.authenticationType, 'REST-HEADER');
+        });
+
+        it('should log replication with error code on failure', () => {
+            setServerAccessLogger(mockLogger);
+            const req = {
+                serverAccessLog: {
+                    backbeat: true,
+                    replication: true,
+                    enabled: true,
+                    loggingEnabled: {
+                        TargetBucket: 'log-bucket',
+                        TargetPrefix: 'logs/',
+                    },
+                    bucketOwner: 'bucket-owner-id',
+                    bucketName: 'dest-bucket',
+                    objectKey: 'replicated.txt',
+                    startTime: process.hrtime.bigint(),
+                    startTimeUnixMS: Date.now(),
+                },
+                method: 'PUT',
+                apiMethod: 'routeBackbeat',
+                headers: {},
+                socket: {},
+            };
+            const res = {
+                serverAccessLog: {
+                    errorCode: 'InternalError',
+                    endTurnAroundTime: process.hrtime.bigint(),
+                },
+                statusCode: 500,
+                getHeader: () => null,
+            };
+
+            logServerAccess(req, res);
+
+            assert.strictEqual(mockLogger.write.callCount, 1);
+            const loggedData = JSON.parse(mockLogger.write.firstCall.args[0].trim());
+            assert.strictEqual(loggedData.operation, 'REST.PUT.OBJECT');
+            assert.strictEqual(loggedData.loggingEnabled, true);
+            assert.strictEqual(loggedData.errorCode, 'InternalError');
+            assert.strictEqual(loggedData.httpCode, 500);
         });
 
     });

--- a/tests/unit/utils/serverAccessLogger.js
+++ b/tests/unit/utils/serverAccessLogger.js
@@ -324,6 +324,20 @@ describe('serverAccessLogger utility functions', () => {
             const result = getOperation(req);
             assert.strictEqual(result, 'REST.PUT.OBJECT_TAGGING');
         });
+
+        it('should return REST.PUT.ACL for ACL-only replication', () => {
+            const req = {
+                method: 'PUT',
+                apiMethod: 'routeBackbeat',
+                serverAccessLog: {
+                    backbeat: true,
+                    replication: true,
+                    acl: true,
+                },
+            };
+            const result = getOperation(req);
+            assert.strictEqual(result, 'REST.PUT.ACL');
+        });
     });
 
     describe('getRequester', () => {
@@ -1970,6 +1984,80 @@ describe('serverAccessLogger utility functions', () => {
             assert.strictEqual(loggedData.requestURI,
                 `PUT /dest-bucket/replicated.txt?tagging&versionId=${versionId} HTTP/1.1`);
             assert.strictEqual(loggedData.versionId, versionId);
+
+            // HTTP-layer fields that AWS blanks for replication
+            assert.strictEqual(loggedData.clientIP, undefined);
+            assert.strictEqual(loggedData.userAgent, undefined);
+            assert.strictEqual(loggedData.referer, undefined);
+
+            // Replication identity preserved
+            assert.strictEqual(loggedData.requester,
+                'arn:aws:sts::123456789012:assumed-role/replication-role/backbeat-replication');
+        });
+
+        it('should produce a REST.PUT.ACL entry for ACL-only replication', () => {
+            setServerAccessLogger(mockLogger);
+            const authInfo = {
+                getAccountDisplayName: () => 'replicationAccount',
+                getCanonicalID: () => 'replication-canonical-id',
+                isRequesterPublicUser: () => false,
+                isRequesterAnIAMUser: () => false,
+                getArn: () =>
+                    'arn:aws:sts::123456789012:assumed-role/replication-role/backbeat-replication',
+                getAuthVersion: () => 'AWS4-HMAC-SHA256',
+                getAuthType: () => 'REST-HEADER',
+                getAccessKey: () => 'replication-access-key',
+            };
+            const versionId = 'aIXVkw5Tw2Pd00000000001I4j3QKsvf';
+            const req = {
+                serverAccessLog: {
+                    backbeat: true,
+                    replication: true,
+                    acl: true,
+                    aclRequired: 'Yes',
+                    enabled: true,
+                    loggingEnabled: {
+                        TargetBucket: 'log-bucket',
+                        TargetPrefix: 'logs/',
+                    },
+                    bucketOwner: 'bucket-owner-id',
+                    bucketName: 'dest-bucket',
+                    objectKey: 'replicated.txt',
+                    authInfo,
+                    startTime: process.hrtime.bigint(),
+                    startTimeUnixMS: Date.now(),
+                },
+                method: 'PUT',
+                apiMethod: 'routeBackbeat',
+                url: `/_/backbeat/metadata/dest-bucket/replicated.txt?versionId=${versionId}`,
+                query: { versionId },
+                httpVersion: '1.1',
+                headers: {
+                    host: '127.0.0.1:8000',
+                    referer: 'http://example.com',
+                    'user-agent': 'aws-sdk-nodejs/2.1692.0',
+                },
+                socket: {},
+            };
+            const res = {
+                serverAccessLog: {
+                    endTurnAroundTime: process.hrtime.bigint(),
+                },
+                statusCode: 200,
+                getHeader: () => null,
+            };
+
+            logServerAccess(req, res);
+
+            assert.strictEqual(mockLogger.write.callCount, 1);
+            const loggedData = JSON.parse(mockLogger.write.firstCall.args[0].trim());
+
+            assert.strictEqual(loggedData.operation, 'REST.PUT.ACL');
+            assert.strictEqual(loggedData.loggingEnabled, true);
+            assert.strictEqual(loggedData.requestURI,
+                `PUT /dest-bucket/replicated.txt?acl&versionId=${versionId} HTTP/1.1`);
+            assert.strictEqual(loggedData.versionId, versionId);
+            assert.strictEqual(loggedData.aclRequired, 'Yes');
 
             // HTTP-layer fields that AWS blanks for replication
             assert.strictEqual(loggedData.clientIP, undefined);

--- a/tests/unit/utils/serverAccessLogger.js
+++ b/tests/unit/utils/serverAccessLogger.js
@@ -296,6 +296,20 @@ describe('serverAccessLogger utility functions', () => {
             const result = getOperation(req);
             assert.strictEqual(result, 'REST.PUT.OBJECT');
         });
+
+        it('should return REST.DELETE.OBJECT for delete-marker replication', () => {
+            const req = {
+                method: 'PUT',
+                apiMethod: 'routeBackbeat',
+                serverAccessLog: {
+                    backbeat: true,
+                    replication: true,
+                    deleteMarker: true,
+                },
+            };
+            const result = getOperation(req);
+            assert.strictEqual(result, 'REST.DELETE.OBJECT');
+        });
     });
 
     describe('getRequester', () => {
@@ -1810,6 +1824,75 @@ describe('serverAccessLogger utility functions', () => {
             assert.strictEqual(loggedData.hostHeader, '127.0.0.1:8000');
             assert.strictEqual(loggedData.signatureVersion, 'AWS4-HMAC-SHA256');
             assert.strictEqual(loggedData.authenticationType, 'REST-HEADER');
+        });
+
+        it('should produce a REST.DELETE.OBJECT entry for delete-marker replication', () => {
+            setServerAccessLogger(mockLogger);
+            const authInfo = {
+                getAccountDisplayName: () => 'replicationAccount',
+                getCanonicalID: () => 'replication-canonical-id',
+                isRequesterPublicUser: () => false,
+                isRequesterAnIAMUser: () => false,
+                getArn: () =>
+                    'arn:aws:sts::123456789012:assumed-role/replication-role/backbeat-replication',
+                getAuthVersion: () => 'AWS4-HMAC-SHA256',
+                getAuthType: () => 'REST-HEADER',
+                getAccessKey: () => 'replication-access-key',
+            };
+            const req = {
+                serverAccessLog: {
+                    backbeat: true,
+                    replication: true,
+                    deleteMarker: true,
+                    enabled: true,
+                    loggingEnabled: {
+                        TargetBucket: 'log-bucket',
+                        TargetPrefix: 'logs/',
+                    },
+                    bucketOwner: 'bucket-owner-id',
+                    bucketName: 'dest-bucket',
+                    objectKey: 'replicated.txt',
+                    authInfo,
+                    startTime: process.hrtime.bigint(),
+                    startTimeUnixMS: Date.now(),
+                },
+                method: 'PUT',
+                apiMethod: 'routeBackbeat',
+                url: '/_/backbeat/metadata/dest-bucket/replicated.txt',
+                httpVersion: '1.1',
+                headers: {
+                    host: '127.0.0.1:8000',
+                    referer: 'http://example.com',
+                    'user-agent': 'aws-sdk-nodejs/2.1692.0',
+                },
+                socket: {},
+            };
+            const res = {
+                serverAccessLog: {
+                    endTurnAroundTime: process.hrtime.bigint(),
+                },
+                statusCode: 200,
+                getHeader: () => null,
+            };
+
+            logServerAccess(req, res);
+
+            assert.strictEqual(mockLogger.write.callCount, 1);
+            const loggedData = JSON.parse(mockLogger.write.firstCall.args[0].trim());
+
+            assert.strictEqual(loggedData.operation, 'REST.DELETE.OBJECT');
+            assert.strictEqual(loggedData.loggingEnabled, true);
+            assert.strictEqual(loggedData.requestURI,
+                'DELETE /dest-bucket/replicated.txt HTTP/1.1');
+
+            // HTTP-layer fields that AWS blanks for replication
+            assert.strictEqual(loggedData.clientIP, undefined);
+            assert.strictEqual(loggedData.userAgent, undefined);
+            assert.strictEqual(loggedData.referer, undefined);
+
+            // Replication identity preserved
+            assert.strictEqual(loggedData.requester,
+                'arn:aws:sts::123456789012:assumed-role/replication-role/backbeat-replication');
         });
 
         it('should log replication with error code on failure', () => {

--- a/tests/unit/utils/serverAccessLogger.js
+++ b/tests/unit/utils/serverAccessLogger.js
@@ -310,6 +310,20 @@ describe('serverAccessLogger utility functions', () => {
             const result = getOperation(req);
             assert.strictEqual(result, 'REST.DELETE.OBJECT');
         });
+
+        it('should return REST.PUT.OBJECT_TAGGING for tag-only replication', () => {
+            const req = {
+                method: 'PUT',
+                apiMethod: 'routeBackbeat',
+                serverAccessLog: {
+                    backbeat: true,
+                    replication: true,
+                    tagging: true,
+                },
+            };
+            const result = getOperation(req);
+            assert.strictEqual(result, 'REST.PUT.OBJECT_TAGGING');
+        });
     });
 
     describe('getRequester', () => {
@@ -1884,6 +1898,78 @@ describe('serverAccessLogger utility functions', () => {
             assert.strictEqual(loggedData.loggingEnabled, true);
             assert.strictEqual(loggedData.requestURI,
                 'DELETE /dest-bucket/replicated.txt HTTP/1.1');
+
+            // HTTP-layer fields that AWS blanks for replication
+            assert.strictEqual(loggedData.clientIP, undefined);
+            assert.strictEqual(loggedData.userAgent, undefined);
+            assert.strictEqual(loggedData.referer, undefined);
+
+            // Replication identity preserved
+            assert.strictEqual(loggedData.requester,
+                'arn:aws:sts::123456789012:assumed-role/replication-role/backbeat-replication');
+        });
+
+        it('should produce a REST.PUT.OBJECT_TAGGING entry for tag-only replication', () => {
+            setServerAccessLogger(mockLogger);
+            const authInfo = {
+                getAccountDisplayName: () => 'replicationAccount',
+                getCanonicalID: () => 'replication-canonical-id',
+                isRequesterPublicUser: () => false,
+                isRequesterAnIAMUser: () => false,
+                getArn: () =>
+                    'arn:aws:sts::123456789012:assumed-role/replication-role/backbeat-replication',
+                getAuthVersion: () => 'AWS4-HMAC-SHA256',
+                getAuthType: () => 'REST-HEADER',
+                getAccessKey: () => 'replication-access-key',
+            };
+            const versionId = 'aIXVkw5Tw2Pd00000000001I4j3QKsvf';
+            const req = {
+                serverAccessLog: {
+                    backbeat: true,
+                    replication: true,
+                    tagging: true,
+                    enabled: true,
+                    loggingEnabled: {
+                        TargetBucket: 'log-bucket',
+                        TargetPrefix: 'logs/',
+                    },
+                    bucketOwner: 'bucket-owner-id',
+                    bucketName: 'dest-bucket',
+                    objectKey: 'replicated.txt',
+                    authInfo,
+                    startTime: process.hrtime.bigint(),
+                    startTimeUnixMS: Date.now(),
+                },
+                method: 'PUT',
+                apiMethod: 'routeBackbeat',
+                url: `/_/backbeat/metadata/dest-bucket/replicated.txt?versionId=${versionId}`,
+                query: { versionId },
+                httpVersion: '1.1',
+                headers: {
+                    host: '127.0.0.1:8000',
+                    referer: 'http://example.com',
+                    'user-agent': 'aws-sdk-nodejs/2.1692.0',
+                },
+                socket: {},
+            };
+            const res = {
+                serverAccessLog: {
+                    endTurnAroundTime: process.hrtime.bigint(),
+                },
+                statusCode: 200,
+                getHeader: () => null,
+            };
+
+            logServerAccess(req, res);
+
+            assert.strictEqual(mockLogger.write.callCount, 1);
+            const loggedData = JSON.parse(mockLogger.write.firstCall.args[0].trim());
+
+            assert.strictEqual(loggedData.operation, 'REST.PUT.OBJECT_TAGGING');
+            assert.strictEqual(loggedData.loggingEnabled, true);
+            assert.strictEqual(loggedData.requestURI,
+                `PUT /dest-bucket/replicated.txt?tagging&versionId=${versionId} HTTP/1.1`);
+            assert.strictEqual(loggedData.versionId, versionId);
 
             // HTTP-layer fields that AWS blanks for replication
             assert.strictEqual(loggedData.clientIP, undefined);


### PR DESCRIPTION
Replication writes via the backbeat `putData` route are now visible in the destination bucket's server access logs.

Reads from the source bucket are already logged as `REST.GET.OBJECT`.

Study of AWS server access logging with replication: https://scality.atlassian.net/browse/S3C-11048?focusedCommentId=473763