### PR TITLE
CLDSRV-898: handle checksums in CompleteMultipartUpload

### DIFF
--- a/lib/api/apiUtils/integrity/validateChecksums.js
+++ b/lib/api/apiUtils/integrity/validateChecksums.js
@@ -36,7 +36,7 @@ const errMPUTypeInvalid = errorInstances.InvalidRequest.customizeDescription(
     'Value for x-amz-checksum-type header is invalid.',
 );
 const errMPUTypeWithoutAlgo = errorInstances.InvalidRequest.customizeDescription(
-    'The x-amz-checksum-type header can only be used ' + 'with the x-amz-checksum-algorithm header.',
+    'The x-amz-checksum-type header can only be used with the x-amz-checksum-algorithm header.',
 );
 
 // Methods that validate BOTH Content-MD5 and x-amz-checksum-* against the

--- a/lib/api/apiUtils/integrity/validateChecksums.js
+++ b/lib/api/apiUtils/integrity/validateChecksums.js
@@ -164,6 +164,20 @@ const algorithms = Object.freeze({
 });
 
 /**
+ * List per-algorithm `x-amz-checksum-<algo>` value headers, excluding the
+ * `x-amz-checksum-type` and `x-amz-checksum-algorithm` configuration
+ * headers.
+ *
+ * @param {object} headers - HTTP request headers (lowercased keys)
+ * @returns {string[]} matching header names
+ */
+function listChecksumValueHeaders(headers) {
+    return Object.keys(headers).filter(
+        h => h.startsWith('x-amz-checksum-') && h !== 'x-amz-checksum-type' && h !== 'x-amz-checksum-algorithm',
+    );
+}
+
+/**
  * Validate the x-amz-checksum-<algo> header against a buffered body.
  *
  * @param {object} headers - HTTP request headers (lowercased keys)
@@ -172,7 +186,7 @@ const algorithms = Object.freeze({
  *   null on success; otherwise a ChecksumError with details.
  */
 async function validateXAmzChecksums(headers, body) {
-    const checksumHeaders = Object.keys(headers).filter(header => header.startsWith('x-amz-checksum-'));
+    const checksumHeaders = listChecksumValueHeaders(headers);
     const xAmzChecksumCnt = checksumHeaders.length;
     if (xAmzChecksumCnt > 1) {
         return { error: ChecksumError.MultipleChecksumTypes, details: { algorithms: checksumHeaders } };
@@ -256,7 +270,7 @@ function getChecksumDataFromHeaders(headers) {
         return null;
     };
 
-    const checksumHeaders = Object.keys(headers).filter(header => header.startsWith('x-amz-checksum-'));
+    const checksumHeaders = listChecksumValueHeaders(headers);
     const xAmzChecksumCnt = checksumHeaders.length;
     if (xAmzChecksumCnt > 1) {
         return { error: ChecksumError.MultipleChecksumTypes, details: { algorithms: checksumHeaders } };
@@ -441,9 +455,7 @@ function arsenalErrorFromChecksumError(err) {
 function validateCompleteMultipartUploadChecksum(headers, finalChecksum) {
     // x-amz-checksum-type can be present in a completeMPU request so we drop it.
     // x-amz-checksum-algorithm is ignored by AWS in this context so we drop it.
-    const valueHeaders = Object.keys(headers).filter(
-        h => h.startsWith('x-amz-checksum-') && h !== 'x-amz-checksum-type' && h !== 'x-amz-checksum-algorithm',
-    );
+    const valueHeaders = listChecksumValueHeaders(headers);
 
     if (valueHeaders.length === 0) {
         return null;

--- a/lib/api/apiUtils/integrity/validateChecksums.js
+++ b/lib/api/apiUtils/integrity/validateChecksums.js
@@ -39,10 +39,9 @@ const errMPUTypeWithoutAlgo = errorInstances.InvalidRequest.customizeDescription
     'The x-amz-checksum-type header can only be used ' + 'with the x-amz-checksum-algorithm header.',
 );
 
+// Methods that validate BOTH Content-MD5 and x-amz-checksum-* against the
+// buffered request body. For these, x-amz-checksum-* is the body digest.
 const checksumedMethods = Object.freeze({
-    // CompleteMPU's x-amz-checksum-<algo> is the final-object checksum,
-    // not a body digest. Validated in completeMultipartUpload.js instead.
-    // 'completeMultipartUpload': true,
     multiObjectDelete: true,
     bucketPutACL: true,
     bucketPutCors: true,
@@ -61,6 +60,15 @@ const checksumedMethods = Object.freeze({
     objectPutRetention: true,
     objectPutTagging: true,
     objectRestore: true,
+});
+
+// Methods that validate Content-MD5 against the buffered request body but
+// do NOT treat x-amz-checksum-* as a body digest. CompleteMPU's
+// x-amz-checksum-<algo> is the asserted final-object checksum, not a
+// body digest, and is validated separately by
+// validateCompleteMultipartUploadChecksum.
+const md5OnlyMethods = Object.freeze({
+    completeMultipartUpload: true,
 });
 
 const ChecksumError = Object.freeze({
@@ -313,10 +321,37 @@ function getChecksumDataFromHeaders(headers) {
 }
 
 /**
+ * validateContentMd5 - Validate the Content-MD5 header against the
+ * buffered body.
+ * @param {object} headers - http headers
+ * @param {Buffer} body - http request body
+ * @return {object|null} - null on success; otherwise a ChecksumError with details.
+ */
+function validateContentMd5(headers, body) {
+    if (!('content-md5' in headers)) {
+        return { error: ChecksumError.MissingChecksum, details: null };
+    }
+    if (typeof headers['content-md5'] !== 'string') {
+        return { error: ChecksumError.MD5Invalid, details: { expected: headers['content-md5'] } };
+    }
+    if (headers['content-md5'].length !== 24) {
+        return { error: ChecksumError.MD5Invalid, details: { expected: headers['content-md5'] } };
+    }
+    if (!base64Regex.test(headers['content-md5'])) {
+        return { error: ChecksumError.MD5Invalid, details: { expected: headers['content-md5'] } };
+    }
+    const md5 = crypto.createHash('md5').update(body).digest('base64');
+    if (md5 !== headers['content-md5']) {
+        return { error: ChecksumError.MD5Mismatch, details: { calculated: md5, expected: headers['content-md5'] } };
+    }
+    return null;
+}
+
+/**
  * validateChecksumsNoChunking - Validate the checksums of a request.
  * @param {object} headers - http headers
  * @param {Buffer} body - http request body
- * @return {object} - error
+ * @return {Promise<object|null>} - null on success; otherwise a ChecksumError with details.
  */
 async function validateChecksumsNoChunking(headers, body) {
     if (!headers) {
@@ -325,23 +360,10 @@ async function validateChecksumsNoChunking(headers, body) {
 
     let md5Present = false;
     if ('content-md5' in headers) {
-        if (typeof headers['content-md5'] !== 'string') {
-            return { error: ChecksumError.MD5Invalid, details: { expected: headers['content-md5'] } };
+        const md5Err = validateContentMd5(headers, body);
+        if (md5Err) {
+            return md5Err;
         }
-
-        if (headers['content-md5'].length !== 24) {
-            return { error: ChecksumError.MD5Invalid, details: { expected: headers['content-md5'] } };
-        }
-
-        if (!base64Regex.test(headers['content-md5'])) {
-            return { error: ChecksumError.MD5Invalid, details: { expected: headers['content-md5'] } };
-        }
-
-        const md5 = crypto.createHash('md5').update(body).digest('base64');
-        if (md5 !== headers['content-md5']) {
-            return { error: ChecksumError.MD5Mismatch, details: { calculated: md5, expected: headers['content-md5'] } };
-        }
-
         md5Present = true;
     }
 
@@ -408,6 +430,65 @@ function arsenalErrorFromChecksumError(err) {
     }
 }
 
+/**
+ * Validate the optional x-amz-checksum-<algo> header on a CompleteMPU
+ * request against the computed final-object checksum.
+ *
+ * @param {object} headers - request.headers (lowercased keys)
+ * @param {object|null} finalChecksum - { algorithm, type, value } or null
+ * @returns {{error: string, details: object}|null}
+ */
+function validateCompleteMultipartUploadChecksum(headers, finalChecksum) {
+    // x-amz-checksum-type can be present in a completeMPU request so we drop it.
+    // x-amz-checksum-algorithm is ignored by AWS in this context so we drop it.
+    const valueHeaders = Object.keys(headers).filter(
+        h => h.startsWith('x-amz-checksum-') && h !== 'x-amz-checksum-type' && h !== 'x-amz-checksum-algorithm',
+    );
+
+    if (valueHeaders.length === 0) {
+        return null;
+    }
+
+    if (valueHeaders.length > 1) {
+        return { error: ChecksumError.MultipleChecksumTypes, details: { algorithms: valueHeaders } };
+    }
+
+    const headerName = valueHeaders[0];
+    const foundAlgo = headerName.slice('x-amz-checksum-'.length);
+    const foundValue = headers[headerName];
+
+    if (!(foundAlgo in algorithms)) {
+        return { error: ChecksumError.AlgoNotSupported, details: { algorithm: foundAlgo } };
+    }
+
+    const dashIdx = foundValue.lastIndexOf('-');
+    const hasCompositeSuffix = dashIdx > 0 && /^\d+$/.test(foundValue.slice(dashIdx + 1));
+    if (hasCompositeSuffix && !compositeAlgorithms.has(foundAlgo)) {
+        return { error: ChecksumError.MalformedChecksum, details: { algorithm: foundAlgo, expected: foundValue } };
+    }
+    if (!hasCompositeSuffix && !fullObjectAlgorithms.has(foundAlgo)) {
+        return { error: ChecksumError.MalformedChecksum, details: { algorithm: foundAlgo, expected: foundValue } };
+    }
+    const digestPart = hasCompositeSuffix ? foundValue.slice(0, dashIdx) : foundValue;
+    if (!algorithms[foundAlgo].isValidDigest(digestPart)) {
+        return { error: ChecksumError.MalformedChecksum, details: { algorithm: foundAlgo, expected: foundValue } };
+    }
+
+    if (!finalChecksum || finalChecksum.algorithm !== foundAlgo || finalChecksum.value !== foundValue) {
+        return {
+            error: ChecksumError.XAmzMismatch,
+            details: {
+                algorithm: foundAlgo,
+                expected: foundValue,
+                computedAlgorithm: finalChecksum && finalChecksum.algorithm,
+                computed: finalChecksum && finalChecksum.value,
+            },
+        };
+    }
+
+    return null;
+}
+
 async function defaultValidationFunc(request, body, log) {
     const err = await validateChecksumsNoChunking(request.headers, body);
     if (!err) {
@@ -418,6 +499,22 @@ async function defaultValidationFunc(request, body, log) {
         log.debug('failed checksum validation', { method: request.apiMethod }, err);
     }
 
+    return arsenalErrorFromChecksumError(err);
+}
+
+// Validate ONLY Content-MD5 against the buffered body. Used for methods
+// where x-amz-checksum-* has a non-body meaning (e.g. CompleteMPU's
+// final-object checksum assertion) and must not be re-validated here.
+function md5OnlyValidationFunc(request, body, log) {
+    // Content-MD5 is optional. If absent, nothing to validate.
+    if (!('content-md5' in request.headers)) {
+        return null;
+    }
+    const err = validateContentMd5(request.headers, body);
+    if (!err) {
+        return null;
+    }
+    log.debug('failed Content-MD5 validation', { method: request.apiMethod }, err);
     return arsenalErrorFromChecksumError(err);
 }
 
@@ -435,6 +532,10 @@ async function validateMethodChecksumNoChunking(request, body, log) {
 
     if (request.apiMethod in checksumedMethods) {
         return await defaultValidationFunc(request, body, log);
+    }
+
+    if (request.apiMethod in md5OnlyMethods) {
+        return md5OnlyValidationFunc(request, body, log);
     }
 
     return null;
@@ -551,13 +652,13 @@ const COMPOSITE_ALGOS = new Set(['crc32', 'crc32c', 'sha1', 'sha256']);
  * @returns {{ checksum: string, error: null }
  *   | { checksum: null, error: { code: string, details: object } }}
  */
-function computeCompositeMPUChecksum(algorithm, partChecksumsBase64) {
+async function computeCompositeMPUChecksum(algorithm, partChecksumsBase64) {
     if (!COMPOSITE_ALGOS.has(algorithm)) {
         return { checksum: null, error: { code: ChecksumError.MPUAlgoNotSupported, details: { algorithm } } };
     }
 
     const concat = Buffer.concat(partChecksumsBase64.map(c => Buffer.from(c, 'base64')));
-    const digest = algorithms[algorithm].digest(concat);
+    const digest = await algorithms[algorithm].digest(concat);
     return {
         checksum: `${digest}-${partChecksumsBase64.length}`,
         error: null,
@@ -599,4 +700,5 @@ module.exports = {
     getChecksumDataFromMPUHeaders,
     computeCompositeMPUChecksum,
     computeFullObjectMPUChecksum,
+    validateCompleteMultipartUploadChecksum,
 };

--- a/lib/api/apiUtils/integrity/validateChecksums.js
+++ b/lib/api/apiUtils/integrity/validateChecksums.js
@@ -29,8 +29,7 @@ const errTrailerNotSupported = errorInstances.InvalidRequest.customizeDescriptio
 );
 const errMPUAlgoNotSupported = errorInstances.InvalidRequest.customizeDescription(
     'Checksum algorithm provided is unsupported. ' +
-        'Please try again with any of the valid types: ' +
-        '[CRC32, CRC32C, CRC64NVME, SHA1, SHA256]',
+        'Please try again with any of the valid types: [CRC32, CRC32C, CRC64NVME, SHA1, SHA256]',
 );
 const errMPUTypeInvalid = errorInstances.InvalidRequest.customizeDescription(
     'Value for x-amz-checksum-type header is invalid.',

--- a/lib/api/apiUtils/integrity/validateChecksums.js
+++ b/lib/api/apiUtils/integrity/validateChecksums.js
@@ -40,7 +40,9 @@ const errMPUTypeWithoutAlgo = errorInstances.InvalidRequest.customizeDescription
 );
 
 const checksumedMethods = Object.freeze({
-    completeMultipartUpload: true,
+    // CompleteMPU's x-amz-checksum-<algo> is the final-object checksum,
+    // not a body digest. Validated in completeMultipartUpload.js instead.
+    // 'completeMultipartUpload': true,
     multiObjectDelete: true,
     bucketPutACL: true,
     bucketPutCors: true,

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -26,7 +26,13 @@ const { setExpirationHeaders } = require('./apiUtils/object/expirationHeaders');
 const { validatePutVersionId } = require('./apiUtils/object/coldStorage');
 const { validateQuotas } = require('./apiUtils/quotas/quotaUtils');
 const { setSSEHeaders } = require('./apiUtils/object/sseHeaders');
-const { algorithms: checksumAlgorithms } = require('./apiUtils/integrity/validateChecksums');
+const {
+    algorithms: checksumAlgorithms,
+    arsenalErrorFromChecksumError,
+    computeCompositeMPUChecksum,
+    computeFullObjectMPUChecksum,
+    validateCompleteMultipartUploadChecksum,
+} = require('./apiUtils/integrity/validateChecksums');
 
 const versionIdUtils = versioning.VersionID;
 
@@ -106,6 +112,82 @@ function validatePerPartChecksums(jsonList, storedParts, mpuSplitter, mpuChecksu
     return null;
 }
 
+/**
+ * Compute the final-object checksum for a CompleteMultipartUpload from the
+ * stored MPU configuration and per-part checksums. Returns null when the MPU
+ * has no checksum configured, when any part is missing its stored
+ * ChecksumValue (defensive — should not happen in steady state), or when the
+ * compute primitive itself reports an error. Errors are logged; the caller
+ * proceeds without a final-object checksum so the response simply omits the
+ * checksum fields rather than failing the whole CompleteMPU.
+ *
+ * @param {array} storedParts - parts from services.getMPUparts (carry ChecksumValue)
+ * @param {array} filteredPartList - validated, ordered subset matching jsonList
+ * @param {object} storedMetadata - MPU overview metadata
+ * @param {string} mpuSplitter - splitter used in part keys
+ * @param {string} uploadId - for log context
+ * @param {object} log - werelogs logger
+ * @returns {object|null} { algorithm, type, value } or null
+ */
+async function computeFinalChecksum(storedParts, filteredPartList, storedMetadata, mpuSplitter, uploadId, log) {
+    const { checksumAlgorithm: algorithm, checksumType: type } = storedMetadata;
+    if (!algorithm || !type) {
+        return null;
+    }
+
+    const storedByKey = new Map();
+    storedParts.forEach(p => storedByKey.set(p.key, p));
+
+    const partInputs = [];
+    const missingPartNumbers = [];
+    for (const fp of filteredPartList) {
+        const stored = storedByKey.get(fp.key);
+        const value = stored && stored.value && stored.value.ChecksumValue;
+        if (!value) {
+            missingPartNumbers.push(fp.key.split(mpuSplitter)[1]);
+            continue;
+        }
+        partInputs.push({ value, length: Number.parseInt(fp.size, 10) });
+    }
+
+    if (missingPartNumbers.length > 0) {
+        log.error('one or more MPU parts missing checksum value; ' + 'skipping final-object checksum computation', {
+            uploadId,
+            algorithm,
+            type,
+            missingPartNumbers,
+        });
+        return null;
+    }
+
+    let result;
+    if (type === 'COMPOSITE') {
+        result = await computeCompositeMPUChecksum(
+            algorithm,
+            partInputs.map(p => p.value),
+        );
+    } else if (type === 'FULL_OBJECT') {
+        result = computeFullObjectMPUChecksum(algorithm, partInputs);
+    } else {
+        log.error('unknown MPU checksumType; skipping final-object checksum computation', {
+            uploadId,
+            checksumType: type,
+        });
+        return null;
+    }
+
+    if (result.error) {
+        log.error('final-object checksum computation failed', {
+            uploadId,
+            checksumErrorCode: result.error.code,
+            checksumErrorDetails: result.error.details,
+        });
+        return null;
+    }
+
+    return { algorithm, type, value: result.checksum };
+}
+
 /*
    Format of xml request:
    <CompleteMultipartUpload>
@@ -167,6 +249,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
         hostname,
     };
     let oldByteLength = null;
+    let finalChecksum = null;
     const responseHeaders = {};
 
     let versionId;
@@ -483,6 +566,81 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     filteredPartsObj,
                     totalMPUSize,
                 );
+            },
+            function computeAndValidateFinalChecksum(
+                destBucket,
+                objMD,
+                mpuBucket,
+                storedParts,
+                jsonList,
+                storedMetadata,
+                completeObjData,
+                mpuOverviewKey,
+                filteredPartsObj,
+                totalMPUSize,
+                next,
+            ) {
+                // External-handled MPUs (ingestion / external backends) come in
+                // with completeObjData set and no filteredPartsObj — the data
+                // store already aggregated the parts, and we have no per-part
+                // info to feed the compute step. Skip in that case.
+                if (!filteredPartsObj) {
+                    return next(
+                        null,
+                        destBucket,
+                        objMD,
+                        mpuBucket,
+                        storedParts,
+                        jsonList,
+                        storedMetadata,
+                        completeObjData,
+                        mpuOverviewKey,
+                        filteredPartsObj,
+                        totalMPUSize,
+                    );
+                }
+                computeFinalChecksum(
+                    storedParts,
+                    filteredPartsObj.partList,
+                    storedMetadata,
+                    splitter,
+                    uploadId,
+                    log,
+                ).then(
+                    fc => {
+                        finalChecksum = fc;
+                        const checksumErr = validateCompleteMultipartUploadChecksum(request.headers, finalChecksum);
+                        if (checksumErr) {
+                            log.debug('x-amz-checksum-<algo> header validation failed on CompleteMPU', {
+                                uploadId,
+                                error: checksumErr.error,
+                                details: checksumErr.details,
+                            });
+                            return next(arsenalErrorFromChecksumError(checksumErr), destBucket);
+                        }
+                        return next(
+                            null,
+                            destBucket,
+                            objMD,
+                            mpuBucket,
+                            storedParts,
+                            jsonList,
+                            storedMetadata,
+                            completeObjData,
+                            mpuOverviewKey,
+                            filteredPartsObj,
+                            totalMPUSize,
+                        );
+                    },
+                    computeErr => {
+                        log.error('final-object checksum compute threw', {
+                            uploadId,
+                            error: computeErr,
+                        });
+                        return next(computeErr, destBucket);
+                    },
+                );
+                return undefined;
             },
             function processParts(
                 destBucket,
@@ -1016,3 +1174,4 @@ function completeMultipartUpload(authInfo, request, log, callback) {
 
 module.exports = completeMultipartUpload;
 module.exports.validatePerPartChecksums = validatePerPartChecksums;
+module.exports.computeFinalChecksum = computeFinalChecksum;

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -764,6 +764,9 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     'expires',
                     'eventualStorageBucket',
                     'dataStoreName',
+                    'checksumAlgorithm',
+                    'checksumType',
+                    'checksumIsDefault',
                 ];
                 const metadataKeysToPull = Object.keys(storedMetadata).filter(
                     item => keysNotNeeded.indexOf(item) === -1,
@@ -801,6 +804,12 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     overheadField: constants.overheadField,
                     log,
                 };
+                // Persist FULL_OBJECT final-object checksum on the new ObjectMD.
+                // COMPOSITE is intentionally skipped to prevent metadata bloat,
+                // to be done in S3C-10399.
+                if (finalChecksum && finalChecksum.type === 'FULL_OBJECT') {
+                    metaStoreParams.checksum = finalChecksum;
+                }
                 // If key already exists
                 if (objMD) {
                     // Re-use creation-time if we can

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -353,16 +353,14 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                                 // Legacy MPU created before checksumType was tracked.
                                 const typeErr = errorInstances.InvalidRequest.customizeDescription(
                                     'The upload was not created with a checksum mode. ' +
-                                        'The complete request must not include a ' +
-                                        'x-amz-checksum-type header.',
+                                        'The complete request must not include a x-amz-checksum-type header.',
                                 );
                                 return next(typeErr, destBucket);
                             }
                             if (headerTypeUpper !== mpuType.toUpperCase()) {
                                 const typeErr = errorInstances.InvalidRequest.customizeDescription(
-                                    `The upload was created using the ${mpuType} ` +
-                                        'checksum mode. The complete request must ' +
-                                        'use the same checksum mode.',
+                                    `The upload was created using the ${mpuType} checksum mode. ` +
+                                        'The complete request must use the same checksum mode.',
                                 );
                                 return next(typeErr, destBucket);
                             }

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -1165,6 +1165,11 @@ function completeMultipartUpload(authInfo, request, log, callback) {
             const isVersionedObj = vcfg && vcfg.Status === 'Enabled';
 
             xmlParams.eTag = `"${aggregateETag}"`;
+            if (finalChecksum) {
+                xmlParams.checksumAlgorithm = finalChecksum.algorithm;
+                xmlParams.checksumValue = finalChecksum.value;
+                xmlParams.checksumType = finalChecksum.type;
+            }
             const xml = convertToXml('completeMultipartUpload', xmlParams);
             pushMetric('completeMultipartUpload', log, {
                 oldByteLength: isVersionedObj ? null : oldByteLength,

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -26,11 +26,85 @@ const { setExpirationHeaders } = require('./apiUtils/object/expirationHeaders');
 const { validatePutVersionId } = require('./apiUtils/object/coldStorage');
 const { validateQuotas } = require('./apiUtils/quotas/quotaUtils');
 const { setSSEHeaders } = require('./apiUtils/object/sseHeaders');
+const { algorithms: checksumAlgorithms } = require('./apiUtils/integrity/validateChecksums');
 
 const versionIdUtils = versioning.VersionID;
 
 let splitter = constants.splitter;
 const REPLICATION_ACTION = 'MPU';
+
+const allChecksumXmlTags = Object.values(checksumAlgorithms).map(algo => algo.xmlTag);
+
+/**
+ * Validate per-part checksums in a CompleteMultipartUpload request body
+ * against the stored MPU configuration and stored part metadata.
+ *
+ * Rules (per AWS):
+ * - If a Part element includes a Checksum<Algo> field that does not match the
+ *   MPU's configured checksumAlgorithm, return BadDigest.
+ * - If a Part element includes the matching Checksum<Algo> field but the value
+ *   does not match the stored part's ChecksumValue, return InvalidPart.
+ * - If checksumType === 'COMPOSITE' and checksumIsDefault is false, every part
+ *   in the request body MUST include the matching Checksum<Algo> field;
+ *   missing → InvalidRequest.
+ *
+ * @param {object} jsonList - parsed CompleteMultipartUpload XML
+ * @param {array} storedParts - parts as returned by services.getMPUparts
+ * @param {string} mpuSplitter - splitter used in part keys
+ * @param {object} mpuChecksum - { algorithm, type, isDefault }
+ * @returns {Error|null}
+ */
+function validatePerPartChecksums(jsonList, storedParts, mpuSplitter, mpuChecksum) {
+    const mpuAlgo = mpuChecksum.algorithm;
+    if (!mpuAlgo) {
+        // Legacy / pre-checksums MPU, no algorithm tracked, nothing to validate.
+        return null;
+    }
+    const expectedTag = checksumAlgorithms[mpuAlgo] ? checksumAlgorithms[mpuAlgo].xmlTag : null;
+    // Skip enforcement if the MPU's algorithm is unknown (shouldn't happen).
+    const requireForEachPart = mpuChecksum.type === 'COMPOSITE' && !mpuChecksum.isDefault && expectedTag !== null;
+
+    const storedByPartNumber = new Map();
+    storedParts.forEach(item => {
+        const partNumber = Number.parseInt(item.key.split(mpuSplitter)[1], 10);
+        storedByPartNumber.set(partNumber, item);
+    });
+
+    for (const part of jsonList.Part || []) {
+        const partNumber = Number.parseInt(part.PartNumber[0], 10);
+
+        const presentTags = allChecksumXmlTags.filter(tag => part[tag]);
+
+        for (const tag of presentTags) {
+            if (tag !== expectedTag) {
+                const algoLabel = tag.replace(/^Checksum/, '').toLowerCase();
+                return errorInstances.BadDigest.customizeDescription(
+                    `The ${algoLabel} you specified for part ${partNumber} did not match what we received.`,
+                );
+            }
+        }
+
+        if (expectedTag && presentTags.includes(expectedTag)) {
+            const providedValue = part[expectedTag][0];
+            const storedPart = storedByPartNumber.get(partNumber);
+            const storedValue = storedPart && storedPart.value && storedPart.value.ChecksumValue;
+            if (!storedValue || providedValue !== storedValue) {
+                return errorInstances.InvalidPart.customizeDescription(
+                    'One or more of the specified parts could not be found.  ' +
+                        'The part may not have been uploaded, or the specified ' +
+                        "entity tag may not match the part's entity tag.",
+                );
+            }
+        } else if (requireForEachPart) {
+            return errorInstances.InvalidRequest.customizeDescription(
+                `The upload was created using a ${mpuAlgo} checksum. ` +
+                    'The complete request must include the checksum for each ' +
+                    `part. It was missing for part ${partNumber} in the request.`,
+            );
+        }
+    }
+    return null;
+}
 
 /*
    Format of xml request:
@@ -159,6 +233,38 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                             log.error('error validating request', { error: err });
                             return next(err, destBucket);
                         }
+                        // Validate x-amz-checksum-type header (if present) matches
+                        // the checksum type the MPU was created with.
+                        // x-amz-checksum-algorithm is not validated: AWS ignores
+                        // a mismatch on this header for CompleteMultipartUpload.
+                        const headerType = request.headers['x-amz-checksum-type'];
+                        if (headerType) {
+                            const headerTypeUpper = headerType.toUpperCase();
+                            if (headerTypeUpper !== 'COMPOSITE' && headerTypeUpper !== 'FULL_OBJECT') {
+                                const typeErr = errorInstances.InvalidRequest.customizeDescription(
+                                    'Value for x-amz-checksum-type header is invalid.',
+                                );
+                                return next(typeErr, destBucket);
+                            }
+                            const mpuType = storedMetadata.checksumType;
+                            if (!mpuType) {
+                                // Legacy MPU created before checksumType was tracked.
+                                const typeErr = errorInstances.InvalidRequest.customizeDescription(
+                                    'The upload was not created with a checksum mode. ' +
+                                        'The complete request must not include a ' +
+                                        'x-amz-checksum-type header.',
+                                );
+                                return next(typeErr, destBucket);
+                            }
+                            if (headerTypeUpper !== mpuType.toUpperCase()) {
+                                const typeErr = errorInstances.InvalidRequest.customizeDescription(
+                                    `The upload was created using the ${mpuType} ` +
+                                        'checksum mode. The complete request must ' +
+                                        'use the same checksum mode.',
+                                );
+                                return next(typeErr, destBucket);
+                            }
+                        }
                         return next(null, destBucket, objMD, mpuBucket, storedMetadata);
                     },
                 );
@@ -251,6 +357,18 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     }
                     const storedParts = result.Contents;
                     const totalMPUSize = storedParts.reduce((acc, part) => acc + part.value.Size, 0);
+                    const mpuChecksum = {
+                        algorithm: storedMetadata.checksumAlgorithm,
+                        type: storedMetadata.checksumType,
+                        isDefault: storedMetadata.checksumIsDefault,
+                    };
+                    const checksumErr = validatePerPartChecksums(jsonList, storedParts, splitter, mpuChecksum);
+                    if (checksumErr) {
+                        log.debug('per-part checksum validation failed', {
+                            error: checksumErr,
+                        });
+                        return next(checksumErr, destBucket);
+                    }
                     return next(
                         null,
                         destBucket,
@@ -897,3 +1015,4 @@ function completeMultipartUpload(authInfo, request, log, callback) {
 }
 
 module.exports = completeMultipartUpload;
+module.exports.validatePerPartChecksums = validatePerPartChecksums;

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -126,12 +126,21 @@ function validatePerPartChecksums(jsonList, storedParts, mpuSplitter, mpuChecksu
 
 /**
  * Compute the final-object checksum for a CompleteMultipartUpload from the
- * stored MPU configuration and per-part checksums. Returns null when the MPU
- * has no checksum configured, when any part is missing its stored
- * ChecksumValue (defensive — should not happen in steady state), or when the
- * compute primitive itself reports an error. Errors are logged; the caller
- * proceeds without a final-object checksum so the response simply omits the
- * checksum fields rather than failing the whole CompleteMPU.
+ * stored MPU configuration and per-part checksums.
+ *
+ * Returns `{ result, error }`:
+ *   - Success: `{ result: { algorithm, type, value }, error: null }`
+ *   - No MPU checksum configured: `{ result: null, error: null }`
+ *   - "Should-not-happen" branch (missing stored ChecksumValue, unknown
+ *     checksumType, compute primitive error): behavior depends on whether
+ *     the client opted in to checksums —
+ *       - Default MPU (`checksumIsDefault === true`): the client never
+ *         asked for a checksum; soft-fail with `{ result: null, error: null }`
+ *         so the response simply omits the checksum field.
+ *       - Explicit MPU (`checksumIsDefault === false`): the client asked
+ *         for a checksum at CreateMPU; silently dropping it would violate
+ *         the contract. Return `{ result: null, error: <InternalError> }`
+ *         for the caller to fail the CompleteMPU.
  *
  * @param {array} storedParts - parts from services.getMPUparts (carry ChecksumValue)
  * @param {array} filteredPartList - validated, ordered subset matching jsonList
@@ -139,12 +148,22 @@ function validatePerPartChecksums(jsonList, storedParts, mpuSplitter, mpuChecksu
  * @param {string} mpuSplitter - splitter used in part keys
  * @param {string} uploadId - for log context
  * @param {object} log - werelogs logger
- * @returns {object|null} { algorithm, type, value } or null
+ * @returns {Promise<{ result: ({algorithm, type, value}|null), error: (ArsenalError|null) }>}
  */
 async function computeFinalChecksum(storedParts, filteredPartList, storedMetadata, mpuSplitter, uploadId, log) {
-    const { checksumAlgorithm: algorithm, checksumType: type } = storedMetadata;
+    const algorithm = storedMetadata.checksumAlgorithm;
+    const type = storedMetadata.checksumType;
     if (!algorithm || !type) {
-        return null;
+        return { result: null, error: null };
+    }
+    const isDefault = !!storedMetadata.checksumIsDefault;
+
+    function failOrSkip(message, extra) {
+        log.error(message, { uploadId, algorithm, type, ...extra });
+        if (isDefault) {
+            return { result: null, error: null };
+        }
+        return { result: null, error: errorInstances.InternalError.customizeDescription(message) };
     }
 
     const storedByKey = new Map();
@@ -163,41 +182,29 @@ async function computeFinalChecksum(storedParts, filteredPartList, storedMetadat
     }
 
     if (missingPartNumbers.length > 0) {
-        log.error('one or more MPU parts missing checksum value; ' + 'skipping final-object checksum computation', {
-            uploadId,
-            algorithm,
-            type,
-            missingPartNumbers,
-        });
-        return null;
+        return failOrSkip('one or more MPU parts missing checksum value', { missingPartNumbers });
     }
 
-    let result;
+    let computed;
     if (type === 'COMPOSITE') {
-        result = await computeCompositeMPUChecksum(
+        computed = await computeCompositeMPUChecksum(
             algorithm,
             partInputs.map(p => p.value),
         );
     } else if (type === 'FULL_OBJECT') {
-        result = computeFullObjectMPUChecksum(algorithm, partInputs);
+        computed = computeFullObjectMPUChecksum(algorithm, partInputs);
     } else {
-        log.error('unknown MPU checksumType; skipping final-object checksum computation', {
-            uploadId,
-            checksumType: type,
-        });
-        return null;
+        return failOrSkip('unknown MPU checksumType', { checksumType: type });
     }
 
-    if (result.error) {
-        log.error('final-object checksum computation failed', {
-            uploadId,
-            checksumErrorCode: result.error.code,
-            checksumErrorDetails: result.error.details,
+    if (computed.error) {
+        return failOrSkip('final-object checksum computation failed', {
+            checksumErrorCode: computed.error.code,
+            checksumErrorDetails: computed.error.details,
         });
-        return null;
     }
 
-    return { algorithm, type, value: result.checksum };
+    return { result: { algorithm, type, value: computed.checksum }, error: null };
 }
 
 /*
@@ -579,7 +586,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     totalMPUSize,
                 );
             },
-            function computeAndValidateFinalChecksum(
+            function processParts(
                 destBucket,
                 objMD,
                 mpuBucket,
@@ -597,19 +604,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                 // store already aggregated the parts, and we have no per-part
                 // info to feed the compute step. Skip in that case.
                 if (!filteredPartsObj) {
-                    return next(
-                        null,
-                        destBucket,
-                        objMD,
-                        mpuBucket,
-                        storedParts,
-                        jsonList,
-                        storedMetadata,
-                        completeObjData,
-                        mpuOverviewKey,
-                        filteredPartsObj,
-                        totalMPUSize,
-                    );
+                    return continueProcessParts(null);
                 }
                 computeFinalChecksum(
                     storedParts,
@@ -619,30 +614,33 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     uploadId,
                     log,
                 ).then(
-                    fc => {
-                        finalChecksum = fc;
-                        const checksumErr = validateCompleteMultipartUploadChecksum(request.headers, finalChecksum);
-                        if (checksumErr) {
-                            log.debug('x-amz-checksum-<algo> header validation failed on CompleteMPU', {
+                    ({ result, error }) => {
+                        if (error) {
+                            log.error('failing CompleteMPU due to final-object checksum error', {
                                 uploadId,
-                                error: checksumErr.error,
-                                details: checksumErr.details,
+                                error,
                             });
-                            return next(arsenalErrorFromChecksumError(checksumErr), destBucket);
+                            return next(error, destBucket);
                         }
-                        return next(
-                            null,
-                            destBucket,
-                            objMD,
-                            mpuBucket,
-                            storedParts,
-                            jsonList,
-                            storedMetadata,
-                            completeObjData,
-                            mpuOverviewKey,
-                            filteredPartsObj,
-                            totalMPUSize,
-                        );
+                        try {
+                            finalChecksum = result;
+                            const checksumErr = validateCompleteMultipartUploadChecksum(request.headers, finalChecksum);
+                            if (checksumErr) {
+                                log.debug('x-amz-checksum-<algo> header validation failed on CompleteMPU', {
+                                    uploadId,
+                                    error: checksumErr.error,
+                                    details: checksumErr.details,
+                                });
+                                return next(arsenalErrorFromChecksumError(checksumErr), destBucket);
+                            }
+                            return continueProcessParts(null);
+                        } catch (resolveErr) {
+                            log.error('unexpected throw after final-checksum compute', {
+                                uploadId,
+                                error: resolveErr,
+                            });
+                            return next(resolveErr, destBucket);
+                        }
                     },
                     computeErr => {
                         log.error('final-object checksum compute threw', {
@@ -653,69 +651,72 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     },
                 );
                 return undefined;
-            },
-            function processParts(
-                destBucket,
-                objMD,
-                mpuBucket,
-                storedParts,
-                jsonList,
-                storedMetadata,
-                completeObjData,
-                mpuOverviewKey,
-                filteredPartsObj,
-                totalMPUSize,
-                next,
-            ) {
-                // if mpu was completed on backend that stored mpu MD externally,
-                // skip MD processing steps
-                if (completeObjData && skipMpuPartProcessing(completeObjData)) {
-                    const dataLocations = [
-                        {
-                            key: completeObjData.key,
-                            size: completeObjData.contentLength,
-                            start: 0,
-                            dataStoreVersionId: completeObjData.dataStoreVersionId,
-                            dataStoreName: storedMetadata.dataStoreName,
-                            dataStoreETag: completeObjData.eTag,
-                            dataStoreType: completeObjData.dataStoreType,
-                        },
-                    ];
-                    const calculatedSize = completeObjData.contentLength;
-                    return next(
-                        null,
-                        destBucket,
-                        objMD,
-                        mpuBucket,
-                        storedMetadata,
-                        completeObjData.eTag,
-                        calculatedSize,
-                        dataLocations,
-                        [mpuOverviewKey],
-                        null,
-                        completeObjData,
-                        totalMPUSize,
-                    );
-                }
 
-                const partsInfo = generateMpuPartStorageInfo(filteredPartsObj.partList);
-                if (partsInfo.error) {
-                    return next(partsInfo.error, destBucket);
-                }
-                const { keysToDelete, extraPartLocations } = filteredPartsObj;
-                const { aggregateETag, dataLocations, calculatedSize } = partsInfo;
+                function continueProcessParts() {
+                    // if mpu was completed on backend that stored mpu MD externally,
+                    // skip MD processing steps
+                    if (completeObjData && skipMpuPartProcessing(completeObjData)) {
+                        const dataLocations = [
+                            {
+                                key: completeObjData.key,
+                                size: completeObjData.contentLength,
+                                start: 0,
+                                dataStoreVersionId: completeObjData.dataStoreVersionId,
+                                dataStoreName: storedMetadata.dataStoreName,
+                                dataStoreETag: completeObjData.eTag,
+                                dataStoreType: completeObjData.dataStoreType,
+                            },
+                        ];
+                        const calculatedSize = completeObjData.contentLength;
+                        return next(
+                            null,
+                            destBucket,
+                            objMD,
+                            mpuBucket,
+                            storedMetadata,
+                            completeObjData.eTag,
+                            calculatedSize,
+                            dataLocations,
+                            [mpuOverviewKey],
+                            null,
+                            completeObjData,
+                            totalMPUSize,
+                        );
+                    }
 
-                if (completeObjData) {
-                    const dataLocations = [
-                        {
-                            key: completeObjData.key,
-                            size: calculatedSize,
-                            start: 0,
-                            dataStoreName: storedMetadata.dataStoreName,
-                            dataStoreETag: aggregateETag,
-                            dataStoreType: completeObjData.dataStoreType,
-                        },
-                    ];
+                    const partsInfo = generateMpuPartStorageInfo(filteredPartsObj.partList);
+                    if (partsInfo.error) {
+                        return next(partsInfo.error, destBucket);
+                    }
+                    const { keysToDelete, extraPartLocations } = filteredPartsObj;
+                    const { aggregateETag, dataLocations, calculatedSize } = partsInfo;
+
+                    if (completeObjData) {
+                        const dataLocations = [
+                            {
+                                key: completeObjData.key,
+                                size: calculatedSize,
+                                start: 0,
+                                dataStoreName: storedMetadata.dataStoreName,
+                                dataStoreETag: aggregateETag,
+                                dataStoreType: completeObjData.dataStoreType,
+                            },
+                        ];
+                        return next(
+                            null,
+                            destBucket,
+                            objMD,
+                            mpuBucket,
+                            storedMetadata,
+                            aggregateETag,
+                            calculatedSize,
+                            dataLocations,
+                            keysToDelete,
+                            extraPartLocations,
+                            completeObjData,
+                            totalMPUSize,
+                        );
+                    }
                     return next(
                         null,
                         destBucket,
@@ -727,24 +728,10 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                         dataLocations,
                         keysToDelete,
                         extraPartLocations,
-                        completeObjData,
+                        null,
                         totalMPUSize,
                     );
                 }
-                return next(
-                    null,
-                    destBucket,
-                    objMD,
-                    mpuBucket,
-                    storedMetadata,
-                    aggregateETag,
-                    calculatedSize,
-                    dataLocations,
-                    keysToDelete,
-                    extraPartLocations,
-                    null,
-                    totalMPUSize,
-                );
             },
             function prepForStoring(
                 destBucket,

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -81,6 +81,18 @@ function validatePerPartChecksums(jsonList, storedParts, mpuSplitter, mpuChecksu
 
         const presentTags = allChecksumXmlTags.filter(tag => part[tag]);
 
+        // AWS rejects any per-part Checksum<X> field on a default MPU
+        // (one created without an explicit ChecksumAlgorithm) with
+        // InvalidPart — even when the value is correct and even when the
+        // field matches the implicit default algorithm.
+        if (mpuChecksum.isDefault && presentTags.length > 0) {
+            return errorInstances.InvalidPart.customizeDescription(
+                'One or more of the specified parts could not be found.  ' +
+                    'The part may not have been uploaded, or the specified ' +
+                    "entity tag may not match the part's entity tag.",
+            );
+        }
+
         for (const tag of presentTags) {
             if (tag !== expectedTag) {
                 const algoLabel = tag.replace(/^Checksum/, '').toLowerCase();

--- a/tests/functional/aws-node-sdk/test/object/completeMpuChecksum.js
+++ b/tests/functional/aws-node-sdk/test/object/completeMpuChecksum.js
@@ -134,7 +134,7 @@ describe('CompleteMultipartUpload final-object checksum', () =>
             });
         });
 
-        it('should return CRC64NVME/FULL_OBJECT on response when CreateMPU sent no checksum headers', async () => {
+        it('should return CRC64NVME/FULL_OBJECT on CompleteMPU when CreateMPU sent no checksum headers', async () => {
             const key = `complete-default-${Date.now()}`;
 
             const create = await s3.send(
@@ -205,18 +205,14 @@ describe('CompleteMultipartUpload final-object checksum', () =>
             }
 
             async function assertInvalidPart(promise) {
-                let caught;
-                try {
-                    await promise;
-                } catch (err) {
-                    caught = err;
-                }
-                assert(caught, 'expected CompleteMPU to reject');
-                assert.strictEqual(
-                    caught.name,
-                    'InvalidPart',
-                    `expected InvalidPart, got ${caught.name}: ${caught.message}`,
-                );
+                await assert.rejects(promise, err => {
+                    assert.strictEqual(
+                        err.name,
+                        'InvalidPart',
+                        `expected InvalidPart, got ${err.name}: ${err.message}`,
+                    );
+                    return true;
+                });
             }
 
             it('should return InvalidPart when Part includes matching ChecksumCRC64NVME (correct value)', async () => {

--- a/tests/functional/aws-node-sdk/test/object/completeMpuChecksum.js
+++ b/tests/functional/aws-node-sdk/test/object/completeMpuChecksum.js
@@ -1,0 +1,256 @@
+'use strict';
+
+const assert = require('assert');
+const {
+    CreateBucketCommand,
+    CreateMultipartUploadCommand,
+    UploadPartCommand,
+    CompleteMultipartUploadCommand,
+    HeadObjectCommand,
+    DeleteBucketCommand,
+} = require('@aws-sdk/client-s3');
+
+const withV4 = require('../support/withV4');
+const BucketUtility = require('../../lib/utility/bucket-util');
+const { algorithms } = require('../../../../../lib/api/apiUtils/integrity/validateChecksums');
+
+const bucket = `mpu-complete-checksum-${Date.now()}`;
+const partBody = Buffer.from('I am a part body for complete-MPU testing', 'utf8');
+
+// All AWS-valid (algorithm, type) pairs for an MPU. CompleteMPU should
+// surface the resulting final-object checksum and ChecksumType in the
+// response for every combination here, plus the implicit default.
+const COMBOS = [
+    { algo: 'CRC32', type: 'FULL_OBJECT' },
+    { algo: 'CRC32', type: 'COMPOSITE' },
+    { algo: 'CRC32C', type: 'FULL_OBJECT' },
+    { algo: 'CRC32C', type: 'COMPOSITE' },
+    { algo: 'CRC64NVME', type: 'FULL_OBJECT' },
+    { algo: 'SHA1', type: 'COMPOSITE' },
+    { algo: 'SHA256', type: 'COMPOSITE' },
+];
+
+const tagField = algo => `Checksum${algo}`;
+
+describe('CompleteMultipartUpload final-object checksum', () =>
+    withV4(sigCfg => {
+        let bucketUtil;
+        let s3;
+
+        before(async () => {
+            bucketUtil = new BucketUtility('default', sigCfg);
+            s3 = bucketUtil.s3;
+            await s3.send(new CreateBucketCommand({ Bucket: bucket }));
+        });
+
+        after(async () => {
+            await bucketUtil.empty(bucket);
+            await s3.send(new DeleteBucketCommand({ Bucket: bucket }));
+        });
+
+        COMBOS.forEach(({ algo, type }) => {
+            const field = tagField(algo);
+            it(`should return ${algo}/${type} on CompleteMPU response`, async () => {
+                const key = `complete-${algo.toLowerCase()}-${type.toLowerCase()}-${Date.now()}`;
+                const partChecksum = await algorithms[algo.toLowerCase()].digest(partBody);
+
+                const create = await s3.send(
+                    new CreateMultipartUploadCommand({
+                        Bucket: bucket,
+                        Key: key,
+                        ChecksumAlgorithm: algo,
+                        ChecksumType: type,
+                    }),
+                );
+
+                const uploadPart = await s3.send(
+                    new UploadPartCommand({
+                        Bucket: bucket,
+                        Key: key,
+                        UploadId: create.UploadId,
+                        PartNumber: 1,
+                        Body: partBody,
+                        [field]: partChecksum,
+                    }),
+                );
+
+                const complete = await s3.send(
+                    new CompleteMultipartUploadCommand({
+                        Bucket: bucket,
+                        Key: key,
+                        UploadId: create.UploadId,
+                        MultipartUpload: {
+                            Parts: [
+                                {
+                                    PartNumber: 1,
+                                    ETag: uploadPart.ETag,
+                                    [field]: partChecksum,
+                                },
+                            ],
+                        },
+                    }),
+                );
+
+                assert(complete[field], `expected ${field} in CompleteMPU response, got: ${JSON.stringify(complete)}`);
+                assert.strictEqual(complete.ChecksumType, type);
+                if (type === 'COMPOSITE') {
+                    assert(
+                        complete[field].endsWith('-1'),
+                        `expected -1 suffix for 1-part COMPOSITE, got ${complete[field]}`,
+                    );
+                } else {
+                    assert(
+                        !complete[field].includes('-'),
+                        `FULL_OBJECT value should have no suffix, got ${complete[field]}`,
+                    );
+                }
+
+                // HeadObject with ChecksumMode=ENABLED must surface the same
+                // value that CompleteMPU returned for FULL_OBJECT MPUs.
+                // COMPOSITE storage is deferred, so HeadObject leaves the field absent — matching
+                // cloudserver's current intentional skip.
+                const head = await s3.send(
+                    new HeadObjectCommand({
+                        Bucket: bucket,
+                        Key: key,
+                        ChecksumMode: 'ENABLED',
+                    }),
+                );
+                if (type === 'FULL_OBJECT') {
+                    assert.strictEqual(
+                        head[field],
+                        complete[field],
+                        `HeadObject ${field} should match CompleteMPU response`,
+                    );
+                    assert.strictEqual(head.ChecksumType, type);
+                } else {
+                    assert.strictEqual(
+                        head[field],
+                        undefined,
+                        `COMPOSITE storage is deferred; HeadObject should not surface ${field}`,
+                    );
+                    assert.strictEqual(head.ChecksumType, undefined);
+                }
+            });
+        });
+
+        it('should return CRC64NVME/FULL_OBJECT on response when CreateMPU sent no checksum headers', async () => {
+            const key = `complete-default-${Date.now()}`;
+
+            const create = await s3.send(
+                new CreateMultipartUploadCommand({
+                    Bucket: bucket,
+                    Key: key,
+                }),
+            );
+
+            const uploadPart = await s3.send(
+                new UploadPartCommand({
+                    Bucket: bucket,
+                    Key: key,
+                    UploadId: create.UploadId,
+                    PartNumber: 1,
+                    Body: partBody,
+                }),
+            );
+
+            const complete = await s3.send(
+                new CompleteMultipartUploadCommand({
+                    Bucket: bucket,
+                    Key: key,
+                    UploadId: create.UploadId,
+                    MultipartUpload: {
+                        Parts: [{ PartNumber: 1, ETag: uploadPart.ETag }],
+                    },
+                }),
+            );
+
+            assert(
+                complete.ChecksumCRC64NVME,
+                `expected ChecksumCRC64NVME for default MPU, got: ${JSON.stringify(complete)}`,
+            );
+            assert.strictEqual(complete.ChecksumType, 'FULL_OBJECT');
+
+            // Default MPU is FULL_OBJECT — checksum is persisted, so
+            // HeadObject must return the same value.
+            const head = await s3.send(
+                new HeadObjectCommand({
+                    Bucket: bucket,
+                    Key: key,
+                    ChecksumMode: 'ENABLED',
+                }),
+            );
+            assert.strictEqual(head.ChecksumCRC64NVME, complete.ChecksumCRC64NVME);
+            assert.strictEqual(head.ChecksumType, 'FULL_OBJECT');
+        });
+
+        // AWS S3 rejects any per-part
+        // Checksum<X> field on a default MPU (one created without an
+        // explicit ChecksumAlgorithm) with InvalidPart — even when the
+        // field matches the implicit CRC64NVME algorithm and value.
+        describe('default MPU rejects per-part Checksum fields', () => {
+            async function setupDefaultMpu() {
+                const key = `complete-default-rejects-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+                const create = await s3.send(new CreateMultipartUploadCommand({ Bucket: bucket, Key: key }));
+                const uploadPart = await s3.send(
+                    new UploadPartCommand({
+                        Bucket: bucket,
+                        Key: key,
+                        UploadId: create.UploadId,
+                        PartNumber: 1,
+                        Body: partBody,
+                    }),
+                );
+                return { key, uploadId: create.UploadId, eTag: uploadPart.ETag };
+            }
+
+            async function assertInvalidPart(promise) {
+                let caught;
+                try {
+                    await promise;
+                } catch (err) {
+                    caught = err;
+                }
+                assert(caught, 'expected CompleteMPU to reject');
+                assert.strictEqual(
+                    caught.name,
+                    'InvalidPart',
+                    `expected InvalidPart, got ${caught.name}: ${caught.message}`,
+                );
+            }
+
+            it('should return InvalidPart when Part includes matching ChecksumCRC64NVME (correct value)', async () => {
+                const { key, uploadId, eTag } = await setupDefaultMpu();
+                const crc64 = await algorithms.crc64nvme.digest(partBody);
+                await assertInvalidPart(
+                    s3.send(
+                        new CompleteMultipartUploadCommand({
+                            Bucket: bucket,
+                            Key: key,
+                            UploadId: uploadId,
+                            MultipartUpload: {
+                                Parts: [{ PartNumber: 1, ETag: eTag, ChecksumCRC64NVME: crc64 }],
+                            },
+                        }),
+                    ),
+                );
+            });
+
+            it('should return InvalidPart when Part includes a non-matching algorithm field', async () => {
+                const { key, uploadId, eTag } = await setupDefaultMpu();
+                const crc32 = await algorithms.crc32.digest(partBody);
+                await assertInvalidPart(
+                    s3.send(
+                        new CompleteMultipartUploadCommand({
+                            Bucket: bucket,
+                            Key: key,
+                            UploadId: uploadId,
+                            MultipartUpload: {
+                                Parts: [{ PartNumber: 1, ETag: eTag, ChecksumCRC32: crc32 }],
+                            },
+                        }),
+                    ),
+                );
+            });
+        });
+    }));

--- a/tests/functional/aws-node-sdk/test/object/mpuVersion.js
+++ b/tests/functional/aws-node-sdk/test/object/mpuVersion.js
@@ -142,14 +142,6 @@ function checkObjMdAndUpdate(objMDBefore, objMDAfter, props) {
         // eslint-disable-next-line no-param-reassign
         delete objMDBefore['content-type'];
     }
-    if (objMDBefore.checksum && !objMDAfter.checksum) {
-        // The initial PutObject stores a checksum, but the MPU restore path does not
-        // (CompleteMultipartUpload checksum storage is not yet implemented).
-        // Once it is, the restored object should carry a checksum and this workaround
-        // should be removed.
-        // eslint-disable-next-line no-param-reassign
-        delete objMDBefore.checksum;
-    }
 }
 
 function clearUploadIdAndRestoreStatusFromVersions(versions) {
@@ -353,6 +345,7 @@ describe('MPU with x-scal-s3-version-id header', () => {
                         'archive',
                         'dataStoreName',
                         'originOp',
+                        'checksum',
                     ]);
 
                     assert.deepStrictEqual(objMDAfter, objMDBefore);
@@ -393,6 +386,7 @@ describe('MPU with x-scal-s3-version-id header', () => {
                     'x-amz-restore',
                     'archive',
                     'dataStoreName',
+                    'checksum',
                 ]);
 
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
@@ -438,6 +432,7 @@ describe('MPU with x-scal-s3-version-id header', () => {
                     'x-amz-restore',
                     'archive',
                     'dataStoreName',
+                    'checksum',
                 ]);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
             });
@@ -482,6 +477,7 @@ describe('MPU with x-scal-s3-version-id header', () => {
                     'x-amz-restore',
                     'archive',
                     'dataStoreName',
+                    'checksum',
                 ]);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
             });
@@ -524,6 +520,7 @@ describe('MPU with x-scal-s3-version-id header', () => {
                     'x-amz-restore',
                     'archive',
                     'dataStoreName',
+                    'checksum',
                 ]);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
             });
@@ -569,6 +566,7 @@ describe('MPU with x-scal-s3-version-id header', () => {
                     'x-amz-restore',
                     'archive',
                     'dataStoreName',
+                    'checksum',
                 ]);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
             });
@@ -619,6 +617,7 @@ describe('MPU with x-scal-s3-version-id header', () => {
                     'x-amz-restore',
                     'archive',
                     'dataStoreName',
+                    'checksum',
                 ]);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
             });
@@ -666,6 +665,7 @@ describe('MPU with x-scal-s3-version-id header', () => {
                     'x-amz-restore',
                     'archive',
                     'dataStoreName',
+                    'checksum',
                 ]);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
             });
@@ -711,6 +711,7 @@ describe('MPU with x-scal-s3-version-id header', () => {
                     'x-amz-restore',
                     'archive',
                     'dataStoreName',
+                    'checksum',
                 ]);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
             });
@@ -764,6 +765,7 @@ describe('MPU with x-scal-s3-version-id header', () => {
                     'x-amz-restore',
                     'archive',
                     'dataStoreName',
+                    'checksum',
                 ]);
                 assert.deepStrictEqual(objMDAfter, objMDBefore);
             });
@@ -807,6 +809,7 @@ describe('MPU with x-scal-s3-version-id header', () => {
                     'x-amz-restore',
                     'archive',
                     'dataStoreName',
+                    'checksum',
                 ]);
 
                 assert(isDeepStrictEqual(objMDAfter, objMDBefore), 'Objects should be deeply equal');

--- a/tests/functional/raw-node/test/xAmzChecksum.js
+++ b/tests/functional/raw-node/test/xAmzChecksum.js
@@ -186,7 +186,7 @@ describe('Test x-amz-checksums', () => {
     for (const algo of algos) {
         for (const method of methods) {
             itSkipIfAWS(
-                `${method.Name} should respond BadDigest ` + `with invalid x-amz-checksum-${algo.name.toLowerCase()}`,
+                `${method.Name} should respond BadDigest with invalid x-amz-checksum-${algo.name.toLowerCase()}`,
                 done => {
                     const headers = {
                         [`x-amz-checksum-${algo.name.toLowerCase()}`]: algo.validWrong,
@@ -274,8 +274,7 @@ describe('Test x-amz-checksums', () => {
     for (const algo of algos) {
         for (const method of methods) {
             itSkipIfAWS(
-                `${method.Name} should not respond BadDigest if ` +
-                    `x-amz-checksum-${algo.name.toLowerCase()} is correct`,
+                `${method.Name} should not respond BadDigest if x-amz-checksum-${algo.name.toLowerCase()} is correct`,
                 done => {
                     const url = `http://localhost:8000/${bucket}/${method.Key}?${method.Query}`;
                     const req = new HttpRequestAuthV4(

--- a/tests/functional/raw-node/test/xAmzChecksum.js
+++ b/tests/functional/raw-node/test/xAmzChecksum.js
@@ -24,13 +24,11 @@ describe('Test x-amz-checksums', () => {
             validWrong: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
         },
     ];
+    // CompleteMultipartUpload intentionally not listed here: its
+    // x-amz-checksum-<algo> header is the expected final-object checksum,
+    // not a body digest, so it's not part of the buffered-body validator
+    // path tested below.
     const methods = [
-        {
-            Name: 'CompleteMultipartupload',
-            Query: 'uploadId=77a4ce46b9bf4ea69d9e0cc3f0bb1aae',
-            Key: objectKey,
-            HTTPMethod: 'POST',
-        },
         {
             Name: 'DeleteObjects',
             Query: 'delete',

--- a/tests/unit/api/apiUtils/integrity/computeMpuChecksums.js
+++ b/tests/unit/api/apiUtils/integrity/computeMpuChecksums.js
@@ -27,34 +27,34 @@ describe('computeCompositeMPUChecksum', () => {
 
     COMPOSITE_ALGOS.forEach(algo => {
         const label = algo.toUpperCase();
-        it(`should match ${label}(decode(c1) || ... || decode(cN)) + "-N"`, () => {
+        it(`should match ${label}(decode(c1) || ... || decode(cN)) + "-N"`, async () => {
             const partChecksums = parts.map(p => algorithms[algo].digest(p));
             const expectedConcat = Buffer.concat(partChecksums.map(c => Buffer.from(c, 'base64')));
             const expected = `${algorithms[algo].digest(expectedConcat)}-3`;
 
-            const got = computeCompositeMPUChecksum(algo, partChecksums);
+            const got = await computeCompositeMPUChecksum(algo, partChecksums);
             assert.strictEqual(got.error, null);
             assert.strictEqual(got.checksum, expected);
         });
     });
 
-    it('should return N=1 for a single part', () => {
+    it('should return N=1 for a single part', async () => {
         const partChecksums = [algorithms.sha256.digest(parts[0])];
-        const got = computeCompositeMPUChecksum('sha256', partChecksums);
+        const got = await computeCompositeMPUChecksum('sha256', partChecksums);
         assert.strictEqual(got.error, null);
         assert(got.checksum.endsWith('-1'));
     });
 
-    it('should return an error object on unsupported algorithm', () => {
-        const got = computeCompositeMPUChecksum('md5', ['AAAA']);
+    it('should return an error object on unsupported algorithm', async () => {
+        const got = await computeCompositeMPUChecksum('md5', ['AAAA']);
         assert.strictEqual(got.checksum, null);
         assert(got.error);
         assert.strictEqual(got.error.code, 'MPUAlgoNotSupported');
         assert.deepStrictEqual(got.error.details, { algorithm: 'md5' });
     });
 
-    it('should return an error object for crc64nvme (not allowed for COMPOSITE)', () => {
-        const got = computeCompositeMPUChecksum('crc64nvme', ['AQIDBAUGBwg=']);
+    it('should return an error object for crc64nvme (not allowed for COMPOSITE)', async () => {
+        const got = await computeCompositeMPUChecksum('crc64nvme', ['AQIDBAUGBwg=']);
         assert.strictEqual(got.checksum, null);
         assert.strictEqual(got.error.code, 'MPUAlgoNotSupported');
     });

--- a/tests/unit/api/apiUtils/integrity/validateChecksums.js
+++ b/tests/unit/api/apiUtils/integrity/validateChecksums.js
@@ -338,8 +338,6 @@ describe('validateMethodChecksumNoChunking', () => {
     describe('when checksum mismatches', () => {
         Object.keys(checksumedMethods).forEach(method => {
             it(`should return BadDigest error for ${method} when checksum mismatch`, async () => {
-                config.integrityChecks[method] = true;
-
                 const body = 'Hello, World!';
                 const wrongMd5 = '1B2M2Y8AsgTpgAmY7PhCfg==';
                 const request = {
@@ -360,8 +358,6 @@ describe('validateMethodChecksumNoChunking', () => {
     describe('when checksum mismatches', () => {
         Object.keys(checksumedMethods).forEach(method => {
             it(`should return InvalidDigest error for ${method} when checksum mismatch`, async () => {
-                config.integrityChecks[method] = true;
-
                 const body = 'Hello, World!';
                 const wrongMd5 = 'wrongchecksum123=';
                 const request = {
@@ -382,8 +378,6 @@ describe('validateMethodChecksumNoChunking', () => {
     describe('when no checksum is provided', () => {
         Object.keys(checksumedMethods).forEach(method => {
             it(`should return null for ${method} when no checksum is provided`, async () => {
-                config.integrityChecks[method] = true;
-
                 const body = 'Hello, World!';
                 const request = {
                     apiMethod: method,
@@ -401,8 +395,6 @@ describe('validateMethodChecksumNoChunking', () => {
     describe('when checksum matches', () => {
         Object.keys(checksumedMethods).forEach(method => {
             it(`should return null for ${method} when checksum matches`, async () => {
-                config.integrityChecks[method] = true;
-
                 const body = 'Hello, World!';
                 const correctMd5 = crypto.createHash('md5').update(body, 'utf8').digest('base64');
                 const request = {
@@ -443,9 +435,8 @@ describe('validateMethodChecksumNoChunking', () => {
     });
 
     describe('when method is not in validation function mapping', () => {
-        it('should return null for unsupported method even when enabled in config', async () => {
+        it('should return null for unsupported method', async () => {
             const unsupportedMethod = 'someUnsupportedMethod';
-            config.integrityChecks[unsupportedMethod] = true;
 
             const body = 'Hello, World!';
             const wrongMd5 = 'wrongchecksum123=';
@@ -502,7 +493,6 @@ describe('validateMethodChecksumNoChunking', () => {
         const correctMd5 = crypto.createHash('md5').update(body, 'utf8').digest('base64');
 
         it('should return null when Content-MD5 matches the body', async () => {
-            config.integrityChecks.completeMultipartUpload = true;
             const request = {
                 apiMethod: 'completeMultipartUpload',
                 headers: { 'content-md5': correctMd5 },
@@ -513,7 +503,6 @@ describe('validateMethodChecksumNoChunking', () => {
         });
 
         it('should return BadDigest when Content-MD5 does not match the body', async () => {
-            config.integrityChecks.completeMultipartUpload = true;
             const request = {
                 apiMethod: 'completeMultipartUpload',
                 headers: { 'content-md5': '1B2M2Y8AsgTpgAmY7PhCfg==' },
@@ -524,7 +513,6 @@ describe('validateMethodChecksumNoChunking', () => {
         });
 
         it('should return InvalidDigest when Content-MD5 is malformed', async () => {
-            config.integrityChecks.completeMultipartUpload = true;
             const request = {
                 apiMethod: 'completeMultipartUpload',
                 headers: { 'content-md5': 'wrongchecksum123=' },
@@ -535,7 +523,6 @@ describe('validateMethodChecksumNoChunking', () => {
         });
 
         it('should return null when no Content-MD5 header is present', async () => {
-            config.integrityChecks.completeMultipartUpload = true;
             const request = {
                 apiMethod: 'completeMultipartUpload',
                 headers: {},
@@ -550,7 +537,6 @@ describe('validateMethodChecksumNoChunking', () => {
             // the other methods, this wrong x-amz-checksum-sha256 (treated
             // as a body digest) would return BadDigest. The md5-only path
             // must ignore it — the final-object validator handles it later.
-            config.integrityChecks.completeMultipartUpload = true;
             const request = {
                 apiMethod: 'completeMultipartUpload',
                 headers: { 'x-amz-checksum-sha256': 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=' },

--- a/tests/unit/api/apiUtils/integrity/validateChecksums.js
+++ b/tests/unit/api/apiUtils/integrity/validateChecksums.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const crypto = require('crypto');
-const sinon = require('sinon');
 
+const { DummyRequestLogger } = require('../../../helpers');
 const {
     validateChecksumsNoChunking,
     ChecksumError,
@@ -25,7 +25,7 @@ describe('validateChecksumsNoChunking MD5', () => {
             };
 
             const result = await validateChecksumsNoChunking(headers, body);
-            assert.strictEqual(result, null);
+            assert.ifError(result);
         });
     });
 
@@ -234,6 +234,40 @@ describe('validateChecksumsNoChunking CRC32, CRC32C, SHA1, SHA256, CRC64NVME', (
         assert.deepStrictEqual(result.details.algorithms, ['x-amz-checksum-sha1', 'x-amz-checksum-sha256']);
     });
 
+    it('should ignore x-amz-checksum-algorithm alongside a valid x-amz-checksum-<algo> value', async () => {
+        const body = 'sha256 data';
+        const headers = {
+            'content-type': 'application/json',
+            'x-amz-checksum-algorithm': 'SHA256',
+            'x-amz-checksum-sha256': 'jS/UevcoKxbM33kmPFujS72ior/9/i374VmGvbTAwAc=',
+        };
+        const result = await validateChecksumsNoChunking(headers, body);
+        assert.ifError(result);
+    });
+
+    it('should ignore x-amz-checksum-type alongside a valid x-amz-checksum-<algo> value', async () => {
+        const body = 'sha256 data';
+        const headers = {
+            'content-type': 'application/json',
+            'x-amz-checksum-type': 'FULL_OBJECT',
+            'x-amz-checksum-sha256': 'jS/UevcoKxbM33kmPFujS72ior/9/i374VmGvbTAwAc=',
+        };
+        const result = await validateChecksumsNoChunking(headers, body);
+        assert.ifError(result);
+    });
+
+    it('should ignore both x-amz-checksum-algorithm and x-amz-checksum-type when combined with a value', async () => {
+        const body = 'sha256 data';
+        const headers = {
+            'content-type': 'application/json',
+            'x-amz-checksum-algorithm': 'SHA256',
+            'x-amz-checksum-type': 'FULL_OBJECT',
+            'x-amz-checksum-sha256': 'jS/UevcoKxbM33kmPFujS72ior/9/i374VmGvbTAwAc=',
+        };
+        const result = await validateChecksumsNoChunking(headers, body);
+        assert.ifError(result);
+    });
+
     for (const algo of algos) {
         it('should return error AlgoNotSupported if x-amz-sdk-checksum-algorithm algo not supported', async () => {
             const headers = {
@@ -291,16 +325,13 @@ describe('validateChecksumsNoChunking CRC32, CRC32C, SHA1, SHA256, CRC64NVME', (
 });
 
 describe('validateMethodChecksumNoChunking', () => {
-    let sandbox;
     let originalIntegrityChecks;
 
     beforeEach(() => {
-        sandbox = sinon.createSandbox();
         originalIntegrityChecks = { ...config.integrityChecks };
     });
 
     afterEach(() => {
-        sandbox.restore();
         config.integrityChecks = originalIntegrityChecks;
     });
 
@@ -317,12 +348,11 @@ describe('validateMethodChecksumNoChunking', () => {
                         'content-md5': wrongMd5,
                     },
                 };
-                const log = { debug: sandbox.stub() };
+                const log = new DummyRequestLogger();
 
                 const result = await validateMethodChecksumNoChunking(request, body, log);
 
                 assert.deepStrictEqual(result, ArsenalErrors.BadDigest, 'Expected BadDigest error');
-                assert(log.debug.calledOnce);
             });
         });
     });
@@ -340,12 +370,11 @@ describe('validateMethodChecksumNoChunking', () => {
                         'content-md5': wrongMd5,
                     },
                 };
-                const log = { debug: sandbox.stub() };
+                const log = new DummyRequestLogger();
 
                 const result = await validateMethodChecksumNoChunking(request, body, log);
 
                 assert.deepStrictEqual(result, ArsenalErrors.InvalidDigest, 'Expected BadDigest error');
-                assert(log.debug.calledOnce);
             });
         });
     });
@@ -360,12 +389,11 @@ describe('validateMethodChecksumNoChunking', () => {
                     apiMethod: method,
                     headers: {},
                 };
-                const log = { debug: sandbox.stub() };
+                const log = new DummyRequestLogger();
 
                 const result = await validateMethodChecksumNoChunking(request, body, log);
 
-                assert.strictEqual(result, null);
-                assert(log.debug.notCalled);
+                assert.ifError(result);
             });
         });
     });
@@ -383,12 +411,11 @@ describe('validateMethodChecksumNoChunking', () => {
                         'content-md5': correctMd5,
                     },
                 };
-                const log = { debug: sandbox.stub() };
+                const log = new DummyRequestLogger();
 
                 const result = await validateMethodChecksumNoChunking(request, body, log);
 
-                assert.strictEqual(result, null);
-                assert(log.debug.notCalled);
+                assert.ifError(result);
             });
         });
     });
@@ -406,12 +433,11 @@ describe('validateMethodChecksumNoChunking', () => {
                         'content-md5': wrongMd5,
                     },
                 };
-                const log = { debug: sandbox.stub() };
+                const log = new DummyRequestLogger();
 
                 const result = await validateMethodChecksumNoChunking(request, body, log);
 
-                assert.strictEqual(result, null);
-                assert(log.debug.notCalled);
+                assert.ifError(result);
             });
         });
     });
@@ -429,12 +455,11 @@ describe('validateMethodChecksumNoChunking', () => {
                     'content-md5': wrongMd5,
                 },
             };
-            const log = { debug: sandbox.stub() };
+            const log = new DummyRequestLogger();
 
             const result = await validateMethodChecksumNoChunking(request, body, log);
 
-            assert.strictEqual(result, null);
-            assert(log.debug.notCalled);
+            assert.ifError(result);
         });
     });
 
@@ -446,11 +471,11 @@ describe('validateMethodChecksumNoChunking', () => {
                     'content-md5': 'wrongchecksum123=',
                 },
             };
-            const log = { debug: sandbox.stub() };
+            const log = new DummyRequestLogger();
 
             const result = await validateMethodChecksumNoChunking(request, body, log);
 
-            assert.strictEqual(result, null);
+            assert.ifError(result);
         });
 
         it('should return null when request apiMethod is undefined in config', async () => {
@@ -461,11 +486,11 @@ describe('validateMethodChecksumNoChunking', () => {
                     'content-md5': 'wrongchecksum123=',
                 },
             };
-            const log = { debug: sandbox.stub() };
+            const log = new DummyRequestLogger();
 
             const result = await validateMethodChecksumNoChunking(request, body, log);
 
-            assert.strictEqual(result, null);
+            assert.ifError(result);
         });
     });
 
@@ -482,9 +507,9 @@ describe('validateMethodChecksumNoChunking', () => {
                 apiMethod: 'completeMultipartUpload',
                 headers: { 'content-md5': correctMd5 },
             };
-            const log = { debug: sandbox.stub() };
+            const log = new DummyRequestLogger();
             const result = await validateMethodChecksumNoChunking(request, body, log);
-            assert.strictEqual(result, null);
+            assert.ifError(result);
         });
 
         it('should return BadDigest when Content-MD5 does not match the body', async () => {
@@ -493,10 +518,9 @@ describe('validateMethodChecksumNoChunking', () => {
                 apiMethod: 'completeMultipartUpload',
                 headers: { 'content-md5': '1B2M2Y8AsgTpgAmY7PhCfg==' },
             };
-            const log = { debug: sandbox.stub() };
+            const log = new DummyRequestLogger();
             const result = await validateMethodChecksumNoChunking(request, body, log);
             assert.deepStrictEqual(result, ArsenalErrors.BadDigest);
-            assert(log.debug.calledOnce);
         });
 
         it('should return InvalidDigest when Content-MD5 is malformed', async () => {
@@ -505,7 +529,7 @@ describe('validateMethodChecksumNoChunking', () => {
                 apiMethod: 'completeMultipartUpload',
                 headers: { 'content-md5': 'wrongchecksum123=' },
             };
-            const log = { debug: sandbox.stub() };
+            const log = new DummyRequestLogger();
             const result = await validateMethodChecksumNoChunking(request, body, log);
             assert.deepStrictEqual(result, ArsenalErrors.InvalidDigest);
         });
@@ -516,9 +540,9 @@ describe('validateMethodChecksumNoChunking', () => {
                 apiMethod: 'completeMultipartUpload',
                 headers: {},
             };
-            const log = { debug: sandbox.stub() };
+            const log = new DummyRequestLogger();
             const result = await validateMethodChecksumNoChunking(request, body, log);
-            assert.strictEqual(result, null);
+            assert.ifError(result);
         });
 
         it('should NOT validate x-amz-checksum-* as a body digest (final-object semantics)', async () => {
@@ -531,9 +555,9 @@ describe('validateMethodChecksumNoChunking', () => {
                 apiMethod: 'completeMultipartUpload',
                 headers: { 'x-amz-checksum-sha256': 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=' },
             };
-            const log = { debug: sandbox.stub() };
+            const log = new DummyRequestLogger();
             const result = await validateMethodChecksumNoChunking(request, body, log);
-            assert.strictEqual(result, null);
+            assert.ifError(result);
         });
     });
 });
@@ -550,12 +574,12 @@ describe('getChecksumDataFromHeaders', () => {
 
     it('should return null when no headers', () => {
         const result = getChecksumDataFromHeaders({});
-        assert.strictEqual(result, null);
+        assert.ifError(result);
     });
 
     it('should return null when no checksum headers, no trailer, no sdk algo', () => {
         const result = getChecksumDataFromHeaders({ 'content-type': 'application/octet-stream' });
-        assert.strictEqual(result, null);
+        assert.ifError(result);
     });
 
     for (const [algo, digest] of Object.entries(validDigests)) {
@@ -589,6 +613,31 @@ describe('getChecksumDataFromHeaders', () => {
             'x-amz-checksum-sha256': validDigests.sha256,
         });
         assert.strictEqual(result.error, ChecksumError.MultipleChecksumTypes);
+    });
+
+    it('should ignore x-amz-checksum-algorithm alongside a valid x-amz-checksum-<algo> value', () => {
+        const result = getChecksumDataFromHeaders({
+            'x-amz-checksum-algorithm': 'SHA256',
+            'x-amz-checksum-sha256': validDigests.sha256,
+        });
+        assert.deepStrictEqual(result, { algorithm: 'sha256', isTrailer: false, expected: validDigests.sha256 });
+    });
+
+    it('should ignore x-amz-checksum-type alongside a valid x-amz-checksum-<algo> value', () => {
+        const result = getChecksumDataFromHeaders({
+            'x-amz-checksum-type': 'FULL_OBJECT',
+            'x-amz-checksum-sha256': validDigests.sha256,
+        });
+        assert.deepStrictEqual(result, { algorithm: 'sha256', isTrailer: false, expected: validDigests.sha256 });
+    });
+
+    it('should ignore both x-amz-checksum-algorithm and x-amz-checksum-type when combined with a value', () => {
+        const result = getChecksumDataFromHeaders({
+            'x-amz-checksum-algorithm': 'SHA256',
+            'x-amz-checksum-type': 'FULL_OBJECT',
+            'x-amz-checksum-sha256': validDigests.sha256,
+        });
+        assert.deepStrictEqual(result, { algorithm: 'sha256', isTrailer: false, expected: validDigests.sha256 });
     });
 
     it('should return MissingCorresponding when x-amz-sdk-checksum-algorithm has no x-amz-checksum- or trailer', () => {
@@ -683,7 +732,7 @@ describe('getChecksumDataFromHeaders', () => {
 describe('arsenalErrorFromChecksumError', () => {
     it('should return null for MissingChecksum', () => {
         const result = arsenalErrorFromChecksumError({ error: ChecksumError.MissingChecksum, details: null });
-        assert.strictEqual(result, null);
+        assert.ifError(result);
     });
 
     it('should return BadDigest mentioning CRC32 for XAmzMismatch with crc32', () => {
@@ -1011,7 +1060,7 @@ describe('validateCompleteMultipartUploadChecksum', () => {
             { host: 'example.com' },
             { algorithm: 'sha256', type: 'COMPOSITE', value: `${SHA256_A}-3` },
         );
-        assert.strictEqual(err, null);
+        assert.ifError(err);
     });
 
     it('should ignore x-amz-checksum-type and x-amz-checksum-algorithm headers', () => {
@@ -1022,7 +1071,7 @@ describe('validateCompleteMultipartUploadChecksum', () => {
             },
             { algorithm: 'sha256', type: 'COMPOSITE', value: `${SHA256_A}-3` },
         );
-        assert.strictEqual(err, null);
+        assert.ifError(err);
     });
 
     it('should return null when COMPOSITE header value matches (digest-N form)', () => {
@@ -1030,7 +1079,7 @@ describe('validateCompleteMultipartUploadChecksum', () => {
             { 'x-amz-checksum-sha256': `${SHA256_A}-3` },
             { algorithm: 'sha256', type: 'COMPOSITE', value: `${SHA256_A}-3` },
         );
-        assert.strictEqual(err, null);
+        assert.ifError(err);
     });
 
     it('should return null when FULL_OBJECT header value matches (no suffix)', () => {
@@ -1041,7 +1090,7 @@ describe('validateCompleteMultipartUploadChecksum', () => {
             { 'x-amz-checksum-crc32': CRC32_A },
             { algorithm: 'crc32', type: 'FULL_OBJECT', value: CRC32_A },
         );
-        assert.strictEqual(err, null);
+        assert.ifError(err);
     });
 
     it('should return XAmzMismatch when header value differs', () => {
@@ -1075,7 +1124,7 @@ describe('validateCompleteMultipartUploadChecksum', () => {
 
     it('should return null when finalChecksum is null and no header present', () => {
         const err = validateCompleteMultipartUploadChecksum({ host: 'example.com' }, null);
-        assert.strictEqual(err, null);
+        assert.ifError(err);
     });
 
     it('should return MultipleChecksumTypes when multiple x-amz-checksum-* headers are sent', () => {

--- a/tests/unit/api/apiUtils/integrity/validateChecksums.js
+++ b/tests/unit/api/apiUtils/integrity/validateChecksums.js
@@ -10,6 +10,7 @@ const {
     getChecksumDataFromHeaders,
     arsenalErrorFromChecksumError,
     getChecksumDataFromMPUHeaders,
+    validateCompleteMultipartUploadChecksum,
 } = require('../../../../../lib/api/apiUtils/integrity/validateChecksums');
 const { errors: ArsenalErrors } = require('arsenal');
 const { config } = require('../../../../../lib/Config');
@@ -464,6 +465,74 @@ describe('validateMethodChecksumNoChunking', () => {
 
             const result = await validateMethodChecksumNoChunking(request, body, log);
 
+            assert.strictEqual(result, null);
+        });
+    });
+
+    // CompleteMPU is not in `checksumedMethods` (x-amz-checksum-* is the
+    // final-object checksum, not a body digest) but it still must validate
+    // Content-MD5 against the XML body when present.
+    describe('completeMultipartUpload (md5-only path)', () => {
+        const body = 'Hello, World!';
+        const correctMd5 = crypto.createHash('md5').update(body, 'utf8').digest('base64');
+
+        it('should return null when Content-MD5 matches the body', async () => {
+            config.integrityChecks.completeMultipartUpload = true;
+            const request = {
+                apiMethod: 'completeMultipartUpload',
+                headers: { 'content-md5': correctMd5 },
+            };
+            const log = { debug: sandbox.stub() };
+            const result = await validateMethodChecksumNoChunking(request, body, log);
+            assert.strictEqual(result, null);
+        });
+
+        it('should return BadDigest when Content-MD5 does not match the body', async () => {
+            config.integrityChecks.completeMultipartUpload = true;
+            const request = {
+                apiMethod: 'completeMultipartUpload',
+                headers: { 'content-md5': '1B2M2Y8AsgTpgAmY7PhCfg==' },
+            };
+            const log = { debug: sandbox.stub() };
+            const result = await validateMethodChecksumNoChunking(request, body, log);
+            assert.deepStrictEqual(result, ArsenalErrors.BadDigest);
+            assert(log.debug.calledOnce);
+        });
+
+        it('should return InvalidDigest when Content-MD5 is malformed', async () => {
+            config.integrityChecks.completeMultipartUpload = true;
+            const request = {
+                apiMethod: 'completeMultipartUpload',
+                headers: { 'content-md5': 'wrongchecksum123=' },
+            };
+            const log = { debug: sandbox.stub() };
+            const result = await validateMethodChecksumNoChunking(request, body, log);
+            assert.deepStrictEqual(result, ArsenalErrors.InvalidDigest);
+        });
+
+        it('should return null when no Content-MD5 header is present', async () => {
+            config.integrityChecks.completeMultipartUpload = true;
+            const request = {
+                apiMethod: 'completeMultipartUpload',
+                headers: {},
+            };
+            const log = { debug: sandbox.stub() };
+            const result = await validateMethodChecksumNoChunking(request, body, log);
+            assert.strictEqual(result, null);
+        });
+
+        it('should NOT validate x-amz-checksum-* as a body digest (final-object semantics)', async () => {
+            // If we routed CompleteMPU through `defaultValidationFunc` like
+            // the other methods, this wrong x-amz-checksum-sha256 (treated
+            // as a body digest) would return BadDigest. The md5-only path
+            // must ignore it — the final-object validator handles it later.
+            config.integrityChecks.completeMultipartUpload = true;
+            const request = {
+                apiMethod: 'completeMultipartUpload',
+                headers: { 'x-amz-checksum-sha256': 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=' },
+            };
+            const log = { debug: sandbox.stub() };
+            const result = await validateMethodChecksumNoChunking(request, body, log);
             assert.strictEqual(result, null);
         });
     });
@@ -928,5 +997,194 @@ describe('getChecksumDataFromMPUHeaders', () => {
                 assert.strictEqual(result.details.type, type);
             });
         }
+    });
+});
+
+describe('validateCompleteMultipartUploadChecksum', () => {
+    // Real-length placeholder digests that pass `isValidDigest`.
+    const SHA256_A = 'ypeBEsobvcr6wjGzmiPcTaeG7/gUfE5yuYB3ha/uSLs=';
+    const SHA256_B = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=';
+    const CRC32_A = 'AAAAAA==';
+
+    it('should return null when no x-amz-checksum-<algo> header is present', () => {
+        const err = validateCompleteMultipartUploadChecksum(
+            { host: 'example.com' },
+            { algorithm: 'sha256', type: 'COMPOSITE', value: `${SHA256_A}-3` },
+        );
+        assert.strictEqual(err, null);
+    });
+
+    it('should ignore x-amz-checksum-type and x-amz-checksum-algorithm headers', () => {
+        const err = validateCompleteMultipartUploadChecksum(
+            {
+                'x-amz-checksum-type': 'COMPOSITE',
+                'x-amz-checksum-algorithm': 'SHA256',
+            },
+            { algorithm: 'sha256', type: 'COMPOSITE', value: `${SHA256_A}-3` },
+        );
+        assert.strictEqual(err, null);
+    });
+
+    it('should return null when COMPOSITE header value matches (digest-N form)', () => {
+        const err = validateCompleteMultipartUploadChecksum(
+            { 'x-amz-checksum-sha256': `${SHA256_A}-3` },
+            { algorithm: 'sha256', type: 'COMPOSITE', value: `${SHA256_A}-3` },
+        );
+        assert.strictEqual(err, null);
+    });
+
+    it('should return null when FULL_OBJECT header value matches (no suffix)', () => {
+        // Use crc32 (a dual-form algorithm) for the FULL_OBJECT case — sha256
+        // is COMPOSITE-only, so a no-suffix sha256 value is shape-malformed
+        // regardless of the MPU's `type`.
+        const err = validateCompleteMultipartUploadChecksum(
+            { 'x-amz-checksum-crc32': CRC32_A },
+            { algorithm: 'crc32', type: 'FULL_OBJECT', value: CRC32_A },
+        );
+        assert.strictEqual(err, null);
+    });
+
+    it('should return XAmzMismatch when header value differs', () => {
+        const err = validateCompleteMultipartUploadChecksum(
+            { 'x-amz-checksum-sha256': `${SHA256_B}-3` },
+            { algorithm: 'sha256', type: 'COMPOSITE', value: `${SHA256_A}-3` },
+        );
+        assert(err);
+        assert.strictEqual(err.error, ChecksumError.XAmzMismatch);
+        assert.strictEqual(err.details.algorithm, 'sha256');
+    });
+
+    it('should return XAmzMismatch when header algorithm differs from MPU', () => {
+        const err = validateCompleteMultipartUploadChecksum(
+            { 'x-amz-checksum-crc32': CRC32_A },
+            { algorithm: 'sha256', type: 'COMPOSITE', value: `${SHA256_A}-3` },
+        );
+        assert(err);
+        assert.strictEqual(err.error, ChecksumError.XAmzMismatch);
+        assert.strictEqual(err.details.algorithm, 'crc32');
+    });
+
+    it('should return XAmzMismatch when header is present but finalChecksum is null', () => {
+        // Use a shape-valid value (sha256 is COMPOSITE-only, so it requires
+        // the `-N` suffix) so we exercise the finalChecksum=null path
+        // rather than the shape-mismatch path.
+        const err = validateCompleteMultipartUploadChecksum({ 'x-amz-checksum-sha256': `${SHA256_A}-3` }, null);
+        assert(err);
+        assert.strictEqual(err.error, ChecksumError.XAmzMismatch);
+    });
+
+    it('should return null when finalChecksum is null and no header present', () => {
+        const err = validateCompleteMultipartUploadChecksum({ host: 'example.com' }, null);
+        assert.strictEqual(err, null);
+    });
+
+    it('should return MultipleChecksumTypes when multiple x-amz-checksum-* headers are sent', () => {
+        const err = validateCompleteMultipartUploadChecksum(
+            {
+                'x-amz-checksum-sha256': SHA256_A,
+                'x-amz-checksum-crc32': CRC32_A,
+            },
+            { algorithm: 'sha256', type: 'COMPOSITE', value: `${SHA256_A}-3` },
+        );
+        assert(err);
+        assert.strictEqual(err.error, ChecksumError.MultipleChecksumTypes);
+        assert.deepStrictEqual(err.details.algorithms.sort(), ['x-amz-checksum-crc32', 'x-amz-checksum-sha256']);
+    });
+
+    it('should return MalformedChecksum when the header value is not a valid digest', () => {
+        // AWS S3 returns InvalidRequest "Value for x-amz-checksum-sha256
+        // header is invalid." for a malformed value (verified us-east-1,
+        // 2026-05-13). Falling through to a misleading "did not match"
+        // BadDigest would be wrong.
+        const err = validateCompleteMultipartUploadChecksum(
+            { 'x-amz-checksum-sha256': '!!!not-base64!!!' },
+            { algorithm: 'sha256', type: 'COMPOSITE', value: `${SHA256_A}-3` },
+        );
+        assert(err);
+        assert.strictEqual(err.error, ChecksumError.MalformedChecksum);
+        assert.strictEqual(err.details.algorithm, 'sha256');
+        assert.strictEqual(err.details.expected, '!!!not-base64!!!');
+    });
+
+    it('should return MalformedChecksum when the digest-N prefix is the wrong length', () => {
+        // 'abc' is valid base64 chars but not a 44-char SHA256 digest.
+        const err = validateCompleteMultipartUploadChecksum(
+            { 'x-amz-checksum-sha256': 'abc-3' },
+            { algorithm: 'sha256', type: 'COMPOSITE', value: `${SHA256_A}-3` },
+        );
+        assert(err);
+        assert.strictEqual(err.error, ChecksumError.MalformedChecksum);
+    });
+
+    it('should return MalformedChecksum when a FULL_OBJECT-only algorithm carries a `-N` suffix', () => {
+        // crc64nvme only exists as FULL_OBJECT — a `<digest>-N` value is
+        // shape-malformed, not a mismatch. Without the shape check the
+        // suffix would be silently stripped and the digest would validate,
+        // causing this to fall through as XAmzMismatch.
+        const CRC64NVME_VALID = 'AAAAAAAAAAAA'; // 12 chars
+        const err = validateCompleteMultipartUploadChecksum(
+            { 'x-amz-checksum-crc64nvme': `${CRC64NVME_VALID}-5` },
+            { algorithm: 'crc64nvme', type: 'FULL_OBJECT', value: CRC64NVME_VALID },
+        );
+        assert(err);
+        assert.strictEqual(err.error, ChecksumError.MalformedChecksum);
+        assert.strictEqual(err.details.algorithm, 'crc64nvme');
+        assert.strictEqual(err.details.expected, `${CRC64NVME_VALID}-5`);
+    });
+
+    it('should return MalformedChecksum when a COMPOSITE-only algorithm lacks the `-N` suffix', () => {
+        // sha1 only exists as COMPOSITE — a bare `<digest>` value is
+        // shape-malformed.
+        const SHA1_VALID = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAA'; // 28 chars
+        const err = validateCompleteMultipartUploadChecksum(
+            { 'x-amz-checksum-sha1': SHA1_VALID },
+            { algorithm: 'sha1', type: 'COMPOSITE', value: `${SHA1_VALID}-3` },
+        );
+        assert(err);
+        assert.strictEqual(err.error, ChecksumError.MalformedChecksum);
+        assert.strictEqual(err.details.algorithm, 'sha1');
+    });
+
+    it('should return XAmzMismatch (not MalformedChecksum) when a dual-form algorithm sends the wrong shape', () => {
+        // crc32 supports both FULL_OBJECT and COMPOSITE, so `<digest>-N`
+        // against a FULL_OBJECT MPU is shape-valid; the type mismatch
+        // is a regular value mismatch, not malformed.
+        const err = validateCompleteMultipartUploadChecksum(
+            { 'x-amz-checksum-crc32': `${CRC32_A}-3` },
+            { algorithm: 'crc32', type: 'FULL_OBJECT', value: CRC32_A },
+        );
+        assert(err);
+        assert.strictEqual(err.error, ChecksumError.XAmzMismatch);
+    });
+
+    it('should return XAmzMismatch (not MalformedChecksum) when a dual-form algorithm omits a required suffix', () => {
+        // Symmetric: bare `<digest>` against a COMPOSITE crc32 MPU is
+        // shape-valid (crc32 also supports FULL_OBJECT) but value-mismatched.
+        const err = validateCompleteMultipartUploadChecksum(
+            { 'x-amz-checksum-crc32': CRC32_A },
+            { algorithm: 'crc32', type: 'COMPOSITE', value: `${CRC32_A}-3` },
+        );
+        assert(err);
+        assert.strictEqual(err.error, ChecksumError.XAmzMismatch);
+    });
+
+    it('should return AlgoNotSupported when x-amz-checksum-<algo> uses an unsupported algorithm', () => {
+        // Must scan ALL x-amz-checksum-* headers, not just the supported
+        // algorithms — otherwise a bogus header is silently ignored and the
+        // request proceeds.
+        const err = validateCompleteMultipartUploadChecksum(
+            { 'x-amz-checksum-bad': 'anything' },
+            { algorithm: 'sha256', type: 'COMPOSITE', value: `${SHA256_A}-3` },
+        );
+        assert(err);
+        assert.strictEqual(err.error, ChecksumError.AlgoNotSupported);
+        assert.strictEqual(err.details.algorithm, 'bad');
+    });
+
+    it('should reject an unsupported x-amz-checksum-<algo> header even when finalChecksum is null', () => {
+        const err = validateCompleteMultipartUploadChecksum({ 'x-amz-checksum-md5': 'anything' }, null);
+        assert(err);
+        assert.strictEqual(err.error, ChecksumError.AlgoNotSupported);
+        assert.strictEqual(err.details.algorithm, 'md5');
     });
 });

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -4519,3 +4519,174 @@ describe('CompleteMultipartUpload final-object checksum storage', () => {
         assert.strictEqual(md.checksumIsDefault, undefined);
     });
 });
+
+describe('CompleteMultipartUpload final-object checksum response', () => {
+    const log = new DummyRequestLogger();
+    const authInfo = makeAuthInfo('accessKey1');
+    const namespace = 'default';
+    const bucketName = 'bucketname-final-checksum-resp';
+    const objectKey = 'testObject';
+    const partBody = Buffer.from('I am a part\n', 'utf8');
+    const partHash = crypto.createHash('md5').update(partBody).digest('hex');
+
+    const bucketPutRequest = {
+        bucketName,
+        namespace,
+        headers: { host: `${bucketName}.s3.amazonaws.com` },
+        url: '/',
+        post:
+            '<CreateBucketConfiguration ' +
+            'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+            '<LocationConstraint>scality-internal-mem</LocationConstraint>' +
+            '</CreateBucketConfiguration >',
+        actionImplicitDenies: false,
+    };
+
+    const RESPONSE_MATRIX = [
+        { algorithm: 'crc32', type: 'FULL_OBJECT' },
+        { algorithm: 'crc32c', type: 'FULL_OBJECT' },
+        { algorithm: 'crc64nvme', type: 'FULL_OBJECT' },
+        { algorithm: 'crc32', type: 'COMPOSITE' },
+        { algorithm: 'crc32c', type: 'COMPOSITE' },
+        { algorithm: 'sha1', type: 'COMPOSITE' },
+        { algorithm: 'sha256', type: 'COMPOSITE' },
+    ];
+
+    function bucketPutP() {
+        return new Promise((resolve, reject) =>
+            bucketPut(authInfo, bucketPutRequest, log, err => (err ? reject(err) : resolve())),
+        );
+    }
+
+    function initiateMpuP(headers) {
+        return new Promise((resolve, reject) => {
+            initiateMultipartUpload(
+                authInfo,
+                {
+                    bucketName,
+                    namespace,
+                    objectKey,
+                    headers: { host: `${bucketName}.s3.amazonaws.com`, ...headers },
+                    url: `/${objectKey}?uploads`,
+                    actionImplicitDenies: false,
+                },
+                log,
+                (err, xml) => {
+                    if (err) {
+                        return reject(err);
+                    }
+                    return parseString(xml, (parseErr, json) =>
+                        parseErr ? reject(parseErr) : resolve(json.InitiateMultipartUploadResult.UploadId[0]),
+                    );
+                },
+            );
+        });
+    }
+
+    function uploadPartP(uploadId, headers = {}) {
+        return new Promise((resolve, reject) => {
+            const partRequest = new DummyRequest(
+                {
+                    bucketName,
+                    namespace,
+                    objectKey,
+                    headers: { host: `${bucketName}.s3.amazonaws.com`, ...headers },
+                    url: `/${objectKey}?partNumber=1&uploadId=${uploadId}`,
+                    query: { partNumber: '1', uploadId },
+                    partHash,
+                    actionImplicitDenies: false,
+                },
+                partBody,
+            );
+            objectPutPart(authInfo, partRequest, undefined, log, err => (err ? reject(err) : resolve()));
+        });
+    }
+
+    // Resolves with { xml, headers } so callers can inspect both the
+    // response body and the response headers.
+    function completeMpuP(uploadId, partChecksumXml = '') {
+        const completeBody =
+            '<CompleteMultipartUpload>' +
+            '<Part>' +
+            '<PartNumber>1</PartNumber>' +
+            `<ETag>"${partHash}"</ETag>${partChecksumXml}` +
+            '</Part>' +
+            '</CompleteMultipartUpload>';
+        return new Promise((resolve, reject) => {
+            completeMultipartUpload(
+                authInfo,
+                {
+                    bucketName,
+                    namespace,
+                    objectKey,
+                    parsedHost: 's3.amazonaws.com',
+                    url: `/${objectKey}?uploadId=${uploadId}`,
+                    headers: { host: `${bucketName}.s3.amazonaws.com` },
+                    query: { uploadId },
+                    post: completeBody,
+                    actionImplicitDenies: false,
+                },
+                log,
+                (err, xml, headers) => (err ? reject(err) : resolve({ xml, headers })),
+            );
+        });
+    }
+
+    function parseXmlP(xmlStr) {
+        return new Promise((resolve, reject) =>
+            parseString(xmlStr, (err, json) => (err ? reject(err) : resolve(json))),
+        );
+    }
+
+    beforeEach(() => cleanup());
+
+    RESPONSE_MATRIX.forEach(({ algorithm, type }) => {
+        const upper = algorithm.toUpperCase();
+        const tag = TAG_BY_ALGO[algorithm];
+
+        it(`should emit ${type} ${upper} in response XML`, async () => {
+            await bucketPutP();
+            const uploadId = await initiateMpuP({
+                'x-amz-checksum-algorithm': upper,
+                'x-amz-checksum-type': type,
+            });
+            const partChecksum = await algorithms[algorithm].digest(partBody);
+            const uploadHeaders = type === 'COMPOSITE' ? { [`x-amz-checksum-${algorithm}`]: partChecksum } : {};
+            await uploadPartP(uploadId, uploadHeaders);
+            const partChecksumXml = type === 'COMPOSITE' ? `<${tag}>${partChecksum}</${tag}>` : '';
+            const { xml, headers } = await completeMpuP(uploadId, partChecksumXml);
+            const json = await parseXmlP(xml);
+            const result = json.CompleteMultipartUploadResult;
+            assert(result[tag], `expected ${tag} in response XML`);
+            const xmlValue = result[tag][0];
+            assert(typeof xmlValue === 'string' && xmlValue.length > 0);
+            assert.strictEqual(result.ChecksumType[0], type);
+            // COMPOSITE values carry the "-N" suffix; FULL_OBJECT do not.
+            if (type === 'COMPOSITE') {
+                assert(xmlValue.endsWith('-1'), `expected -1 suffix for 1-part COMPOSITE, got ${xmlValue}`);
+            } else {
+                assert(!xmlValue.includes('-'), `FULL_OBJECT value should have no suffix, got ${xmlValue}`);
+            }
+            // AWS-verified: CompleteMPU does NOT emit
+            // x-amz-checksum-* / x-amz-checksum-type response headers.
+            assert.strictEqual(headers[`x-amz-checksum-${algorithm}`], undefined);
+            assert.strictEqual(headers['x-amz-checksum-type'], undefined);
+        });
+    });
+
+    it('should emit FULL_OBJECT CRC64NVME for default MPU (no checksum headers)', async () => {
+        // AWS-verified: a default MPU still surfaces the CRC64NVME
+        // checksum and ChecksumType=FULL_OBJECT in the CompleteMPU response
+        // BODY (not headers).
+        await bucketPutP();
+        const uploadId = await initiateMpuP({});
+        await uploadPartP(uploadId);
+        const { xml, headers } = await completeMpuP(uploadId);
+        const json = await parseXmlP(xml);
+        const result = json.CompleteMultipartUploadResult;
+        assert(result.ChecksumCRC64NVME, 'default MPU should emit ChecksumCRC64NVME');
+        assert.strictEqual(result.ChecksumType[0], 'FULL_OBJECT');
+        assert.strictEqual(headers['x-amz-checksum-crc64nvme'], undefined);
+        assert.strictEqual(headers['x-amz-checksum-type'], undefined);
+    });
+});

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -4097,7 +4097,7 @@ describe('CompleteMultipartUpload body-checksum bypass', () => {
     const log = new DummyRequestLogger();
 
     it(
-        'validateMethodChecksumNoChunking returns null for completeMultipartUpload ' +
+        'should skip body-checksum validation for completeMultipartUpload ' +
             'even when x-amz-checksum-sha256 does not match the body digest',
         async () => {
             const body = Buffer.from(
@@ -4119,8 +4119,7 @@ describe('CompleteMultipartUpload body-checksum bypass', () => {
     );
 
     it(
-        'validateMethodChecksumNoChunking still rejects body mismatch for methods ' +
-            'that remain in checksumedMethods (sanity check)',
+        'should still reject body mismatch for methods that remain in checksumedMethods ' + '(sanity check)',
         async () => {
             const body = Buffer.from('{"Objects":[]}');
             const finalObjectChecksum = '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';
@@ -4133,4 +4132,209 @@ describe('CompleteMultipartUpload body-checksum bypass', () => {
             assert.strictEqual(err.is.BadDigest, true);
         },
     );
+});
+
+describe('computeFinalChecksum', () => {
+    const log = new DummyRequestLogger();
+    const uploadId = UPLOAD_ID;
+
+    function partListFromStored(stored) {
+        return stored.map(s => ({
+            key: s.key,
+            ETag: `"${s.value.ETag}"`,
+            size: s.value.Size,
+            locations: s.value.partLocations,
+        }));
+    }
+
+    it('should return null when MPU has no checksumAlgorithm', async () => {
+        const stored = [makeStoredPart(1, { algorithm: 'sha256', value: SAMPLE_DIGESTS.sha256[0] })];
+        const got = await computeFinalChecksum(stored, partListFromStored(stored), {}, splitter, uploadId, log);
+        assert.strictEqual(got, null);
+    });
+
+    it('should return null when MPU has no checksumType', async () => {
+        const stored = [makeStoredPart(1, { algorithm: 'sha256', value: SAMPLE_DIGESTS.sha256[0] })];
+        const got = await computeFinalChecksum(
+            stored,
+            partListFromStored(stored),
+            { checksumAlgorithm: 'sha256' },
+            splitter,
+            uploadId,
+            log,
+        );
+        assert.strictEqual(got, null);
+    });
+
+    it('should return COMPOSITE checksum with -N suffix for SHA256 MPU', async () => {
+        const [d1, d2, d3] = [SAMPLE_DIGESTS.sha256[0], SAMPLE_DIGESTS.sha256[1], SAMPLE_DIGESTS.sha256[0]];
+        const stored = [
+            makeStoredPart(1, { algorithm: 'sha256', value: d1 }),
+            makeStoredPart(2, { algorithm: 'sha256', value: d2 }),
+            makeStoredPart(3, { algorithm: 'sha256', value: d3 }),
+        ];
+        const got = await computeFinalChecksum(
+            stored,
+            partListFromStored(stored),
+            { checksumAlgorithm: 'sha256', checksumType: 'COMPOSITE' },
+            splitter,
+            uploadId,
+            log,
+        );
+        assert(got);
+        assert.strictEqual(got.algorithm, 'sha256');
+        assert.strictEqual(got.type, 'COMPOSITE');
+        assert(got.value.endsWith('-3'), `expected -N suffix, got ${got.value}`);
+        // computeCompositeMPUChecksum's deterministic output for these
+        // exact placeholder digests:
+        const expected = crypto
+            .createHash('sha256')
+            .update(Buffer.concat([d1, d2, d3].map(x => Buffer.from(x, 'base64'))))
+            .digest('base64');
+        assert.strictEqual(got.value, `${expected}-3`);
+    });
+
+    ['sha1', 'crc32', 'crc32c'].forEach(algo => {
+        it(`should compute COMPOSITE checksum for ${algo.toUpperCase()}`, async () => {
+            const [d1, d2] = SAMPLE_DIGESTS[algo];
+            const stored = [
+                makeStoredPart(1, { algorithm: algo, value: d1 }),
+                makeStoredPart(2, { algorithm: algo, value: d2 }),
+            ];
+            const got = await computeFinalChecksum(
+                stored,
+                partListFromStored(stored),
+                { checksumAlgorithm: algo, checksumType: 'COMPOSITE' },
+                splitter,
+                uploadId,
+                log,
+            );
+            assert(got);
+            assert.strictEqual(got.algorithm, algo);
+            assert.strictEqual(got.type, 'COMPOSITE');
+            assert(got.value.endsWith('-2'));
+        });
+    });
+
+    it('should return FULL_OBJECT checksum without -N suffix for CRC64NVME', async () => {
+        // Real CRCs over real bytes so we can verify against the equivalent
+        // direct CRC of the concatenation.
+        const a = crypto.randomBytes(1024);
+        const b = crypto.randomBytes(2048);
+        const dA = await algorithms.crc64nvme.digest(a);
+        const dB = await algorithms.crc64nvme.digest(b);
+        const stored = [
+            {
+                key: `${UPLOAD_ID}${splitter}1`,
+                value: {
+                    ETag: 'e',
+                    Size: a.length,
+                    ChecksumAlgorithm: 'crc64nvme',
+                    ChecksumValue: dA,
+                    partLocations: [],
+                },
+            },
+            {
+                key: `${UPLOAD_ID}${splitter}2`,
+                value: {
+                    ETag: 'e',
+                    Size: b.length,
+                    ChecksumAlgorithm: 'crc64nvme',
+                    ChecksumValue: dB,
+                    partLocations: [],
+                },
+            },
+        ];
+        const got = await computeFinalChecksum(
+            stored,
+            partListFromStored(stored),
+            { checksumAlgorithm: 'crc64nvme', checksumType: 'FULL_OBJECT' },
+            splitter,
+            uploadId,
+            log,
+        );
+        assert(got);
+        assert.strictEqual(got.algorithm, 'crc64nvme');
+        assert.strictEqual(got.type, 'FULL_OBJECT');
+        assert(!got.value.includes('-'), `FULL_OBJECT should have no -N suffix, got ${got.value}`);
+        const expected = await algorithms.crc64nvme.digest(Buffer.concat([a, b]));
+        assert.strictEqual(got.value, expected);
+    });
+
+    it('should return null and log when a part is missing ChecksumValue', async () => {
+        const stored = [
+            makeStoredPart(1, { algorithm: 'sha256', value: SAMPLE_DIGESTS.sha256[0] }),
+            makeStoredPart(2, null),
+            makeStoredPart(3, { algorithm: 'sha256', value: SAMPLE_DIGESTS.sha256[1] }),
+        ];
+        const got = await computeFinalChecksum(
+            stored,
+            partListFromStored(stored),
+            { checksumAlgorithm: 'sha256', checksumType: 'COMPOSITE' },
+            splitter,
+            uploadId,
+            log,
+        );
+        assert.strictEqual(got, null);
+    });
+
+    it('should return null when checksumType is unknown', async () => {
+        const stored = [makeStoredPart(1, { algorithm: 'sha256', value: SAMPLE_DIGESTS.sha256[0] })];
+        const got = await computeFinalChecksum(
+            stored,
+            partListFromStored(stored),
+            { checksumAlgorithm: 'sha256', checksumType: 'WEIRD' },
+            splitter,
+            uploadId,
+            log,
+        );
+        assert.strictEqual(got, null);
+    });
+
+    it(
+        'should return null when underlying compute reports an error ' + '(crc64nvme COMPOSITE is not allowed)',
+        async () => {
+            const stored = [makeStoredPart(1, { algorithm: 'crc64nvme', value: SAMPLE_DIGESTS.crc64nvme[0] })];
+            const got = await computeFinalChecksum(
+                stored,
+                partListFromStored(stored),
+                { checksumAlgorithm: 'crc64nvme', checksumType: 'COMPOSITE' },
+                splitter,
+                uploadId,
+                log,
+            );
+            assert.strictEqual(got, null);
+        },
+    );
+
+    it('should compute over filteredPartList (subset), not all storedParts', async () => {
+        const [d1, d2, d3] = [SAMPLE_DIGESTS.sha256[0], SAMPLE_DIGESTS.sha256[1], SAMPLE_DIGESTS.sha256[0]];
+        const stored = [
+            makeStoredPart(1, { algorithm: 'sha256', value: d1 }),
+            makeStoredPart(2, { algorithm: 'sha256', value: d2 }),
+            makeStoredPart(3, { algorithm: 'sha256', value: d3 }),
+        ];
+        // User completes only parts 1 and 3, dropping 2 (orphan).
+        const filtered = [stored[0], stored[2]].map(s => ({
+            key: s.key,
+            ETag: `"${s.value.ETag}"`,
+            size: s.value.Size,
+            locations: s.value.partLocations,
+        }));
+        const got = await computeFinalChecksum(
+            stored,
+            filtered,
+            { checksumAlgorithm: 'sha256', checksumType: 'COMPOSITE' },
+            splitter,
+            uploadId,
+            log,
+        );
+        assert(got);
+        assert(got.value.endsWith('-2'), `should reflect 2 completed parts, got ${got.value}`);
+        const expected = crypto
+            .createHash('sha256')
+            .update(Buffer.concat([d1, d3].map(x => Buffer.from(x, 'base64'))))
+            .digest('base64');
+        assert.strictEqual(got.value, `${expected}-2`);
+    });
 });

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -12,15 +12,12 @@ const { bucketPut } = require('../../../lib/api/bucketPut');
 const bucketPutPolicy = require('../../../lib/api/bucketPutPolicy');
 const bucketPutVersioning = require('../../../lib/api/bucketPutVersioning');
 const objectPut = require('../../../lib/api/objectPut');
-const completeMultipartUpload
-    = require('../../../lib/api/completeMultipartUpload');
+const completeMultipartUpload = require('../../../lib/api/completeMultipartUpload');
 const constants = require('../../../constants');
-const { cleanup, DummyRequestLogger, makeAuthInfo, versioningTestUtils }
-    = require('../helpers');
+const { cleanup, DummyRequestLogger, makeAuthInfo, versioningTestUtils } = require('../helpers');
 const getObjectLegalHold = require('../../../lib/api/objectGetLegalHold');
 const getObjectRetention = require('../../../lib/api/objectGetRetention');
-const initiateMultipartUpload
-    = require('../../../lib/api/initiateMultipartUpload');
+const initiateMultipartUpload = require('../../../lib/api/initiateMultipartUpload');
 const multipartDelete = require('../../../lib/api/multipartDelete');
 const objectPutPart = require('../../../lib/api/objectPutPart');
 const DummyRequest = require('../DummyRequest');
@@ -29,9 +26,7 @@ const metadataswitch = require('../metadataswitch');
 const { fakeMetadataArchive } = require('../../functional/aws-node-sdk/test/utils/init');
 const { config } = require('../../../lib/Config');
 
-const {
-    LOCATION_NAME_CRR,
-} = require('../../constants');
+const { LOCATION_NAME_CRR } = require('../../constants');
 
 const { data } = require('../../../lib/data/wrapper');
 const { metadata } = storage.metadata.inMemory.metadata;
@@ -56,16 +51,17 @@ const bucketPutRequest = {
     namespace,
     headers: { host: `${bucketName}.s3.amazonaws.com` },
     url: '/',
-    post: '<CreateBucketConfiguration ' +
-    'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
-    '<LocationConstraint>scality-internal-mem</LocationConstraint>' +
-    '</CreateBucketConfiguration >',
+    post:
+        '<CreateBucketConfiguration ' +
+        'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+        '<LocationConstraint>scality-internal-mem</LocationConstraint>' +
+        '</CreateBucketConfiguration >',
     actionImplicitDenies: false,
 };
 const lockEnabledBucketRequest = Object.assign({}, bucketPutRequest);
 lockEnabledBucketRequest.bucketName = lockedBucket;
 lockEnabledBucketRequest.headers = {
-    'host': `${lockedBucket}.s3.amazonaws.com`,
+    host: `${lockedBucket}.s3.amazonaws.com`,
     'x-amz-bucket-object-lock-enabled': 'true',
 };
 const initiateRequest = {
@@ -84,13 +80,13 @@ retentionInitiateRequest.bucketName = lockedBucket;
 retentionInitiateRequest.headers = {
     'x-amz-object-lock-mode': 'GOVERNANCE',
     'x-amz-object-lock-retain-until-date': futureDate,
-    'host': `${lockedBucket}.s3.amazonaws.com`,
+    host: `${lockedBucket}.s3.amazonaws.com`,
 };
 const legalHoldInitiateRequest = Object.assign({}, initiateRequest);
 legalHoldInitiateRequest.bucketName = lockedBucket;
 legalHoldInitiateRequest.headers = {
     'x-amz-object-lock-legal-hold': 'ON',
-    'host': `${lockedBucket}.s3.amazonaws.com`,
+    host: `${lockedBucket}.s3.amazonaws.com`,
 };
 
 const getObjectLockInfoRequest = {
@@ -112,29 +108,31 @@ const expectedLegalHold = {
 function _createPutPartRequest(uploadId, partNumber, partBody) {
     const md5Hash = crypto.createHash('md5').update(partBody);
     const partHash = md5Hash.digest('hex');
-    return new DummyRequest({
-        bucketName,
-        namespace,
-        objectKey,
-        headers: { host: `${bucketName}.s3.amazonaws.com` },
-        url: `/${objectKey}?partNumber=${partNumber}&uploadId=${uploadId}`,
-        query: {
-            partNumber,
-            uploadId,
+    return new DummyRequest(
+        {
+            bucketName,
+            namespace,
+            objectKey,
+            headers: { host: `${bucketName}.s3.amazonaws.com` },
+            url: `/${objectKey}?partNumber=${partNumber}&uploadId=${uploadId}`,
+            query: {
+                partNumber,
+                uploadId,
+            },
+            partHash,
+            actionImplicitDenies: false,
         },
-        partHash,
-        actionImplicitDenies: false,
-    }, partBody);
+        partBody,
+    );
 }
 
 function _createCompleteMpuRequest(uploadId, parts) {
     const completeBody = [];
     completeBody.push('<CompleteMultipartUpload>');
     parts.forEach(part => {
-        completeBody.push('<Part>' +
-            `<PartNumber>${part.partNumber}</PartNumber>` +
-            `<ETag>"${part.eTag}"</ETag>` +
-            '</Part>');
+        completeBody.push(
+            '<Part>' + `<PartNumber>${part.partNumber}</PartNumber>` + `<ETag>"${part.eTag}"</ETag>` + '</Part>',
+        );
     });
     completeBody.push('</CompleteMultipartUpload>');
     return {
@@ -159,8 +157,8 @@ async function _uploadMpuObject(params = {}) {
         return json.InitiateMultipartUploadResult.UploadId[0];
     };
     const _objectPutPart = util.promisify(objectPutPart);
-    const _completeMultipartUpload = (...params) => util.promisify(cb =>
-        completeMultipartUpload(...params, (err, xml, headers) => cb(err, { xml, headers })))();
+    const _completeMultipartUpload = (...params) =>
+        util.promisify(cb => completeMultipartUpload(...params, (err, xml, headers) => cb(err, { xml, headers })))();
 
     const headers = { ...initiateRequest.headers };
     if (params.location) {
@@ -194,41 +192,33 @@ describe('Multipart Upload API', () => {
     });
 
     it('mpuBucketPrefix should be a defined constant', () => {
-        assert(constants.mpuBucketPrefix,
-            'Expected mpuBucketPrefix to be defined');
+        assert(constants.mpuBucketPrefix, 'Expected mpuBucketPrefix to be defined');
     });
 
     it('should initiate a multipart upload', done => {
         bucketPut(authInfo, bucketPutRequest, log, err => {
             assert.ifError(err);
-            initiateMultipartUpload(authInfo, initiateRequest,
-                log, (err, result) => {
-                    assert.ifError(err);
-                    parseString(result, (err, json) => {
-                        assert.strictEqual(json.InitiateMultipartUploadResult
-                            .Bucket[0], bucketName);
-                        assert.strictEqual(json.InitiateMultipartUploadResult
-                            .Key[0], objectKey);
-                        assert(json.InitiateMultipartUploadResult.UploadId[0]);
-                        assert(metadata.buckets.get(mpuBucket)._name,
-                            mpuBucket);
-                        const mpuKeys = metadata.keyMaps.get(mpuBucket);
-                        assert.strictEqual(mpuKeys.size, 1);
-                        assert(mpuKeys.keys().next().value
-                            .startsWith(`overview${splitter}${objectKey}`));
-                        done();
-                    });
+            initiateMultipartUpload(authInfo, initiateRequest, log, (err, result) => {
+                assert.ifError(err);
+                parseString(result, (err, json) => {
+                    assert.strictEqual(json.InitiateMultipartUploadResult.Bucket[0], bucketName);
+                    assert.strictEqual(json.InitiateMultipartUploadResult.Key[0], objectKey);
+                    assert(json.InitiateMultipartUploadResult.UploadId[0]);
+                    assert(metadata.buckets.get(mpuBucket)._name, mpuBucket);
+                    const mpuKeys = metadata.keyMaps.get(mpuBucket);
+                    assert.strictEqual(mpuKeys.size, 1);
+                    assert(mpuKeys.keys().next().value.startsWith(`overview${splitter}${objectKey}`));
+                    done();
                 });
+            });
         });
     });
 
-    it('should return an error on an initiate multipart upload call if ' +
-        'no destination bucket', done => {
-        initiateMultipartUpload(authInfo, initiateRequest,
-            log, err => {
-                assert(err.is.NoSuchBucket);
-                done();
-            });
+    it('should return an error on an initiate multipart upload call if ' + 'no destination bucket', done => {
+        initiateMultipartUpload(authInfo, initiateRequest, log, err => {
+            assert(err.is.NoSuchBucket);
+            done();
+        });
     });
 
     it('should not mpu with storage-class header not equal to STANDARD', done => {
@@ -242,296 +232,50 @@ describe('Multipart Upload API', () => {
             },
             url: `/${objectKey}?uploads`,
         };
-        initiateMultipartUpload(authInfo, initiateRequestCold,
-            log, err => {
-                assert.strictEqual(err.is.InvalidStorageClass, true);
-                done();
-            });
+        initiateMultipartUpload(authInfo, initiateRequestCold, log, err => {
+            assert.strictEqual(err.is.InvalidStorageClass, true);
+            done();
+        });
     });
 
     it('should upload a part', done => {
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => {
-                const mpuKeys = metadata.keyMaps.get(mpuBucket);
-                assert.strictEqual(mpuKeys.size, 1);
-                assert(mpuKeys.keys().next().value
-                    .startsWith(`overview${splitter}${objectKey}`));
-                parseString(result, next);
-            },
-        ],
-        (err, json) => {
-            // Need to build request in here since do not have uploadId
-            // until here
-            assert.ifError(err);
-            const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-            const md5Hash = crypto.createHash('md5');
-            const bufferBody = Buffer.from(postBody);
-            md5Hash.update(bufferBody);
-            const partHash = md5Hash.digest('hex');
-            const partRequest = new DummyRequest({
-                bucketName,
-                objectKey,
-                namespace,
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
+        async.waterfall(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => {
+                    const mpuKeys = metadata.keyMaps.get(mpuBucket);
+                    assert.strictEqual(mpuKeys.size, 1);
+                    assert(mpuKeys.keys().next().value.startsWith(`overview${splitter}${objectKey}`));
+                    parseString(result, next);
                 },
-                partHash,
-            }, postBody);
-            objectPutPart(authInfo, partRequest, undefined, log, err => {
+            ],
+            (err, json) => {
+                // Need to build request in here since do not have uploadId
+                // until here
                 assert.ifError(err);
-                const keysInMPUkeyMap = [];
-                metadata.keyMaps.get(mpuBucket).forEach((val, key) => {
-                    keysInMPUkeyMap.push(key);
-                });
-                const sortedKeyMap = keysInMPUkeyMap.sort(a => {
-                    if (a.slice(0, 8) === 'overview') {
-                        return -1;
-                    }
-                    return 0;
-                });
-                const overviewEntry = sortedKeyMap[0];
-                const partKey = sortedKeyMap[1];
-                const partEntryArray = partKey.split(splitter);
-                const partUploadId = partEntryArray[0];
-                const firstPartNumber = partEntryArray[1];
-                const partETag = metadata.keyMaps.get(mpuBucket)
-                                                 .get(partKey)['content-md5'];
-                assert.strictEqual(keysInMPUkeyMap.length, 2);
-                assert.strictEqual(metadata.keyMaps.get(mpuBucket)
-                                                   .get(overviewEntry).key,
-                                   objectKey);
-                assert.strictEqual(partUploadId, testUploadId);
-                assert.strictEqual(firstPartNumber, '00001');
-                assert.strictEqual(partETag, partHash);
-                done();
-            });
-        });
-    });
-
-    it('should upload a part even if the client sent a base 64 ETag ' +
-    '(and the stored ETag in metadata should be hex)', done => {
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, json) => {
-            // Need to build request in here since do not have uploadId
-            // until here
-            assert.ifError(err);
-            const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-            const md5Hash = crypto.createHash('md5');
-            const bufferBody = Buffer.from(postBody);
-            const partHash = md5Hash.update(bufferBody).digest('hex');
-            const partRequest = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
-                },
-                partHash,
-            }, postBody);
-            objectPutPart(authInfo, partRequest, undefined, log, err => {
-                assert.ifError(err);
-                const keysInMPUkeyMap = [];
-                metadata.keyMaps.get(mpuBucket).forEach((val, key) => {
-                    keysInMPUkeyMap.push(key);
-                });
-                const sortedKeyMap = keysInMPUkeyMap.sort(a => {
-                    if (a.slice(0, 8) === 'overview') {
-                        return -1;
-                    }
-                    return 0;
-                });
-                const partKey = sortedKeyMap[1];
-                const partETag = metadata.keyMaps.get(mpuBucket)
-                                                 .get(partKey)['content-md5'];
-                assert.strictEqual(keysInMPUkeyMap.length, 2);
-                assert.strictEqual(partETag, partHash);
-                done();
-            });
-        });
-    });
-
-    it('should return an error if too many parts', done => {
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, json) => {
-            // Need to build request in here since do not have uploadId
-            // until here
-            assert.ifError(err);
-            const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-            const md5Hash = crypto.createHash('md5');
-            const bufferBody = Buffer.from(postBody);
-            md5Hash.update(bufferBody);
-            const partHash = md5Hash.digest('hex');
-            const partRequest = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                query: {
-                    partNumber: '10001',
-                    uploadId: testUploadId,
-                },
-                partHash,
-            }, postBody);
-            objectPutPart(authInfo, partRequest, undefined, log,
-                (err, result) => {
-                    assert(err.is.TooManyParts);
-                    assert.strictEqual(result, undefined);
-                    done();
-                });
-        });
-    });
-
-    it('should return an error if part number is not an integer', done => {
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, json) => {
-            // Need to build request in here since do not have uploadId
-            // until here
-            assert.ifError(err);
-            const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-            const md5Hash = crypto.createHash('md5');
-            const bufferBody = Buffer.from(postBody);
-            md5Hash.update(bufferBody);
-            const partHash = md5Hash.digest('hex');
-            const partRequest = new DummyRequest({
-                bucketName,
-                objectKey,
-                namespace,
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                query: {
-                    partNumber: 'I am not an integer',
-                    uploadId: testUploadId,
-                },
-                partHash,
-            }, postBody);
-            objectPutPart(authInfo, partRequest, undefined, log,
-                (err, result) => {
-                    assert(err.is.InvalidArgument);
-                    assert.strictEqual(result, undefined);
-                    done();
-                });
-        });
-    });
-
-    it('should return an error if content-length is too large', done => {
-        // Note this is only faking a large file
-        // by setting a large content-length.  It is not actually putting a
-        // large file.  Functional tests will test actual large data.
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, json) => {
-            // Need to build request in here since do not have uploadId
-            // until here
-            assert.ifError(err);
-            const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-            const md5Hash = crypto.createHash('md5');
-            const bufferBody = Buffer.from(postBody);
-            md5Hash.update(bufferBody);
-            const partHash = md5Hash.digest('hex');
-            const partRequest = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                headers: {
-                    'host': `${bucketName}.s3.amazonaws.com`,
-                    'content-length': '5368709121',
-                },
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
-                },
-                partHash,
-                parsedContentLength: 5368709121,
-            }, postBody);
-            objectPutPart(authInfo, partRequest, undefined,
-                log, (err, result) => {
-                    assert(err.is.EntityTooLarge);
-                    assert.strictEqual(result, undefined);
-                    done();
-                });
-        });
-    });
-
-    it('should upload two parts', done => {
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, json) => {
-            // Need to build request in here since do not have uploadId
-            // until here
-            assert.ifError(err);
-            const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-            const md5Hash = crypto.createHash('md5');
-            const bufferBody = Buffer.from(postBody);
-            md5Hash.update(bufferBody);
-            const partHash = md5Hash.digest('hex');
-            const partRequest1 = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
-                },
-                partHash,
-            }, postBody);
-            objectPutPart(authInfo, partRequest1, undefined, log, () => {
-                const postBody2 = Buffer.from('I am a second part', 'utf8');
-                const md5Hash2 = crypto.createHash('md5');
-                const bufferBody2 = Buffer.from(postBody2);
-                md5Hash2.update(bufferBody2);
-                const secondCalculatedMD5 = md5Hash2.digest('hex');
-                const partRequest2 = new DummyRequest({
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    url: `/${objectKey}?partNumber=` +
-                        `1&uploadId=${testUploadId}`,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    query: {
-                        partNumber: '2',
-                        uploadId: testUploadId,
+                const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                const md5Hash = crypto.createHash('md5');
+                const bufferBody = Buffer.from(postBody);
+                md5Hash.update(bufferBody);
+                const partHash = md5Hash.digest('hex');
+                const partRequest = new DummyRequest(
+                    {
+                        bucketName,
+                        objectKey,
+                        namespace,
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        query: {
+                            partNumber: '1',
+                            uploadId: testUploadId,
+                        },
+                        partHash,
                     },
-                    partHash: secondCalculatedMD5,
-                }, postBody2);
-                objectPutPart(authInfo, partRequest2, undefined, log, err => {
+                    postBody,
+                );
+                objectPutPart(authInfo, partRequest, undefined, log, err => {
                     assert.ifError(err);
-
                     const keysInMPUkeyMap = [];
                     metadata.keyMaps.get(mpuBucket).forEach((val, key) => {
                         keysInMPUkeyMap.push(key);
@@ -543,684 +287,980 @@ describe('Multipart Upload API', () => {
                         return 0;
                     });
                     const overviewEntry = sortedKeyMap[0];
-                    const partKey = sortedKeyMap[2];
-                    const secondPartEntryArray = partKey.split(splitter);
-                    const partUploadId = secondPartEntryArray[0];
-                    const secondPartETag = metadata.keyMaps.get(mpuBucket)
-                                                   .get(partKey)['content-md5'];
-                    const secondPartNumber = secondPartEntryArray[1];
-                    assert.strictEqual(keysInMPUkeyMap.length, 3);
-                    assert.strictEqual(metadata
-                        .keyMaps.get(mpuBucket).get(overviewEntry).key,
-                        objectKey);
+                    const partKey = sortedKeyMap[1];
+                    const partEntryArray = partKey.split(splitter);
+                    const partUploadId = partEntryArray[0];
+                    const firstPartNumber = partEntryArray[1];
+                    const partETag = metadata.keyMaps.get(mpuBucket).get(partKey)['content-md5'];
+                    assert.strictEqual(keysInMPUkeyMap.length, 2);
+                    assert.strictEqual(metadata.keyMaps.get(mpuBucket).get(overviewEntry).key, objectKey);
                     assert.strictEqual(partUploadId, testUploadId);
-                    assert.strictEqual(secondPartNumber, '00002');
-                    assert.strictEqual(secondPartETag, secondCalculatedMD5);
+                    assert.strictEqual(firstPartNumber, '00001');
+                    assert.strictEqual(partETag, partHash);
                     done();
                 });
-            });
-        });
+            },
+        );
+    });
+
+    it(
+        'should upload a part even if the client sent a base 64 ETag ' +
+            '(and the stored ETag in metadata should be hex)',
+        done => {
+            async.waterfall(
+                [
+                    next => bucketPut(authInfo, bucketPutRequest, log, next),
+                    (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                    (result, corsHeaders, next) => parseString(result, next),
+                ],
+                (err, json) => {
+                    // Need to build request in here since do not have uploadId
+                    // until here
+                    assert.ifError(err);
+                    const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                    const md5Hash = crypto.createHash('md5');
+                    const bufferBody = Buffer.from(postBody);
+                    const partHash = md5Hash.update(bufferBody).digest('hex');
+                    const partRequest = new DummyRequest(
+                        {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                            query: {
+                                partNumber: '1',
+                                uploadId: testUploadId,
+                            },
+                            partHash,
+                        },
+                        postBody,
+                    );
+                    objectPutPart(authInfo, partRequest, undefined, log, err => {
+                        assert.ifError(err);
+                        const keysInMPUkeyMap = [];
+                        metadata.keyMaps.get(mpuBucket).forEach((val, key) => {
+                            keysInMPUkeyMap.push(key);
+                        });
+                        const sortedKeyMap = keysInMPUkeyMap.sort(a => {
+                            if (a.slice(0, 8) === 'overview') {
+                                return -1;
+                            }
+                            return 0;
+                        });
+                        const partKey = sortedKeyMap[1];
+                        const partETag = metadata.keyMaps.get(mpuBucket).get(partKey)['content-md5'];
+                        assert.strictEqual(keysInMPUkeyMap.length, 2);
+                        assert.strictEqual(partETag, partHash);
+                        done();
+                    });
+                },
+            );
+        },
+    );
+
+    it('should return an error if too many parts', done => {
+        async.waterfall(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+            ],
+            (err, json) => {
+                // Need to build request in here since do not have uploadId
+                // until here
+                assert.ifError(err);
+                const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                const md5Hash = crypto.createHash('md5');
+                const bufferBody = Buffer.from(postBody);
+                md5Hash.update(bufferBody);
+                const partHash = md5Hash.digest('hex');
+                const partRequest = new DummyRequest(
+                    {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        query: {
+                            partNumber: '10001',
+                            uploadId: testUploadId,
+                        },
+                        partHash,
+                    },
+                    postBody,
+                );
+                objectPutPart(authInfo, partRequest, undefined, log, (err, result) => {
+                    assert(err.is.TooManyParts);
+                    assert.strictEqual(result, undefined);
+                    done();
+                });
+            },
+        );
+    });
+
+    it('should return an error if part number is not an integer', done => {
+        async.waterfall(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+            ],
+            (err, json) => {
+                // Need to build request in here since do not have uploadId
+                // until here
+                assert.ifError(err);
+                const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                const md5Hash = crypto.createHash('md5');
+                const bufferBody = Buffer.from(postBody);
+                md5Hash.update(bufferBody);
+                const partHash = md5Hash.digest('hex');
+                const partRequest = new DummyRequest(
+                    {
+                        bucketName,
+                        objectKey,
+                        namespace,
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        query: {
+                            partNumber: 'I am not an integer',
+                            uploadId: testUploadId,
+                        },
+                        partHash,
+                    },
+                    postBody,
+                );
+                objectPutPart(authInfo, partRequest, undefined, log, (err, result) => {
+                    assert(err.is.InvalidArgument);
+                    assert.strictEqual(result, undefined);
+                    done();
+                });
+            },
+        );
+    });
+
+    it('should return an error if content-length is too large', done => {
+        // Note this is only faking a large file
+        // by setting a large content-length.  It is not actually putting a
+        // large file.  Functional tests will test actual large data.
+        async.waterfall(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+            ],
+            (err, json) => {
+                // Need to build request in here since do not have uploadId
+                // until here
+                assert.ifError(err);
+                const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                const md5Hash = crypto.createHash('md5');
+                const bufferBody = Buffer.from(postBody);
+                md5Hash.update(bufferBody);
+                const partHash = md5Hash.digest('hex');
+                const partRequest = new DummyRequest(
+                    {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        headers: {
+                            host: `${bucketName}.s3.amazonaws.com`,
+                            'content-length': '5368709121',
+                        },
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        query: {
+                            partNumber: '1',
+                            uploadId: testUploadId,
+                        },
+                        partHash,
+                        parsedContentLength: 5368709121,
+                    },
+                    postBody,
+                );
+                objectPutPart(authInfo, partRequest, undefined, log, (err, result) => {
+                    assert(err.is.EntityTooLarge);
+                    assert.strictEqual(result, undefined);
+                    done();
+                });
+            },
+        );
+    });
+
+    it('should upload two parts', done => {
+        async.waterfall(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+            ],
+            (err, json) => {
+                // Need to build request in here since do not have uploadId
+                // until here
+                assert.ifError(err);
+                const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                const md5Hash = crypto.createHash('md5');
+                const bufferBody = Buffer.from(postBody);
+                md5Hash.update(bufferBody);
+                const partHash = md5Hash.digest('hex');
+                const partRequest1 = new DummyRequest(
+                    {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        query: {
+                            partNumber: '1',
+                            uploadId: testUploadId,
+                        },
+                        partHash,
+                    },
+                    postBody,
+                );
+                objectPutPart(authInfo, partRequest1, undefined, log, () => {
+                    const postBody2 = Buffer.from('I am a second part', 'utf8');
+                    const md5Hash2 = crypto.createHash('md5');
+                    const bufferBody2 = Buffer.from(postBody2);
+                    md5Hash2.update(bufferBody2);
+                    const secondCalculatedMD5 = md5Hash2.digest('hex');
+                    const partRequest2 = new DummyRequest(
+                        {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            url: `/${objectKey}?partNumber=` + `1&uploadId=${testUploadId}`,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            query: {
+                                partNumber: '2',
+                                uploadId: testUploadId,
+                            },
+                            partHash: secondCalculatedMD5,
+                        },
+                        postBody2,
+                    );
+                    objectPutPart(authInfo, partRequest2, undefined, log, err => {
+                        assert.ifError(err);
+
+                        const keysInMPUkeyMap = [];
+                        metadata.keyMaps.get(mpuBucket).forEach((val, key) => {
+                            keysInMPUkeyMap.push(key);
+                        });
+                        const sortedKeyMap = keysInMPUkeyMap.sort(a => {
+                            if (a.slice(0, 8) === 'overview') {
+                                return -1;
+                            }
+                            return 0;
+                        });
+                        const overviewEntry = sortedKeyMap[0];
+                        const partKey = sortedKeyMap[2];
+                        const secondPartEntryArray = partKey.split(splitter);
+                        const partUploadId = secondPartEntryArray[0];
+                        const secondPartETag = metadata.keyMaps.get(mpuBucket).get(partKey)['content-md5'];
+                        const secondPartNumber = secondPartEntryArray[1];
+                        assert.strictEqual(keysInMPUkeyMap.length, 3);
+                        assert.strictEqual(metadata.keyMaps.get(mpuBucket).get(overviewEntry).key, objectKey);
+                        assert.strictEqual(partUploadId, testUploadId);
+                        assert.strictEqual(secondPartNumber, '00002');
+                        assert.strictEqual(secondPartETag, secondCalculatedMD5);
+                        done();
+                    });
+                });
+            },
+        );
     });
 
     it('should complete a multipart upload', done => {
         const partBody = Buffer.from('I am a part\n', 'utf8');
-        initiateRequest.headers['x-amz-meta-stuff'] =
-            'I am some user metadata';
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, json) => {
-            // Need to build request in here since do not have uploadId
-            // until here
-            assert.ifError(err);
-            const testUploadId =
-                json.InitiateMultipartUploadResult.UploadId[0];
-            const partHash = crypto.createHash('md5').update(partBody).digest('hex');
-            const partRequest = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
-                },
-                // Note that the body of the post set in the request here does
-                // not really matter in this test.
-                // The put is not going through the route so the md5 is being
-                // calculated above and manually being set in the request below.
-                // What is being tested is that the partHash being sent
-                // to the API for the part is stored and then used to
-                // calculate the final ETag upon completion
-                // of the multipart upload.
-                partHash,
-            }, partBody);
-            objectPutPart(authInfo, partRequest, undefined, log, () => {
-                const completeBody = '<CompleteMultipartUpload>' +
-                    '<Part>' +
-                    '<PartNumber>1</PartNumber>' +
-                    `<ETag>"${partHash}"</ETag>` +
-                    '</Part>' +
-                    '</CompleteMultipartUpload>';
-                const completeRequest = {
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    parsedHost: 's3.amazonaws.com',
-                    url: `/${objectKey}?uploadId=${testUploadId}`,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    query: { uploadId: testUploadId },
-                    post: completeBody,
-                    actionImplicitDenies: false,
-                };
-                const awsVerifiedETag =
-                    '"953e9e776f285afc0bfcf1ab4668299d-1"';
-                completeMultipartUpload(authInfo,
-                    completeRequest, log, (err, result) => {
+        initiateRequest.headers['x-amz-meta-stuff'] = 'I am some user metadata';
+        async.waterfall(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+            ],
+            (err, json) => {
+                // Need to build request in here since do not have uploadId
+                // until here
+                assert.ifError(err);
+                const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                const partHash = crypto.createHash('md5').update(partBody).digest('hex');
+                const partRequest = new DummyRequest(
+                    {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        query: {
+                            partNumber: '1',
+                            uploadId: testUploadId,
+                        },
+                        // Note that the body of the post set in the request here does
+                        // not really matter in this test.
+                        // The put is not going through the route so the md5 is being
+                        // calculated above and manually being set in the request below.
+                        // What is being tested is that the partHash being sent
+                        // to the API for the part is stored and then used to
+                        // calculate the final ETag upon completion
+                        // of the multipart upload.
+                        partHash,
+                    },
+                    partBody,
+                );
+                objectPutPart(authInfo, partRequest, undefined, log, () => {
+                    const completeBody =
+                        '<CompleteMultipartUpload>' +
+                        '<Part>' +
+                        '<PartNumber>1</PartNumber>' +
+                        `<ETag>"${partHash}"</ETag>` +
+                        '</Part>' +
+                        '</CompleteMultipartUpload>';
+                    const completeRequest = {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        parsedHost: 's3.amazonaws.com',
+                        url: `/${objectKey}?uploadId=${testUploadId}`,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        query: { uploadId: testUploadId },
+                        post: completeBody,
+                        actionImplicitDenies: false,
+                    };
+                    const awsVerifiedETag = '"953e9e776f285afc0bfcf1ab4668299d-1"';
+                    completeMultipartUpload(authInfo, completeRequest, log, (err, result) => {
                         assert.ifError(err);
                         parseString(result, (err, json) => {
                             assert.ifError(err);
                             assert.strictEqual(
                                 json.CompleteMultipartUploadResult.Location[0],
-                                `http://${bucketName}.s3.amazonaws.com`
-                                + `/${objectKey}`);
-                            assert.strictEqual(
-                                json.CompleteMultipartUploadResult.Bucket[0],
-                                bucketName);
-                            assert.strictEqual(
-                                json.CompleteMultipartUploadResult.Key[0],
-                                objectKey);
-                            assert.strictEqual(
-                                json.CompleteMultipartUploadResult.ETag[0],
-                                awsVerifiedETag);
-                            const MD = metadata.keyMaps.get(bucketName)
-                                                       .get(objectKey);
+                                `http://${bucketName}.s3.amazonaws.com` + `/${objectKey}`,
+                            );
+                            assert.strictEqual(json.CompleteMultipartUploadResult.Bucket[0], bucketName);
+                            assert.strictEqual(json.CompleteMultipartUploadResult.Key[0], objectKey);
+                            assert.strictEqual(json.CompleteMultipartUploadResult.ETag[0], awsVerifiedETag);
+                            const MD = metadata.keyMaps.get(bucketName).get(objectKey);
                             assert(MD);
-                            assert.strictEqual(MD['x-amz-meta-stuff'],
-                                'I am some user metadata');
+                            assert.strictEqual(MD['x-amz-meta-stuff'], 'I am some user metadata');
                             assert.strictEqual(MD.uploadId, testUploadId);
                             done();
                         });
                     });
-            });
-        });
+                });
+            },
+        );
     });
 
-    it('should complete a multipart upload even if etag is sent ' +
-        'in post body without quotes (a la Cyberduck)', done => {
-        const partBody = Buffer.from('I am a part\n', 'utf8');
-        initiateRequest.headers['x-amz-meta-stuff'] =
-            'I am some user metadata';
-        async.waterfall([
-            function waterfall1(next) {
-                bucketPut(authInfo, bucketPutRequest, log, next);
-            },
-            function waterfall2(corsHeaders, next) {
-                initiateMultipartUpload(
-                    authInfo, initiateRequest, log, next);
-            },
-            function waterfall3(result, corsHeaders, next) {
-                parseString(result, next);
-            },
-        ],
-        (err, json) => {
-            // Need to build request in here since do not have uploadId
-            // until here
-            assert.ifError(err);
-            const testUploadId =
-                json.InitiateMultipartUploadResult.UploadId[0];
-            const partHash = crypto.createHash('md5').update(partBody).digest('hex');
-            const partRequest = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
-                },
-                partHash,
-            }, partBody);
-            objectPutPart(authInfo, partRequest, undefined, log, () => {
-                const completeBody = '<CompleteMultipartUpload>' +
-                    '<Part>' +
-                    '<PartNumber>1</PartNumber>' +
-                    // ETag without quotes
-                    `<ETag>${partHash}</ETag>` +
-                    '</Part>' +
-                    '</CompleteMultipartUpload>';
-                const completeRequest = {
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    parsedHost: 's3.amazonaws.com',
-                    url: `/${objectKey}?uploadId=${testUploadId}`,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    query: { uploadId: testUploadId },
-                    post: completeBody,
-                    actionImplicitDenies: false,
-                };
-                const awsVerifiedETag =
-                    '"953e9e776f285afc0bfcf1ab4668299d-1"';
-                completeMultipartUpload(authInfo,
-                    completeRequest, log, (err, result) => {
-                        assert.ifError(err);
-                        parseString(result, (err, json) => {
+    it(
+        'should complete a multipart upload even if etag is sent ' + 'in post body without quotes (a la Cyberduck)',
+        done => {
+            const partBody = Buffer.from('I am a part\n', 'utf8');
+            initiateRequest.headers['x-amz-meta-stuff'] = 'I am some user metadata';
+            async.waterfall(
+                [
+                    function waterfall1(next) {
+                        bucketPut(authInfo, bucketPutRequest, log, next);
+                    },
+                    function waterfall2(corsHeaders, next) {
+                        initiateMultipartUpload(authInfo, initiateRequest, log, next);
+                    },
+                    function waterfall3(result, corsHeaders, next) {
+                        parseString(result, next);
+                    },
+                ],
+                (err, json) => {
+                    // Need to build request in here since do not have uploadId
+                    // until here
+                    assert.ifError(err);
+                    const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                    const partHash = crypto.createHash('md5').update(partBody).digest('hex');
+                    const partRequest = new DummyRequest(
+                        {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                            query: {
+                                partNumber: '1',
+                                uploadId: testUploadId,
+                            },
+                            partHash,
+                        },
+                        partBody,
+                    );
+                    objectPutPart(authInfo, partRequest, undefined, log, () => {
+                        const completeBody =
+                            '<CompleteMultipartUpload>' +
+                            '<Part>' +
+                            '<PartNumber>1</PartNumber>' +
+                            // ETag without quotes
+                            `<ETag>${partHash}</ETag>` +
+                            '</Part>' +
+                            '</CompleteMultipartUpload>';
+                        const completeRequest = {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            parsedHost: 's3.amazonaws.com',
+                            url: `/${objectKey}?uploadId=${testUploadId}`,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            query: { uploadId: testUploadId },
+                            post: completeBody,
+                            actionImplicitDenies: false,
+                        };
+                        const awsVerifiedETag = '"953e9e776f285afc0bfcf1ab4668299d-1"';
+                        completeMultipartUpload(authInfo, completeRequest, log, (err, result) => {
                             assert.ifError(err);
-                            assert.strictEqual(
-                                json.CompleteMultipartUploadResult.Location[0],
-                                `http://${bucketName}.s3.amazonaws.com`
-                                + `/${objectKey}`);
-                            assert.strictEqual(
-                                json.CompleteMultipartUploadResult.Bucket[0],
-                                bucketName);
-                            assert.strictEqual(
-                                json.CompleteMultipartUploadResult.Key[0],
-                                objectKey);
-                            assert.strictEqual(
-                                json.CompleteMultipartUploadResult.ETag[0],
-                                awsVerifiedETag);
-                            const MD = metadata.keyMaps.get(bucketName)
-                                                       .get(objectKey);
-                            assert(MD);
-                            assert.strictEqual(MD['x-amz-meta-stuff'],
-                                               'I am some user metadata');
-                            done();
-                        });
-                    });
-            });
-        });
-    });
-
-    it('should return an error if a complete multipart upload' +
-    ' request contains malformed xml', done => {
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, json) => {
-            // Need to build request in here since do not have uploadId
-            // until here
-            const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-            const md5Hash = crypto.createHash('md5');
-            const bufferBody = Buffer.from(postBody);
-            md5Hash.update(bufferBody);
-            const partHash = md5Hash.digest('hex');
-            const partRequest = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
-                },
-                partHash,
-            }, postBody);
-            objectPutPart(authInfo, partRequest, undefined, log, () => {
-                const completeBody = 'Malformed xml';
-                const completeRequest = {
-                    bucketName,
-                    objectKey,
-                    namespace,
-                    url: `/${objectKey}?uploadId=${testUploadId}`,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    query: { uploadId: testUploadId },
-                    post: completeBody,
-                    partHash,
-                    actionImplicitDenies: false,
-                };
-                completeMultipartUpload(authInfo,
-                    completeRequest, log, err => {
-                        assert.strictEqual(err.is.MalformedXML, true);
-                        assert.strictEqual(metadata.keyMaps.get(mpuBucket).size,
-                                           2);
-                        done();
-                    });
-            });
-        });
-    });
-
-    it('should return an error if the complete ' +
-    'multipart upload request contains xml that ' +
-    'does not conform to the AWS spec', done => {
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, json) => {
-            // Need to build request in here since do not have uploadId
-            // until here
-            const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-            const md5Hash = crypto.createHash('md5');
-            const bufferBody = Buffer.from(postBody);
-            md5Hash.update(bufferBody);
-            const partHash = md5Hash.digest('hex');
-            const partRequest = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
-                },
-                partHash,
-            }, postBody);
-            objectPutPart(authInfo, partRequest, undefined, log, () => {
-                // XML is missing any part listing so does
-                // not conform to the AWS spec
-                const completeBody = '<CompleteMultipartUpload>' +
-                    '</CompleteMultipartUpload>';
-                const completeRequest = {
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    url: `/${objectKey}?uploadId=${testUploadId}`,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    query: { uploadId: testUploadId },
-                    post: completeBody,
-                    partHash,
-                    actionImplicitDenies: false,
-                };
-                completeMultipartUpload(authInfo, completeRequest, log, err => {
-                    assert(err.is.MalformedXML);
-                    done();
-                });
-            });
-        });
-    });
-
-    it('should return an error if the complete ' +
-    'multipart upload request contains xml with ' +
-    'a part list that is not in numerical order', done => {
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, json) => {
-            // Need to build request in here since do not have uploadId
-            // until here
-            const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-            const md5Hash = crypto.createHash('md5');
-            const fullSizedPart = crypto.randomBytes(5 * 1024 * 1024);
-            const bufferBody = Buffer.from(fullSizedPart);
-            md5Hash.update(bufferBody);
-            const partHash = md5Hash.digest('hex');
-            const partRequest1 = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
-                },
-                partHash,
-            }, fullSizedPart);
-            const partRequest2 = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                query: {
-                    partNumber: '2',
-                    uploadId: testUploadId,
-                },
-                partHash,
-            }, fullSizedPart);
-            objectPutPart(authInfo, partRequest1, undefined, log, () => {
-                objectPutPart(authInfo, partRequest2, undefined, log, () => {
-                    const completeBody = '<CompleteMultipartUpload>' +
-                        '<Part>' +
-                        '<PartNumber>2</PartNumber>' +
-                        `<ETag>"${partHash}"</ETag>` +
-                        '</Part>' +
-                        '<Part>' +
-                        '<PartNumber>1</PartNumber>' +
-                        `<ETag>"${partHash}"</ETag>` +
-                        '</Part>' +
-                        '</CompleteMultipartUpload>';
-                    const completeRequest = {
-                        bucketName,
-                        namespace,
-                        objectKey,
-                        url: `/${objectKey}?uploadId=${testUploadId}`,
-                        headers: { host: `${bucketName}.s3.amazonaws.com` },
-                        query: { uploadId: testUploadId },
-                        post: completeBody,
-                        partHash,
-                        actionImplicitDenies: false,
-                    };
-                    completeMultipartUpload(authInfo,
-                        completeRequest, log, err => {
-                            assert(err.is.InvalidPartOrder);
-                            assert.strictEqual(metadata.keyMaps
-                                                       .get(mpuBucket).size, 3);
-                            done();
-                        });
-                });
-            });
-        });
-    });
-
-    it('should return InvalidPart error if the complete ' +
-    'multipart upload request contains xml with a missing part', done => {
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, json) => {
-            // Need to build request in here since do not have uploadId
-            // until here
-            const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-            const md5Hash = crypto.createHash('md5');
-            const fullSizedPart = crypto.randomBytes(5 * 1024 * 1024);
-            const bufferBody = Buffer.from(fullSizedPart);
-            md5Hash.update(bufferBody);
-            const partHash = md5Hash.digest('hex');
-            const partRequest = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
-                },
-                partHash,
-            }, fullSizedPart);
-            objectPutPart(authInfo, partRequest, undefined, log, () => {
-                const completeBody = '<CompleteMultipartUpload>' +
-                    '<Part>' +
-                    '<PartNumber>99999</PartNumber>' +
-                    `<ETag>"${partHash}"</ETag>` +
-                    '</Part>' +
-                    '</CompleteMultipartUpload>';
-                const completeRequest = {
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    url: `/${objectKey}?uploadId=${testUploadId}`,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    query: { uploadId: testUploadId },
-                    post: completeBody,
-                    partHash,
-                    actionImplicitDenies: false,
-                };
-                completeMultipartUpload(authInfo, completeRequest, log, err => {
-                    assert(err.is.InvalidPart);
-                    assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 2);
-                    done();
-                });
-            });
-        });
-    });
-
-    it('should return an error if the complete multipart upload request '
-    + 'contains xml with a part ETag that does not match the md5 for '
-    + 'the part that was actually sent', done => {
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, json) => {
-            // Need to build request in here since do not have uploadId
-            // until here
-            const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-            const wrongMD5 = '3858f62230ac3c915f300c664312c11f-9';
-            const fullSizedPart = crypto.randomBytes(5 * 1024 * 1024);
-            const partRequest1 = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
-                },
-            }, fullSizedPart);
-            const partRequest2 = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                query: {
-                    partNumber: '2',
-                    uploadId: testUploadId,
-                },
-            }, postBody);
-            objectPutPart(authInfo, partRequest1, undefined, log, err => {
-                assert.deepStrictEqual(err, null);
-                const partHash = partRequest1.partHash;
-                objectPutPart(authInfo, partRequest2, undefined, log, err => {
-                    assert.deepStrictEqual(err, null);
-                    const completeBody = '<CompleteMultipartUpload>' +
-                        '<Part>' +
-                        '<PartNumber>1</PartNumber>' +
-                        `<ETag>"${partHash}"</ETag>` +
-                        '</Part>' +
-                        '<Part>' +
-                        '<PartNumber>2</PartNumber>' +
-                        `<ETag>${wrongMD5}</ETag>` +
-                        '</Part>' +
-                        '</CompleteMultipartUpload>';
-                    const completeRequest = {
-                        bucketName,
-                        namespace,
-                        objectKey,
-                        url: `/${objectKey}?uploadId=${testUploadId}`,
-                        headers: { host: `${bucketName}.s3.amazonaws.com` },
-                        query: { uploadId: testUploadId },
-                        post: completeBody,
-                        partHash,
-                        actionImplicitDenies: false,
-                    };
-                    assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 3);
-                    completeMultipartUpload(authInfo,
-                        completeRequest, log, err => {
-                            assert(err.is.InvalidPart);
-                            done();
-                        });
-                });
-            });
-        });
-    });
-
-    it('should return an error if there is a part ' +
-    'other than the last part that is less than 5MB ' +
-    'in size', done => {
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, json) => {
-            // Need to build request in here since do not have uploadId
-            // until here
-            const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-            const md5Hash = crypto.createHash('md5');
-            const bufferBody = Buffer.from(postBody);
-            md5Hash.update(bufferBody);
-            const partHash = md5Hash.digest('hex');
-            const partRequest1 = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                headers: {
-                    'host': `${bucketName}.s3.amazonaws.com`,
-                    'content-length': '100',
-                },
-                parsedContentLength: 100,
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
-                },
-                partHash,
-            }, postBody);
-            const partRequest2 = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                headers: {
-                    'host': `${bucketName}.s3.amazonaws.com`,
-                    'content-length': '200',
-                },
-                parsedContentLength: 200,
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                query: {
-                    partNumber: '2',
-                    uploadId: testUploadId,
-                },
-                partHash,
-            }, postBody);
-            objectPutPart(authInfo, partRequest1, undefined, log, () => {
-                objectPutPart(authInfo, partRequest2, undefined, log, () => {
-                    const completeBody = '<CompleteMultipartUpload>' +
-                        '<Part>' +
-                        '<PartNumber>1</PartNumber>' +
-                        `<ETag>"${partHash}"</ETag>` +
-                        '</Part>' +
-                        '<Part>' +
-                        '<PartNumber>2</PartNumber>' +
-                        `<ETag>"${partHash}"</ETag>` +
-                        '</Part>' +
-                        '</CompleteMultipartUpload>';
-                    const completeRequest = {
-                        bucketName,
-                        namespace,
-                        objectKey,
-                        headers: { host: `${bucketName}.s3.amazonaws.com` },
-                        url: `/${objectKey}?uploadId=${testUploadId}`,
-                        query: { uploadId: testUploadId },
-                        post: completeBody,
-                        partHash,
-                        actionImplicitDenies: false,
-                    };
-                    assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 3);
-                    completeMultipartUpload(authInfo,
-                        completeRequest, log, err => {
-                            assert(err.is.EntityTooSmall);
-                            done();
-                        });
-                });
-            });
-        });
-    });
-
-    it('should aggregate the sizes of the parts', done => {
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, json) => {
-            // Need to build request in here since do not have uploadId
-            // until her
-            const testUploadId =
-                json.InitiateMultipartUploadResult.UploadId[0];
-            const md5Hash = crypto.createHash('md5');
-            const bufferBody = Buffer.from(postBody);
-            md5Hash.update(bufferBody);
-            const partHash = md5Hash.digest('hex');
-            const partRequest1 = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                headers: {
-                    'host': `${bucketName}.s3.amazonaws.com`,
-                    'content-length': '6000000',
-                },
-                parsedContentLength: 6000000,
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
-                },
-                partHash,
-            }, postBody);
-            const partRequest2 = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                headers: {
-                    'host': `${bucketName}.s3.amazonaws.com`,
-                    'content-length': '100',
-                },
-                parsedContentLength: 100,
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                query: {
-                    partNumber: '2',
-                    uploadId: testUploadId,
-                },
-                post: postBody,
-                partHash,
-            }, postBody);
-            objectPutPart(authInfo, partRequest1, undefined, log, () => {
-                objectPutPart(authInfo, partRequest2, undefined, log, () => {
-                    const completeBody = '<CompleteMultipartUpload>' +
-                        '<Part>' +
-                        '<PartNumber>1</PartNumber>' +
-                        `<ETag>"${partHash}"</ETag>` +
-                        '</Part>' +
-                        '<Part>' +
-                        '<PartNumber>2</PartNumber>' +
-                        `<ETag>"${partHash}"</ETag>` +
-                        '</Part>' +
-                        '</CompleteMultipartUpload>';
-                    const completeRequest = {
-                        bucketName,
-                        namespace,
-                        objectKey,
-                        headers: { host: `${bucketName}.s3.amazonaws.com` },
-                        url: `/${objectKey}?uploadId=${testUploadId}`,
-                        query: { uploadId: testUploadId },
-                        post: completeBody,
-                        partHash,
-                        actionImplicitDenies: false,
-                    };
-                    completeMultipartUpload(authInfo,
-                        completeRequest, log, (err, result) => {
-                            assert.strictEqual(err, null);
-                            parseString(result, err => {
-                                assert.strictEqual(err, null);
-                                const MD = metadata.keyMaps
-                                                   .get(bucketName)
-                                                   .get(objectKey);
+                            parseString(result, (err, json) => {
+                                assert.ifError(err);
+                                assert.strictEqual(
+                                    json.CompleteMultipartUploadResult.Location[0],
+                                    `http://${bucketName}.s3.amazonaws.com` + `/${objectKey}`,
+                                );
+                                assert.strictEqual(json.CompleteMultipartUploadResult.Bucket[0], bucketName);
+                                assert.strictEqual(json.CompleteMultipartUploadResult.Key[0], objectKey);
+                                assert.strictEqual(json.CompleteMultipartUploadResult.ETag[0], awsVerifiedETag);
+                                const MD = metadata.keyMaps.get(bucketName).get(objectKey);
                                 assert(MD);
-                                assert.strictEqual(MD['content-length'],
-                                                   6000100);
+                                assert.strictEqual(MD['x-amz-meta-stuff'], 'I am some user metadata');
                                 done();
                             });
                         });
+                    });
+                },
+            );
+        },
+    );
+
+    it('should return an error if a complete multipart upload' + ' request contains malformed xml', done => {
+        async.waterfall(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+            ],
+            (err, json) => {
+                // Need to build request in here since do not have uploadId
+                // until here
+                const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                const md5Hash = crypto.createHash('md5');
+                const bufferBody = Buffer.from(postBody);
+                md5Hash.update(bufferBody);
+                const partHash = md5Hash.digest('hex');
+                const partRequest = new DummyRequest(
+                    {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        query: {
+                            partNumber: '1',
+                            uploadId: testUploadId,
+                        },
+                        partHash,
+                    },
+                    postBody,
+                );
+                objectPutPart(authInfo, partRequest, undefined, log, () => {
+                    const completeBody = 'Malformed xml';
+                    const completeRequest = {
+                        bucketName,
+                        objectKey,
+                        namespace,
+                        url: `/${objectKey}?uploadId=${testUploadId}`,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        query: { uploadId: testUploadId },
+                        post: completeBody,
+                        partHash,
+                        actionImplicitDenies: false,
+                    };
+                    completeMultipartUpload(authInfo, completeRequest, log, err => {
+                        assert.strictEqual(err.is.MalformedXML, true);
+                        assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 2);
+                        done();
+                    });
                 });
-            });
-        });
+            },
+        );
+    });
+
+    it(
+        'should return an error if the complete ' +
+            'multipart upload request contains xml that ' +
+            'does not conform to the AWS spec',
+        done => {
+            async.waterfall(
+                [
+                    next => bucketPut(authInfo, bucketPutRequest, log, next),
+                    (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                    (result, corsHeaders, next) => parseString(result, next),
+                ],
+                (err, json) => {
+                    // Need to build request in here since do not have uploadId
+                    // until here
+                    const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                    const md5Hash = crypto.createHash('md5');
+                    const bufferBody = Buffer.from(postBody);
+                    md5Hash.update(bufferBody);
+                    const partHash = md5Hash.digest('hex');
+                    const partRequest = new DummyRequest(
+                        {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            query: {
+                                partNumber: '1',
+                                uploadId: testUploadId,
+                            },
+                            partHash,
+                        },
+                        postBody,
+                    );
+                    objectPutPart(authInfo, partRequest, undefined, log, () => {
+                        // XML is missing any part listing so does
+                        // not conform to the AWS spec
+                        const completeBody = '<CompleteMultipartUpload>' + '</CompleteMultipartUpload>';
+                        const completeRequest = {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            url: `/${objectKey}?uploadId=${testUploadId}`,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            query: { uploadId: testUploadId },
+                            post: completeBody,
+                            partHash,
+                            actionImplicitDenies: false,
+                        };
+                        completeMultipartUpload(authInfo, completeRequest, log, err => {
+                            assert(err.is.MalformedXML);
+                            done();
+                        });
+                    });
+                },
+            );
+        },
+    );
+
+    it(
+        'should return an error if the complete ' +
+            'multipart upload request contains xml with ' +
+            'a part list that is not in numerical order',
+        done => {
+            async.waterfall(
+                [
+                    next => bucketPut(authInfo, bucketPutRequest, log, next),
+                    (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                    (result, corsHeaders, next) => parseString(result, next),
+                ],
+                (err, json) => {
+                    // Need to build request in here since do not have uploadId
+                    // until here
+                    const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                    const md5Hash = crypto.createHash('md5');
+                    const fullSizedPart = crypto.randomBytes(5 * 1024 * 1024);
+                    const bufferBody = Buffer.from(fullSizedPart);
+                    md5Hash.update(bufferBody);
+                    const partHash = md5Hash.digest('hex');
+                    const partRequest1 = new DummyRequest(
+                        {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                            query: {
+                                partNumber: '1',
+                                uploadId: testUploadId,
+                            },
+                            partHash,
+                        },
+                        fullSizedPart,
+                    );
+                    const partRequest2 = new DummyRequest(
+                        {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                            query: {
+                                partNumber: '2',
+                                uploadId: testUploadId,
+                            },
+                            partHash,
+                        },
+                        fullSizedPart,
+                    );
+                    objectPutPart(authInfo, partRequest1, undefined, log, () => {
+                        objectPutPart(authInfo, partRequest2, undefined, log, () => {
+                            const completeBody =
+                                '<CompleteMultipartUpload>' +
+                                '<Part>' +
+                                '<PartNumber>2</PartNumber>' +
+                                `<ETag>"${partHash}"</ETag>` +
+                                '</Part>' +
+                                '<Part>' +
+                                '<PartNumber>1</PartNumber>' +
+                                `<ETag>"${partHash}"</ETag>` +
+                                '</Part>' +
+                                '</CompleteMultipartUpload>';
+                            const completeRequest = {
+                                bucketName,
+                                namespace,
+                                objectKey,
+                                url: `/${objectKey}?uploadId=${testUploadId}`,
+                                headers: { host: `${bucketName}.s3.amazonaws.com` },
+                                query: { uploadId: testUploadId },
+                                post: completeBody,
+                                partHash,
+                                actionImplicitDenies: false,
+                            };
+                            completeMultipartUpload(authInfo, completeRequest, log, err => {
+                                assert(err.is.InvalidPartOrder);
+                                assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 3);
+                                done();
+                            });
+                        });
+                    });
+                },
+            );
+        },
+    );
+
+    it(
+        'should return InvalidPart error if the complete ' +
+            'multipart upload request contains xml with a missing part',
+        done => {
+            async.waterfall(
+                [
+                    next => bucketPut(authInfo, bucketPutRequest, log, next),
+                    (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                    (result, corsHeaders, next) => parseString(result, next),
+                ],
+                (err, json) => {
+                    // Need to build request in here since do not have uploadId
+                    // until here
+                    const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                    const md5Hash = crypto.createHash('md5');
+                    const fullSizedPart = crypto.randomBytes(5 * 1024 * 1024);
+                    const bufferBody = Buffer.from(fullSizedPart);
+                    md5Hash.update(bufferBody);
+                    const partHash = md5Hash.digest('hex');
+                    const partRequest = new DummyRequest(
+                        {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                            query: {
+                                partNumber: '1',
+                                uploadId: testUploadId,
+                            },
+                            partHash,
+                        },
+                        fullSizedPart,
+                    );
+                    objectPutPart(authInfo, partRequest, undefined, log, () => {
+                        const completeBody =
+                            '<CompleteMultipartUpload>' +
+                            '<Part>' +
+                            '<PartNumber>99999</PartNumber>' +
+                            `<ETag>"${partHash}"</ETag>` +
+                            '</Part>' +
+                            '</CompleteMultipartUpload>';
+                        const completeRequest = {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            url: `/${objectKey}?uploadId=${testUploadId}`,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            query: { uploadId: testUploadId },
+                            post: completeBody,
+                            partHash,
+                            actionImplicitDenies: false,
+                        };
+                        completeMultipartUpload(authInfo, completeRequest, log, err => {
+                            assert(err.is.InvalidPart);
+                            assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 2);
+                            done();
+                        });
+                    });
+                },
+            );
+        },
+    );
+
+    it(
+        'should return an error if the complete multipart upload request ' +
+            'contains xml with a part ETag that does not match the md5 for ' +
+            'the part that was actually sent',
+        done => {
+            async.waterfall(
+                [
+                    next => bucketPut(authInfo, bucketPutRequest, log, next),
+                    (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                    (result, corsHeaders, next) => parseString(result, next),
+                ],
+                (err, json) => {
+                    // Need to build request in here since do not have uploadId
+                    // until here
+                    const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                    const wrongMD5 = '3858f62230ac3c915f300c664312c11f-9';
+                    const fullSizedPart = crypto.randomBytes(5 * 1024 * 1024);
+                    const partRequest1 = new DummyRequest(
+                        {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            query: {
+                                partNumber: '1',
+                                uploadId: testUploadId,
+                            },
+                        },
+                        fullSizedPart,
+                    );
+                    const partRequest2 = new DummyRequest(
+                        {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            query: {
+                                partNumber: '2',
+                                uploadId: testUploadId,
+                            },
+                        },
+                        postBody,
+                    );
+                    objectPutPart(authInfo, partRequest1, undefined, log, err => {
+                        assert.deepStrictEqual(err, null);
+                        const partHash = partRequest1.partHash;
+                        objectPutPart(authInfo, partRequest2, undefined, log, err => {
+                            assert.deepStrictEqual(err, null);
+                            const completeBody =
+                                '<CompleteMultipartUpload>' +
+                                '<Part>' +
+                                '<PartNumber>1</PartNumber>' +
+                                `<ETag>"${partHash}"</ETag>` +
+                                '</Part>' +
+                                '<Part>' +
+                                '<PartNumber>2</PartNumber>' +
+                                `<ETag>${wrongMD5}</ETag>` +
+                                '</Part>' +
+                                '</CompleteMultipartUpload>';
+                            const completeRequest = {
+                                bucketName,
+                                namespace,
+                                objectKey,
+                                url: `/${objectKey}?uploadId=${testUploadId}`,
+                                headers: { host: `${bucketName}.s3.amazonaws.com` },
+                                query: { uploadId: testUploadId },
+                                post: completeBody,
+                                partHash,
+                                actionImplicitDenies: false,
+                            };
+                            assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 3);
+                            completeMultipartUpload(authInfo, completeRequest, log, err => {
+                                assert(err.is.InvalidPart);
+                                done();
+                            });
+                        });
+                    });
+                },
+            );
+        },
+    );
+
+    it(
+        'should return an error if there is a part ' + 'other than the last part that is less than 5MB ' + 'in size',
+        done => {
+            async.waterfall(
+                [
+                    next => bucketPut(authInfo, bucketPutRequest, log, next),
+                    (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                    (result, corsHeaders, next) => parseString(result, next),
+                ],
+                (err, json) => {
+                    // Need to build request in here since do not have uploadId
+                    // until here
+                    const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                    const md5Hash = crypto.createHash('md5');
+                    const bufferBody = Buffer.from(postBody);
+                    md5Hash.update(bufferBody);
+                    const partHash = md5Hash.digest('hex');
+                    const partRequest1 = new DummyRequest(
+                        {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            headers: {
+                                host: `${bucketName}.s3.amazonaws.com`,
+                                'content-length': '100',
+                            },
+                            parsedContentLength: 100,
+                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                            query: {
+                                partNumber: '1',
+                                uploadId: testUploadId,
+                            },
+                            partHash,
+                        },
+                        postBody,
+                    );
+                    const partRequest2 = new DummyRequest(
+                        {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            headers: {
+                                host: `${bucketName}.s3.amazonaws.com`,
+                                'content-length': '200',
+                            },
+                            parsedContentLength: 200,
+                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                            query: {
+                                partNumber: '2',
+                                uploadId: testUploadId,
+                            },
+                            partHash,
+                        },
+                        postBody,
+                    );
+                    objectPutPart(authInfo, partRequest1, undefined, log, () => {
+                        objectPutPart(authInfo, partRequest2, undefined, log, () => {
+                            const completeBody =
+                                '<CompleteMultipartUpload>' +
+                                '<Part>' +
+                                '<PartNumber>1</PartNumber>' +
+                                `<ETag>"${partHash}"</ETag>` +
+                                '</Part>' +
+                                '<Part>' +
+                                '<PartNumber>2</PartNumber>' +
+                                `<ETag>"${partHash}"</ETag>` +
+                                '</Part>' +
+                                '</CompleteMultipartUpload>';
+                            const completeRequest = {
+                                bucketName,
+                                namespace,
+                                objectKey,
+                                headers: { host: `${bucketName}.s3.amazonaws.com` },
+                                url: `/${objectKey}?uploadId=${testUploadId}`,
+                                query: { uploadId: testUploadId },
+                                post: completeBody,
+                                partHash,
+                                actionImplicitDenies: false,
+                            };
+                            assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 3);
+                            completeMultipartUpload(authInfo, completeRequest, log, err => {
+                                assert(err.is.EntityTooSmall);
+                                done();
+                            });
+                        });
+                    });
+                },
+            );
+        },
+    );
+
+    it('should aggregate the sizes of the parts', done => {
+        async.waterfall(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+            ],
+            (err, json) => {
+                // Need to build request in here since do not have uploadId
+                // until her
+                const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                const md5Hash = crypto.createHash('md5');
+                const bufferBody = Buffer.from(postBody);
+                md5Hash.update(bufferBody);
+                const partHash = md5Hash.digest('hex');
+                const partRequest1 = new DummyRequest(
+                    {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        headers: {
+                            host: `${bucketName}.s3.amazonaws.com`,
+                            'content-length': '6000000',
+                        },
+                        parsedContentLength: 6000000,
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        query: {
+                            partNumber: '1',
+                            uploadId: testUploadId,
+                        },
+                        partHash,
+                    },
+                    postBody,
+                );
+                const partRequest2 = new DummyRequest(
+                    {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        headers: {
+                            host: `${bucketName}.s3.amazonaws.com`,
+                            'content-length': '100',
+                        },
+                        parsedContentLength: 100,
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        query: {
+                            partNumber: '2',
+                            uploadId: testUploadId,
+                        },
+                        post: postBody,
+                        partHash,
+                    },
+                    postBody,
+                );
+                objectPutPart(authInfo, partRequest1, undefined, log, () => {
+                    objectPutPart(authInfo, partRequest2, undefined, log, () => {
+                        const completeBody =
+                            '<CompleteMultipartUpload>' +
+                            '<Part>' +
+                            '<PartNumber>1</PartNumber>' +
+                            `<ETag>"${partHash}"</ETag>` +
+                            '</Part>' +
+                            '<Part>' +
+                            '<PartNumber>2</PartNumber>' +
+                            `<ETag>"${partHash}"</ETag>` +
+                            '</Part>' +
+                            '</CompleteMultipartUpload>';
+                        const completeRequest = {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            url: `/${objectKey}?uploadId=${testUploadId}`,
+                            query: { uploadId: testUploadId },
+                            post: completeBody,
+                            partHash,
+                            actionImplicitDenies: false,
+                        };
+                        completeMultipartUpload(authInfo, completeRequest, log, (err, result) => {
+                            assert.strictEqual(err, null);
+                            parseString(result, err => {
+                                assert.strictEqual(err, null);
+                                const MD = metadata.keyMaps.get(bucketName).get(objectKey);
+                                assert(MD);
+                                assert.strictEqual(MD['content-length'], 6000100);
+                                done();
+                            });
+                        });
+                    });
+                });
+            },
+        );
     });
 
     it('should set a canned ACL for a multipart upload', done => {
@@ -1229,7 +1269,7 @@ describe('Multipart Upload API', () => {
             namespace,
             objectKey,
             headers: {
-                'host': `${bucketName}.s3.amazonaws.com`,
+                host: `${bucketName}.s3.amazonaws.com`,
                 'x-amz-meta-stuff': 'I am some user metadata',
                 'x-amz-acl': 'authenticated-read',
             },
@@ -1237,103 +1277,105 @@ describe('Multipart Upload API', () => {
             actionImplicitDenies: false,
         };
 
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, json) => {
-            // Need to build request in here since do not have uploadId
-            // until here
-            const testUploadId =
-                json.InitiateMultipartUploadResult.UploadId[0];
-            const md5Hash = crypto.createHash('md5');
-            const bufferBody = Buffer.from(postBody);
-            md5Hash.update(bufferBody);
-            const partHash = md5Hash.digest('hex');
-            const partRequest1 = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                headers: {
-                    'host': `${bucketName}.s3.amazonaws.com`,
-                    'content-length': 6000000,
-                },
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
-                },
-                partHash,
-            }, postBody);
-            const partRequest2 = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                headers: {
-                    'host': `${bucketName}.s3.amazonaws.com`,
-                    'content-length': 100,
-                },
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                query: {
-                    partNumber: '2',
-                    uploadId: testUploadId,
-                },
-                partHash,
-            }, postBody);
-            objectPutPart(authInfo, partRequest1, undefined, log, () => {
-                objectPutPart(authInfo, partRequest2, undefined, log, () => {
-                    const completeBody = '<CompleteMultipartUpload>' +
-                        '<Part>' +
-                        '<PartNumber>1</PartNumber>' +
-                        `<ETag>"${partHash}"</ETag>` +
-                        '</Part>' +
-                        '<Part>' +
-                        '<PartNumber>2</PartNumber>' +
-                        `<ETag>"${partHash}"</ETag>` +
-                        '</Part>' +
-                        '</CompleteMultipartUpload>';
-                    const completeRequest = {
+        async.waterfall(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+            ],
+            (err, json) => {
+                // Need to build request in here since do not have uploadId
+                // until here
+                const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                const md5Hash = crypto.createHash('md5');
+                const bufferBody = Buffer.from(postBody);
+                md5Hash.update(bufferBody);
+                const partHash = md5Hash.digest('hex');
+                const partRequest1 = new DummyRequest(
+                    {
                         bucketName,
                         namespace,
                         objectKey,
-                        headers: { host: `${bucketName}.s3.amazonaws.com` },
-                        url: `/${objectKey}?uploadId=${testUploadId}`,
-                        query: { uploadId: testUploadId },
-                        post: completeBody,
+                        headers: {
+                            host: `${bucketName}.s3.amazonaws.com`,
+                            'content-length': 6000000,
+                        },
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        query: {
+                            partNumber: '1',
+                            uploadId: testUploadId,
+                        },
                         partHash,
-                        actionImplicitDenies: false,
-                    };
-                    completeMultipartUpload(authInfo,
-                        completeRequest, log, (err, result) => {
+                    },
+                    postBody,
+                );
+                const partRequest2 = new DummyRequest(
+                    {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        headers: {
+                            host: `${bucketName}.s3.amazonaws.com`,
+                            'content-length': 100,
+                        },
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        query: {
+                            partNumber: '2',
+                            uploadId: testUploadId,
+                        },
+                        partHash,
+                    },
+                    postBody,
+                );
+                objectPutPart(authInfo, partRequest1, undefined, log, () => {
+                    objectPutPart(authInfo, partRequest2, undefined, log, () => {
+                        const completeBody =
+                            '<CompleteMultipartUpload>' +
+                            '<Part>' +
+                            '<PartNumber>1</PartNumber>' +
+                            `<ETag>"${partHash}"</ETag>` +
+                            '</Part>' +
+                            '<Part>' +
+                            '<PartNumber>2</PartNumber>' +
+                            `<ETag>"${partHash}"</ETag>` +
+                            '</Part>' +
+                            '</CompleteMultipartUpload>';
+                        const completeRequest = {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            url: `/${objectKey}?uploadId=${testUploadId}`,
+                            query: { uploadId: testUploadId },
+                            post: completeBody,
+                            partHash,
+                            actionImplicitDenies: false,
+                        };
+                        completeMultipartUpload(authInfo, completeRequest, log, (err, result) => {
                             assert.strictEqual(err, null);
                             parseString(result, err => {
                                 assert.strictEqual(err, null);
-                                const MD = metadata.keyMaps
-                                                   .get(bucketName)
-                                                   .get(objectKey);
+                                const MD = metadata.keyMaps.get(bucketName).get(objectKey);
                                 assert(MD);
-                                assert.strictEqual(MD.acl.Canned,
-                                                   'authenticated-read');
+                                assert.strictEqual(MD.acl.Canned, 'authenticated-read');
                                 done();
                             });
                         });
+                    });
                 });
-            });
-        });
+            },
+        );
     });
 
     it('should set specific ACL grants for a multipart upload', done => {
-        const granteeId = '79a59df900b949e55d96a1e698fbace' +
-            'dfd6e09d98eacf8f8d5218e7cd47ef2be';
+        const granteeId = '79a59df900b949e55d96a1e698fbace' + 'dfd6e09d98eacf8f8d5218e7cd47ef2be';
         const granteeEmail = 'sampleAccount1@sampling.com';
         const initiateRequest = {
             bucketName,
             namespace,
             objectKey,
             headers: {
-                'host': `${bucketName}.s3.amazonaws.com`,
+                host: `${bucketName}.s3.amazonaws.com`,
                 'x-amz-meta-stuff': 'I am some user metadata',
                 'x-amz-grant-read': `emailAddress="${granteeEmail}"`,
             },
@@ -1341,60 +1383,314 @@ describe('Multipart Upload API', () => {
             actionImplicitDenies: false,
         };
 
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, json) => {
-            // Need to build request in here since do not have uploadId
-            // until here
-            const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-            const md5Hash = crypto.createHash('md5');
-            const bufferBody = Buffer.from(postBody);
-            md5Hash.update(bufferBody);
-            const partHash = md5Hash.digest('hex');
-            const partRequest1 = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                headers: {
-                    'host': `${bucketName}.s3.amazonaws.com`,
-                    'content-length': 6000000,
+        async.waterfall(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+            ],
+            (err, json) => {
+                // Need to build request in here since do not have uploadId
+                // until here
+                const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                const md5Hash = crypto.createHash('md5');
+                const bufferBody = Buffer.from(postBody);
+                md5Hash.update(bufferBody);
+                const partHash = md5Hash.digest('hex');
+                const partRequest1 = new DummyRequest(
+                    {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        headers: {
+                            host: `${bucketName}.s3.amazonaws.com`,
+                            'content-length': 6000000,
+                        },
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        query: {
+                            partNumber: '1',
+                            uploadId: testUploadId,
+                        },
+                        partHash,
+                    },
+                    postBody,
+                );
+                const partRequest2 = new DummyRequest(
+                    {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        headers: {
+                            host: `${bucketName}.s3.amazonaws.com`,
+                            'content-length': 100,
+                        },
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        query: {
+                            partNumber: '2',
+                            uploadId: testUploadId,
+                        },
+                        post: postBody,
+                        partHash,
+                    },
+                    postBody,
+                );
+                objectPutPart(authInfo, partRequest1, undefined, log, () => {
+                    objectPutPart(authInfo, partRequest2, undefined, log, () => {
+                        const completeBody =
+                            '<CompleteMultipartUpload>' +
+                            '<Part>' +
+                            '<PartNumber>1</PartNumber>' +
+                            `<ETag>"${partHash}"</ETag>` +
+                            '</Part>' +
+                            '<Part>' +
+                            '<PartNumber>2</PartNumber>' +
+                            `<ETag>"${partHash}"</ETag>` +
+                            '</Part>' +
+                            '</CompleteMultipartUpload>';
+                        const completeRequest = {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            url: `/${objectKey}?uploadId=${testUploadId}`,
+                            query: { uploadId: testUploadId },
+                            post: completeBody,
+                            partHash,
+                            actionImplicitDenies: false,
+                        };
+                        completeMultipartUpload(authInfo, completeRequest, log, (err, result) => {
+                            assert.strictEqual(err, null);
+                            parseString(result, err => {
+                                assert.strictEqual(err, null);
+                                const MD = metadata.keyMaps.get(bucketName).get(objectKey);
+                                assert(MD);
+                                assert.strictEqual(MD.acl.READ[0], granteeId);
+                                done();
+                            });
+                        });
+                    });
+                });
+            },
+        );
+    });
+
+    it('should abort/delete a multipart upload', done => {
+        async.waterfall(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+            ],
+            (err, json) => {
+                // Need to build request in here since do not have uploadId
+                // until here
+                const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                const bufferMD5 = Buffer.from(postBody, 'base64');
+                const partHash = bufferMD5.toString('hex');
+                const partRequest = new DummyRequest(
+                    {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        query: {
+                            partNumber: '1',
+                            uploadId: testUploadId,
+                        },
+                        partHash,
+                    },
+                    postBody,
+                );
+                objectPutPart(authInfo, partRequest, undefined, log, () => {
+                    const deleteRequest = {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        url: `/${objectKey}?uploadId=${testUploadId}`,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        query: { uploadId: testUploadId },
+                        actionImplicitDenies: false,
+                    };
+                    assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 2);
+                    multipartDelete(authInfo, deleteRequest, log, err => {
+                        assert.strictEqual(err, null);
+                        assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 0);
+                        done();
+                    });
+                });
+            },
+        );
+    });
+
+    it(
+        'should return no error if attempt to abort/delete ' +
+            'a multipart upload that does not exist and not using ' +
+            'legacyAWSBehavior',
+        done => {
+            async.waterfall(
+                [
+                    next => bucketPut(authInfo, bucketPutRequest, log, next),
+                    (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                    (result, corsHeaders, next) => {
+                        const mpuKeys = metadata.keyMaps.get(mpuBucket);
+                        assert.strictEqual(mpuKeys.size, 1);
+                        parseString(result, next);
+                    },
+                ],
+                (err, json) => {
+                    // Need to build request in here since do not have uploadId
+                    // until here
+                    const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                    const bufferMD5 = Buffer.from(postBody, 'base64');
+                    const partHash = bufferMD5.toString('hex');
+                    const partRequest = new DummyRequest(
+                        {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                            query: {
+                                partNumber: '1',
+                                uploadId: testUploadId,
+                            },
+                            partHash,
+                        },
+                        postBody,
+                    );
+                    objectPutPart(authInfo, partRequest, undefined, log, () => {
+                        const deleteRequest = {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            url: `/${objectKey}?uploadId=${testUploadId}`,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            query: { uploadId: 'non-existent-upload-id' },
+                            actionImplicitDenies: false,
+                        };
+                        assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 2);
+                        multipartDelete(authInfo, deleteRequest, log, err => {
+                            assert.strictEqual(err, null, `Expected no err but got ${err}`);
+                            done();
+                        });
+                    });
                 },
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
+            );
+        },
+    );
+
+    it('should not leave orphans in data when overwriting an object with a MPU', done => {
+        const fullSizedPart = crypto.randomBytes(5 * 1024 * 1024);
+        const partBody = Buffer.from('I am a part\n', 'utf8');
+        async.waterfall(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+                (json, next) => {
+                    const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                    const partRequest = new DummyRequest(
+                        {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                            query: {
+                                partNumber: '1',
+                                uploadId: testUploadId,
+                            },
+                        },
+                        fullSizedPart,
+                    );
+                    objectPutPart(authInfo, partRequest, undefined, log, (err, partpartHash) => {
+                        assert.deepStrictEqual(err, null);
+                        next(null, testUploadId, partpartHash);
+                    });
                 },
-                partHash,
-            }, postBody);
-            const partRequest2 = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                headers: {
-                    'host': `${bucketName}.s3.amazonaws.com`,
-                    'content-length': 100,
+                (testUploadId, part1partHash, next) => {
+                    const part2Request = new DummyRequest(
+                        {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                            query: {
+                                partNumber: '2',
+                                uploadId: testUploadId,
+                            },
+                        },
+                        partBody,
+                    );
+                    objectPutPart(authInfo, part2Request, undefined, log, (err, part2partHash) => {
+                        assert.deepStrictEqual(err, null);
+                        next(null, testUploadId, part1partHash, part2partHash);
+                    });
                 },
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                query: {
-                    partNumber: '2',
-                    uploadId: testUploadId,
-                },
-                post: postBody,
-                partHash,
-            }, postBody);
-            objectPutPart(authInfo, partRequest1, undefined, log, () => {
-                objectPutPart(authInfo, partRequest2, undefined, log, () => {
-                    const completeBody = '<CompleteMultipartUpload>' +
+                (testUploadId, part1partHash, part2partHash, next) => {
+                    const completeBody =
+                        '<CompleteMultipartUpload>' +
                         '<Part>' +
                         '<PartNumber>1</PartNumber>' +
-                        `<ETag>"${partHash}"</ETag>` +
+                        `<ETag>"${part1partHash}"</ETag>` +
                         '</Part>' +
                         '<Part>' +
                         '<PartNumber>2</PartNumber>' +
+                        `<ETag>"${part2partHash}"</ETag>` +
+                        '</Part>' +
+                        '</CompleteMultipartUpload>';
+                    const completeRequest = {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        parsedHost: 's3.amazonaws.com',
+                        url: `/${objectKey}?uploadId=${testUploadId}`,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        query: { uploadId: testUploadId },
+                        post: completeBody,
+                        actionImplicitDenies: false,
+                    };
+                    completeMultipartUpload(authInfo, completeRequest, log, (err, result) => {
+                        assert.deepStrictEqual(err, null);
+                        next(null, result);
+                    });
+                },
+                (result, next) => {
+                    assert.strictEqual(ds[0], undefined);
+                    assert.deepStrictEqual(ds[1].value, fullSizedPart);
+                    assert.deepStrictEqual(ds[2].value, partBody);
+                    initiateMultipartUpload(authInfo, initiateRequest, log, next);
+                },
+                (result, corsHeaders, next) => parseString(result, next),
+                (json, next) => {
+                    const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                    const overwritePartBody = Buffer.from('I am an overwrite part\n', 'utf8');
+                    const md5Hash = crypto.createHash('md5').update(overwritePartBody);
+                    const partHash = md5Hash.digest('hex');
+                    const partRequest = new DummyRequest(
+                        {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                            query: {
+                                partNumber: '1',
+                                uploadId: testUploadId,
+                            },
+                            partHash,
+                        },
+                        overwritePartBody,
+                    );
+                    objectPutPart(authInfo, partRequest, undefined, log, () => next(null, testUploadId, partHash));
+                },
+                (testUploadId, partHash, next) => {
+                    const completeBody =
+                        '<CompleteMultipartUpload>' +
+                        '<Part>' +
+                        '<PartNumber>1</PartNumber>' +
                         `<ETag>"${partHash}"</ETag>` +
                         '</Part>' +
                         '</CompleteMultipartUpload>';
@@ -1402,620 +1698,388 @@ describe('Multipart Upload API', () => {
                         bucketName,
                         namespace,
                         objectKey,
-                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        parsedHost: 's3.amazonaws.com',
                         url: `/${objectKey}?uploadId=${testUploadId}`,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
                         query: { uploadId: testUploadId },
                         post: completeBody,
-                        partHash,
                         actionImplicitDenies: false,
                     };
-                    completeMultipartUpload(authInfo,
-                        completeRequest, log, (err, result) => {
-                            assert.strictEqual(err, null);
-                            parseString(result, err => {
-                                assert.strictEqual(err, null);
-                                const MD = metadata.keyMaps
-                                                   .get(bucketName)
-                                                   .get(objectKey);
-                                assert(MD);
-                                assert.strictEqual(MD.acl.READ[0], granteeId);
-                                done();
-                            });
-                        });
-                });
-            });
-        });
-    });
-
-    it('should abort/delete a multipart upload', done => {
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, json) => {
-            // Need to build request in here since do not have uploadId
-            // until here
-            const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-            const bufferMD5 = Buffer.from(postBody, 'base64');
-            const partHash = bufferMD5.toString('hex');
-            const partRequest = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
+                    completeMultipartUpload(authInfo, completeRequest, log, next);
                 },
-                partHash,
-            }, postBody);
-            objectPutPart(authInfo, partRequest, undefined, log, () => {
-                const deleteRequest = {
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    url: `/${objectKey}?uploadId=${testUploadId}`,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    query: { uploadId: testUploadId },
-                    actionImplicitDenies: false,
-                };
-                assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 2);
-                multipartDelete(authInfo, deleteRequest, log, err => {
-                    assert.strictEqual(err, null);
-                    assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 0);
-                    done();
-                });
-            });
-        });
-    });
-
-    it('should return no error if attempt to abort/delete ' +
-        'a multipart upload that does not exist and not using ' +
-        'legacyAWSBehavior', done => {
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => {
-                const mpuKeys = metadata.keyMaps.get(mpuBucket);
-                assert.strictEqual(mpuKeys.size, 1);
-                parseString(result, next);
-            },
-        ],
-        (err, json) => {
-            // Need to build request in here since do not have uploadId
-            // until here
-            const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-            const bufferMD5 = Buffer.from(postBody, 'base64');
-            const partHash = bufferMD5.toString('hex');
-            const partRequest = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
-                },
-                partHash,
-            }, postBody);
-            objectPutPart(authInfo, partRequest, undefined, log, () => {
-                const deleteRequest = {
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    url: `/${objectKey}?uploadId=${testUploadId}`,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    query: { uploadId: 'non-existent-upload-id' },
-                    actionImplicitDenies: false,
-                };
-                assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 2);
-                multipartDelete(authInfo, deleteRequest, log, err => {
-                    assert.strictEqual(err, null,
-                        `Expected no err but got ${err}`);
-                    done();
-                });
-            });
-        });
-    });
-
-    it('should not leave orphans in data when overwriting an object with a MPU',
-    done => {
-        const fullSizedPart = crypto.randomBytes(5 * 1024 * 1024);
-        const partBody = Buffer.from('I am a part\n', 'utf8');
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-            (json, next) => {
-                const testUploadId =
-                          json.InitiateMultipartUploadResult.UploadId[0];
-                const partRequest = new DummyRequest({
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                    query: {
-                        partNumber: '1',
-                        uploadId: testUploadId,
-                    },
-                }, fullSizedPart);
-                objectPutPart(authInfo, partRequest, undefined, log, (err,
-                    partpartHash) => {
-                    assert.deepStrictEqual(err, null);
-                    next(null, testUploadId, partpartHash);
-                });
-            },
-            (testUploadId, part1partHash, next) => {
-                const part2Request = new DummyRequest({
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                    query: {
-                        partNumber: '2',
-                        uploadId: testUploadId,
-                    },
-                }, partBody);
-                objectPutPart(authInfo, part2Request, undefined, log, (err,
-                    part2partHash) => {
-                    assert.deepStrictEqual(err, null);
-                    next(null, testUploadId, part1partHash,
-                         part2partHash);
-                });
-            },
-            (testUploadId, part1partHash, part2partHash, next) => {
-                const completeBody = '<CompleteMultipartUpload>' +
-                    '<Part>' +
-                    '<PartNumber>1</PartNumber>' +
-                    `<ETag>"${part1partHash}"</ETag>` +
-                    '</Part>' +
-                    '<Part>' +
-                    '<PartNumber>2</PartNumber>' +
-                    `<ETag>"${part2partHash}"</ETag>` +
-                    '</Part>' +
-                    '</CompleteMultipartUpload>';
-                const completeRequest = {
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    parsedHost: 's3.amazonaws.com',
-                    url: `/${objectKey}?uploadId=${testUploadId}`,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    query: { uploadId: testUploadId },
-                    post: completeBody,
-                    actionImplicitDenies: false,
-                };
-                completeMultipartUpload(authInfo, completeRequest, log,
-                                        (err, result) => {
-                                            assert.deepStrictEqual(err, null);
-                                            next(null, result);
-                                        });
-            },
-            (result, next) => {
+            ],
+            err => {
+                assert.deepStrictEqual(err, null);
                 assert.strictEqual(ds[0], undefined);
-                assert.deepStrictEqual(ds[1].value, fullSizedPart);
-                assert.deepStrictEqual(ds[2].value, partBody);
-                initiateMultipartUpload(authInfo, initiateRequest, log, next);
+                assert.strictEqual(ds[1], undefined);
+                assert.strictEqual(ds[2], undefined);
+                assert.deepStrictEqual(ds[3].value, Buffer.from('I am an overwrite part\n', 'utf8'));
+                done();
             },
-            (result, corsHeaders, next) => parseString(result, next),
-            (json, next) => {
-                const testUploadId =
-                    json.InitiateMultipartUploadResult.UploadId[0];
-                const overwritePartBody =
-                    Buffer.from('I am an overwrite part\n', 'utf8');
-                const md5Hash = crypto.createHash('md5')
-                    .update(overwritePartBody);
-                const partHash = md5Hash.digest('hex');
-                const partRequest = new DummyRequest({
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                    query: {
-                        partNumber: '1',
-                        uploadId: testUploadId,
-                    },
-                    partHash,
-                }, overwritePartBody);
-                objectPutPart(authInfo, partRequest, undefined, log, () =>
-                    next(null, testUploadId, partHash));
-            },
-            (testUploadId, partHash, next) => {
-                const completeBody = '<CompleteMultipartUpload>' +
-                    '<Part>' +
-                    '<PartNumber>1</PartNumber>' +
-                    `<ETag>"${partHash}"</ETag>` +
-                    '</Part>' +
-                    '</CompleteMultipartUpload>';
-                const completeRequest = {
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    parsedHost: 's3.amazonaws.com',
-                    url: `/${objectKey}?uploadId=${testUploadId}`,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    query: { uploadId: testUploadId },
-                    post: completeBody,
-                    actionImplicitDenies: false,
-                };
-                completeMultipartUpload(authInfo, completeRequest, log, next);
-            },
-        ],
-        err => {
-            assert.deepStrictEqual(err, null);
-            assert.strictEqual(ds[0], undefined);
-            assert.strictEqual(ds[1], undefined);
-            assert.strictEqual(ds[2], undefined);
-            assert.deepStrictEqual(ds[3].value,
-                Buffer.from('I am an overwrite part\n', 'utf8'));
-            done();
-        });
-    });
-
-    it('should not leave orphans in data when overwriting an object part',
-    done => {
-        const fullSizedPart = crypto.randomBytes(5 * 1024 * 1024);
-        const overWritePart = Buffer.from('Overwrite content', 'utf8');
-        let uploadId;
-
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-            (json, next) => {
-                uploadId = json.InitiateMultipartUploadResult.UploadId[0];
-                const requestObj = {
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    url: `/${objectKey}?partNumber=1&uploadId=${uploadId}`,
-                    query: {
-                        partNumber: '1',
-                        uploadId,
-                    },
-                };
-                const partRequest = new DummyRequest(requestObj, fullSizedPart);
-                objectPutPart(authInfo, partRequest, undefined, log, err => {
-                    assert.deepStrictEqual(err, null);
-                    next(null, requestObj);
-                });
-            },
-            (requestObj, next) => {
-                assert.deepStrictEqual(ds[1].value, fullSizedPart);
-                const partRequest = new DummyRequest(requestObj, overWritePart);
-                objectPutPart(authInfo, partRequest, undefined, log,
-                    (err, partpartHash) => {
-                        assert.deepStrictEqual(err, null);
-                        next(null, partpartHash);
-                    });
-            },
-            (partpartHash, next) => {
-                const completeBody = '<CompleteMultipartUpload>' +
-                    '<Part>' +
-                    '<PartNumber>1</PartNumber>' +
-                    `<ETag>"${partpartHash}"</ETag>` +
-                    '</Part>' +
-                    '</CompleteMultipartUpload>';
-
-                const completeRequest = {
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    parsedHost: 's3.amazonaws.com',
-                    url: `/${objectKey}?uploadId=${uploadId}`,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    query: { uploadId },
-                    post: completeBody,
-                    actionImplicitDenies: false,
-                };
-                completeMultipartUpload(authInfo, completeRequest, log, next);
-            },
-        ],
-        err => {
-            assert.deepStrictEqual(err, null);
-            assert.strictEqual(ds[0], undefined);
-            assert.deepStrictEqual(ds[1], undefined);
-            assert.deepStrictEqual(ds[2].value, overWritePart);
-            done();
-        });
-    });
-
-    it('should leave orphaned data when overwriting an object part during completeMPU',
-    done => {
-        const fullSizedPart = crypto.randomBytes(5 * 1024 * 1024);
-        const overWritePart = Buffer.from('Overwrite content', 'utf8');
-        let uploadId;
-
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-            (json, next) => {
-                uploadId = json.InitiateMultipartUploadResult.UploadId[0];
-                const requestObj = {
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    url: `/${objectKey}?partNumber=1&uploadId=${uploadId}`,
-                    query: {
-                        partNumber: '1',
-                        uploadId,
-                    },
-                };
-                const partRequest = new DummyRequest(requestObj, fullSizedPart);
-                objectPutPart(authInfo, partRequest, undefined, log, (err, partpartHash) => {
-                    assert.deepStrictEqual(err, null);
-                    next(null, requestObj, partpartHash);
-                });
-            },
-            (requestObj, partpartHash, next) => {
-                assert.deepStrictEqual(ds[1].value, fullSizedPart);
-                async.parallel([
-                    done => {
-                        const partRequest = new DummyRequest(requestObj, overWritePart);
-                        objectPutPart(authInfo, partRequest, undefined, log, err => {
-                            assert.deepStrictEqual(err, null);
-                            done();
-                        });
-                    },
-                    done => {
-                        const completeBody = '<CompleteMultipartUpload>' +
-                              '<Part>' +
-                              '<PartNumber>1</PartNumber>' +
-                              `<ETag>"${partpartHash}"</ETag>` +
-                              '</Part>' +
-                              '</CompleteMultipartUpload>';
-
-                        const completeRequest = {
-                            bucketName,
-                            namespace,
-                            objectKey,
-                            parsedHost: 's3.amazonaws.com',
-                            url: `/${objectKey}?uploadId=${uploadId}`,
-                            headers: { host: `${bucketName}.s3.amazonaws.com` },
-                            query: { uploadId },
-                            post: completeBody,
-                            actionImplicitDenies: false,
-                        };
-                        completeMultipartUpload(authInfo, completeRequest, log, done);
-                    },
-                ], err => next(err));
-            },
-        ],
-        err => {
-            assert.deepStrictEqual(err, null);
-            assert.strictEqual(ds[0], undefined);
-            assert.deepStrictEqual(ds[1].value, fullSizedPart);
-            assert.deepStrictEqual(ds[2].value, overWritePart);
-            done();
-        });
-    });
-
-    it('should throw an error on put of an object part with an invalid ' +
-    'uploadId', done => {
-        const testUploadId = 'invalidUploadID';
-        const partRequest = new DummyRequest({
-            bucketName,
-            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-            query: {
-                partNumber: '1',
-                uploadId: testUploadId,
-            },
-        }, postBody);
-
-        bucketPut(authInfo, bucketPutRequest, log, () =>
-          objectPutPart(authInfo, partRequest, undefined, log, err => {
-              assert(err.is.NoSuchUpload);
-              done();
-          })
         );
     });
 
-    it('should complete an MPU with fewer parts than were originally ' +
-        'put and delete data from left out parts', done => {
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, json) => {
-            // Need to build request in here since do not have uploadId
-            // until here
-            assert.ifError(err);
-            const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-            const fullSizedPart = crypto.randomBytes(5 * 1024 * 1024);
-            const partRequest1 = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
+    it('should not leave orphans in data when overwriting an object part', done => {
+        const fullSizedPart = crypto.randomBytes(5 * 1024 * 1024);
+        const overWritePart = Buffer.from('Overwrite content', 'utf8');
+        let uploadId;
+
+        async.waterfall(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+                (json, next) => {
+                    uploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                    const requestObj = {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        url: `/${objectKey}?partNumber=1&uploadId=${uploadId}`,
+                        query: {
+                            partNumber: '1',
+                            uploadId,
+                        },
+                    };
+                    const partRequest = new DummyRequest(requestObj, fullSizedPart);
+                    objectPutPart(authInfo, partRequest, undefined, log, err => {
+                        assert.deepStrictEqual(err, null);
+                        next(null, requestObj);
+                    });
                 },
-            }, fullSizedPart);
-            const partRequest2 = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                query: {
-                    partNumber: '2',
-                    uploadId: testUploadId,
+                (requestObj, next) => {
+                    assert.deepStrictEqual(ds[1].value, fullSizedPart);
+                    const partRequest = new DummyRequest(requestObj, overWritePart);
+                    objectPutPart(authInfo, partRequest, undefined, log, (err, partpartHash) => {
+                        assert.deepStrictEqual(err, null);
+                        next(null, partpartHash);
+                    });
                 },
-            }, postBody);
-            objectPutPart(authInfo, partRequest1, undefined, log, err => {
-                assert.deepStrictEqual(err, null);
-                const md5Hash = crypto.createHash('md5').update(fullSizedPart);
-                const partHash = md5Hash.digest('hex');
-                objectPutPart(authInfo, partRequest2, undefined, log, err => {
-                    assert.deepStrictEqual(err, null);
-                    const completeBody = '<CompleteMultipartUpload>' +
-                            '<Part>' +
-                            '<PartNumber>1</PartNumber>' +
-                            `<ETag>"${partHash}"</ETag>` +
-                            '</Part>' +
-                            '</CompleteMultipartUpload>';
+                (partpartHash, next) => {
+                    const completeBody =
+                        '<CompleteMultipartUpload>' +
+                        '<Part>' +
+                        '<PartNumber>1</PartNumber>' +
+                        `<ETag>"${partpartHash}"</ETag>` +
+                        '</Part>' +
+                        '</CompleteMultipartUpload>';
+
                     const completeRequest = {
                         bucketName,
                         namespace,
                         objectKey,
-                        url: `/${objectKey}?uploadId=${testUploadId}`,
+                        parsedHost: 's3.amazonaws.com',
+                        url: `/${objectKey}?uploadId=${uploadId}`,
                         headers: { host: `${bucketName}.s3.amazonaws.com` },
-                        query: { uploadId: testUploadId },
+                        query: { uploadId },
                         post: completeBody,
-                        partHash,
                         actionImplicitDenies: false,
                     };
-                    // show that second part data is there
-                    assert(ds[2]);
-                    completeMultipartUpload(authInfo,
-                        completeRequest, log, err => {
-                            assert.strictEqual(err, null);
-                            process.nextTick(() => {
-                                // data has been deleted
-                                assert.strictEqual(ds[2], undefined);
-                                done();
-                            });
-                        });
-                });
-            });
-        });
+                    completeMultipartUpload(authInfo, completeRequest, log, next);
+                },
+            ],
+            err => {
+                assert.deepStrictEqual(err, null);
+                assert.strictEqual(ds[0], undefined);
+                assert.deepStrictEqual(ds[1], undefined);
+                assert.deepStrictEqual(ds[2].value, overWritePart);
+                done();
+            },
+        );
     });
 
-    it('should not delete data locations on completeMultipartUpload retry',
-    done => {
+    it('should leave orphaned data when overwriting an object part during completeMPU', done => {
+        const fullSizedPart = crypto.randomBytes(5 * 1024 * 1024);
+        const overWritePart = Buffer.from('Overwrite content', 'utf8');
+        let uploadId;
+
+        async.waterfall(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+                (json, next) => {
+                    uploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                    const requestObj = {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        url: `/${objectKey}?partNumber=1&uploadId=${uploadId}`,
+                        query: {
+                            partNumber: '1',
+                            uploadId,
+                        },
+                    };
+                    const partRequest = new DummyRequest(requestObj, fullSizedPart);
+                    objectPutPart(authInfo, partRequest, undefined, log, (err, partpartHash) => {
+                        assert.deepStrictEqual(err, null);
+                        next(null, requestObj, partpartHash);
+                    });
+                },
+                (requestObj, partpartHash, next) => {
+                    assert.deepStrictEqual(ds[1].value, fullSizedPart);
+                    async.parallel(
+                        [
+                            done => {
+                                const partRequest = new DummyRequest(requestObj, overWritePart);
+                                objectPutPart(authInfo, partRequest, undefined, log, err => {
+                                    assert.deepStrictEqual(err, null);
+                                    done();
+                                });
+                            },
+                            done => {
+                                const completeBody =
+                                    '<CompleteMultipartUpload>' +
+                                    '<Part>' +
+                                    '<PartNumber>1</PartNumber>' +
+                                    `<ETag>"${partpartHash}"</ETag>` +
+                                    '</Part>' +
+                                    '</CompleteMultipartUpload>';
+
+                                const completeRequest = {
+                                    bucketName,
+                                    namespace,
+                                    objectKey,
+                                    parsedHost: 's3.amazonaws.com',
+                                    url: `/${objectKey}?uploadId=${uploadId}`,
+                                    headers: { host: `${bucketName}.s3.amazonaws.com` },
+                                    query: { uploadId },
+                                    post: completeBody,
+                                    actionImplicitDenies: false,
+                                };
+                                completeMultipartUpload(authInfo, completeRequest, log, done);
+                            },
+                        ],
+                        err => next(err),
+                    );
+                },
+            ],
+            err => {
+                assert.deepStrictEqual(err, null);
+                assert.strictEqual(ds[0], undefined);
+                assert.deepStrictEqual(ds[1].value, fullSizedPart);
+                assert.deepStrictEqual(ds[2].value, overWritePart);
+                done();
+            },
+        );
+    });
+
+    it('should throw an error on put of an object part with an invalid ' + 'uploadId', done => {
+        const testUploadId = 'invalidUploadID';
+        const partRequest = new DummyRequest(
+            {
+                bucketName,
+                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                query: {
+                    partNumber: '1',
+                    uploadId: testUploadId,
+                },
+            },
+            postBody,
+        );
+
+        bucketPut(authInfo, bucketPutRequest, log, () =>
+            objectPutPart(authInfo, partRequest, undefined, log, err => {
+                assert(err.is.NoSuchUpload);
+                done();
+            }),
+        );
+    });
+
+    it(
+        'should complete an MPU with fewer parts than were originally ' + 'put and delete data from left out parts',
+        done => {
+            async.waterfall(
+                [
+                    next => bucketPut(authInfo, bucketPutRequest, log, next),
+                    (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                    (result, corsHeaders, next) => parseString(result, next),
+                ],
+                (err, json) => {
+                    // Need to build request in here since do not have uploadId
+                    // until here
+                    assert.ifError(err);
+                    const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                    const fullSizedPart = crypto.randomBytes(5 * 1024 * 1024);
+                    const partRequest1 = new DummyRequest(
+                        {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            query: {
+                                partNumber: '1',
+                                uploadId: testUploadId,
+                            },
+                        },
+                        fullSizedPart,
+                    );
+                    const partRequest2 = new DummyRequest(
+                        {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            query: {
+                                partNumber: '2',
+                                uploadId: testUploadId,
+                            },
+                        },
+                        postBody,
+                    );
+                    objectPutPart(authInfo, partRequest1, undefined, log, err => {
+                        assert.deepStrictEqual(err, null);
+                        const md5Hash = crypto.createHash('md5').update(fullSizedPart);
+                        const partHash = md5Hash.digest('hex');
+                        objectPutPart(authInfo, partRequest2, undefined, log, err => {
+                            assert.deepStrictEqual(err, null);
+                            const completeBody =
+                                '<CompleteMultipartUpload>' +
+                                '<Part>' +
+                                '<PartNumber>1</PartNumber>' +
+                                `<ETag>"${partHash}"</ETag>` +
+                                '</Part>' +
+                                '</CompleteMultipartUpload>';
+                            const completeRequest = {
+                                bucketName,
+                                namespace,
+                                objectKey,
+                                url: `/${objectKey}?uploadId=${testUploadId}`,
+                                headers: { host: `${bucketName}.s3.amazonaws.com` },
+                                query: { uploadId: testUploadId },
+                                post: completeBody,
+                                partHash,
+                                actionImplicitDenies: false,
+                            };
+                            // show that second part data is there
+                            assert(ds[2]);
+                            completeMultipartUpload(authInfo, completeRequest, log, err => {
+                                assert.strictEqual(err, null);
+                                process.nextTick(() => {
+                                    // data has been deleted
+                                    assert.strictEqual(ds[2], undefined);
+                                    done();
+                                });
+                            });
+                        });
+                    });
+                },
+            );
+        },
+    );
+
+    it('should not delete data locations on completeMultipartUpload retry', done => {
         const partBody = Buffer.from('foo', 'utf8');
         let origDeleteObject;
-        async.waterfall([
-            next =>
-                bucketPut(authInfo, bucketPutRequest, log, err => next(err)),
-            next =>
-                initiateMultipartUpload(authInfo, initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-            (json, next) => {
-                const testUploadId =
-                    json.InitiateMultipartUploadResult.UploadId[0];
-                const partRequest = _createPutPartRequest(testUploadId, 1,
-                    partBody);
-                objectPutPart(authInfo, partRequest, undefined, log,
-                    (err, eTag) => next(err, eTag, testUploadId));
-            },
-            (eTag, testUploadId, next) => {
-                origDeleteObject = metadataBackend.deleteObject;
-                metadataBackend.deleteObject = (
-                    bucketName, objName, params, log, cb) => {
+        async.waterfall(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, err => next(err)),
+                next => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+                (json, next) => {
+                    const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                    const partRequest = _createPutPartRequest(testUploadId, 1, partBody);
+                    objectPutPart(authInfo, partRequest, undefined, log, (err, eTag) => next(err, eTag, testUploadId));
+                },
+                (eTag, testUploadId, next) => {
+                    origDeleteObject = metadataBackend.deleteObject;
+                    metadataBackend.deleteObject = (bucketName, objName, params, log, cb) => {
                         // prevent deletions from MPU bucket only
-                    if (bucketName === mpuBucket) {
-                        return process.nextTick(
-                            () => cb(errors.InternalError));
-                    }
-                    return origDeleteObject(
-                        bucketName, objName, params, log, cb);
-                };
-                const parts = [{ partNumber: 1, eTag }];
-                const completeRequest = _createCompleteMpuRequest(
-                    testUploadId, parts);
-                completeMultipartUpload(authInfo, completeRequest, log, err => {
-                    // expect a failure here because we could not
-                    // remove the overview key
-                    assert(err.is.InternalError);
-                    next(null, eTag, testUploadId);
-                });
+                        if (bucketName === mpuBucket) {
+                            return process.nextTick(() => cb(errors.InternalError));
+                        }
+                        return origDeleteObject(bucketName, objName, params, log, cb);
+                    };
+                    const parts = [{ partNumber: 1, eTag }];
+                    const completeRequest = _createCompleteMpuRequest(testUploadId, parts);
+                    completeMultipartUpload(authInfo, completeRequest, log, err => {
+                        // expect a failure here because we could not
+                        // remove the overview key
+                        assert(err.is.InternalError);
+                        next(null, eTag, testUploadId);
+                    });
+                },
+                (eTag, testUploadId, next) => {
+                    // allow MPU bucket metadata deletions to happen again
+                    metadataBackend.deleteObject = origDeleteObject;
+                    // retry the completeMultipartUpload with the same
+                    // metadata, as an application would normally do after
+                    // a failure
+                    const parts = [{ partNumber: 1, eTag }];
+                    const completeRequest = _createCompleteMpuRequest(testUploadId, parts);
+                    completeMultipartUpload(authInfo, completeRequest, log, next);
+                },
+            ],
+            err => {
+                assert.ifError(err);
+                // check that the original data has not been deleted
+                // during the replay
+                assert.strictEqual(ds[0], undefined);
+                assert.notStrictEqual(ds[1], undefined);
+                assert.deepStrictEqual(ds[1].value, partBody);
+                done();
             },
-            (eTag, testUploadId, next) => {
-                // allow MPU bucket metadata deletions to happen again
-                metadataBackend.deleteObject = origDeleteObject;
-                // retry the completeMultipartUpload with the same
-                // metadata, as an application would normally do after
-                // a failure
-                const parts = [{ partNumber: 1, eTag }];
-                const completeRequest = _createCompleteMpuRequest(
-                    testUploadId, parts);
-                completeMultipartUpload(authInfo, completeRequest, log, next);
-            },
-        ], err => {
-            assert.ifError(err);
-            // check that the original data has not been deleted
-            // during the replay
-            assert.strictEqual(ds[0], undefined);
-            assert.notStrictEqual(ds[1], undefined);
-            assert.deepStrictEqual(ds[1].value, partBody);
-            done();
-        });
+        );
     });
 
     it('should abort an MPU and delete its MD if it has been created by a failed complete before', done => {
         const delMeta = metadataBackend.deleteObject;
         metadataBackend.deleteObject = (bucketName, objName, params, log, cb) => cb(errors.InternalError);
         const partBody = Buffer.from('I am a part\n', 'utf8');
-        initiateRequest.headers['x-amz-meta-stuff'] =
-            'I am some user metadata';
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, json) => {
-            assert.ifError(err);
-            const testUploadId =
-                json.InitiateMultipartUploadResult.UploadId[0];
-            const partHash = crypto.createHash('md5').update(partBody).digest('hex');
-            const partRequest = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
-                },
-                partHash,
-            }, partBody);
-            objectPutPart(authInfo, partRequest, undefined, log, () => {
-                const completeBody = '<CompleteMultipartUpload>' +
-                    '<Part>' +
-                    '<PartNumber>1</PartNumber>' +
-                    `<ETag>"${partHash}"</ETag>` +
-                    '</Part>' +
-                    '</CompleteMultipartUpload>';
-                const completeRequest = {
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    parsedHost: 's3.amazonaws.com',
-                    url: `/${objectKey}?uploadId=${testUploadId}`,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    query: { uploadId: testUploadId },
-                    post: completeBody,
-                    actionImplicitDenies: false,
-                };
-                completeMultipartUpload(authInfo,
-                    completeRequest, log, err => {
+        initiateRequest.headers['x-amz-meta-stuff'] = 'I am some user metadata';
+        async.waterfall(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+            ],
+            (err, json) => {
+                assert.ifError(err);
+                const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                const partHash = crypto.createHash('md5').update(partBody).digest('hex');
+                const partRequest = new DummyRequest(
+                    {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        query: {
+                            partNumber: '1',
+                            uploadId: testUploadId,
+                        },
+                        partHash,
+                    },
+                    partBody,
+                );
+                objectPutPart(authInfo, partRequest, undefined, log, () => {
+                    const completeBody =
+                        '<CompleteMultipartUpload>' +
+                        '<Part>' +
+                        '<PartNumber>1</PartNumber>' +
+                        `<ETag>"${partHash}"</ETag>` +
+                        '</Part>' +
+                        '</CompleteMultipartUpload>';
+                    const completeRequest = {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        parsedHost: 's3.amazonaws.com',
+                        url: `/${objectKey}?uploadId=${testUploadId}`,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        query: { uploadId: testUploadId },
+                        post: completeBody,
+                        actionImplicitDenies: false,
+                    };
+                    completeMultipartUpload(authInfo, completeRequest, log, err => {
                         assert(err.is.InternalError);
-                        const MD = metadata.keyMaps.get(bucketName)
-                                                    .get(objectKey);
+                        const MD = metadata.keyMaps.get(bucketName).get(objectKey);
                         assert(MD);
-                        assert.strictEqual(MD['x-amz-meta-stuff'],
-                            'I am some user metadata');
+                        assert.strictEqual(MD['x-amz-meta-stuff'], 'I am some user metadata');
                         assert.strictEqual(MD.uploadId, testUploadId);
 
                         metadataBackend.deleteObject = delMeta;
@@ -2035,145 +2099,155 @@ describe('Multipart Upload API', () => {
                             done();
                         });
                     });
-            });
-        });
+                });
+            },
+        );
     });
 
     it('should complete an MPU and promote its MD if it has been created by a failed complete before', done => {
         const delMeta = metadataBackend.deleteObject;
         metadataBackend.deleteObject = (bucketName, objName, params, log, cb) => cb(errors.InternalError);
         const partBody = Buffer.from('I am a part\n', 'utf8');
-        initiateRequest.headers['x-amz-meta-stuff'] =
-            'I am some user metadata';
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, json) => {
-            assert.ifError(err);
-            const testUploadId =
-                json.InitiateMultipartUploadResult.UploadId[0];
-            const partHash = crypto.createHash('md5').update(partBody).digest('hex');
-            const partRequest = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
-                },
-                partHash,
-            }, partBody);
-            objectPutPart(authInfo, partRequest, undefined, log, () => {
-                const completeBody = '<CompleteMultipartUpload>' +
-                    '<Part>' +
-                    '<PartNumber>1</PartNumber>' +
-                    `<ETag>"${partHash}"</ETag>` +
-                    '</Part>' +
-                    '</CompleteMultipartUpload>';
-                const completeRequest = {
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    parsedHost: 's3.amazonaws.com',
-                    url: `/${objectKey}?uploadId=${testUploadId}`,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    query: { uploadId: testUploadId },
-                    post: completeBody,
-                    actionImplicitDenies: false,
-                };
-                completeMultipartUpload(authInfo,
-                    completeRequest, log, err => {
+        initiateRequest.headers['x-amz-meta-stuff'] = 'I am some user metadata';
+        async.waterfall(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+            ],
+            (err, json) => {
+                assert.ifError(err);
+                const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                const partHash = crypto.createHash('md5').update(partBody).digest('hex');
+                const partRequest = new DummyRequest(
+                    {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        query: {
+                            partNumber: '1',
+                            uploadId: testUploadId,
+                        },
+                        partHash,
+                    },
+                    partBody,
+                );
+                objectPutPart(authInfo, partRequest, undefined, log, () => {
+                    const completeBody =
+                        '<CompleteMultipartUpload>' +
+                        '<Part>' +
+                        '<PartNumber>1</PartNumber>' +
+                        `<ETag>"${partHash}"</ETag>` +
+                        '</Part>' +
+                        '</CompleteMultipartUpload>';
+                    const completeRequest = {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        parsedHost: 's3.amazonaws.com',
+                        url: `/${objectKey}?uploadId=${testUploadId}`,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        query: { uploadId: testUploadId },
+                        post: completeBody,
+                        actionImplicitDenies: false,
+                    };
+                    completeMultipartUpload(authInfo, completeRequest, log, err => {
                         assert(err.is.InternalError);
                         const MD = metadata.keyMaps.get(bucketName).get(objectKey);
                         assert(MD);
-                        assert.strictEqual(MD['x-amz-meta-stuff'],
-                            'I am some user metadata');
+                        assert.strictEqual(MD['x-amz-meta-stuff'], 'I am some user metadata');
                         assert.strictEqual(MD.uploadId, testUploadId);
                         metadataBackend.deleteObject = delMeta;
                         assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 2);
-                        completeMultipartUpload(authInfo,
-                            completeRequest, log, err => {
-                                assert.ifError(err);
-                                const MD = metadata.keyMaps.get(bucketName)
-                                                    .get(objectKey);
-                                assert(MD);
-                                assert.strictEqual(MD['x-amz-meta-stuff'],
-                                    'I am some user metadata');
-                                assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 0);
-                                done();
-                            });
+                        completeMultipartUpload(authInfo, completeRequest, log, err => {
+                            assert.ifError(err);
+                            const MD = metadata.keyMaps.get(bucketName).get(objectKey);
+                            assert(MD);
+                            assert.strictEqual(MD['x-amz-meta-stuff'], 'I am some user metadata');
+                            assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 0);
+                            done();
+                        });
                     });
-            });
-        });
+                });
+            },
+        );
     });
 
     it('should not pass needOplogUpdate when writing new object', done => {
-        async.series([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            async () => _uploadMpuObject(),
-            async () => {
-                const options = metadataswitch.putObjectMD.lastCall.args[3];
-                assert.strictEqual(options.needOplogUpdate, undefined);
-                assert.strictEqual(options.originOp, undefined);
-            },
-        ], done);
+        async.series(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                async () => _uploadMpuObject(),
+                async () => {
+                    const options = metadataswitch.putObjectMD.lastCall.args[3];
+                    assert.strictEqual(options.needOplogUpdate, undefined);
+                    assert.strictEqual(options.originOp, undefined);
+                },
+            ],
+            done,
+        );
     });
 
     it('should not pass needOplogUpdate when replacing object', done => {
-        async.series([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            async () => _uploadMpuObject(),
-            async () => _uploadMpuObject(),
-            async () => {
-                const options = metadataswitch.putObjectMD.lastCall.args[3];
-                assert.strictEqual(options.needOplogUpdate, undefined);
-                assert.strictEqual(options.originOp, undefined);
-            },
-        ], done);
+        async.series(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                async () => _uploadMpuObject(),
+                async () => _uploadMpuObject(),
+                async () => {
+                    const options = metadataswitch.putObjectMD.lastCall.args[3];
+                    assert.strictEqual(options.needOplogUpdate, undefined);
+                    assert.strictEqual(options.originOp, undefined);
+                },
+            ],
+            done,
+        );
     });
 
     it('should pass needOplogUpdate to metadata when replacing archived object', done => {
         const archived = {
-            archiveInfo: { foo: 0, bar: 'stuff' }
+            archiveInfo: { foo: 0, bar: 'stuff' },
         };
 
-        async.series([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            async () => _uploadMpuObject(),
-            next => fakeMetadataArchive(bucketName, objectKey, undefined, archived, next),
-            async () => _uploadMpuObject(),
-            async () => {
-                const options = metadataswitch.putObjectMD.lastCall.args[3];
-                assert.strictEqual(options.needOplogUpdate, true);
-                assert.strictEqual(options.originOp, 's3:ReplaceArchivedObject');
-            },
-        ], done);
+        async.series(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                async () => _uploadMpuObject(),
+                next => fakeMetadataArchive(bucketName, objectKey, undefined, archived, next),
+                async () => _uploadMpuObject(),
+                async () => {
+                    const options = metadataswitch.putObjectMD.lastCall.args[3];
+                    assert.strictEqual(options.needOplogUpdate, true);
+                    assert.strictEqual(options.originOp, 's3:ReplaceArchivedObject');
+                },
+            ],
+            done,
+        );
     });
 
     it('should pass needOplogUpdate to metadata when replacing archived object in version suspended bucket', done => {
         const archived = {
-            archiveInfo: { foo: 0, bar: 'stuff' }
+            archiveInfo: { foo: 0, bar: 'stuff' },
         };
 
-        const suspendVersioningRequest = versioningTestUtils
-            .createBucketPutVersioningReq(bucketName, 'Suspended');
-        async.series([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            next => bucketPutVersioning(authInfo, suspendVersioningRequest, log, next),
-            async () => _uploadMpuObject(),
-            next => fakeMetadataArchive(bucketName, objectKey, undefined, archived, next),
-            async () => _uploadMpuObject(),
-            async () => {
-                const options = metadataswitch.putObjectMD.lastCall.args[3];
-                assert.strictEqual(options.needOplogUpdate, true);
-                assert.strictEqual(options.originOp, 's3:ReplaceArchivedObject');
-            },
-        ], done);
+        const suspendVersioningRequest = versioningTestUtils.createBucketPutVersioningReq(bucketName, 'Suspended');
+        async.series(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                next => bucketPutVersioning(authInfo, suspendVersioningRequest, log, next),
+                async () => _uploadMpuObject(),
+                next => fakeMetadataArchive(bucketName, objectKey, undefined, archived, next),
+                async () => _uploadMpuObject(),
+                async () => {
+                    const options = metadataswitch.putObjectMD.lastCall.args[3];
+                    assert.strictEqual(options.needOplogUpdate, true);
+                    assert.strictEqual(options.originOp, 's3:ReplaceArchivedObject');
+                },
+            ],
+            done,
+        );
     });
 
     it('should fail to initiate a multipart upload if location constraint is crr', done => {
@@ -2194,11 +2268,10 @@ describe('Multipart Upload API', () => {
 
         bucketPut(authInfo, bucketPutRequest, log, err => {
             assert.ifError(err);
-            initiateMultipartUpload(authInfo, initiateRequest,
-                log, err => {
-                    assert(err.is.InvalidArgument);
-                    done();
-                });
+            initiateMultipartUpload(authInfo, initiateRequest, log, err => {
+                assert(err.is.InvalidArgument);
+                done();
+            });
         });
     });
 
@@ -2206,134 +2279,47 @@ describe('Multipart Upload API', () => {
         const partBody = Buffer.from('I am a part\n', 'utf8');
         let batchDeleteStub;
 
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, json) => {
-            assert.ifError(err);
-            const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-            const partHash = crypto.createHash('md5').update(partBody).digest('hex');
-            const partRequest = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
-                },
-                partHash,
-            }, partBody);
-
-            objectPutPart(authInfo, partRequest, undefined, log, () => {
-                // Mock batchDeleteObjectMetadata to fail with non-retryable error
-                const services = require('../../../lib/services');
-                batchDeleteStub = sinon.stub(services, 'batchDeleteObjectMetadata')
-                    .callsFake((mpuBucketName, keysToDelete, log, cb) =>
-                        // Simulate a non-retryable error that should be converted to retryable
-                         cb(errors.NoSuchKey)
-                    );
-
-                const completeBody = '<CompleteMultipartUpload>' +
-                    '<Part>' +
-                    '<PartNumber>1</PartNumber>' +
-                    `<ETag>"${partHash}"</ETag>` +
-                    '</Part>' +
-                    '</CompleteMultipartUpload>';
-                const completeRequest = {
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    parsedHost: 's3.amazonaws.com',
-                    url: `/${objectKey}?uploadId=${testUploadId}`,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    query: { uploadId: testUploadId },
-                    post: completeBody,
-                    actionImplicitDenies: false,
-                };
-
-                completeMultipartUpload(authInfo, completeRequest, log, err => {
-                    // Restore original function
-                    batchDeleteStub.restore();
-
-                    // Should get an error (retryable behavior)
-                    assert(err, 'Expected an error when metadata deletion fails');
-
-                    // Verify S3 object was created successfully despite the error
-                    const objMD = metadata.keyMaps.get(bucketName).get(objectKey);
-                    assert(objMD, 'S3 object should exist even when metadata cleanup fails');
-                    assert.strictEqual(objMD.uploadId, testUploadId);
-
-                    done();
-                });
-            });
-        });
-    });
-
-    it('should not return error if batchDeleteExtraParts fails', done => {
-        const fullSizedPart = crypto.randomBytes(5 * 1024 * 1024);
-        const partBody = Buffer.from('I am a smaller part\n', 'utf8');
-        let batchDeleteStub;
-
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, json) => {
-            assert.ifError(err);
-            const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-
-            // Upload part 1 (will be included in completion)
-            const partRequest1 = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
-                },
-            }, fullSizedPart);
-
-            objectPutPart(authInfo, partRequest1, undefined, log, (err, part1ETag) => {
+        async.waterfall(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+            ],
+            (err, json) => {
                 assert.ifError(err);
-
-                // Upload part 2 (will be an "extra part" not included in completion)
-                const partRequest2 = new DummyRequest({
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    url: `/${objectKey}?partNumber=2&uploadId=${testUploadId}`,
-                    query: {
-                        partNumber: '2',
-                        uploadId: testUploadId,
+                const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                const partHash = crypto.createHash('md5').update(partBody).digest('hex');
+                const partRequest = new DummyRequest(
+                    {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        query: {
+                            partNumber: '1',
+                            uploadId: testUploadId,
+                        },
+                        partHash,
                     },
-                }, partBody);
+                    partBody,
+                );
 
-                objectPutPart(authInfo, partRequest2, undefined, log, err => {
-                    assert.ifError(err);
-
-                    // Mock data.batchDelete to fail when deleting extra parts
-                    const { data } = require('../../../lib/data/wrapper');
-                    batchDeleteStub = sinon.stub(data, 'batchDelete')
-                        .callsFake((locations, method, dataStoreName, log, cb) =>
-                            // Always fail extra part deletion
-                             cb(new Error('Simulated extra part deletion failure'))
+                objectPutPart(authInfo, partRequest, undefined, log, () => {
+                    // Mock batchDeleteObjectMetadata to fail with non-retryable error
+                    const services = require('../../../lib/services');
+                    batchDeleteStub = sinon
+                        .stub(services, 'batchDeleteObjectMetadata')
+                        .callsFake((mpuBucketName, keysToDelete, log, cb) =>
+                            // Simulate a non-retryable error that should be converted to retryable
+                            cb(errors.NoSuchKey),
                         );
 
-                    // Complete MPU with only part 1 (part 2 becomes "extra part")
-                    const completeBody = '<CompleteMultipartUpload>' +
+                    const completeBody =
+                        '<CompleteMultipartUpload>' +
                         '<Part>' +
                         '<PartNumber>1</PartNumber>' +
-                        `<ETag>"${part1ETag}"</ETag>` +
+                        `<ETag>"${partHash}"</ETag>` +
                         '</Part>' +
                         '</CompleteMultipartUpload>';
                     const completeRequest = {
@@ -2352,42 +2338,143 @@ describe('Multipart Upload API', () => {
                         // Restore original function
                         batchDeleteStub.restore();
 
-                        // Should NOT get an error despite extra part deletion failing
-                        assert.ifError(err, 'Should not return error when extra part deletion fails');
+                        // Should get an error (retryable behavior)
+                        assert(err, 'Expected an error when metadata deletion fails');
 
-                        // Verify S3 object was created successfully
+                        // Verify S3 object was created successfully despite the error
                         const objMD = metadata.keyMaps.get(bucketName).get(objectKey);
-                        assert(objMD, 'S3 object should exist');
+                        assert(objMD, 'S3 object should exist even when metadata cleanup fails');
                         assert.strictEqual(objMD.uploadId, testUploadId);
-
-                        // Verify MPU metadata was cleaned up
-                        assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 0,
-                            'MPU metadata should be cleaned up');
 
                         done();
                     });
                 });
-            });
-        });
+            },
+        );
+    });
+
+    it('should not return error if batchDeleteExtraParts fails', done => {
+        const fullSizedPart = crypto.randomBytes(5 * 1024 * 1024);
+        const partBody = Buffer.from('I am a smaller part\n', 'utf8');
+        let batchDeleteStub;
+
+        async.waterfall(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+            ],
+            (err, json) => {
+                assert.ifError(err);
+                const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+
+                // Upload part 1 (will be included in completion)
+                const partRequest1 = new DummyRequest(
+                    {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        query: {
+                            partNumber: '1',
+                            uploadId: testUploadId,
+                        },
+                    },
+                    fullSizedPart,
+                );
+
+                objectPutPart(authInfo, partRequest1, undefined, log, (err, part1ETag) => {
+                    assert.ifError(err);
+
+                    // Upload part 2 (will be an "extra part" not included in completion)
+                    const partRequest2 = new DummyRequest(
+                        {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            url: `/${objectKey}?partNumber=2&uploadId=${testUploadId}`,
+                            query: {
+                                partNumber: '2',
+                                uploadId: testUploadId,
+                            },
+                        },
+                        partBody,
+                    );
+
+                    objectPutPart(authInfo, partRequest2, undefined, log, err => {
+                        assert.ifError(err);
+
+                        // Mock data.batchDelete to fail when deleting extra parts
+                        const { data } = require('../../../lib/data/wrapper');
+                        batchDeleteStub = sinon
+                            .stub(data, 'batchDelete')
+                            .callsFake((locations, method, dataStoreName, log, cb) =>
+                                // Always fail extra part deletion
+                                cb(new Error('Simulated extra part deletion failure')),
+                            );
+
+                        // Complete MPU with only part 1 (part 2 becomes "extra part")
+                        const completeBody =
+                            '<CompleteMultipartUpload>' +
+                            '<Part>' +
+                            '<PartNumber>1</PartNumber>' +
+                            `<ETag>"${part1ETag}"</ETag>` +
+                            '</Part>' +
+                            '</CompleteMultipartUpload>';
+                        const completeRequest = {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            parsedHost: 's3.amazonaws.com',
+                            url: `/${objectKey}?uploadId=${testUploadId}`,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            query: { uploadId: testUploadId },
+                            post: completeBody,
+                            actionImplicitDenies: false,
+                        };
+
+                        completeMultipartUpload(authInfo, completeRequest, log, err => {
+                            // Restore original function
+                            batchDeleteStub.restore();
+
+                            // Should NOT get an error despite extra part deletion failing
+                            assert.ifError(err, 'Should not return error when extra part deletion fails');
+
+                            // Verify S3 object was created successfully
+                            const objMD = metadata.keyMaps.get(bucketName).get(objectKey);
+                            assert(objMD, 'S3 object should exist');
+                            assert.strictEqual(objMD.uploadId, testUploadId);
+
+                            // Verify MPU metadata was cleaned up
+                            assert.strictEqual(
+                                metadata.keyMaps.get(mpuBucket).size,
+                                0,
+                                'MPU metadata should be cleaned up',
+                            );
+
+                            done();
+                        });
+                    });
+                });
+            },
+        );
     });
 });
 
 describe('complete mpu with versioning', () => {
-    const objData = ['foo0', 'foo1', 'foo2'].map(str =>
-        Buffer.from(str, 'utf8'));
+    const objData = ['foo0', 'foo1', 'foo2'].map(str => Buffer.from(str, 'utf8'));
 
-    const enableVersioningRequest =
-        versioningTestUtils.createBucketPutVersioningReq(bucketName, 'Enabled');
-    const suspendVersioningRequest = versioningTestUtils
-          .createBucketPutVersioningReq(bucketName, 'Suspended');
+    const enableVersioningRequest = versioningTestUtils.createBucketPutVersioningReq(bucketName, 'Enabled');
+    const suspendVersioningRequest = versioningTestUtils.createBucketPutVersioningReq(bucketName, 'Suspended');
     let testPutObjectRequests;
 
     beforeEach(done => {
         cleanup();
         testPutObjectRequests = objData
-              .slice(0, 2)
-              .map(data => versioningTestUtils.createPutObjectRequest(
-                  bucketName, objectKey, data));
+            .slice(0, 2)
+            .map(data => versioningTestUtils.createPutObjectRequest(bucketName, objectKey, data));
         bucketPut(authInfo, bucketPutRequest, log, done);
     });
 
@@ -2396,291 +2483,271 @@ describe('complete mpu with versioning', () => {
         done();
     });
 
-    it('should delete null version when creating new null version, ' +
-    'when null version is the latest version', done => {
-        async.waterfall([
-            next => bucketPutVersioning(authInfo,
-                suspendVersioningRequest, log, err => next(err)),
-            next => initiateMultipartUpload(
-                authInfo, initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-            (json, next) => {
-                const partBody = objData[2];
-                const testUploadId =
-                    json.InitiateMultipartUploadResult.UploadId[0];
-                const partRequest = _createPutPartRequest(testUploadId, 1,
-                    partBody);
-                objectPutPart(authInfo, partRequest, undefined, log,
-                    (err, eTag) => next(err, eTag, testUploadId));
-            },
-            (eTag, testUploadId, next) => {
-                const origPutObject = metadataBackend.putObject;
-                let callCount = 0;
-                metadataBackend.putObject =
-                    (putBucketName, objName, objVal, params, log, cb) => {
-                        if (callCount === 0) {
-                            // first putObject sets the completeInProgress flag in the overview key
-                            assert.strictEqual(putBucketName, `${constants.mpuBucketPrefix}${bucketName}`);
-                            assert.strictEqual(
-                                objName, `overview${splitter}${objectKey}${splitter}${testUploadId}`);
-                            assert.strictEqual(objVal.completeInProgress, true);
-                        } else {
-                            assert.strictEqual(params.replayId, testUploadId);
-                            assert.strictEqual(objVal.originOp, 's3:ObjectCreated:CompleteMultipartUpload');
+    it(
+        'should delete null version when creating new null version, ' + 'when null version is the latest version',
+        done => {
+            async.waterfall(
+                [
+                    next => bucketPutVersioning(authInfo, suspendVersioningRequest, log, err => next(err)),
+                    next => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                    (result, corsHeaders, next) => parseString(result, next),
+                    (json, next) => {
+                        const partBody = objData[2];
+                        const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                        const partRequest = _createPutPartRequest(testUploadId, 1, partBody);
+                        objectPutPart(authInfo, partRequest, undefined, log, (err, eTag) =>
+                            next(err, eTag, testUploadId),
+                        );
+                    },
+                    (eTag, testUploadId, next) => {
+                        const origPutObject = metadataBackend.putObject;
+                        let callCount = 0;
+                        metadataBackend.putObject = (putBucketName, objName, objVal, params, log, cb) => {
+                            if (callCount === 0) {
+                                // first putObject sets the completeInProgress flag in the overview key
+                                assert.strictEqual(putBucketName, `${constants.mpuBucketPrefix}${bucketName}`);
+                                assert.strictEqual(
+                                    objName,
+                                    `overview${splitter}${objectKey}${splitter}${testUploadId}`,
+                                );
+                                assert.strictEqual(objVal.completeInProgress, true);
+                            } else {
+                                assert.strictEqual(params.replayId, testUploadId);
+                                assert.strictEqual(objVal.originOp, 's3:ObjectCreated:CompleteMultipartUpload');
+                                metadataBackend.putObject = origPutObject;
+                            }
+                            origPutObject(putBucketName, objName, objVal, params, log, cb);
+                            callCount += 1;
+                        };
+                        const parts = [{ partNumber: 1, eTag }];
+                        const completeRequest = _createCompleteMpuRequest(testUploadId, parts);
+                        completeMultipartUpload(authInfo, completeRequest, log, err => next(err, testUploadId));
+                    },
+                    (testUploadId, next) => {
+                        const origPutObject = metadataBackend.putObject;
+                        metadataBackend.putObject = (putBucketName, objName, objVal, params, log, cb) => {
+                            assert.strictEqual(params.oldReplayId, testUploadId);
+                            assert.strictEqual(objVal.originOp, 's3:ObjectCreated:Put');
                             metadataBackend.putObject = origPutObject;
-                        }
-                        origPutObject(
-                            putBucketName, objName, objVal, params, log, cb);
-                        callCount += 1;
-                    };
-                const parts = [{ partNumber: 1, eTag }];
-                const completeRequest = _createCompleteMpuRequest(testUploadId,
-                    parts);
-                completeMultipartUpload(authInfo, completeRequest, log,
-                                        err => next(err, testUploadId));
-            },
-            (testUploadId, next) => {
-                const origPutObject = metadataBackend.putObject;
-                metadataBackend.putObject =
-                    (putBucketName, objName, objVal, params, log, cb) => {
-                        assert.strictEqual(params.oldReplayId, testUploadId);
-                        assert.strictEqual(objVal.originOp, 's3:ObjectCreated:Put');
-                        metadataBackend.putObject = origPutObject;
-                        origPutObject(
-                            putBucketName, objName, objVal, params, log, cb);
-                    };
-                // overwrite null version with a non-MPU object
-                objectPut(authInfo, testPutObjectRequests[1],
-                          undefined, log, err => next(err));
-            },
-        ], err => {
-            assert.ifError(err, `Unexpected err: ${err}`);
-            done();
-        });
-    });
-
-    it('should delete null version when creating new null version, ' +
-    'when null version is not the latest version', done => {
-        async.waterfall([
-            // putting null version: put obj before versioning configured
-            next => objectPut(authInfo, testPutObjectRequests[0],
-                undefined, log, err => next(err)),
-            next => bucketPutVersioning(authInfo,
-                enableVersioningRequest, log, err => next(err)),
-            // put another version:
-            next => objectPut(authInfo, testPutObjectRequests[1],
-                undefined, log, err => next(err)),
-            next => bucketPutVersioning(authInfo,
-                suspendVersioningRequest, log, err => next(err)),
-            next => {
-                versioningTestUtils.assertDataStoreValues(
-                    ds, objData.slice(0, 2));
-                initiateMultipartUpload(authInfo, initiateRequest, log, next);
-            },
-            (result, corsHeaders, next) => parseString(result, next),
-            (json, next) => {
-                const partBody = objData[2];
-                const testUploadId =
-                    json.InitiateMultipartUploadResult.UploadId[0];
-                const partRequest = _createPutPartRequest(testUploadId, 1,
-                    partBody);
-                objectPutPart(authInfo, partRequest, undefined, log,
-                    (err, eTag) => next(err, eTag, testUploadId));
-            },
-            (eTag, testUploadId, next) => {
-                const origPutObject = metadataBackend.putObject;
-                let callCount = 0;
-                metadataBackend.putObject =
-                    (putBucketName, objName, objVal, params, log, cb) => {
-                        if (callCount === 0) {
-                            // first putObject sets the completeInProgress flag in the overview key
-                            assert.strictEqual(putBucketName, `${constants.mpuBucketPrefix}${bucketName}`);
-                            assert.strictEqual(
-                                objName, `overview${splitter}${objectKey}${splitter}${testUploadId}`);
-                            assert.strictEqual(objVal.completeInProgress, true);
-                        } else {
-                            assert.strictEqual(params.replayId, testUploadId);
-                            metadataBackend.putObject = origPutObject;
-                        }
-                        origPutObject(
-                            putBucketName, objName, objVal, params, log, cb);
-                        callCount += 1;
-                    };
-                const parts = [{ partNumber: 1, eTag }];
-                const completeRequest = _createCompleteMpuRequest(testUploadId,
-                    parts);
-                completeMultipartUpload(authInfo, completeRequest, log,
-                                        err => next(err, testUploadId));
-            },
-            (testUploadId, next) => {
-                versioningTestUtils.assertDataStoreValues(
-                    ds, [undefined, objData[1], objData[2]]);
-
-                const origPutObject = metadataBackend.putObject;
-                metadataBackend.putObject =
-                    (putBucketName, objName, objVal, params, log, cb) => {
-                        assert.strictEqual(params.oldReplayId, testUploadId);
-                        metadataBackend.putObject = origPutObject;
-                        origPutObject(
-                            putBucketName, objName, objVal, params, log, cb);
-                    };
-                // overwrite null version with a non-MPU object
-                objectPut(authInfo, testPutObjectRequests[1],
-                          undefined, log, err => next(err));
-            },
-        ], err => {
-            assert.ifError(err, `Unexpected err: ${err}`);
-            done();
-        });
-    });
-
-    it('should finish deleting metadata on completeMultipartUpload retry',
-    done => {
-        let origDeleteObject;
-        async.waterfall([
-            next => bucketPutVersioning(authInfo,
-                enableVersioningRequest, log, err => next(err)),
-            next =>
-                initiateMultipartUpload(authInfo, initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-            (json, next) => {
-                const partBody = objData[2];
-                const testUploadId =
-                    json.InitiateMultipartUploadResult.UploadId[0];
-                const partRequest = _createPutPartRequest(testUploadId, 1,
-                    partBody);
-                objectPutPart(authInfo, partRequest, undefined, log,
-                    (err, eTag) => next(err, eTag, testUploadId));
-            },
-            (eTag, testUploadId, next) => {
-                origDeleteObject = metadataBackend.deleteObject;
-                metadataBackend.deleteObject = (
-                    bucketName, objName, params, log, cb) => {
-                        // prevent deletions from MPU bucket only
-                    if (bucketName === mpuBucket) {
-                        return process.nextTick(
-                            () => cb(errors.InternalError));
-                    }
-                    return origDeleteObject(
-                        bucketName, objName, params, log, cb);
-                };
-                const parts = [{ partNumber: 1, eTag }];
-                const completeRequest = _createCompleteMpuRequest(
-                    testUploadId, parts);
-                completeMultipartUpload(authInfo, completeRequest, log, err => {
-                    // expect a failure here because we could not
-                    // remove the overview key
-                    assert.strictEqual(err.is.InternalError, true);
-                    next(null, eTag, testUploadId);
-                });
-            },
-            (eTag, testUploadId, next) => {
-                // allow MPU bucket metadata deletions to happen again
-                metadataBackend.deleteObject = origDeleteObject;
-                // retry the completeMultipartUpload with the same
-                // metadata, as an application would normally do after
-                // a failure
-                const parts = [{ partNumber: 1, eTag }];
-                const completeRequest = _createCompleteMpuRequest(
-                    testUploadId, parts);
-                completeMultipartUpload(authInfo, completeRequest, log, next);
-            },
-        ], err => {
-            assert.ifError(err);
-            let nbVersions = 0;
-            for (const key of metadata.keyMaps.get(bucketName).keys()) {
-                if (key !== objectKey && key.startsWith(objectKey)) {
-                    nbVersions += 1;
-                }
-            }
-            // There should be only one version of the object, since
-            // the second call should not have created a new version
-            assert.strictEqual(nbVersions, 1);
-            for (const key of metadata.keyMaps.get(mpuBucket).keys()) {
-                assert.fail('There should be no more keys in MPU bucket, ' +
-                            `found "${key}"`);
-            }
-            done();
-        });
-    });
-
-    it('should complete an MPU and promote its MD if it has been created by a failed complete before' +
-        'without creating a new version', done => {
-        const delMeta = metadataBackend.deleteObject;
-        metadataBackend.deleteObject = (bucketName, objName, params, log, cb) => cb(errors.InternalError);
-        const partBody = Buffer.from('I am a part\n', 'utf8');
-        initiateRequest.headers['x-amz-meta-stuff'] =
-            'I am some user metadata';
-        async.waterfall([
-            next => bucketPutVersioning(authInfo,
-                enableVersioningRequest, log, err => next(err)),
-            next => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, json) => {
-            assert.ifError(err);
-            const testUploadId =
-                json.InitiateMultipartUploadResult.UploadId[0];
-            const partHash = crypto.createHash('md5').update(partBody).digest('hex');
-            const partRequest = new DummyRequest({
-                bucketName,
-                namespace,
-                objectKey,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
+                            origPutObject(putBucketName, objName, objVal, params, log, cb);
+                        };
+                        // overwrite null version with a non-MPU object
+                        objectPut(authInfo, testPutObjectRequests[1], undefined, log, err => next(err));
+                    },
+                ],
+                err => {
+                    assert.ifError(err, `Unexpected err: ${err}`);
+                    done();
                 },
-                partHash,
-            }, partBody);
-            objectPutPart(authInfo, partRequest, undefined, log, () => {
-                const completeBody = '<CompleteMultipartUpload>' +
-                    '<Part>' +
-                    '<PartNumber>1</PartNumber>' +
-                    `<ETag>"${partHash}"</ETag>` +
-                    '</Part>' +
-                    '</CompleteMultipartUpload>';
-                const completeRequest = {
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    parsedHost: 's3.amazonaws.com',
-                    url: `/${objectKey}?uploadId=${testUploadId}`,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    query: { uploadId: testUploadId },
-                    post: completeBody,
-                    actionImplicitDenies: false,
-                };
-                completeMultipartUpload(authInfo,
-                    completeRequest, log, err => {
-                        assert(err.is.InternalError);
-                        const MD = metadata.keyMaps.get(bucketName)
-                                                    .get(objectKey);
-                        assert(MD);
-                        const firstVersionId = MD.versionId;
-                        assert.strictEqual(MD['x-amz-meta-stuff'],
-                            'I am some user metadata');
-                        assert.strictEqual(MD.uploadId, testUploadId);
-                        metadataBackend.deleteObject = delMeta;
-                        assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 2);
-                        completeMultipartUpload(authInfo,
-                            completeRequest, log, err => {
+            );
+        },
+    );
+
+    it(
+        'should delete null version when creating new null version, ' + 'when null version is not the latest version',
+        done => {
+            async.waterfall(
+                [
+                    // putting null version: put obj before versioning configured
+                    next => objectPut(authInfo, testPutObjectRequests[0], undefined, log, err => next(err)),
+                    next => bucketPutVersioning(authInfo, enableVersioningRequest, log, err => next(err)),
+                    // put another version:
+                    next => objectPut(authInfo, testPutObjectRequests[1], undefined, log, err => next(err)),
+                    next => bucketPutVersioning(authInfo, suspendVersioningRequest, log, err => next(err)),
+                    next => {
+                        versioningTestUtils.assertDataStoreValues(ds, objData.slice(0, 2));
+                        initiateMultipartUpload(authInfo, initiateRequest, log, next);
+                    },
+                    (result, corsHeaders, next) => parseString(result, next),
+                    (json, next) => {
+                        const partBody = objData[2];
+                        const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                        const partRequest = _createPutPartRequest(testUploadId, 1, partBody);
+                        objectPutPart(authInfo, partRequest, undefined, log, (err, eTag) =>
+                            next(err, eTag, testUploadId),
+                        );
+                    },
+                    (eTag, testUploadId, next) => {
+                        const origPutObject = metadataBackend.putObject;
+                        let callCount = 0;
+                        metadataBackend.putObject = (putBucketName, objName, objVal, params, log, cb) => {
+                            if (callCount === 0) {
+                                // first putObject sets the completeInProgress flag in the overview key
+                                assert.strictEqual(putBucketName, `${constants.mpuBucketPrefix}${bucketName}`);
+                                assert.strictEqual(
+                                    objName,
+                                    `overview${splitter}${objectKey}${splitter}${testUploadId}`,
+                                );
+                                assert.strictEqual(objVal.completeInProgress, true);
+                            } else {
+                                assert.strictEqual(params.replayId, testUploadId);
+                                metadataBackend.putObject = origPutObject;
+                            }
+                            origPutObject(putBucketName, objName, objVal, params, log, cb);
+                            callCount += 1;
+                        };
+                        const parts = [{ partNumber: 1, eTag }];
+                        const completeRequest = _createCompleteMpuRequest(testUploadId, parts);
+                        completeMultipartUpload(authInfo, completeRequest, log, err => next(err, testUploadId));
+                    },
+                    (testUploadId, next) => {
+                        versioningTestUtils.assertDataStoreValues(ds, [undefined, objData[1], objData[2]]);
+
+                        const origPutObject = metadataBackend.putObject;
+                        metadataBackend.putObject = (putBucketName, objName, objVal, params, log, cb) => {
+                            assert.strictEqual(params.oldReplayId, testUploadId);
+                            metadataBackend.putObject = origPutObject;
+                            origPutObject(putBucketName, objName, objVal, params, log, cb);
+                        };
+                        // overwrite null version with a non-MPU object
+                        objectPut(authInfo, testPutObjectRequests[1], undefined, log, err => next(err));
+                    },
+                ],
+                err => {
+                    assert.ifError(err, `Unexpected err: ${err}`);
+                    done();
+                },
+            );
+        },
+    );
+
+    it('should finish deleting metadata on completeMultipartUpload retry', done => {
+        let origDeleteObject;
+        async.waterfall(
+            [
+                next => bucketPutVersioning(authInfo, enableVersioningRequest, log, err => next(err)),
+                next => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+                (json, next) => {
+                    const partBody = objData[2];
+                    const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                    const partRequest = _createPutPartRequest(testUploadId, 1, partBody);
+                    objectPutPart(authInfo, partRequest, undefined, log, (err, eTag) => next(err, eTag, testUploadId));
+                },
+                (eTag, testUploadId, next) => {
+                    origDeleteObject = metadataBackend.deleteObject;
+                    metadataBackend.deleteObject = (bucketName, objName, params, log, cb) => {
+                        // prevent deletions from MPU bucket only
+                        if (bucketName === mpuBucket) {
+                            return process.nextTick(() => cb(errors.InternalError));
+                        }
+                        return origDeleteObject(bucketName, objName, params, log, cb);
+                    };
+                    const parts = [{ partNumber: 1, eTag }];
+                    const completeRequest = _createCompleteMpuRequest(testUploadId, parts);
+                    completeMultipartUpload(authInfo, completeRequest, log, err => {
+                        // expect a failure here because we could not
+                        // remove the overview key
+                        assert.strictEqual(err.is.InternalError, true);
+                        next(null, eTag, testUploadId);
+                    });
+                },
+                (eTag, testUploadId, next) => {
+                    // allow MPU bucket metadata deletions to happen again
+                    metadataBackend.deleteObject = origDeleteObject;
+                    // retry the completeMultipartUpload with the same
+                    // metadata, as an application would normally do after
+                    // a failure
+                    const parts = [{ partNumber: 1, eTag }];
+                    const completeRequest = _createCompleteMpuRequest(testUploadId, parts);
+                    completeMultipartUpload(authInfo, completeRequest, log, next);
+                },
+            ],
+            err => {
+                assert.ifError(err);
+                let nbVersions = 0;
+                for (const key of metadata.keyMaps.get(bucketName).keys()) {
+                    if (key !== objectKey && key.startsWith(objectKey)) {
+                        nbVersions += 1;
+                    }
+                }
+                // There should be only one version of the object, since
+                // the second call should not have created a new version
+                assert.strictEqual(nbVersions, 1);
+                for (const key of metadata.keyMaps.get(mpuBucket).keys()) {
+                    assert.fail('There should be no more keys in MPU bucket, ' + `found "${key}"`);
+                }
+                done();
+            },
+        );
+    });
+
+    it(
+        'should complete an MPU and promote its MD if it has been created by a failed complete before' +
+            'without creating a new version',
+        done => {
+            const delMeta = metadataBackend.deleteObject;
+            metadataBackend.deleteObject = (bucketName, objName, params, log, cb) => cb(errors.InternalError);
+            const partBody = Buffer.from('I am a part\n', 'utf8');
+            initiateRequest.headers['x-amz-meta-stuff'] = 'I am some user metadata';
+            async.waterfall(
+                [
+                    next => bucketPutVersioning(authInfo, enableVersioningRequest, log, err => next(err)),
+                    next => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                    (result, corsHeaders, next) => parseString(result, next),
+                ],
+                (err, json) => {
+                    assert.ifError(err);
+                    const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                    const partHash = crypto.createHash('md5').update(partBody).digest('hex');
+                    const partRequest = new DummyRequest(
+                        {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                            query: {
+                                partNumber: '1',
+                                uploadId: testUploadId,
+                            },
+                            partHash,
+                        },
+                        partBody,
+                    );
+                    objectPutPart(authInfo, partRequest, undefined, log, () => {
+                        const completeBody =
+                            '<CompleteMultipartUpload>' +
+                            '<Part>' +
+                            '<PartNumber>1</PartNumber>' +
+                            `<ETag>"${partHash}"</ETag>` +
+                            '</Part>' +
+                            '</CompleteMultipartUpload>';
+                        const completeRequest = {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            parsedHost: 's3.amazonaws.com',
+                            url: `/${objectKey}?uploadId=${testUploadId}`,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            query: { uploadId: testUploadId },
+                            post: completeBody,
+                            actionImplicitDenies: false,
+                        };
+                        completeMultipartUpload(authInfo, completeRequest, log, err => {
+                            assert(err.is.InternalError);
+                            const MD = metadata.keyMaps.get(bucketName).get(objectKey);
+                            assert(MD);
+                            const firstVersionId = MD.versionId;
+                            assert.strictEqual(MD['x-amz-meta-stuff'], 'I am some user metadata');
+                            assert.strictEqual(MD.uploadId, testUploadId);
+                            metadataBackend.deleteObject = delMeta;
+                            assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 2);
+                            completeMultipartUpload(authInfo, completeRequest, log, err => {
                                 assert.ifError(err);
-                                const MD = metadata.keyMaps.get(bucketName)
-                                                    .get(objectKey);
+                                const MD = metadata.keyMaps.get(bucketName).get(objectKey);
                                 assert(MD);
                                 assert.strictEqual(MD.versionId, firstVersionId);
-                                assert.strictEqual(MD['x-amz-meta-stuff'],
-                                    'I am some user metadata');
+                                assert.strictEqual(MD['x-amz-meta-stuff'], 'I am some user metadata');
                                 assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 0);
                                 done();
                             });
+                        });
                     });
-            });
-        });
-    });
+                },
+            );
+        },
+    );
 });
 
 describe('multipart upload with object lock', () => {
@@ -2691,82 +2758,74 @@ describe('multipart upload with object lock', () => {
 
     after(cleanup);
 
-    it('mpu object should contain retention info when mpu initiated with ' +
-    'object retention', done => {
+    it('mpu object should contain retention info when mpu initiated with ' + 'object retention', done => {
         let versionId;
-        async.waterfall([
-            next => initiateMultipartUpload(authInfo, retentionInitiateRequest,
-                log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-            (json, next) => {
-                const partBody = Buffer.from('foobar', 'utf8');
-                const testUploadId =
-                    json.InitiateMultipartUploadResult.UploadId[0];
-                const partRequest = _createPutPartRequest(testUploadId, 1,
-                    partBody);
-                partRequest.bucketName = lockedBucket;
-                partRequest.headers = { host: `${lockedBucket}.s3.amazonaws.com` };
-                objectPutPart(authInfo, partRequest, undefined, log,
-                    (err, eTag) => next(err, eTag, testUploadId));
+        async.waterfall(
+            [
+                next => initiateMultipartUpload(authInfo, retentionInitiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+                (json, next) => {
+                    const partBody = Buffer.from('foobar', 'utf8');
+                    const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                    const partRequest = _createPutPartRequest(testUploadId, 1, partBody);
+                    partRequest.bucketName = lockedBucket;
+                    partRequest.headers = { host: `${lockedBucket}.s3.amazonaws.com` };
+                    objectPutPart(authInfo, partRequest, undefined, log, (err, eTag) => next(err, eTag, testUploadId));
+                },
+                (eTag, testUploadId, next) => {
+                    const parts = [{ partNumber: 1, eTag }];
+                    const completeRequest = _createCompleteMpuRequest(testUploadId, parts);
+                    completeRequest.bucketName = lockedBucket;
+                    completeRequest.headers = { host: `${lockedBucket}.s3.amazonaws.com` };
+                    completeMultipartUpload(authInfo, completeRequest, log, next);
+                },
+                (xml, headers, next) => {
+                    versionId = headers['x-amz-version-id'];
+                    getObjectRetention(authInfo, getObjectLockInfoRequest, log, next);
+                },
+                (result, corsHeaders, next) => parseString(result, next),
+            ],
+            (err, json) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(json.Retention, expectedRetentionConfig);
+                changeObjectLock([{ bucket: lockedBucket, key: objectKey, versionId }], '', done);
             },
-            (eTag, testUploadId, next) => {
-                const parts = [{ partNumber: 1, eTag }];
-                const completeRequest = _createCompleteMpuRequest(testUploadId,
-                    parts);
-                completeRequest.bucketName = lockedBucket;
-                completeRequest.headers = { host: `${lockedBucket}.s3.amazonaws.com` };
-                completeMultipartUpload(authInfo, completeRequest, log, next);
-            },
-            (xml, headers, next) => {
-                versionId = headers['x-amz-version-id'];
-                getObjectRetention(authInfo, getObjectLockInfoRequest, log, next);
-            },
-            (result, corsHeaders, next) => parseString(result, next),
-        ], (err, json) => {
-            assert.ifError(err);
-            assert.deepStrictEqual(json.Retention, expectedRetentionConfig);
-            changeObjectLock(
-                [{ bucket: lockedBucket, key: objectKey, versionId }], '', done);
-        });
+        );
     });
 
-    it('mpu object should contain legal hold info when mpu initiated with ' +
-    'legal hold', done => {
+    it('mpu object should contain legal hold info when mpu initiated with ' + 'legal hold', done => {
         let versionId;
-        async.waterfall([
-            next => initiateMultipartUpload(authInfo, legalHoldInitiateRequest,
-                log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-            (json, next) => {
-                const partBody = Buffer.from('foobar', 'utf8');
-                const testUploadId =
-                    json.InitiateMultipartUploadResult.UploadId[0];
-                const partRequest = _createPutPartRequest(testUploadId, 1,
-                    partBody);
-                partRequest.bucketName = lockedBucket;
-                partRequest.headers = { host: `${lockedBucket}.s3.amazonaws.com` };
-                objectPutPart(authInfo, partRequest, undefined, log,
-                    (err, eTag) => next(err, eTag, testUploadId));
+        async.waterfall(
+            [
+                next => initiateMultipartUpload(authInfo, legalHoldInitiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+                (json, next) => {
+                    const partBody = Buffer.from('foobar', 'utf8');
+                    const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                    const partRequest = _createPutPartRequest(testUploadId, 1, partBody);
+                    partRequest.bucketName = lockedBucket;
+                    partRequest.headers = { host: `${lockedBucket}.s3.amazonaws.com` };
+                    objectPutPart(authInfo, partRequest, undefined, log, (err, eTag) => next(err, eTag, testUploadId));
+                },
+                (eTag, testUploadId, next) => {
+                    const parts = [{ partNumber: 1, eTag }];
+                    const completeRequest = _createCompleteMpuRequest(testUploadId, parts);
+                    completeRequest.bucketName = lockedBucket;
+                    completeRequest.headers = { host: `${lockedBucket}.s3.amazonaws.com` };
+                    completeMultipartUpload(authInfo, completeRequest, log, next);
+                },
+                (xml, headers, next) => {
+                    versionId = headers['x-amz-version-id'];
+                    getObjectLegalHold(authInfo, getObjectLockInfoRequest, log, next);
+                },
+                (result, corsHeaders, next) => parseString(result, next),
+            ],
+            (err, json) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(json.LegalHold, expectedLegalHold);
+                changeObjectLock([{ bucket: lockedBucket, key: objectKey, versionId }], '', done);
             },
-            (eTag, testUploadId, next) => {
-                const parts = [{ partNumber: 1, eTag }];
-                const completeRequest = _createCompleteMpuRequest(testUploadId,
-                    parts);
-                completeRequest.bucketName = lockedBucket;
-                completeRequest.headers = { host: `${lockedBucket}.s3.amazonaws.com` };
-                completeMultipartUpload(authInfo, completeRequest, log, next);
-            },
-            (xml, headers, next) => {
-                versionId = headers['x-amz-version-id'];
-                getObjectLegalHold(authInfo, getObjectLockInfoRequest, log, next);
-            },
-            (result, corsHeaders, next) => parseString(result, next),
-        ], (err, json) => {
-            assert.ifError(err);
-            assert.deepStrictEqual(json.LegalHold, expectedLegalHold);
-            changeObjectLock(
-                [{ bucket: lockedBucket, key: objectKey, versionId }], '', done);
-        });
+        );
     });
 });
 
@@ -2784,46 +2843,56 @@ describe('multipart upload overheadField', () => {
     });
 
     it('should pass overheadField', done => {
-        async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfo,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => {
-                const mpuKeys = metadata.keyMaps.get(mpuBucket);
-                assert.strictEqual(mpuKeys.size, 1);
-                assert(mpuKeys.keys().next().value
-                    .startsWith(`overview${splitter}${objectKey}`));
-                parseString(result, next);
-            },
-        ],
-        (err, json) => {
-            // Need to build request in here since do not have uploadId
-            // until here
-            assert.ifError(err);
-            const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-            const md5Hash = crypto.createHash('md5');
-            const bufferBody = Buffer.from(postBody);
-            md5Hash.update(bufferBody);
-            const partHash = md5Hash.digest('hex');
-            const partRequest = new DummyRequest({
-                bucketName,
-                objectKey,
-                namespace,
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
+        async.waterfall(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => {
+                    const mpuKeys = metadata.keyMaps.get(mpuBucket);
+                    assert.strictEqual(mpuKeys.size, 1);
+                    assert(mpuKeys.keys().next().value.startsWith(`overview${splitter}${objectKey}`));
+                    parseString(result, next);
                 },
-                partHash,
-            }, postBody);
-            objectPutPart(authInfo, partRequest, undefined, log, err => {
+            ],
+            (err, json) => {
+                // Need to build request in here since do not have uploadId
+                // until here
                 assert.ifError(err);
-                sinon.assert.calledWith(metadataswitch.putObjectMD.lastCall,
-                    any, any, any, sinon.match({ overheadField: sinon.match.array }), any, any);
-                done();
-            });
-        });
+                const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                const md5Hash = crypto.createHash('md5');
+                const bufferBody = Buffer.from(postBody);
+                md5Hash.update(bufferBody);
+                const partHash = md5Hash.digest('hex');
+                const partRequest = new DummyRequest(
+                    {
+                        bucketName,
+                        objectKey,
+                        namespace,
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        query: {
+                            partNumber: '1',
+                            uploadId: testUploadId,
+                        },
+                        partHash,
+                    },
+                    postBody,
+                );
+                objectPutPart(authInfo, partRequest, undefined, log, err => {
+                    assert.ifError(err);
+                    sinon.assert.calledWith(
+                        metadataswitch.putObjectMD.lastCall,
+                        any,
+                        any,
+                        any,
+                        sinon.match({ overheadField: sinon.match.array }),
+                        any,
+                        any,
+                    );
+                    done();
+                });
+            },
+        );
     });
 });
 
@@ -2850,12 +2919,13 @@ describe('complete mpu with bucket policy', () => {
     const partBody = Buffer.from('I am a part\n', 'utf8');
     const md5Hash = crypto.createHash('md5').update(partBody);
     const partHash = md5Hash.digest('hex');
-    const completeBody = '<CompleteMultipartUpload>' +
-    '<Part>' +
-    '<PartNumber>1</PartNumber>' +
-    `<ETag>"${partHash}"</ETag>` +
-    '</Part>' +
-    '</CompleteMultipartUpload>';
+    const completeBody =
+        '<CompleteMultipartUpload>' +
+        '<Part>' +
+        '<PartNumber>1</PartNumber>' +
+        `<ETag>"${partHash}"</ETag>` +
+        '</Part>' +
+        '</CompleteMultipartUpload>';
 
     beforeEach(done => {
         cleanup();
@@ -2882,56 +2952,64 @@ describe('complete mpu with bucket policy', () => {
         /** root user doesn't check bucket policy */
         const authNotRoot = makeAuthInfo(canonicalID, 'not-root');
 
-        async.waterfall([
-            next => bucketPutPolicy(authInfo,
-                bucketPutPolicyRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authNotRoot,
-                initiateReqFixed, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-            (json, next) => {
-                const testUploadId =
-                json.InitiateMultipartUploadResult.UploadId[0];
-                const partRequest = new DummyRequest(Object.assign({
-                    socket: {
-                        remoteAddress: '1.1.1.1',
-                    },
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                    query: {
-                        partNumber: '1',
-                        uploadId: testUploadId,
-                    },
-                    partHash,
-                }, requestFix), partBody);
-                objectPutPart(authNotRoot, partRequest,
-                    undefined, log, err => next(err, testUploadId));
+        async.waterfall(
+            [
+                next => bucketPutPolicy(authInfo, bucketPutPolicyRequest, log, next),
+                (corsHeaders, next) => initiateMultipartUpload(authNotRoot, initiateReqFixed, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+                (json, next) => {
+                    const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                    const partRequest = new DummyRequest(
+                        Object.assign(
+                            {
+                                socket: {
+                                    remoteAddress: '1.1.1.1',
+                                },
+                                bucketName,
+                                namespace,
+                                objectKey,
+                                headers: { host: `${bucketName}.s3.amazonaws.com` },
+                                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                                query: {
+                                    partNumber: '1',
+                                    uploadId: testUploadId,
+                                },
+                                partHash,
+                            },
+                            requestFix,
+                        ),
+                        partBody,
+                    );
+                    objectPutPart(authNotRoot, partRequest, undefined, log, err => next(err, testUploadId));
+                },
+                (testUploadId, next) => {
+                    const completeRequest = new DummyRequest(
+                        Object.assign(
+                            {
+                                socket: {
+                                    remoteAddress: '1.1.1.1',
+                                },
+                                bucketName,
+                                namespace,
+                                objectKey,
+                                parsedHost: 's3.amazonaws.com',
+                                url: `/${objectKey}?uploadId=${testUploadId}`,
+                                headers: { host: `${bucketName}.s3.amazonaws.com` },
+                                query: { uploadId: testUploadId },
+                                post: completeBody,
+                                actionImplicitDenies: false,
+                            },
+                            requestFix,
+                        ),
+                    );
+                    completeMultipartUpload(authNotRoot, completeRequest, log, next);
+                },
+            ],
+            err => {
+                assert.ifError(err);
+                done();
             },
-            (testUploadId, next) => {
-                const completeRequest = new DummyRequest(Object.assign({
-                    socket: {
-                        remoteAddress: '1.1.1.1',
-                    },
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    parsedHost: 's3.amazonaws.com',
-                    url: `/${objectKey}?uploadId=${testUploadId}`,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    query: { uploadId: testUploadId },
-                    post: completeBody,
-                    actionImplicitDenies: false,
-                }, requestFix));
-                completeMultipartUpload(authNotRoot, completeRequest,
-                    log, next);
-            },
-        ],
-        err => {
-            assert.ifError(err);
-            done();
-        });
+        );
     });
 
     it('should set bucketOwnerId if requester is not destination bucket owner', done => {
@@ -2947,66 +3025,76 @@ describe('complete mpu with bucket policy', () => {
                 },
             ],
         });
-        async.waterfall([
-            next => bucketPutPolicy(authInfo, bucketPutPolicyRequest, log, next),
-            (corsHeaders, next) => initiateMultipartUpload(authInfoOtherAcc,
-                initiateRequest, log, next),
-            (result, corsHeaders, next) => parseString(result, next),
-        ],
-        (err, json) => {
-            // Need to build request in here since do not have uploadId
-            // until here
-            assert.ifError(err);
-            const testUploadId =
-                json.InitiateMultipartUploadResult.UploadId[0];
-            const partHash = crypto.createHash('md5').update(partBody).digest('hex');
-            const partRequest = new DummyRequest(Object.assign({
-                bucketName,
-                namespace,
-                objectKey,
-                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                query: {
-                    partNumber: '1',
-                    uploadId: testUploadId,
-                },
-                // Note that the body of the post set in the request here does
-                // not really matter in this test.
-                // The put is not going through the route so the md5 is being
-                // calculated above and manually being set in the request below.
-                // What is being tested is that the partHash being sent
-                // to the API for the part is stored and then used to
-                // calculate the final ETag upon completion
-                // of the multipart upload.
-                partHash,
-                socket: {
-                    remoteAddress: '1.1.1.1',
-                },
-            }, requestFix), partBody);
-            objectPutPart(authInfoOtherAcc, partRequest, undefined, log, err => {
+        async.waterfall(
+            [
+                next => bucketPutPolicy(authInfo, bucketPutPolicyRequest, log, next),
+                (corsHeaders, next) => initiateMultipartUpload(authInfoOtherAcc, initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+            ],
+            (err, json) => {
+                // Need to build request in here since do not have uploadId
+                // until here
                 assert.ifError(err);
-                const completeBody = '<CompleteMultipartUpload>' +
-                    '<Part>' +
-                    '<PartNumber>1</PartNumber>' +
-                    `<ETag>"${partHash}"</ETag>` +
-                    '</Part>' +
-                    '</CompleteMultipartUpload>';
-                const completeRequest = new DummyRequest(Object.assign({
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    parsedHost: 's3.amazonaws.com',
-                    url: `/${objectKey}?uploadId=${testUploadId}`,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    query: { uploadId: testUploadId },
-                    post: completeBody,
-                    actionImplicitDenies: false,
-                    socket: {
-                        remoteAddress: '1.1.1.1',
-                    },
-                }, requestFix));
-                completeMultipartUpload(authInfoOtherAcc,
-                    completeRequest, log, err => {
+                const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                const partHash = crypto.createHash('md5').update(partBody).digest('hex');
+                const partRequest = new DummyRequest(
+                    Object.assign(
+                        {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                            query: {
+                                partNumber: '1',
+                                uploadId: testUploadId,
+                            },
+                            // Note that the body of the post set in the request here does
+                            // not really matter in this test.
+                            // The put is not going through the route so the md5 is being
+                            // calculated above and manually being set in the request below.
+                            // What is being tested is that the partHash being sent
+                            // to the API for the part is stored and then used to
+                            // calculate the final ETag upon completion
+                            // of the multipart upload.
+                            partHash,
+                            socket: {
+                                remoteAddress: '1.1.1.1',
+                            },
+                        },
+                        requestFix,
+                    ),
+                    partBody,
+                );
+                objectPutPart(authInfoOtherAcc, partRequest, undefined, log, err => {
+                    assert.ifError(err);
+                    const completeBody =
+                        '<CompleteMultipartUpload>' +
+                        '<Part>' +
+                        '<PartNumber>1</PartNumber>' +
+                        `<ETag>"${partHash}"</ETag>` +
+                        '</Part>' +
+                        '</CompleteMultipartUpload>';
+                    const completeRequest = new DummyRequest(
+                        Object.assign(
+                            {
+                                bucketName,
+                                namespace,
+                                objectKey,
+                                parsedHost: 's3.amazonaws.com',
+                                url: `/${objectKey}?uploadId=${testUploadId}`,
+                                headers: { host: `${bucketName}.s3.amazonaws.com` },
+                                query: { uploadId: testUploadId },
+                                post: completeBody,
+                                actionImplicitDenies: false,
+                                socket: {
+                                    remoteAddress: '1.1.1.1',
+                                },
+                            },
+                            requestFix,
+                        ),
+                    );
+                    completeMultipartUpload(authInfoOtherAcc, completeRequest, log, err => {
                         assert.ifError(err);
                         sinon.assert.calledWith(
                             metadataswitch.putObjectMD.lastCall,
@@ -3015,12 +3103,13 @@ describe('complete mpu with bucket policy', () => {
                             sinon.match({ bucketOwnerId: authInfo.canonicalId }),
                             sinon.match.any,
                             sinon.match.any,
-                            sinon.match.any
+                            sinon.match.any,
                         );
                         done();
                     });
-            });
-        });
+                });
+            },
+        );
     });
 });
 
@@ -3035,10 +3124,16 @@ describe('multipart upload in ingestion bucket', () => {
         versionID = versioning.VersionID.encode(versioning.VersionID.generateVersionId('0', ''));
 
         // Setup multi-backend, this is required for ingestion
-        data.switch(new storage.data.MultipleBackendGateway({
-            'us-east-1': dataClient,
-            'us-east-2': dataClient,
-        }, metadata, data.locStorageCheckFn));
+        data.switch(
+            new storage.data.MultipleBackendGateway(
+                {
+                    'us-east-1': dataClient,
+                    'us-east-2': dataClient,
+                },
+                metadata,
+                data.locStorageCheckFn,
+            ),
+        );
         data.implName = 'multipleBackends';
 
         // "mock" the data location, simulating a backend supporting MPU
@@ -3076,17 +3171,19 @@ describe('multipart upload in ingestion bucket', () => {
         sinon.restore();
     });
 
-    const newPutIngestBucketRequest = location => new DummyRequest({
-        bucketName,
-        namespace,
-        headers: { host: `${bucketName}.s3.amazonaws.com` },
-        url: '/',
-        post: '<?xml version="1.0" encoding="UTF-8"?>' +
-            '<CreateBucketConfiguration ' +
-            'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
-            `<LocationConstraint>${location}</LocationConstraint>` +
-            '</CreateBucketConfiguration>',
-    });
+    const newPutIngestBucketRequest = location =>
+        new DummyRequest({
+            bucketName,
+            namespace,
+            headers: { host: `${bucketName}.s3.amazonaws.com` },
+            url: '/',
+            post:
+                '<?xml version="1.0" encoding="UTF-8"?>' +
+                '<CreateBucketConfiguration ' +
+                'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+                `<LocationConstraint>${location}</LocationConstraint>` +
+                '</CreateBucketConfiguration>',
+        });
     const archiveRestoreRequested = {
         archiveInfo: { foo: 0, bar: 'stuff' }, // opaque, can be anything...
         restoreRequestedAt: new Date().toString(),
@@ -3184,14 +3281,15 @@ describe('initiateMultipartUpload with objectKeyByteLimit', () => {
         config.objectKeyByteLimit = originalObjectKeyByteLimit;
     });
 
-    const createTestInitiateRequest = longKey => new DummyRequest({
-        bucketName,
-        namespace,
-        objectKey: longKey,
-        headers: {},
-        url: `/${bucketName}/${longKey}?uploads`,
-        query: { uploads: '' },
-    });
+    const createTestInitiateRequest = longKey =>
+        new DummyRequest({
+            bucketName,
+            namespace,
+            objectKey: longKey,
+            headers: {},
+            url: `/${bucketName}/${longKey}?uploads`,
+            query: { uploads: '' },
+        });
 
     it('should reject object key longer than 915 bytes by default', done => {
         const longKey = 'a'.repeat(916);
@@ -3264,18 +3362,21 @@ describe('objectPutPart checksum response headers', () => {
 
     it('should return x-amz-checksum-sha256 response header when x-amz-checksum-sha256 is provided', done => {
         const sha256Value = crypto.createHash('sha256').update(postBody).digest('base64');
-        const partRequest = new DummyRequest({
-            bucketName,
-            namespace,
-            objectKey,
-            headers: {
-                host: `${bucketName}.s3.amazonaws.com`,
-                'x-amz-checksum-sha256': sha256Value,
+        const partRequest = new DummyRequest(
+            {
+                bucketName,
+                namespace,
+                objectKey,
+                headers: {
+                    host: `${bucketName}.s3.amazonaws.com`,
+                    'x-amz-checksum-sha256': sha256Value,
+                },
+                url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                query: { partNumber: '1', uploadId: testUploadId },
+                actionImplicitDenies: false,
             },
-            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-            query: { partNumber: '1', uploadId: testUploadId },
-            actionImplicitDenies: false,
-        }, postBody);
+            postBody,
+        );
 
         objectPutPart(authInfo, partRequest, undefined, log, (err, _hexDigest, resHeaders) => {
             assert.ifError(err);
@@ -3405,28 +3506,34 @@ describe('initiateMultipartUpload checksum headers', () => {
 
         validCombos.forEach(([algo, type]) => {
             it(`should accept ${algo} + ${type}`, done => {
-                initiateMPU({
-                    'x-amz-checksum-algorithm': algo,
-                    'x-amz-checksum-type': type,
-                }, (err, _xml, headers) => {
-                    assert.ifError(err);
-                    assert.strictEqual(headers['x-amz-checksum-algorithm'], algo);
-                    assert.strictEqual(headers['x-amz-checksum-type'], type);
-                    done();
-                });
+                initiateMPU(
+                    {
+                        'x-amz-checksum-algorithm': algo,
+                        'x-amz-checksum-type': type,
+                    },
+                    (err, _xml, headers) => {
+                        assert.ifError(err);
+                        assert.strictEqual(headers['x-amz-checksum-algorithm'], algo);
+                        assert.strictEqual(headers['x-amz-checksum-type'], type);
+                        done();
+                    },
+                );
             });
         });
 
         it('should store checksumIsDefault as false in MPU metadata', done => {
-            initiateMPU({
-                'x-amz-checksum-algorithm': 'CRC32',
-                'x-amz-checksum-type': 'COMPOSITE',
-            }, err => {
-                assert.ifError(err);
-                const md = getMPUOverviewMD();
-                assert.strictEqual(md.checksumIsDefault, false);
-                done();
-            });
+            initiateMPU(
+                {
+                    'x-amz-checksum-algorithm': 'CRC32',
+                    'x-amz-checksum-type': 'COMPOSITE',
+                },
+                err => {
+                    assert.ifError(err);
+                    const md = getMPUOverviewMD();
+                    assert.strictEqual(md.checksumIsDefault, false);
+                    done();
+                },
+            );
         });
     });
 
@@ -3439,13 +3546,16 @@ describe('initiateMultipartUpload checksum headers', () => {
         });
 
         it('should reject unknown type', done => {
-            initiateMPU({
-                'x-amz-checksum-algorithm': 'CRC32',
-                'x-amz-checksum-type': 'BADTYPE',
-            }, err => {
-                assert.strictEqual(err.message, 'InvalidRequest');
-                done();
-            });
+            initiateMPU(
+                {
+                    'x-amz-checksum-algorithm': 'CRC32',
+                    'x-amz-checksum-type': 'BADTYPE',
+                },
+                err => {
+                    assert.strictEqual(err.message, 'InvalidRequest');
+                    done();
+                },
+            );
         });
 
         it('should reject type without algorithm', done => {
@@ -3456,34 +3566,43 @@ describe('initiateMultipartUpload checksum headers', () => {
         });
 
         it('should reject FULL_OBJECT with SHA256', done => {
-            initiateMPU({
-                'x-amz-checksum-algorithm': 'SHA256',
-                'x-amz-checksum-type': 'FULL_OBJECT',
-            }, err => {
-                assert.strictEqual(err.message, 'InvalidRequest');
-                done();
-            });
+            initiateMPU(
+                {
+                    'x-amz-checksum-algorithm': 'SHA256',
+                    'x-amz-checksum-type': 'FULL_OBJECT',
+                },
+                err => {
+                    assert.strictEqual(err.message, 'InvalidRequest');
+                    done();
+                },
+            );
         });
 
         it('should reject COMPOSITE with CRC64NVME', done => {
-            initiateMPU({
-                'x-amz-checksum-algorithm': 'CRC64NVME',
-                'x-amz-checksum-type': 'COMPOSITE',
-            }, err => {
-                assert.strictEqual(err.message, 'InvalidRequest');
-                done();
-            });
+            initiateMPU(
+                {
+                    'x-amz-checksum-algorithm': 'CRC64NVME',
+                    'x-amz-checksum-type': 'COMPOSITE',
+                },
+                err => {
+                    assert.strictEqual(err.message, 'InvalidRequest');
+                    done();
+                },
+            );
         });
 
         it('should return algorithm error before type error when both are invalid', done => {
-            initiateMPU({
-                'x-amz-checksum-algorithm': 'INVALID',
-                'x-amz-checksum-type': 'BADTYPE',
-            }, err => {
-                assert.strictEqual(err.message, 'InvalidRequest');
-                assert.match(err.description, /algorithm/);
-                done();
-            });
+            initiateMPU(
+                {
+                    'x-amz-checksum-algorithm': 'INVALID',
+                    'x-amz-checksum-type': 'BADTYPE',
+                },
+                err => {
+                    assert.strictEqual(err.message, 'InvalidRequest');
+                    assert.match(err.description, /algorithm/);
+                    done();
+                },
+            );
         });
     });
 });

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -27,6 +27,7 @@ const multipartDelete = require('../../../lib/api/multipartDelete');
 const objectPutPart = require('../../../lib/api/objectPutPart');
 const services = require('../../../lib/services');
 const DummyRequest = require('../DummyRequest');
+const mpuUtils = require('../utils/mpuUtils');
 const changeObjectLock = require('../../utilities/objectLock-util');
 const metadataswitch = require('../metadataswitch');
 const { fakeMetadataArchive } = require('../../functional/aws-node-sdk/test/utils/init');
@@ -1327,9 +1328,9 @@ describe('Multipart Upload API', () => {
                             actionImplicitDenies: false,
                         };
                         completeMultipartUpload(authInfo, completeRequest, log, (err, result) => {
-                            assert.strictEqual(err, null);
+                            assert.ifError(err);
                             parseString(result, err => {
-                                assert.strictEqual(err, null);
+                                assert.ifError(err);
                                 const MD = metadata.keyMaps.get(bucketName).get(objectKey);
                                 assert(MD);
                                 assert.strictEqual(MD['content-length'], 6000100);
@@ -1431,9 +1432,9 @@ describe('Multipart Upload API', () => {
                             actionImplicitDenies: false,
                         };
                         completeMultipartUpload(authInfo, completeRequest, log, (err, result) => {
-                            assert.strictEqual(err, null);
+                            assert.ifError(err);
                             parseString(result, err => {
-                                assert.strictEqual(err, null);
+                                assert.ifError(err);
                                 const MD = metadata.keyMaps.get(bucketName).get(objectKey);
                                 assert(MD);
                                 assert.strictEqual(MD.acl.Canned, 'authenticated-read');
@@ -1538,9 +1539,9 @@ describe('Multipart Upload API', () => {
                             actionImplicitDenies: false,
                         };
                         completeMultipartUpload(authInfo, completeRequest, log, (err, result) => {
-                            assert.strictEqual(err, null);
+                            assert.ifError(err);
                             parseString(result, err => {
-                                assert.strictEqual(err, null);
+                                assert.ifError(err);
                                 const MD = metadata.keyMaps.get(bucketName).get(objectKey);
                                 assert(MD);
                                 assert.strictEqual(MD.acl.READ[0], granteeId);
@@ -1593,7 +1594,7 @@ describe('Multipart Upload API', () => {
                     };
                     assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 2);
                     multipartDelete(authInfo, deleteRequest, log, err => {
-                        assert.strictEqual(err, null);
+                        assert.ifError(err);
                         assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 0);
                         done();
                     });
@@ -2037,7 +2038,7 @@ describe('Multipart Upload API', () => {
                             // show that second part data is there
                             assert(ds[2]);
                             completeMultipartUpload(authInfo, completeRequest, log, err => {
-                                assert.strictEqual(err, null);
+                                assert.ifError(err);
                                 process.nextTick(() => {
                                     // data has been deleted
                                     assert.strictEqual(ds[2], undefined);
@@ -2173,7 +2174,7 @@ describe('Multipart Upload API', () => {
                         };
                         assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 2);
                         multipartDelete(authInfo, deleteRequest, log, err => {
-                            assert.strictEqual(err, null);
+                            assert.ifError(err);
                             assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 0);
                             done();
                         });
@@ -3702,7 +3703,7 @@ describe('validatePerPartChecksums', () => {
                         Part: [makeJsonPart(1, 'etag1', { [tag]: d1 }), makeJsonPart(2, 'etag2', { [tag]: d2 })],
                     };
                     const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
-                    assert.strictEqual(err, null);
+                    assert.ifError(err);
                 });
 
                 it('should return BadDigest when a part uses the wrong checksum field', () => {
@@ -3758,7 +3759,7 @@ describe('validatePerPartChecksums', () => {
                         assert(err.description.includes(algorithm));
                         assert(err.description.includes('part 2 in the request'));
                     } else {
-                        assert.strictEqual(err, null);
+                        assert.ifError(err);
                     }
                 });
             });
@@ -3785,7 +3786,7 @@ describe('validatePerPartChecksums', () => {
         it('should accept when no parts include a checksum field', () => {
             const jsonList = { Part: [makeJsonPart(1, 'etag1'), makeJsonPart(2, 'etag2')] };
             const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
-            assert.strictEqual(err, null);
+            assert.ifError(err);
         });
 
         it('should return InvalidPart when a part includes the matching field (correct value)', () => {
@@ -3830,7 +3831,7 @@ describe('validatePerPartChecksums', () => {
         it('should accept when no parts include a checksum field', () => {
             const jsonList = { Part: [makeJsonPart(1, 'etag1'), makeJsonPart(2, 'etag2')] };
             const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
-            assert.strictEqual(err, null);
+            assert.ifError(err);
         });
 
         it('should accept when a part includes a single Checksum<X> field', () => {
@@ -3841,7 +3842,7 @@ describe('validatePerPartChecksums', () => {
                 ],
             };
             const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
-            assert.strictEqual(err, null);
+            assert.ifError(err);
         });
 
         it('should accept when parts include multiple Checksum<X> fields', () => {
@@ -3855,7 +3856,7 @@ describe('validatePerPartChecksums', () => {
                 ],
             };
             const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
-            assert.strictEqual(err, null);
+            assert.ifError(err);
         });
     });
     describe('edge cases', () => {
@@ -3866,7 +3867,7 @@ describe('validatePerPartChecksums', () => {
                 isDefault: false,
             };
             const err = validatePerPartChecksums({ Part: [] }, [], splitter, mpuChecksum);
-            assert.strictEqual(err, null);
+            assert.ifError(err);
         });
 
         it('should accept a parts list with no Part array (treated as empty)', () => {
@@ -3876,7 +3877,7 @@ describe('validatePerPartChecksums', () => {
                 isDefault: true,
             };
             const err = validatePerPartChecksums({}, [], splitter, mpuChecksum);
-            assert.strictEqual(err, null);
+            assert.ifError(err);
         });
 
         it('should accept a FULL_OBJECT mixed list (one part with checksum, one without)', () => {
@@ -3894,7 +3895,7 @@ describe('validatePerPartChecksums', () => {
                 Part: [makeJsonPart(1, 'etag1', { ChecksumCRC32: d1 }), makeJsonPart(2, 'etag2')],
             };
             const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
-            assert.strictEqual(err, null);
+            assert.ifError(err);
         });
 
         it('should not enforce per-part presence when MPU algorithm is unknown', () => {
@@ -3910,7 +3911,7 @@ describe('validatePerPartChecksums', () => {
                 Part: [makeJsonPart(1, 'etag1'), makeJsonPart(2, 'etag2')],
             };
             const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
-            assert.strictEqual(err, null);
+            assert.ifError(err);
         });
 
         it('should return InvalidPart when stored part has no checksum but request does', () => {
@@ -3936,187 +3937,66 @@ describe('validatePerPartChecksums', () => {
 
 describe('CompleteMultipartUpload x-amz-checksum-type header', () => {
     const log = new DummyRequestLogger();
-    const authInfo = makeAuthInfo('accessKey1');
-    const namespace = 'default';
     const bucketName = 'bucketname-checksum-type';
     const objectKey = 'testObject';
-
-    const bucketPutRequest = {
-        bucketName,
-        namespace,
-        headers: { host: `${bucketName}.s3.amazonaws.com` },
-        url: '/',
-        post:
-            '<CreateBucketConfiguration ' +
-            'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
-            '<LocationConstraint>scality-internal-mem</LocationConstraint>' +
-            '</CreateBucketConfiguration >',
-        actionImplicitDenies: false,
+    const explicitMpuHeaders = {
+        'x-amz-checksum-algorithm': 'CRC32',
+        'x-amz-checksum-type': 'FULL_OBJECT',
     };
 
-    function setupMpu(initiateHeaders, cb) {
-        async.waterfall(
-            [
-                next => bucketPut(authInfo, bucketPutRequest, log, next),
-                (corsHeaders, next) => {
-                    const initiateRequest = {
-                        bucketName,
-                        namespace,
-                        objectKey,
-                        headers: {
-                            host: `${bucketName}.s3.amazonaws.com`,
-                            ...initiateHeaders,
-                        },
-                        url: `/${objectKey}?uploads`,
-                        actionImplicitDenies: false,
-                    };
-                    initiateMultipartUpload(authInfo, initiateRequest, log, next);
-                },
-                (xml, corsHeaders, next) => parseString(xml, next),
-                (json, next) => {
-                    const uploadId = json.InitiateMultipartUploadResult.UploadId[0];
-                    const partBody = Buffer.from('I am a part\n', 'utf8');
-                    const partHash = crypto.createHash('md5').update(partBody).digest('hex');
-                    const partRequest = new DummyRequest(
-                        {
-                            bucketName,
-                            namespace,
-                            objectKey,
-                            headers: { host: `${bucketName}.s3.amazonaws.com` },
-                            url: `/${objectKey}?partNumber=1&uploadId=${uploadId}`,
-                            query: { partNumber: '1', uploadId },
-                            partHash,
-                            actionImplicitDenies: false,
-                        },
-                        partBody,
-                    );
-                    objectPutPart(authInfo, partRequest, undefined, log, err => next(err, uploadId, partHash));
-                },
-            ],
-            cb,
-        );
+    async function setupMpu(initiateHeaders) {
+        await mpuUtils.bucketPutP(bucketName, namespace, log);
+        const uploadId = await mpuUtils.initiateMpuP(bucketName, namespace, objectKey, log, initiateHeaders);
+        await mpuUtils.uploadPartP(bucketName, namespace, objectKey, uploadId, log);
+        return uploadId;
     }
 
-    function makeCompleteRequest(uploadId, partHash, extraHeaders) {
-        const completeBody =
-            '<CompleteMultipartUpload>' +
-            '<Part>' +
-            '<PartNumber>1</PartNumber>' +
-            `<ETag>"${partHash}"</ETag>` +
-            '</Part>' +
-            '</CompleteMultipartUpload>';
-        return {
-            bucketName,
-            namespace,
-            objectKey,
-            parsedHost: 's3.amazonaws.com',
-            url: `/${objectKey}?uploadId=${uploadId}`,
-            headers: {
-                host: `${bucketName}.s3.amazonaws.com`,
-                ...extraHeaders,
-            },
-            query: { uploadId },
-            post: completeBody,
-            actionImplicitDenies: false,
-        };
+    function complete(uploadId, extraHeaders) {
+        return mpuUtils.completeMpuP(bucketName, namespace, objectKey, uploadId, log, { extraHeaders });
     }
 
     beforeEach(() => cleanup());
 
-    it('should accept CompleteMPU when no x-amz-checksum-type header is sent', done => {
-        const initiateHeaders = {
-            'x-amz-checksum-algorithm': 'CRC32',
-            'x-amz-checksum-type': 'FULL_OBJECT',
-        };
-        setupMpu(initiateHeaders, (err, uploadId, partHash) => {
-            assert.ifError(err);
-            const req = makeCompleteRequest(uploadId, partHash, {});
-            completeMultipartUpload(authInfo, req, log, completeErr => {
-                assert.ifError(completeErr);
-                done();
-            });
+    it('should accept CompleteMPU when no x-amz-checksum-type header is sent', async () => {
+        const uploadId = await setupMpu(explicitMpuHeaders);
+        await complete(uploadId, {});
+    });
+
+    it('should accept CompleteMPU when x-amz-checksum-type matches the MPU type', async () => {
+        const uploadId = await setupMpu(explicitMpuHeaders);
+        await complete(uploadId, { 'x-amz-checksum-type': 'FULL_OBJECT' });
+    });
+
+    it('should reject CompleteMPU with InvalidRequest when checksum-type does not match the MPU type', async () => {
+        const uploadId = await setupMpu(explicitMpuHeaders);
+        await assert.rejects(complete(uploadId, { 'x-amz-checksum-type': 'COMPOSITE' }), err => {
+            assert.strictEqual(err.is.InvalidRequest, true);
+            // AWS-style mode-mismatch wording.
+            assert.strictEqual(
+                err.description,
+                'The upload was created using the FULL_OBJECT checksum ' +
+                    'mode. The complete request must use the same checksum ' +
+                    'mode.',
+            );
+            return true;
         });
     });
 
-    it('should accept CompleteMPU when x-amz-checksum-type matches the MPU type', done => {
-        const initiateHeaders = {
-            'x-amz-checksum-algorithm': 'CRC32',
-            'x-amz-checksum-type': 'FULL_OBJECT',
-        };
-        setupMpu(initiateHeaders, (err, uploadId, partHash) => {
-            assert.ifError(err);
-            const req = makeCompleteRequest(uploadId, partHash, {
-                'x-amz-checksum-type': 'FULL_OBJECT',
-            });
-            completeMultipartUpload(authInfo, req, log, completeErr => {
-                assert.ifError(completeErr);
-                done();
-            });
+    it('should reject CompleteMPU with InvalidRequest when x-amz-checksum-type value is bogus', async () => {
+        const uploadId = await setupMpu(explicitMpuHeaders);
+        await assert.rejects(complete(uploadId, { 'x-amz-checksum-type': 'BOGUS' }), err => {
+            assert.strictEqual(err.is.InvalidRequest, true);
+            assert.strictEqual(err.description, 'Value for x-amz-checksum-type header is invalid.');
+            return true;
         });
     });
 
-    it('should reject CompleteMPU with InvalidRequest when x-amz-checksum-type does not match the MPU type', done => {
-        const initiateHeaders = {
-            'x-amz-checksum-algorithm': 'CRC32',
-            'x-amz-checksum-type': 'FULL_OBJECT',
-        };
-        setupMpu(initiateHeaders, (err, uploadId, partHash) => {
-            assert.ifError(err);
-            const req = makeCompleteRequest(uploadId, partHash, {
-                'x-amz-checksum-type': 'COMPOSITE',
-            });
-            completeMultipartUpload(authInfo, req, log, completeErr => {
-                assert(completeErr);
-                assert.strictEqual(completeErr.is.InvalidRequest, true);
-                // AWS-style mode-mismatch wording.
-                assert.strictEqual(
-                    completeErr.description,
-                    'The upload was created using the FULL_OBJECT checksum ' +
-                        'mode. The complete request must use the same checksum ' +
-                        'mode.',
-                );
-                done();
-            });
-        });
+    it('should compare x-amz-checksum-type case-insensitively', async () => {
+        const uploadId = await setupMpu(explicitMpuHeaders);
+        await complete(uploadId, { 'x-amz-checksum-type': 'full_object' });
     });
 
-    it('should reject CompleteMPU with InvalidRequest when x-amz-checksum-type value is bogus', done => {
-        const initiateHeaders = {
-            'x-amz-checksum-algorithm': 'CRC32',
-            'x-amz-checksum-type': 'FULL_OBJECT',
-        };
-        setupMpu(initiateHeaders, (err, uploadId, partHash) => {
-            assert.ifError(err);
-            const req = makeCompleteRequest(uploadId, partHash, {
-                'x-amz-checksum-type': 'BOGUS',
-            });
-            completeMultipartUpload(authInfo, req, log, completeErr => {
-                assert(completeErr);
-                assert.strictEqual(completeErr.is.InvalidRequest, true);
-                assert.strictEqual(completeErr.description, 'Value for x-amz-checksum-type header is invalid.');
-                done();
-            });
-        });
-    });
-
-    it('should compare x-amz-checksum-type case-insensitively', done => {
-        const initiateHeaders = {
-            'x-amz-checksum-algorithm': 'CRC32',
-            'x-amz-checksum-type': 'FULL_OBJECT',
-        };
-        setupMpu(initiateHeaders, (err, uploadId, partHash) => {
-            assert.ifError(err);
-            const req = makeCompleteRequest(uploadId, partHash, {
-                'x-amz-checksum-type': 'full_object',
-            });
-            completeMultipartUpload(authInfo, req, log, completeErr => {
-                assert.ifError(completeErr);
-                done();
-            });
-        });
-    });
-
-    it('should reject CompleteMPU with a dedicated message when the MPU has no checksum mode', done => {
+    it('should reject CompleteMPU with a dedicated message when the MPU has no checksum mode', async () => {
         const original = services.metadataValidateMultipart;
         const stub = sinon.stub(services, 'metadataValidateMultipart').callsFake((params, cb) =>
             original.call(services, params, (validateErr, mpuBucket, mpuOverview, storedMetadata) => {
@@ -4127,23 +4007,20 @@ describe('CompleteMultipartUpload x-amz-checksum-type header', () => {
                 cb(validateErr, mpuBucket, mpuOverview, storedMetadata);
             }),
         );
-        setupMpu({}, (err, uploadId, partHash) => {
-            assert.ifError(err);
-            const req = makeCompleteRequest(uploadId, partHash, {
-                'x-amz-checksum-type': 'FULL_OBJECT',
-            });
-            completeMultipartUpload(authInfo, req, log, completeErr => {
-                stub.restore();
-                assert(completeErr);
-                assert.strictEqual(completeErr.is.InvalidRequest, true);
+        try {
+            const uploadId = await setupMpu({});
+            await assert.rejects(complete(uploadId, { 'x-amz-checksum-type': 'FULL_OBJECT' }), err => {
+                assert.strictEqual(err.is.InvalidRequest, true);
                 assert.strictEqual(
-                    completeErr.description,
+                    err.description,
                     'The upload was not created with a checksum mode. ' +
                         'The complete request must not include a x-amz-checksum-type header.',
                 );
-                done();
+                return true;
             });
-        });
+        } finally {
+            stub.restore();
+        }
     });
 });
 
@@ -4168,24 +4045,21 @@ describe('CompleteMultipartUpload body-checksum bypass', () => {
                 headers: { 'x-amz-checksum-sha256': finalObjectChecksum },
             };
             const err = await validateMethodChecksumNoChunking(request, body, log);
-            assert.strictEqual(err, null);
+            assert.ifError(err);
         },
     );
 
-    it(
-        'should still reject body mismatch for methods that remain in checksumedMethods ' + '(sanity check)',
-        async () => {
-            const body = Buffer.from('{"Objects":[]}');
-            const finalObjectChecksum = '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';
-            const request = {
-                apiMethod: 'multiObjectDelete',
-                headers: { 'x-amz-checksum-sha256': finalObjectChecksum },
-            };
-            const err = await validateMethodChecksumNoChunking(request, body, log);
-            assert(err, 'expected an error for body checksum mismatch');
-            assert.strictEqual(err.is.BadDigest, true);
-        },
-    );
+    it('should still reject body mismatch for methods that remain in checksumedMethods (sanity check)', async () => {
+        const body = Buffer.from('{"Objects":[]}');
+        const finalObjectChecksum = '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';
+        const request = {
+            apiMethod: 'multiObjectDelete',
+            headers: { 'x-amz-checksum-sha256': finalObjectChecksum },
+        };
+        const err = await validateMethodChecksumNoChunking(request, body, log);
+        assert(err, 'expected an error for body checksum mismatch');
+        assert.strictEqual(err.is.BadDigest, true);
+    });
 });
 
 describe('computeFinalChecksum', () => {
@@ -4201,13 +4075,23 @@ describe('computeFinalChecksum', () => {
         }));
     }
 
-    it('should return null when MPU has no checksumAlgorithm', async () => {
+    function assertSoftNull(got) {
+        assert.deepStrictEqual(got, { result: null, error: null });
+    }
+
+    function assertInternalError(got) {
+        assert.strictEqual(got.result, null);
+        assert(got.error, 'expected an error on the result');
+        assert.strictEqual(got.error.is.InternalError, true);
+    }
+
+    it('should return { result: null, error: null } when MPU has no checksumAlgorithm', async () => {
         const stored = [makeStoredPart(1, { algorithm: 'sha256', value: SAMPLE_DIGESTS.sha256[0] })];
         const got = await computeFinalChecksum(stored, partListFromStored(stored), {}, splitter, uploadId, log);
-        assert.strictEqual(got, null);
+        assertSoftNull(got);
     });
 
-    it('should return null when MPU has no checksumType', async () => {
+    it('should return { result: null, error: null } when MPU has no checksumType', async () => {
         const stored = [makeStoredPart(1, { algorithm: 'sha256', value: SAMPLE_DIGESTS.sha256[0] })];
         const got = await computeFinalChecksum(
             stored,
@@ -4217,45 +4101,24 @@ describe('computeFinalChecksum', () => {
             uploadId,
             log,
         );
-        assert.strictEqual(got, null);
+        assertSoftNull(got);
     });
 
-    it('should return COMPOSITE checksum with -N suffix for SHA256 MPU', async () => {
-        const [d1, d2, d3] = [SAMPLE_DIGESTS.sha256[0], SAMPLE_DIGESTS.sha256[1], SAMPLE_DIGESTS.sha256[0]];
-        const stored = [
-            makeStoredPart(1, { algorithm: 'sha256', value: d1 }),
-            makeStoredPart(2, { algorithm: 'sha256', value: d2 }),
-            makeStoredPart(3, { algorithm: 'sha256', value: d3 }),
-        ];
-        const got = await computeFinalChecksum(
-            stored,
-            partListFromStored(stored),
-            { checksumAlgorithm: 'sha256', checksumType: 'COMPOSITE' },
-            splitter,
-            uploadId,
-            log,
-        );
-        assert(got);
-        assert.strictEqual(got.algorithm, 'sha256');
-        assert.strictEqual(got.type, 'COMPOSITE');
-        assert(got.value.endsWith('-3'), `expected -N suffix, got ${got.value}`);
-        // computeCompositeMPUChecksum's deterministic output for these
-        // exact placeholder digests:
-        const expected = crypto
-            .createHash('sha256')
-            .update(Buffer.concat([d1, d2, d3].map(x => Buffer.from(x, 'base64'))))
-            .digest('base64');
-        assert.strictEqual(got.value, `${expected}-3`);
-    });
+    const EXPECTED_COMPOSITE = {
+        sha256: 'vEejNiXBXuAzj1ghK13TfXu99Nfc/iyTLrLBIGDNSQY=-2',
+        sha1: 'Iyp/dAvD9//9rlS1OLDWrZF/MDI=-2',
+        crc32: 'P8qIxQ==-2',
+        crc32c: 'Jnj0vQ==-2',
+    };
 
-    ['sha1', 'crc32', 'crc32c'].forEach(algo => {
+    Object.entries(EXPECTED_COMPOSITE).forEach(([algo, expectedValue]) => {
         it(`should compute COMPOSITE checksum for ${algo.toUpperCase()}`, async () => {
             const [d1, d2] = SAMPLE_DIGESTS[algo];
             const stored = [
                 makeStoredPart(1, { algorithm: algo, value: d1 }),
                 makeStoredPart(2, { algorithm: algo, value: d2 }),
             ];
-            const got = await computeFinalChecksum(
+            const { result, error } = await computeFinalChecksum(
                 stored,
                 partListFromStored(stored),
                 { checksumAlgorithm: algo, checksumType: 'COMPOSITE' },
@@ -4263,59 +4126,82 @@ describe('computeFinalChecksum', () => {
                 uploadId,
                 log,
             );
-            assert(got);
-            assert.strictEqual(got.algorithm, algo);
-            assert.strictEqual(got.type, 'COMPOSITE');
-            assert(got.value.endsWith('-2'));
+            assert.ifError(error);
+            assert.deepStrictEqual(result, { algorithm: algo, type: 'COMPOSITE', value: expectedValue });
         });
     });
 
-    it('should return FULL_OBJECT checksum without -N suffix for CRC64NVME', async () => {
-        // Real CRCs over real bytes so we can verify against the equivalent
-        // direct CRC of the concatenation.
-        const a = crypto.randomBytes(1024);
-        const b = crypto.randomBytes(2048);
-        const dA = await algorithms.crc64nvme.digest(a);
-        const dB = await algorithms.crc64nvme.digest(b);
+    const EXPECTED_FULL_OBJECT = {
+        crc32: 'jDYBxg==',
+        crc32c: 'q4EL7g==',
+        crc64nvme: '0YI0QcH8/Y4=',
+    };
+
+    Object.entries(EXPECTED_FULL_OBJECT).forEach(([algo, expectedValue]) => {
+        it(`should return FULL_OBJECT checksum without -N suffix for ${algo.toUpperCase()}`, async () => {
+            const a = Buffer.alloc(1024, 0xaa);
+            const b = Buffer.alloc(2048, 0x55);
+            const dA = await algorithms[algo].digest(a);
+            const dB = await algorithms[algo].digest(b);
+            const stored = [
+                {
+                    key: `${UPLOAD_ID}${splitter}1`,
+                    value: {
+                        ETag: 'e',
+                        Size: a.length,
+                        ChecksumAlgorithm: algo,
+                        ChecksumValue: dA,
+                        partLocations: [],
+                    },
+                },
+                {
+                    key: `${UPLOAD_ID}${splitter}2`,
+                    value: {
+                        ETag: 'e',
+                        Size: b.length,
+                        ChecksumAlgorithm: algo,
+                        ChecksumValue: dB,
+                        partLocations: [],
+                    },
+                },
+            ];
+            const { result, error } = await computeFinalChecksum(
+                stored,
+                partListFromStored(stored),
+                { checksumAlgorithm: algo, checksumType: 'FULL_OBJECT' },
+                splitter,
+                uploadId,
+                log,
+            );
+            assert.ifError(error);
+            assert.deepStrictEqual(result, { algorithm: algo, type: 'FULL_OBJECT', value: expectedValue });
+        });
+    });
+
+    // Soft-null (`{ result: null, error: null }`) is intentional only for
+    // default MPUs — the client didn't opt in to a checksum, so missing it
+    // on the response is graceful degradation. Explicit MPUs return
+    // `{ result: null, error: InternalError }` because silently dropping
+    // a checksum the client asked for would violate the CreateMPU contract.
+
+    it('should soft-null when a default-MPU part is missing ChecksumValue', async () => {
         const stored = [
-            {
-                key: `${UPLOAD_ID}${splitter}1`,
-                value: {
-                    ETag: 'e',
-                    Size: a.length,
-                    ChecksumAlgorithm: 'crc64nvme',
-                    ChecksumValue: dA,
-                    partLocations: [],
-                },
-            },
-            {
-                key: `${UPLOAD_ID}${splitter}2`,
-                value: {
-                    ETag: 'e',
-                    Size: b.length,
-                    ChecksumAlgorithm: 'crc64nvme',
-                    ChecksumValue: dB,
-                    partLocations: [],
-                },
-            },
+            makeStoredPart(1, { algorithm: 'crc64nvme', value: SAMPLE_DIGESTS.crc64nvme[0] }),
+            makeStoredPart(2, null),
+            makeStoredPart(3, { algorithm: 'crc64nvme', value: SAMPLE_DIGESTS.crc64nvme[1] }),
         ];
         const got = await computeFinalChecksum(
             stored,
             partListFromStored(stored),
-            { checksumAlgorithm: 'crc64nvme', checksumType: 'FULL_OBJECT' },
+            { checksumAlgorithm: 'crc64nvme', checksumType: 'FULL_OBJECT', checksumIsDefault: true },
             splitter,
             uploadId,
             log,
         );
-        assert(got);
-        assert.strictEqual(got.algorithm, 'crc64nvme');
-        assert.strictEqual(got.type, 'FULL_OBJECT');
-        assert(!got.value.includes('-'), `FULL_OBJECT should have no -N suffix, got ${got.value}`);
-        const expected = await algorithms.crc64nvme.digest(Buffer.concat([a, b]));
-        assert.strictEqual(got.value, expected);
+        assertSoftNull(got);
     });
 
-    it('should return null and log when a part is missing ChecksumValue', async () => {
+    it('should return InternalError when an explicit-MPU part is missing ChecksumValue', async () => {
         const stored = [
             makeStoredPart(1, { algorithm: 'sha256', value: SAMPLE_DIGESTS.sha256[0] }),
             makeStoredPart(2, null),
@@ -4324,42 +4210,55 @@ describe('computeFinalChecksum', () => {
         const got = await computeFinalChecksum(
             stored,
             partListFromStored(stored),
-            { checksumAlgorithm: 'sha256', checksumType: 'COMPOSITE' },
+            { checksumAlgorithm: 'sha256', checksumType: 'COMPOSITE', checksumIsDefault: false },
             splitter,
             uploadId,
             log,
         );
-        assert.strictEqual(got, null);
+        assertInternalError(got);
     });
 
-    it('should return null when checksumType is unknown', async () => {
+    it('should soft-null when checksumType is unknown on a default MPU', async () => {
+        const stored = [makeStoredPart(1, { algorithm: 'crc64nvme', value: SAMPLE_DIGESTS.crc64nvme[0] })];
+        const got = await computeFinalChecksum(
+            stored,
+            partListFromStored(stored),
+            { checksumAlgorithm: 'crc64nvme', checksumType: 'WEIRD', checksumIsDefault: true },
+            splitter,
+            uploadId,
+            log,
+        );
+        assertSoftNull(got);
+    });
+
+    it('should return InternalError when checksumType is unknown on an explicit MPU', async () => {
         const stored = [makeStoredPart(1, { algorithm: 'sha256', value: SAMPLE_DIGESTS.sha256[0] })];
         const got = await computeFinalChecksum(
             stored,
             partListFromStored(stored),
-            { checksumAlgorithm: 'sha256', checksumType: 'WEIRD' },
+            { checksumAlgorithm: 'sha256', checksumType: 'WEIRD', checksumIsDefault: false },
             splitter,
             uploadId,
             log,
         );
-        assert.strictEqual(got, null);
+        assertInternalError(got);
     });
 
-    it(
-        'should return null when underlying compute reports an error ' + '(crc64nvme COMPOSITE is not allowed)',
-        async () => {
-            const stored = [makeStoredPart(1, { algorithm: 'crc64nvme', value: SAMPLE_DIGESTS.crc64nvme[0] })];
-            const got = await computeFinalChecksum(
-                stored,
-                partListFromStored(stored),
-                { checksumAlgorithm: 'crc64nvme', checksumType: 'COMPOSITE' },
-                splitter,
-                uploadId,
-                log,
-            );
-            assert.strictEqual(got, null);
-        },
-    );
+    it('should return InternalError when underlying compute reports an error on an explicit MPU', async () => {
+        // crc64nvme + COMPOSITE is not allowed by computeCompositeMPUChecksum.
+        // Reaching here on an explicit MPU means upstream validation failed,
+        // which is exactly the kind of internal-state bug we want to surface.
+        const stored = [makeStoredPart(1, { algorithm: 'crc64nvme', value: SAMPLE_DIGESTS.crc64nvme[0] })];
+        const got = await computeFinalChecksum(
+            stored,
+            partListFromStored(stored),
+            { checksumAlgorithm: 'crc64nvme', checksumType: 'COMPOSITE', checksumIsDefault: false },
+            splitter,
+            uploadId,
+            log,
+        );
+        assertInternalError(got);
+    });
 
     it('should compute over filteredPartList (subset), not all storedParts', async () => {
         const [d1, d2, d3] = [SAMPLE_DIGESTS.sha256[0], SAMPLE_DIGESTS.sha256[1], SAMPLE_DIGESTS.sha256[0]];
@@ -4375,7 +4274,7 @@ describe('computeFinalChecksum', () => {
             size: s.value.Size,
             locations: s.value.partLocations,
         }));
-        const got = await computeFinalChecksum(
+        const { result, error } = await computeFinalChecksum(
             stored,
             filtered,
             { checksumAlgorithm: 'sha256', checksumType: 'COMPOSITE' },
@@ -4383,37 +4282,21 @@ describe('computeFinalChecksum', () => {
             uploadId,
             log,
         );
-        assert(got);
-        assert(got.value.endsWith('-2'), `should reflect 2 completed parts, got ${got.value}`);
+        assert.ifError(error);
+        assert(result);
+        assert(result.value.endsWith('-2'), `should reflect 2 completed parts, got ${result.value}`);
         const expected = crypto
             .createHash('sha256')
             .update(Buffer.concat([d1, d3].map(x => Buffer.from(x, 'base64'))))
             .digest('base64');
-        assert.strictEqual(got.value, `${expected}-2`);
+        assert.strictEqual(result.value, `${expected}-2`);
     });
 });
 
 describe('CompleteMultipartUpload final-object checksum storage', () => {
     const log = new DummyRequestLogger();
-    const authInfo = makeAuthInfo('accessKey1');
-    const namespace = 'default';
     const bucketName = 'bucketname-final-checksum';
     const objectKey = 'testObject';
-    const partBody = Buffer.from('I am a part\n', 'utf8');
-    const partHash = crypto.createHash('md5').update(partBody).digest('hex');
-
-    const bucketPutRequest = {
-        bucketName,
-        namespace,
-        headers: { host: `${bucketName}.s3.amazonaws.com` },
-        url: '/',
-        post:
-            '<CreateBucketConfiguration ' +
-            'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
-            '<LocationConstraint>scality-internal-mem</LocationConstraint>' +
-            '</CreateBucketConfiguration >',
-        actionImplicitDenies: false,
-    };
 
     // (algorithm, type) pairs valid for an MPU per AWS rules.
     // shouldStore reflects Part 3's gating: only FULL_OBJECT is persisted.
@@ -4427,90 +4310,6 @@ describe('CompleteMultipartUpload final-object checksum storage', () => {
         { algorithm: 'sha256', type: 'COMPOSITE', shouldStore: false },
     ];
 
-    function bucketPutP() {
-        return new Promise((resolve, reject) =>
-            bucketPut(authInfo, bucketPutRequest, log, err => (err ? reject(err) : resolve())),
-        );
-    }
-
-    function initiateMpuP(headers) {
-        return new Promise((resolve, reject) => {
-            initiateMultipartUpload(
-                authInfo,
-                {
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    headers: { host: `${bucketName}.s3.amazonaws.com`, ...headers },
-                    url: `/${objectKey}?uploads`,
-                    actionImplicitDenies: false,
-                },
-                log,
-                (err, xml) => {
-                    if (err) {
-                        return reject(err);
-                    }
-                    return parseString(xml, (parseErr, json) =>
-                        parseErr ? reject(parseErr) : resolve(json.InitiateMultipartUploadResult.UploadId[0]),
-                    );
-                },
-            );
-        });
-    }
-
-    function uploadPartP(uploadId, headers = {}) {
-        return new Promise((resolve, reject) => {
-            const partRequest = new DummyRequest(
-                {
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    headers: { host: `${bucketName}.s3.amazonaws.com`, ...headers },
-                    url: `/${objectKey}?partNumber=1&uploadId=${uploadId}`,
-                    query: { partNumber: '1', uploadId },
-                    partHash,
-                    actionImplicitDenies: false,
-                },
-                partBody,
-            );
-            objectPutPart(authInfo, partRequest, undefined, log, err => (err ? reject(err) : resolve()));
-        });
-    }
-
-    function completeMpuP(uploadId, partChecksumXml = '') {
-        const completeBody =
-            '<CompleteMultipartUpload>' +
-            '<Part>' +
-            '<PartNumber>1</PartNumber>' +
-            `<ETag>"${partHash}"</ETag>${partChecksumXml}` +
-            '</Part>' +
-            '</CompleteMultipartUpload>';
-        return new Promise((resolve, reject) => {
-            completeMultipartUpload(
-                authInfo,
-                {
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    parsedHost: 's3.amazonaws.com',
-                    url: `/${objectKey}?uploadId=${uploadId}`,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    query: { uploadId },
-                    post: completeBody,
-                    actionImplicitDenies: false,
-                },
-                log,
-                err => (err ? reject(err) : resolve()),
-            );
-        });
-    }
-
-    function fetchObjectMDP() {
-        return new Promise((resolve, reject) =>
-            metadataswitch.getObjectMD(bucketName, objectKey, {}, log, (err, md) => (err ? reject(err) : resolve(md))),
-        );
-    }
-
     beforeEach(() => cleanup());
 
     STORAGE_MATRIX.forEach(({ algorithm, type, shouldStore }) => {
@@ -4519,19 +4318,19 @@ describe('CompleteMultipartUpload final-object checksum storage', () => {
         const tag = TAG_BY_ALGO[algorithm];
 
         it(`${verb} ${type} ${upper} checksum on the ObjectMD`, async () => {
-            await bucketPutP();
-            const uploadId = await initiateMpuP({
+            await mpuUtils.bucketPutP(bucketName, namespace, log);
+            const uploadId = await mpuUtils.initiateMpuP(bucketName, namespace, objectKey, log, {
                 'x-amz-checksum-algorithm': upper,
                 'x-amz-checksum-type': type,
             });
             // Pre-compute the part's checksum so we can supply it on
             // UploadPart and (for COMPOSITE non-default) in the Complete body.
-            const partChecksum = await algorithms[algorithm].digest(partBody);
+            const partChecksum = await algorithms[algorithm].digest(mpuUtils.partBody);
             const uploadHeaders = type === 'COMPOSITE' ? { [`x-amz-checksum-${algorithm}`]: partChecksum } : {};
-            await uploadPartP(uploadId, uploadHeaders);
+            await mpuUtils.uploadPartP(bucketName, namespace, objectKey, uploadId, log, uploadHeaders);
             const partChecksumXml = type === 'COMPOSITE' ? `<${tag}>${partChecksum}</${tag}>` : '';
-            await completeMpuP(uploadId, partChecksumXml);
-            const md = await fetchObjectMDP();
+            await mpuUtils.completeMpuP(bucketName, namespace, objectKey, uploadId, log, { partChecksumXml });
+            const md = await mpuUtils.getObjectMDP(bucketName, objectKey, log);
             if (shouldStore) {
                 assert(md.checksum, `expected ${type} ${upper} checksum on ObjectMD`);
                 assert.strictEqual(md.checksum.checksumAlgorithm, algorithm);
@@ -4547,11 +4346,11 @@ describe('CompleteMultipartUpload final-object checksum storage', () => {
     it('should persist FULL_OBJECT CRC64NVME checksum for default MPU (no checksum headers)', async () => {
         // No x-amz-checksum-algorithm / x-amz-checksum-type headers — AWS
         // defaults to crc64nvme/FULL_OBJECT and still persists the result.
-        await bucketPutP();
-        const uploadId = await initiateMpuP({});
-        await uploadPartP(uploadId);
-        await completeMpuP(uploadId);
-        const md = await fetchObjectMDP();
+        await mpuUtils.bucketPutP(bucketName, namespace, log);
+        const uploadId = await mpuUtils.initiateMpuP(bucketName, namespace, objectKey, log);
+        await mpuUtils.uploadPartP(bucketName, namespace, objectKey, uploadId, log);
+        await mpuUtils.completeMpuP(bucketName, namespace, objectKey, uploadId, log);
+        const md = await mpuUtils.getObjectMDP(bucketName, objectKey, log);
         assert(md.checksum, 'default MPU should still persist a checksum');
         assert.strictEqual(md.checksum.checksumAlgorithm, 'crc64nvme');
         assert.strictEqual(md.checksum.checksumType, 'FULL_OBJECT');
@@ -4560,14 +4359,14 @@ describe('CompleteMultipartUpload final-object checksum storage', () => {
     it('should not leak checksumAlgorithm/Type/IsDefault into ObjectMD top-level fields', async () => {
         // keysNotNeeded keeps these MPU-overview-only keys out of metaHeaders,
         // which prevents them from sticking around on the final ObjectMD.
-        await bucketPutP();
-        const uploadId = await initiateMpuP({
+        await mpuUtils.bucketPutP(bucketName, namespace, log);
+        const uploadId = await mpuUtils.initiateMpuP(bucketName, namespace, objectKey, log, {
             'x-amz-checksum-algorithm': 'CRC32',
             'x-amz-checksum-type': 'FULL_OBJECT',
         });
-        await uploadPartP(uploadId);
-        await completeMpuP(uploadId);
-        const md = await fetchObjectMDP();
+        await mpuUtils.uploadPartP(bucketName, namespace, objectKey, uploadId, log);
+        await mpuUtils.completeMpuP(bucketName, namespace, objectKey, uploadId, log);
+        const md = await mpuUtils.getObjectMDP(bucketName, objectKey, log);
         assert.strictEqual(md.checksumAlgorithm, undefined);
         assert.strictEqual(md.checksumType, undefined);
         assert.strictEqual(md.checksumIsDefault, undefined);
@@ -4576,25 +4375,8 @@ describe('CompleteMultipartUpload final-object checksum storage', () => {
 
 describe('CompleteMultipartUpload final-object checksum response', () => {
     const log = new DummyRequestLogger();
-    const authInfo = makeAuthInfo('accessKey1');
-    const namespace = 'default';
     const bucketName = 'bucketname-final-checksum-resp';
     const objectKey = 'testObject';
-    const partBody = Buffer.from('I am a part\n', 'utf8');
-    const partHash = crypto.createHash('md5').update(partBody).digest('hex');
-
-    const bucketPutRequest = {
-        bucketName,
-        namespace,
-        headers: { host: `${bucketName}.s3.amazonaws.com` },
-        url: '/',
-        post:
-            '<CreateBucketConfiguration ' +
-            'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
-            '<LocationConstraint>scality-internal-mem</LocationConstraint>' +
-            '</CreateBucketConfiguration >',
-        actionImplicitDenies: false,
-    };
 
     const RESPONSE_MATRIX = [
         { algorithm: 'crc32', type: 'FULL_OBJECT' },
@@ -4606,92 +4388,6 @@ describe('CompleteMultipartUpload final-object checksum response', () => {
         { algorithm: 'sha256', type: 'COMPOSITE' },
     ];
 
-    function bucketPutP() {
-        return new Promise((resolve, reject) =>
-            bucketPut(authInfo, bucketPutRequest, log, err => (err ? reject(err) : resolve())),
-        );
-    }
-
-    function initiateMpuP(headers) {
-        return new Promise((resolve, reject) => {
-            initiateMultipartUpload(
-                authInfo,
-                {
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    headers: { host: `${bucketName}.s3.amazonaws.com`, ...headers },
-                    url: `/${objectKey}?uploads`,
-                    actionImplicitDenies: false,
-                },
-                log,
-                (err, xml) => {
-                    if (err) {
-                        return reject(err);
-                    }
-                    return parseString(xml, (parseErr, json) =>
-                        parseErr ? reject(parseErr) : resolve(json.InitiateMultipartUploadResult.UploadId[0]),
-                    );
-                },
-            );
-        });
-    }
-
-    function uploadPartP(uploadId, headers = {}) {
-        return new Promise((resolve, reject) => {
-            const partRequest = new DummyRequest(
-                {
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    headers: { host: `${bucketName}.s3.amazonaws.com`, ...headers },
-                    url: `/${objectKey}?partNumber=1&uploadId=${uploadId}`,
-                    query: { partNumber: '1', uploadId },
-                    partHash,
-                    actionImplicitDenies: false,
-                },
-                partBody,
-            );
-            objectPutPart(authInfo, partRequest, undefined, log, err => (err ? reject(err) : resolve()));
-        });
-    }
-
-    // Resolves with { xml, headers } so callers can inspect both the
-    // response body and the response headers.
-    function completeMpuP(uploadId, partChecksumXml = '') {
-        const completeBody =
-            '<CompleteMultipartUpload>' +
-            '<Part>' +
-            '<PartNumber>1</PartNumber>' +
-            `<ETag>"${partHash}"</ETag>${partChecksumXml}` +
-            '</Part>' +
-            '</CompleteMultipartUpload>';
-        return new Promise((resolve, reject) => {
-            completeMultipartUpload(
-                authInfo,
-                {
-                    bucketName,
-                    namespace,
-                    objectKey,
-                    parsedHost: 's3.amazonaws.com',
-                    url: `/${objectKey}?uploadId=${uploadId}`,
-                    headers: { host: `${bucketName}.s3.amazonaws.com` },
-                    query: { uploadId },
-                    post: completeBody,
-                    actionImplicitDenies: false,
-                },
-                log,
-                (err, xml, headers) => (err ? reject(err) : resolve({ xml, headers })),
-            );
-        });
-    }
-
-    function parseXmlP(xmlStr) {
-        return new Promise((resolve, reject) =>
-            parseString(xmlStr, (err, json) => (err ? reject(err) : resolve(json))),
-        );
-    }
-
     beforeEach(() => cleanup());
 
     RESPONSE_MATRIX.forEach(({ algorithm, type }) => {
@@ -4699,17 +4395,19 @@ describe('CompleteMultipartUpload final-object checksum response', () => {
         const tag = TAG_BY_ALGO[algorithm];
 
         it(`should emit ${type} ${upper} in response XML`, async () => {
-            await bucketPutP();
-            const uploadId = await initiateMpuP({
+            await mpuUtils.bucketPutP(bucketName, namespace, log);
+            const uploadId = await mpuUtils.initiateMpuP(bucketName, namespace, objectKey, log, {
                 'x-amz-checksum-algorithm': upper,
                 'x-amz-checksum-type': type,
             });
-            const partChecksum = await algorithms[algorithm].digest(partBody);
+            const partChecksum = await algorithms[algorithm].digest(mpuUtils.partBody);
             const uploadHeaders = type === 'COMPOSITE' ? { [`x-amz-checksum-${algorithm}`]: partChecksum } : {};
-            await uploadPartP(uploadId, uploadHeaders);
+            await mpuUtils.uploadPartP(bucketName, namespace, objectKey, uploadId, log, uploadHeaders);
             const partChecksumXml = type === 'COMPOSITE' ? `<${tag}>${partChecksum}</${tag}>` : '';
-            const { xml, headers } = await completeMpuP(uploadId, partChecksumXml);
-            const json = await parseXmlP(xml);
+            const { xml, headers } = await mpuUtils.completeMpuP(bucketName, namespace, objectKey, uploadId, log, {
+                partChecksumXml,
+            });
+            const json = await mpuUtils.parseXmlP(xml);
             const result = json.CompleteMultipartUploadResult;
             assert(result[tag], `expected ${tag} in response XML`);
             const xmlValue = result[tag][0];
@@ -4732,11 +4430,11 @@ describe('CompleteMultipartUpload final-object checksum response', () => {
         // AWS-verified: a default MPU still surfaces the CRC64NVME
         // checksum and ChecksumType=FULL_OBJECT in the CompleteMPU response
         // BODY (not headers).
-        await bucketPutP();
-        const uploadId = await initiateMpuP({});
-        await uploadPartP(uploadId);
-        const { xml, headers } = await completeMpuP(uploadId);
-        const json = await parseXmlP(xml);
+        await mpuUtils.bucketPutP(bucketName, namespace, log);
+        const uploadId = await mpuUtils.initiateMpuP(bucketName, namespace, objectKey, log);
+        await mpuUtils.uploadPartP(bucketName, namespace, objectKey, uploadId, log);
+        const { xml, headers } = await mpuUtils.completeMpuP(bucketName, namespace, objectKey, uploadId, log);
+        const json = await mpuUtils.parseXmlP(xml);
         const result = json.CompleteMultipartUploadResult;
         assert(result.ChecksumCRC64NVME, 'default MPU should emit ChecksumCRC64NVME');
         assert.strictEqual(result.ChecksumType[0], 'FULL_OBJECT');

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -137,9 +137,7 @@ function _createCompleteMpuRequest(uploadId, parts) {
     const completeBody = [];
     completeBody.push('<CompleteMultipartUpload>');
     parts.forEach(part => {
-        completeBody.push(
-            '<Part>' + `<PartNumber>${part.partNumber}</PartNumber>` + `<ETag>"${part.eTag}"</ETag>` + '</Part>',
-        );
+        completeBody.push(`<Part><PartNumber>${part.partNumber}</PartNumber><ETag>"${part.eTag}"</ETag></Part>`);
     });
     completeBody.push('</CompleteMultipartUpload>');
     return {
@@ -294,7 +292,7 @@ describe('Multipart Upload API', () => {
         });
     });
 
-    it('should return an error on an initiate multipart upload call if ' + 'no destination bucket', done => {
+    it('should return an error on an initiate multipart upload call if no destination bucket', done => {
         initiateMultipartUpload(authInfo, initiateRequest, log, err => {
             assert(err.is.NoSuchBucket);
             done();
@@ -608,7 +606,7 @@ describe('Multipart Upload API', () => {
                             bucketName,
                             namespace,
                             objectKey,
-                            url: `/${objectKey}?partNumber=` + `1&uploadId=${testUploadId}`,
+                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
                             headers: { host: `${bucketName}.s3.amazonaws.com` },
                             query: {
                                 partNumber: '2',
@@ -713,7 +711,7 @@ describe('Multipart Upload API', () => {
                             assert.ifError(err);
                             assert.strictEqual(
                                 json.CompleteMultipartUploadResult.Location[0],
-                                `http://${bucketName}.s3.amazonaws.com` + `/${objectKey}`,
+                                `http://${bucketName}.s3.amazonaws.com/${objectKey}`,
                             );
                             assert.strictEqual(json.CompleteMultipartUploadResult.Bucket[0], bucketName);
                             assert.strictEqual(json.CompleteMultipartUploadResult.Key[0], objectKey);
@@ -730,89 +728,84 @@ describe('Multipart Upload API', () => {
         );
     });
 
-    it(
-        'should complete a multipart upload even if etag is sent ' + 'in post body without quotes (a la Cyberduck)',
-        done => {
-            const partBody = Buffer.from('I am a part\n', 'utf8');
-            initiateRequest.headers['x-amz-meta-stuff'] = 'I am some user metadata';
-            async.waterfall(
-                [
-                    function waterfall1(next) {
-                        bucketPut(authInfo, bucketPutRequest, log, next);
-                    },
-                    function waterfall2(corsHeaders, next) {
-                        initiateMultipartUpload(authInfo, initiateRequest, log, next);
-                    },
-                    function waterfall3(result, corsHeaders, next) {
-                        parseString(result, next);
-                    },
-                ],
-                (err, json) => {
-                    // Need to build request in here since do not have uploadId
-                    // until here
-                    assert.ifError(err);
-                    const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-                    const partHash = crypto.createHash('md5').update(partBody).digest('hex');
-                    const partRequest = new DummyRequest(
-                        {
-                            bucketName,
-                            namespace,
-                            objectKey,
-                            headers: { host: `${bucketName}.s3.amazonaws.com` },
-                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                            query: {
-                                partNumber: '1',
-                                uploadId: testUploadId,
-                            },
-                            partHash,
+    it('should complete a multipart upload even if etag is sent in post body without quotes (a la Cyberduck)', done => {
+        const partBody = Buffer.from('I am a part\n', 'utf8');
+        initiateRequest.headers['x-amz-meta-stuff'] = 'I am some user metadata';
+        async.waterfall(
+            [
+                function waterfall1(next) {
+                    bucketPut(authInfo, bucketPutRequest, log, next);
+                },
+                function waterfall2(corsHeaders, next) {
+                    initiateMultipartUpload(authInfo, initiateRequest, log, next);
+                },
+                function waterfall3(result, corsHeaders, next) {
+                    parseString(result, next);
+                },
+            ],
+            (err, json) => {
+                // Need to build request in here since do not have uploadId
+                // until here
+                assert.ifError(err);
+                const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                const partHash = crypto.createHash('md5').update(partBody).digest('hex');
+                const partRequest = new DummyRequest(
+                    {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        query: {
+                            partNumber: '1',
+                            uploadId: testUploadId,
                         },
-                        partBody,
-                    );
-                    objectPutPart(authInfo, partRequest, undefined, log, () => {
-                        const completeBody =
-                            '<CompleteMultipartUpload>' +
-                            '<Part>' +
-                            '<PartNumber>1</PartNumber>' +
-                            // ETag without quotes
-                            `<ETag>${partHash}</ETag>` +
-                            '</Part>' +
-                            '</CompleteMultipartUpload>';
-                        const completeRequest = {
-                            bucketName,
-                            namespace,
-                            objectKey,
-                            parsedHost: 's3.amazonaws.com',
-                            url: `/${objectKey}?uploadId=${testUploadId}`,
-                            headers: { host: `${bucketName}.s3.amazonaws.com` },
-                            query: { uploadId: testUploadId },
-                            post: completeBody,
-                            actionImplicitDenies: false,
-                        };
-                        const awsVerifiedETag = '"953e9e776f285afc0bfcf1ab4668299d-1"';
-                        completeMultipartUpload(authInfo, completeRequest, log, (err, result) => {
+                        partHash,
+                    },
+                    partBody,
+                );
+                objectPutPart(authInfo, partRequest, undefined, log, () => {
+                    const completeBody =
+                        '<CompleteMultipartUpload>' +
+                        '<Part>' +
+                        '<PartNumber>1</PartNumber>' +
+                        // ETag without quotes
+                        `<ETag>${partHash}</ETag></Part></CompleteMultipartUpload>`;
+                    const completeRequest = {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        parsedHost: 's3.amazonaws.com',
+                        url: `/${objectKey}?uploadId=${testUploadId}`,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        query: { uploadId: testUploadId },
+                        post: completeBody,
+                        actionImplicitDenies: false,
+                    };
+                    const awsVerifiedETag = '"953e9e776f285afc0bfcf1ab4668299d-1"';
+                    completeMultipartUpload(authInfo, completeRequest, log, (err, result) => {
+                        assert.ifError(err);
+                        parseString(result, (err, json) => {
                             assert.ifError(err);
-                            parseString(result, (err, json) => {
-                                assert.ifError(err);
-                                assert.strictEqual(
-                                    json.CompleteMultipartUploadResult.Location[0],
-                                    `http://${bucketName}.s3.amazonaws.com` + `/${objectKey}`,
-                                );
-                                assert.strictEqual(json.CompleteMultipartUploadResult.Bucket[0], bucketName);
-                                assert.strictEqual(json.CompleteMultipartUploadResult.Key[0], objectKey);
-                                assert.strictEqual(json.CompleteMultipartUploadResult.ETag[0], awsVerifiedETag);
-                                const MD = metadata.keyMaps.get(bucketName).get(objectKey);
-                                assert(MD);
-                                assert.strictEqual(MD['x-amz-meta-stuff'], 'I am some user metadata');
-                                done();
-                            });
+                            assert.strictEqual(
+                                json.CompleteMultipartUploadResult.Location[0],
+                                `http://${bucketName}.s3.amazonaws.com/${objectKey}`,
+                            );
+                            assert.strictEqual(json.CompleteMultipartUploadResult.Bucket[0], bucketName);
+                            assert.strictEqual(json.CompleteMultipartUploadResult.Key[0], objectKey);
+                            assert.strictEqual(json.CompleteMultipartUploadResult.ETag[0], awsVerifiedETag);
+                            const MD = metadata.keyMaps.get(bucketName).get(objectKey);
+                            assert(MD);
+                            assert.strictEqual(MD['x-amz-meta-stuff'], 'I am some user metadata');
+                            done();
                         });
                     });
-                },
-            );
-        },
-    );
+                });
+            },
+        );
+    });
 
-    it('should return an error if a complete multipart upload' + ' request contains malformed xml', done => {
+    it('should return an error if a complete multipart upload request contains malformed xml', done => {
         async.waterfall(
             [
                 next => bucketPut(authInfo, bucketPutRequest, log, next),
@@ -867,8 +860,7 @@ describe('Multipart Upload API', () => {
 
     it(
         'should return an error if the complete ' +
-            'multipart upload request contains xml that ' +
-            'does not conform to the AWS spec',
+            'multipart upload request contains xml that does not conform to the AWS spec',
         done => {
             async.waterfall(
                 [
@@ -902,7 +894,7 @@ describe('Multipart Upload API', () => {
                     objectPutPart(authInfo, partRequest, undefined, log, () => {
                         // XML is missing any part listing so does
                         // not conform to the AWS spec
-                        const completeBody = '<CompleteMultipartUpload>' + '</CompleteMultipartUpload>';
+                        const completeBody = '<CompleteMultipartUpload></CompleteMultipartUpload>';
                         const completeRequest = {
                             bucketName,
                             namespace,
@@ -926,8 +918,7 @@ describe('Multipart Upload API', () => {
 
     it(
         'should return an error if the complete ' +
-            'multipart upload request contains xml with ' +
-            'a part list that is not in numerical order',
+            'multipart upload request contains xml with a part list that is not in numerical order',
         done => {
             async.waterfall(
                 [
@@ -1076,8 +1067,7 @@ describe('Multipart Upload API', () => {
 
     it(
         'should return an error if the complete multipart upload request ' +
-            'contains xml with a part ETag that does not match the md5 for ' +
-            'the part that was actually sent',
+            'contains xml with a part ETag that does not match the md5 for the part that was actually sent',
         done => {
             async.waterfall(
                 [
@@ -1158,96 +1148,93 @@ describe('Multipart Upload API', () => {
         },
     );
 
-    it(
-        'should return an error if there is a part ' + 'other than the last part that is less than 5MB ' + 'in size',
-        done => {
-            async.waterfall(
-                [
-                    next => bucketPut(authInfo, bucketPutRequest, log, next),
-                    (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
-                    (result, corsHeaders, next) => parseString(result, next),
-                ],
-                (err, json) => {
-                    // Need to build request in here since do not have uploadId
-                    // until here
-                    const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-                    const md5Hash = crypto.createHash('md5');
-                    const bufferBody = Buffer.from(postBody);
-                    md5Hash.update(bufferBody);
-                    const partHash = md5Hash.digest('hex');
-                    const partRequest1 = new DummyRequest(
-                        {
+    it('should return an error if there is a part other than the last part that is less than 5MB in size', done => {
+        async.waterfall(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+            ],
+            (err, json) => {
+                // Need to build request in here since do not have uploadId
+                // until here
+                const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                const md5Hash = crypto.createHash('md5');
+                const bufferBody = Buffer.from(postBody);
+                md5Hash.update(bufferBody);
+                const partHash = md5Hash.digest('hex');
+                const partRequest1 = new DummyRequest(
+                    {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        headers: {
+                            host: `${bucketName}.s3.amazonaws.com`,
+                            'content-length': '100',
+                        },
+                        parsedContentLength: 100,
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        query: {
+                            partNumber: '1',
+                            uploadId: testUploadId,
+                        },
+                        partHash,
+                    },
+                    postBody,
+                );
+                const partRequest2 = new DummyRequest(
+                    {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        headers: {
+                            host: `${bucketName}.s3.amazonaws.com`,
+                            'content-length': '200',
+                        },
+                        parsedContentLength: 200,
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        query: {
+                            partNumber: '2',
+                            uploadId: testUploadId,
+                        },
+                        partHash,
+                    },
+                    postBody,
+                );
+                objectPutPart(authInfo, partRequest1, undefined, log, () => {
+                    objectPutPart(authInfo, partRequest2, undefined, log, () => {
+                        const completeBody =
+                            '<CompleteMultipartUpload>' +
+                            '<Part>' +
+                            '<PartNumber>1</PartNumber>' +
+                            `<ETag>"${partHash}"</ETag>` +
+                            '</Part>' +
+                            '<Part>' +
+                            '<PartNumber>2</PartNumber>' +
+                            `<ETag>"${partHash}"</ETag>` +
+                            '</Part>' +
+                            '</CompleteMultipartUpload>';
+                        const completeRequest = {
                             bucketName,
                             namespace,
                             objectKey,
-                            headers: {
-                                host: `${bucketName}.s3.amazonaws.com`,
-                                'content-length': '100',
-                            },
-                            parsedContentLength: 100,
-                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                            query: {
-                                partNumber: '1',
-                                uploadId: testUploadId,
-                            },
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            url: `/${objectKey}?uploadId=${testUploadId}`,
+                            query: { uploadId: testUploadId },
+                            post: completeBody,
                             partHash,
-                        },
-                        postBody,
-                    );
-                    const partRequest2 = new DummyRequest(
-                        {
-                            bucketName,
-                            namespace,
-                            objectKey,
-                            headers: {
-                                host: `${bucketName}.s3.amazonaws.com`,
-                                'content-length': '200',
-                            },
-                            parsedContentLength: 200,
-                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                            query: {
-                                partNumber: '2',
-                                uploadId: testUploadId,
-                            },
-                            partHash,
-                        },
-                        postBody,
-                    );
-                    objectPutPart(authInfo, partRequest1, undefined, log, () => {
-                        objectPutPart(authInfo, partRequest2, undefined, log, () => {
-                            const completeBody =
-                                '<CompleteMultipartUpload>' +
-                                '<Part>' +
-                                '<PartNumber>1</PartNumber>' +
-                                `<ETag>"${partHash}"</ETag>` +
-                                '</Part>' +
-                                '<Part>' +
-                                '<PartNumber>2</PartNumber>' +
-                                `<ETag>"${partHash}"</ETag>` +
-                                '</Part>' +
-                                '</CompleteMultipartUpload>';
-                            const completeRequest = {
-                                bucketName,
-                                namespace,
-                                objectKey,
-                                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                                url: `/${objectKey}?uploadId=${testUploadId}`,
-                                query: { uploadId: testUploadId },
-                                post: completeBody,
-                                partHash,
-                                actionImplicitDenies: false,
-                            };
-                            assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 3);
-                            completeMultipartUpload(authInfo, completeRequest, log, err => {
-                                assert(err.is.EntityTooSmall);
-                                done();
-                            });
+                            actionImplicitDenies: false,
+                        };
+                        assert.strictEqual(metadata.keyMaps.get(mpuBucket).size, 3);
+                        completeMultipartUpload(authInfo, completeRequest, log, err => {
+                            assert(err.is.EntityTooSmall);
+                            done();
                         });
                     });
-                },
-            );
-        },
-    );
+                });
+            },
+        );
+    });
 
     it('should aggregate the sizes of the parts', done => {
         async.waterfall(
@@ -1448,7 +1435,7 @@ describe('Multipart Upload API', () => {
     });
 
     it('should set specific ACL grants for a multipart upload', done => {
-        const granteeId = '79a59df900b949e55d96a1e698fbace' + 'dfd6e09d98eacf8f8d5218e7cd47ef2be';
+        const granteeId = '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be';
         const granteeEmail = 'sampleAccount1@sampling.com';
         const initiateRequest = {
             bucketName,
@@ -1605,8 +1592,7 @@ describe('Multipart Upload API', () => {
 
     it(
         'should return no error if attempt to abort/delete ' +
-            'a multipart upload that does not exist and not using ' +
-            'legacyAWSBehavior',
+            'a multipart upload that does not exist and not using legacyAWSBehavior',
         done => {
             async.waterfall(
                 [
@@ -1946,7 +1932,7 @@ describe('Multipart Upload API', () => {
         );
     });
 
-    it('should throw an error on put of an object part with an invalid ' + 'uploadId', done => {
+    it('should throw an error on put of an object part with an invalid uploadId', done => {
         const testUploadId = 'invalidUploadID';
         const partRequest = new DummyRequest(
             {
@@ -1968,89 +1954,86 @@ describe('Multipart Upload API', () => {
         );
     });
 
-    it(
-        'should complete an MPU with fewer parts than were originally ' + 'put and delete data from left out parts',
-        done => {
-            async.waterfall(
-                [
-                    next => bucketPut(authInfo, bucketPutRequest, log, next),
-                    (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
-                    (result, corsHeaders, next) => parseString(result, next),
-                ],
-                (err, json) => {
-                    // Need to build request in here since do not have uploadId
-                    // until here
-                    assert.ifError(err);
-                    const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-                    const fullSizedPart = crypto.randomBytes(5 * 1024 * 1024);
-                    const partRequest1 = new DummyRequest(
-                        {
-                            bucketName,
-                            namespace,
-                            objectKey,
-                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                            headers: { host: `${bucketName}.s3.amazonaws.com` },
-                            query: {
-                                partNumber: '1',
-                                uploadId: testUploadId,
-                            },
+    it('should complete an MPU with fewer parts than were originally put and delete data from left out parts', done => {
+        async.waterfall(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                (corsHeaders, next) => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+            ],
+            (err, json) => {
+                // Need to build request in here since do not have uploadId
+                // until here
+                assert.ifError(err);
+                const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                const fullSizedPart = crypto.randomBytes(5 * 1024 * 1024);
+                const partRequest1 = new DummyRequest(
+                    {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        query: {
+                            partNumber: '1',
+                            uploadId: testUploadId,
                         },
-                        fullSizedPart,
-                    );
-                    const partRequest2 = new DummyRequest(
-                        {
-                            bucketName,
-                            namespace,
-                            objectKey,
-                            url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
-                            headers: { host: `${bucketName}.s3.amazonaws.com` },
-                            query: {
-                                partNumber: '2',
-                                uploadId: testUploadId,
-                            },
+                    },
+                    fullSizedPart,
+                );
+                const partRequest2 = new DummyRequest(
+                    {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        url: `/${objectKey}?partNumber=1&uploadId=${testUploadId}`,
+                        headers: { host: `${bucketName}.s3.amazonaws.com` },
+                        query: {
+                            partNumber: '2',
+                            uploadId: testUploadId,
                         },
-                        postBody,
-                    );
-                    objectPutPart(authInfo, partRequest1, undefined, log, err => {
+                    },
+                    postBody,
+                );
+                objectPutPart(authInfo, partRequest1, undefined, log, err => {
+                    assert.deepStrictEqual(err, null);
+                    const md5Hash = crypto.createHash('md5').update(fullSizedPart);
+                    const partHash = md5Hash.digest('hex');
+                    objectPutPart(authInfo, partRequest2, undefined, log, err => {
                         assert.deepStrictEqual(err, null);
-                        const md5Hash = crypto.createHash('md5').update(fullSizedPart);
-                        const partHash = md5Hash.digest('hex');
-                        objectPutPart(authInfo, partRequest2, undefined, log, err => {
-                            assert.deepStrictEqual(err, null);
-                            const completeBody =
-                                '<CompleteMultipartUpload>' +
-                                '<Part>' +
-                                '<PartNumber>1</PartNumber>' +
-                                `<ETag>"${partHash}"</ETag>` +
-                                '</Part>' +
-                                '</CompleteMultipartUpload>';
-                            const completeRequest = {
-                                bucketName,
-                                namespace,
-                                objectKey,
-                                url: `/${objectKey}?uploadId=${testUploadId}`,
-                                headers: { host: `${bucketName}.s3.amazonaws.com` },
-                                query: { uploadId: testUploadId },
-                                post: completeBody,
-                                partHash,
-                                actionImplicitDenies: false,
-                            };
-                            // show that second part data is there
-                            assert(ds[2]);
-                            completeMultipartUpload(authInfo, completeRequest, log, err => {
-                                assert.ifError(err);
-                                process.nextTick(() => {
-                                    // data has been deleted
-                                    assert.strictEqual(ds[2], undefined);
-                                    done();
-                                });
+                        const completeBody =
+                            '<CompleteMultipartUpload>' +
+                            '<Part>' +
+                            '<PartNumber>1</PartNumber>' +
+                            `<ETag>"${partHash}"</ETag>` +
+                            '</Part>' +
+                            '</CompleteMultipartUpload>';
+                        const completeRequest = {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            url: `/${objectKey}?uploadId=${testUploadId}`,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            query: { uploadId: testUploadId },
+                            post: completeBody,
+                            partHash,
+                            actionImplicitDenies: false,
+                        };
+                        // show that second part data is there
+                        assert(ds[2]);
+                        completeMultipartUpload(authInfo, completeRequest, log, err => {
+                            assert.ifError(err);
+                            process.nextTick(() => {
+                                // data has been deleted
+                                assert.strictEqual(ds[2], undefined);
+                                done();
                             });
                         });
                     });
-                },
-            );
-        },
-    );
+                });
+            },
+        );
+    });
 
     it('should not delete data locations on completeMultipartUpload retry', done => {
         const partBody = Buffer.from('foo', 'utf8');
@@ -2563,133 +2546,117 @@ describe('complete mpu with versioning', () => {
         done();
     });
 
-    it(
-        'should delete null version when creating new null version, ' + 'when null version is the latest version',
-        done => {
-            async.waterfall(
-                [
-                    next => bucketPutVersioning(authInfo, suspendVersioningRequest, log, err => next(err)),
-                    next => initiateMultipartUpload(authInfo, initiateRequest, log, next),
-                    (result, corsHeaders, next) => parseString(result, next),
-                    (json, next) => {
-                        const partBody = objData[2];
-                        const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-                        const partRequest = _createPutPartRequest(testUploadId, 1, partBody);
-                        objectPutPart(authInfo, partRequest, undefined, log, (err, eTag) =>
-                            next(err, eTag, testUploadId),
-                        );
-                    },
-                    (eTag, testUploadId, next) => {
-                        const origPutObject = metadataBackend.putObject;
-                        let callCount = 0;
-                        metadataBackend.putObject = (putBucketName, objName, objVal, params, log, cb) => {
-                            if (callCount === 0) {
-                                // first putObject sets the completeInProgress flag in the overview key
-                                assert.strictEqual(putBucketName, `${constants.mpuBucketPrefix}${bucketName}`);
-                                assert.strictEqual(
-                                    objName,
-                                    `overview${splitter}${objectKey}${splitter}${testUploadId}`,
-                                );
-                                assert.strictEqual(objVal.completeInProgress, true);
-                            } else {
-                                assert.strictEqual(params.replayId, testUploadId);
-                                assert.strictEqual(objVal.originOp, 's3:ObjectCreated:CompleteMultipartUpload');
-                                metadataBackend.putObject = origPutObject;
-                            }
-                            origPutObject(putBucketName, objName, objVal, params, log, cb);
-                            callCount += 1;
-                        };
-                        const parts = [{ partNumber: 1, eTag }];
-                        const completeRequest = _createCompleteMpuRequest(testUploadId, parts);
-                        completeMultipartUpload(authInfo, completeRequest, log, err => next(err, testUploadId));
-                    },
-                    (testUploadId, next) => {
-                        const origPutObject = metadataBackend.putObject;
-                        metadataBackend.putObject = (putBucketName, objName, objVal, params, log, cb) => {
-                            assert.strictEqual(params.oldReplayId, testUploadId);
-                            assert.strictEqual(objVal.originOp, 's3:ObjectCreated:Put');
-                            metadataBackend.putObject = origPutObject;
-                            origPutObject(putBucketName, objName, objVal, params, log, cb);
-                        };
-                        // overwrite null version with a non-MPU object
-                        objectPut(authInfo, testPutObjectRequests[1], undefined, log, err => next(err));
-                    },
-                ],
-                err => {
-                    assert.ifError(err, `Unexpected err: ${err}`);
-                    done();
+    it('should delete null version when creating new null version, when it is the latest version', done => {
+        async.waterfall(
+            [
+                next => bucketPutVersioning(authInfo, suspendVersioningRequest, log, err => next(err)),
+                next => initiateMultipartUpload(authInfo, initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
+                (json, next) => {
+                    const partBody = objData[2];
+                    const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                    const partRequest = _createPutPartRequest(testUploadId, 1, partBody);
+                    objectPutPart(authInfo, partRequest, undefined, log, (err, eTag) => next(err, eTag, testUploadId));
                 },
-            );
-        },
-    );
-
-    it(
-        'should delete null version when creating new null version, ' + 'when null version is not the latest version',
-        done => {
-            async.waterfall(
-                [
-                    // putting null version: put obj before versioning configured
-                    next => objectPut(authInfo, testPutObjectRequests[0], undefined, log, err => next(err)),
-                    next => bucketPutVersioning(authInfo, enableVersioningRequest, log, err => next(err)),
-                    // put another version:
-                    next => objectPut(authInfo, testPutObjectRequests[1], undefined, log, err => next(err)),
-                    next => bucketPutVersioning(authInfo, suspendVersioningRequest, log, err => next(err)),
-                    next => {
-                        versioningTestUtils.assertDataStoreValues(ds, objData.slice(0, 2));
-                        initiateMultipartUpload(authInfo, initiateRequest, log, next);
-                    },
-                    (result, corsHeaders, next) => parseString(result, next),
-                    (json, next) => {
-                        const partBody = objData[2];
-                        const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-                        const partRequest = _createPutPartRequest(testUploadId, 1, partBody);
-                        objectPutPart(authInfo, partRequest, undefined, log, (err, eTag) =>
-                            next(err, eTag, testUploadId),
-                        );
-                    },
-                    (eTag, testUploadId, next) => {
-                        const origPutObject = metadataBackend.putObject;
-                        let callCount = 0;
-                        metadataBackend.putObject = (putBucketName, objName, objVal, params, log, cb) => {
-                            if (callCount === 0) {
-                                // first putObject sets the completeInProgress flag in the overview key
-                                assert.strictEqual(putBucketName, `${constants.mpuBucketPrefix}${bucketName}`);
-                                assert.strictEqual(
-                                    objName,
-                                    `overview${splitter}${objectKey}${splitter}${testUploadId}`,
-                                );
-                                assert.strictEqual(objVal.completeInProgress, true);
-                            } else {
-                                assert.strictEqual(params.replayId, testUploadId);
-                                metadataBackend.putObject = origPutObject;
-                            }
-                            origPutObject(putBucketName, objName, objVal, params, log, cb);
-                            callCount += 1;
-                        };
-                        const parts = [{ partNumber: 1, eTag }];
-                        const completeRequest = _createCompleteMpuRequest(testUploadId, parts);
-                        completeMultipartUpload(authInfo, completeRequest, log, err => next(err, testUploadId));
-                    },
-                    (testUploadId, next) => {
-                        versioningTestUtils.assertDataStoreValues(ds, [undefined, objData[1], objData[2]]);
-
-                        const origPutObject = metadataBackend.putObject;
-                        metadataBackend.putObject = (putBucketName, objName, objVal, params, log, cb) => {
-                            assert.strictEqual(params.oldReplayId, testUploadId);
+                (eTag, testUploadId, next) => {
+                    const origPutObject = metadataBackend.putObject;
+                    let callCount = 0;
+                    metadataBackend.putObject = (putBucketName, objName, objVal, params, log, cb) => {
+                        if (callCount === 0) {
+                            // first putObject sets the completeInProgress flag in the overview key
+                            assert.strictEqual(putBucketName, `${constants.mpuBucketPrefix}${bucketName}`);
+                            assert.strictEqual(objName, `overview${splitter}${objectKey}${splitter}${testUploadId}`);
+                            assert.strictEqual(objVal.completeInProgress, true);
+                        } else {
+                            assert.strictEqual(params.replayId, testUploadId);
+                            assert.strictEqual(objVal.originOp, 's3:ObjectCreated:CompleteMultipartUpload');
                             metadataBackend.putObject = origPutObject;
-                            origPutObject(putBucketName, objName, objVal, params, log, cb);
-                        };
-                        // overwrite null version with a non-MPU object
-                        objectPut(authInfo, testPutObjectRequests[1], undefined, log, err => next(err));
-                    },
-                ],
-                err => {
-                    assert.ifError(err, `Unexpected err: ${err}`);
-                    done();
+                        }
+                        origPutObject(putBucketName, objName, objVal, params, log, cb);
+                        callCount += 1;
+                    };
+                    const parts = [{ partNumber: 1, eTag }];
+                    const completeRequest = _createCompleteMpuRequest(testUploadId, parts);
+                    completeMultipartUpload(authInfo, completeRequest, log, err => next(err, testUploadId));
                 },
-            );
-        },
-    );
+                (testUploadId, next) => {
+                    const origPutObject = metadataBackend.putObject;
+                    metadataBackend.putObject = (putBucketName, objName, objVal, params, log, cb) => {
+                        assert.strictEqual(params.oldReplayId, testUploadId);
+                        assert.strictEqual(objVal.originOp, 's3:ObjectCreated:Put');
+                        metadataBackend.putObject = origPutObject;
+                        origPutObject(putBucketName, objName, objVal, params, log, cb);
+                    };
+                    // overwrite null version with a non-MPU object
+                    objectPut(authInfo, testPutObjectRequests[1], undefined, log, err => next(err));
+                },
+            ],
+            err => {
+                assert.ifError(err, `Unexpected err: ${err}`);
+                done();
+            },
+        );
+    });
+
+    it('should delete null version when creating new null version, when it is not the latest version', done => {
+        async.waterfall(
+            [
+                // putting null version: put obj before versioning configured
+                next => objectPut(authInfo, testPutObjectRequests[0], undefined, log, err => next(err)),
+                next => bucketPutVersioning(authInfo, enableVersioningRequest, log, err => next(err)),
+                // put another version:
+                next => objectPut(authInfo, testPutObjectRequests[1], undefined, log, err => next(err)),
+                next => bucketPutVersioning(authInfo, suspendVersioningRequest, log, err => next(err)),
+                next => {
+                    versioningTestUtils.assertDataStoreValues(ds, objData.slice(0, 2));
+                    initiateMultipartUpload(authInfo, initiateRequest, log, next);
+                },
+                (result, corsHeaders, next) => parseString(result, next),
+                (json, next) => {
+                    const partBody = objData[2];
+                    const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                    const partRequest = _createPutPartRequest(testUploadId, 1, partBody);
+                    objectPutPart(authInfo, partRequest, undefined, log, (err, eTag) => next(err, eTag, testUploadId));
+                },
+                (eTag, testUploadId, next) => {
+                    const origPutObject = metadataBackend.putObject;
+                    let callCount = 0;
+                    metadataBackend.putObject = (putBucketName, objName, objVal, params, log, cb) => {
+                        if (callCount === 0) {
+                            // first putObject sets the completeInProgress flag in the overview key
+                            assert.strictEqual(putBucketName, `${constants.mpuBucketPrefix}${bucketName}`);
+                            assert.strictEqual(objName, `overview${splitter}${objectKey}${splitter}${testUploadId}`);
+                            assert.strictEqual(objVal.completeInProgress, true);
+                        } else {
+                            assert.strictEqual(params.replayId, testUploadId);
+                            metadataBackend.putObject = origPutObject;
+                        }
+                        origPutObject(putBucketName, objName, objVal, params, log, cb);
+                        callCount += 1;
+                    };
+                    const parts = [{ partNumber: 1, eTag }];
+                    const completeRequest = _createCompleteMpuRequest(testUploadId, parts);
+                    completeMultipartUpload(authInfo, completeRequest, log, err => next(err, testUploadId));
+                },
+                (testUploadId, next) => {
+                    versioningTestUtils.assertDataStoreValues(ds, [undefined, objData[1], objData[2]]);
+
+                    const origPutObject = metadataBackend.putObject;
+                    metadataBackend.putObject = (putBucketName, objName, objVal, params, log, cb) => {
+                        assert.strictEqual(params.oldReplayId, testUploadId);
+                        metadataBackend.putObject = origPutObject;
+                        origPutObject(putBucketName, objName, objVal, params, log, cb);
+                    };
+                    // overwrite null version with a non-MPU object
+                    objectPut(authInfo, testPutObjectRequests[1], undefined, log, err => next(err));
+                },
+            ],
+            err => {
+                assert.ifError(err, `Unexpected err: ${err}`);
+                done();
+            },
+        );
+    });
 
     it('should finish deleting metadata on completeMultipartUpload retry', done => {
         let origDeleteObject;
@@ -2745,7 +2712,7 @@ describe('complete mpu with versioning', () => {
                 // the second call should not have created a new version
                 assert.strictEqual(nbVersions, 1);
                 for (const key of metadata.keyMaps.get(mpuBucket).keys()) {
-                    assert.fail('There should be no more keys in MPU bucket, ' + `found "${key}"`);
+                    assert.fail(`There should be no more keys in MPU bucket, found "${key}"`);
                 }
                 done();
             },
@@ -2753,8 +2720,8 @@ describe('complete mpu with versioning', () => {
     });
 
     it(
-        'should complete an MPU and promote its MD if it has been created by a failed complete before' +
-            'without creating a new version',
+        'should complete an MPU and promote its MD if it has been created by a failed complete ' +
+            'before without creating a new version',
         done => {
             const delMeta = metadataBackend.deleteObject;
             metadataBackend.deleteObject = (bucketName, objName, params, log, cb) => cb(errors.InternalError);
@@ -2838,7 +2805,7 @@ describe('multipart upload with object lock', () => {
 
     after(cleanup);
 
-    it('mpu object should contain retention info when mpu initiated with ' + 'object retention', done => {
+    it('mpu object should contain retention info when mpu initiated with object retention', done => {
         let versionId;
         async.waterfall(
             [
@@ -2873,7 +2840,7 @@ describe('multipart upload with object lock', () => {
         );
     });
 
-    it('mpu object should contain legal hold info when mpu initiated with ' + 'legal hold', done => {
+    it('mpu object should contain legal hold info when mpu initiated with legal hold', done => {
         let versionId;
         async.waterfall(
             [
@@ -3718,11 +3685,11 @@ describe('validatePerPartChecksums', () => {
                     };
                     const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
                     assert(err);
-                    assert.strictEqual(err.is.BadDigest, true);
+                    assert.strictEqual(err.message, 'BadDigest');
                     // AWS-style message: "The {algo} you specified for part {N} did not match what we received."
                     assert.strictEqual(
                         err.description,
-                        `The ${wrongAlgo} you specified for part 1 did ` + 'not match what we received.',
+                        `The ${wrongAlgo} you specified for part 1 did not match what we received.`,
                     );
                 });
 
@@ -3732,15 +3699,14 @@ describe('validatePerPartChecksums', () => {
                     };
                     const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
                     assert(err);
-                    assert.strictEqual(err.is.InvalidPart, true);
+                    assert.strictEqual(err.message, 'InvalidPart');
                     // AWS reuses its generic InvalidPart message — no algorithm
                     // or part number in the wording.
                     assert.strictEqual(
                         err.description,
                         'One or more of the specified parts could not be ' +
                             'found.  The part may not have been uploaded, or ' +
-                            'the specified entity tag may not match the ' +
-                            "part's entity tag.",
+                            "the specified entity tag may not match the part's entity tag.",
                     );
                 });
 
@@ -3755,9 +3721,9 @@ describe('validatePerPartChecksums', () => {
                     const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
                     if (requiresPerPart) {
                         assert(err);
-                        assert.strictEqual(err.is.InvalidRequest, true);
-                        assert(err.description.includes(algorithm));
-                        assert(err.description.includes('part 2 in the request'));
+                        assert.strictEqual(err.message, 'InvalidRequest');
+                        assert.match(err.description, new RegExp(algorithm));
+                        assert.match(err.description, /part 2 in the request/);
                     } else {
                         assert.ifError(err);
                     }
@@ -3780,8 +3746,7 @@ describe('validatePerPartChecksums', () => {
         const invalidPartMessage =
             'One or more of the specified parts could not be ' +
             'found.  The part may not have been uploaded, or ' +
-            'the specified entity tag may not match the ' +
-            "part's entity tag.";
+            "the specified entity tag may not match the part's entity tag.";
 
         it('should accept when no parts include a checksum field', () => {
             const jsonList = { Part: [makeJsonPart(1, 'etag1'), makeJsonPart(2, 'etag2')] };
@@ -3795,7 +3760,7 @@ describe('validatePerPartChecksums', () => {
             };
             const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
             assert(err);
-            assert.strictEqual(err.is.InvalidPart, true);
+            assert.strictEqual(err.message, 'InvalidPart');
             assert.strictEqual(err.description, invalidPartMessage);
         });
 
@@ -3805,7 +3770,7 @@ describe('validatePerPartChecksums', () => {
             };
             const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
             assert(err);
-            assert.strictEqual(err.is.InvalidPart, true);
+            assert.strictEqual(err.message, 'InvalidPart');
             assert.strictEqual(err.description, invalidPartMessage);
         });
 
@@ -3815,7 +3780,7 @@ describe('validatePerPartChecksums', () => {
             };
             const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
             assert(err);
-            assert.strictEqual(err.is.InvalidPart, true);
+            assert.strictEqual(err.message, 'InvalidPart');
             assert.strictEqual(err.description, invalidPartMessage);
         });
     });
@@ -3930,7 +3895,7 @@ describe('validatePerPartChecksums', () => {
             };
             const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
             assert(err);
-            assert.strictEqual(err.is.InvalidPart, true);
+            assert.strictEqual(err.message, 'InvalidPart');
         });
     });
 });
@@ -3970,13 +3935,12 @@ describe('CompleteMultipartUpload x-amz-checksum-type header', () => {
     it('should reject CompleteMPU with InvalidRequest when checksum-type does not match the MPU type', async () => {
         const uploadId = await setupMpu(explicitMpuHeaders);
         await assert.rejects(complete(uploadId, { 'x-amz-checksum-type': 'COMPOSITE' }), err => {
-            assert.strictEqual(err.is.InvalidRequest, true);
+            assert.strictEqual(err.message, 'InvalidRequest');
             // AWS-style mode-mismatch wording.
             assert.strictEqual(
                 err.description,
                 'The upload was created using the FULL_OBJECT checksum ' +
-                    'mode. The complete request must use the same checksum ' +
-                    'mode.',
+                    'mode. The complete request must use the same checksum mode.',
             );
             return true;
         });
@@ -3985,7 +3949,7 @@ describe('CompleteMultipartUpload x-amz-checksum-type header', () => {
     it('should reject CompleteMPU with InvalidRequest when x-amz-checksum-type value is bogus', async () => {
         const uploadId = await setupMpu(explicitMpuHeaders);
         await assert.rejects(complete(uploadId, { 'x-amz-checksum-type': 'BOGUS' }), err => {
-            assert.strictEqual(err.is.InvalidRequest, true);
+            assert.strictEqual(err.message, 'InvalidRequest');
             assert.strictEqual(err.description, 'Value for x-amz-checksum-type header is invalid.');
             return true;
         });
@@ -4010,7 +3974,7 @@ describe('CompleteMultipartUpload x-amz-checksum-type header', () => {
         try {
             const uploadId = await setupMpu({});
             await assert.rejects(complete(uploadId, { 'x-amz-checksum-type': 'FULL_OBJECT' }), err => {
-                assert.strictEqual(err.is.InvalidRequest, true);
+                assert.strictEqual(err.message, 'InvalidRequest');
                 assert.strictEqual(
                     err.description,
                     'The upload was not created with a checksum mode. ' +
@@ -4058,7 +4022,7 @@ describe('CompleteMultipartUpload body-checksum bypass', () => {
         };
         const err = await validateMethodChecksumNoChunking(request, body, log);
         assert(err, 'expected an error for body checksum mismatch');
-        assert.strictEqual(err.is.BadDigest, true);
+        assert.strictEqual(err.message, 'BadDigest');
     });
 });
 

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -4338,3 +4338,184 @@ describe('computeFinalChecksum', () => {
         assert.strictEqual(got.value, `${expected}-2`);
     });
 });
+
+describe('CompleteMultipartUpload final-object checksum storage', () => {
+    const log = new DummyRequestLogger();
+    const authInfo = makeAuthInfo('accessKey1');
+    const namespace = 'default';
+    const bucketName = 'bucketname-final-checksum';
+    const objectKey = 'testObject';
+    const partBody = Buffer.from('I am a part\n', 'utf8');
+    const partHash = crypto.createHash('md5').update(partBody).digest('hex');
+
+    const bucketPutRequest = {
+        bucketName,
+        namespace,
+        headers: { host: `${bucketName}.s3.amazonaws.com` },
+        url: '/',
+        post:
+            '<CreateBucketConfiguration ' +
+            'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+            '<LocationConstraint>scality-internal-mem</LocationConstraint>' +
+            '</CreateBucketConfiguration >',
+        actionImplicitDenies: false,
+    };
+
+    // (algorithm, type) pairs valid for an MPU per AWS rules.
+    // shouldStore reflects Part 3's gating: only FULL_OBJECT is persisted.
+    const STORAGE_MATRIX = [
+        { algorithm: 'crc32', type: 'FULL_OBJECT', shouldStore: true },
+        { algorithm: 'crc32c', type: 'FULL_OBJECT', shouldStore: true },
+        { algorithm: 'crc64nvme', type: 'FULL_OBJECT', shouldStore: true },
+        { algorithm: 'crc32', type: 'COMPOSITE', shouldStore: false },
+        { algorithm: 'crc32c', type: 'COMPOSITE', shouldStore: false },
+        { algorithm: 'sha1', type: 'COMPOSITE', shouldStore: false },
+        { algorithm: 'sha256', type: 'COMPOSITE', shouldStore: false },
+    ];
+
+    function bucketPutP() {
+        return new Promise((resolve, reject) =>
+            bucketPut(authInfo, bucketPutRequest, log, err => (err ? reject(err) : resolve())),
+        );
+    }
+
+    function initiateMpuP(headers) {
+        return new Promise((resolve, reject) => {
+            initiateMultipartUpload(
+                authInfo,
+                {
+                    bucketName,
+                    namespace,
+                    objectKey,
+                    headers: { host: `${bucketName}.s3.amazonaws.com`, ...headers },
+                    url: `/${objectKey}?uploads`,
+                    actionImplicitDenies: false,
+                },
+                log,
+                (err, xml) => {
+                    if (err) {
+                        return reject(err);
+                    }
+                    return parseString(xml, (parseErr, json) =>
+                        parseErr ? reject(parseErr) : resolve(json.InitiateMultipartUploadResult.UploadId[0]),
+                    );
+                },
+            );
+        });
+    }
+
+    function uploadPartP(uploadId, headers = {}) {
+        return new Promise((resolve, reject) => {
+            const partRequest = new DummyRequest(
+                {
+                    bucketName,
+                    namespace,
+                    objectKey,
+                    headers: { host: `${bucketName}.s3.amazonaws.com`, ...headers },
+                    url: `/${objectKey}?partNumber=1&uploadId=${uploadId}`,
+                    query: { partNumber: '1', uploadId },
+                    partHash,
+                    actionImplicitDenies: false,
+                },
+                partBody,
+            );
+            objectPutPart(authInfo, partRequest, undefined, log, err => (err ? reject(err) : resolve()));
+        });
+    }
+
+    function completeMpuP(uploadId, partChecksumXml = '') {
+        const completeBody =
+            '<CompleteMultipartUpload>' +
+            '<Part>' +
+            '<PartNumber>1</PartNumber>' +
+            `<ETag>"${partHash}"</ETag>${partChecksumXml}` +
+            '</Part>' +
+            '</CompleteMultipartUpload>';
+        return new Promise((resolve, reject) => {
+            completeMultipartUpload(
+                authInfo,
+                {
+                    bucketName,
+                    namespace,
+                    objectKey,
+                    parsedHost: 's3.amazonaws.com',
+                    url: `/${objectKey}?uploadId=${uploadId}`,
+                    headers: { host: `${bucketName}.s3.amazonaws.com` },
+                    query: { uploadId },
+                    post: completeBody,
+                    actionImplicitDenies: false,
+                },
+                log,
+                err => (err ? reject(err) : resolve()),
+            );
+        });
+    }
+
+    function fetchObjectMDP() {
+        return new Promise((resolve, reject) =>
+            metadataswitch.getObjectMD(bucketName, objectKey, {}, log, (err, md) => (err ? reject(err) : resolve(md))),
+        );
+    }
+
+    beforeEach(() => cleanup());
+
+    STORAGE_MATRIX.forEach(({ algorithm, type, shouldStore }) => {
+        const upper = algorithm.toUpperCase();
+        const verb = shouldStore ? 'should persist' : 'should not persist';
+        const tag = TAG_BY_ALGO[algorithm];
+
+        it(`${verb} ${type} ${upper} checksum on the ObjectMD`, async () => {
+            await bucketPutP();
+            const uploadId = await initiateMpuP({
+                'x-amz-checksum-algorithm': upper,
+                'x-amz-checksum-type': type,
+            });
+            // Pre-compute the part's checksum so we can supply it on
+            // UploadPart and (for COMPOSITE non-default) in the Complete body.
+            const partChecksum = await algorithms[algorithm].digest(partBody);
+            const uploadHeaders = type === 'COMPOSITE' ? { [`x-amz-checksum-${algorithm}`]: partChecksum } : {};
+            await uploadPartP(uploadId, uploadHeaders);
+            const partChecksumXml = type === 'COMPOSITE' ? `<${tag}>${partChecksum}</${tag}>` : '';
+            await completeMpuP(uploadId, partChecksumXml);
+            const md = await fetchObjectMDP();
+            if (shouldStore) {
+                assert(md.checksum, `expected ${type} ${upper} checksum on ObjectMD`);
+                assert.strictEqual(md.checksum.checksumAlgorithm, algorithm);
+                assert.strictEqual(md.checksum.checksumType, type);
+                assert(typeof md.checksum.checksumValue === 'string');
+                assert(md.checksum.checksumValue.length > 0);
+            } else {
+                assert.strictEqual(md.checksum, undefined, `${type} ${upper} should not persist on ObjectMD`);
+            }
+        });
+    });
+
+    it('should persist FULL_OBJECT CRC64NVME checksum for default MPU (no checksum headers)', async () => {
+        // No x-amz-checksum-algorithm / x-amz-checksum-type headers — AWS
+        // defaults to crc64nvme/FULL_OBJECT and still persists the result.
+        await bucketPutP();
+        const uploadId = await initiateMpuP({});
+        await uploadPartP(uploadId);
+        await completeMpuP(uploadId);
+        const md = await fetchObjectMDP();
+        assert(md.checksum, 'default MPU should still persist a checksum');
+        assert.strictEqual(md.checksum.checksumAlgorithm, 'crc64nvme');
+        assert.strictEqual(md.checksum.checksumType, 'FULL_OBJECT');
+    });
+
+    it('should not leak checksumAlgorithm/Type/IsDefault into ObjectMD top-level fields', async () => {
+        // keysNotNeeded keeps these MPU-overview-only keys out of metaHeaders,
+        // which prevents them from sticking around on the final ObjectMD.
+        await bucketPutP();
+        const uploadId = await initiateMpuP({
+            'x-amz-checksum-algorithm': 'CRC32',
+            'x-amz-checksum-type': 'FULL_OBJECT',
+        });
+        await uploadPartP(uploadId);
+        await completeMpuP(uploadId);
+        const md = await fetchObjectMDP();
+        assert.strictEqual(md.checksumAlgorithm, undefined);
+        assert.strictEqual(md.checksumType, undefined);
+        assert.strictEqual(md.checksumIsDefault, undefined);
+    });
+});

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -13,6 +13,11 @@ const bucketPutPolicy = require('../../../lib/api/bucketPutPolicy');
 const bucketPutVersioning = require('../../../lib/api/bucketPutVersioning');
 const objectPut = require('../../../lib/api/objectPut');
 const completeMultipartUpload = require('../../../lib/api/completeMultipartUpload');
+const { validatePerPartChecksums, computeFinalChecksum } = completeMultipartUpload;
+const {
+    validateMethodChecksumNoChunking,
+    algorithms,
+} = require('../../../lib/api/apiUtils/integrity/validateChecksums');
 const constants = require('../../../constants');
 const { cleanup, DummyRequestLogger, makeAuthInfo, versioningTestUtils } = require('../helpers');
 const getObjectLegalHold = require('../../../lib/api/objectGetLegalHold');
@@ -20,6 +25,7 @@ const getObjectRetention = require('../../../lib/api/objectGetRetention');
 const initiateMultipartUpload = require('../../../lib/api/initiateMultipartUpload');
 const multipartDelete = require('../../../lib/api/multipartDelete');
 const objectPutPart = require('../../../lib/api/objectPutPart');
+const services = require('../../../lib/services');
 const DummyRequest = require('../DummyRequest');
 const changeObjectLock = require('../../utilities/objectLock-util');
 const metadataswitch = require('../metadataswitch');
@@ -178,6 +184,79 @@ async function _uploadMpuObject(params = {}) {
     const resp = await _completeMultipartUpload(authInfo, { ...completeRequest, headers }, log);
 
     return resp.headers;
+}
+
+// Constants and helpers used by the validatePerPartChecksums and
+// computeFinalChecksum unit tests below.
+const UPLOAD_ID = 'upload-id-1';
+
+// XML element name AWS uses for each algorithm in CompleteMultipartUpload's
+// per-part body.
+const TAG_BY_ALGO = {
+    crc32: 'ChecksumCRC32',
+    crc32c: 'ChecksumCRC32C',
+    crc64nvme: 'ChecksumCRC64NVME',
+    sha1: 'ChecksumSHA1',
+    sha256: 'ChecksumSHA256',
+};
+
+// Two distinct base64 placeholder digests per algorithm. Sized to the real
+// digest lengths so the test data looks realistic, though the validator
+// itself doesn't enforce length.
+const SAMPLE_DIGESTS = {
+    crc32: ['AQIDBA==', 'BQYHCA=='],
+    crc32c: ['CQoLDA==', 'DQ4PEA=='],
+    crc64nvme: ['AQIDBAUGBwg=', 'CQoLDA0ODxA='],
+    sha1: ['YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=', 'YmJiYmJiYmJiYmJiYmJiYmJiYmJiYmI='],
+    sha256: ['YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=', 'YmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmI='],
+};
+
+// Every AWS-valid (algorithm, type) combination for an explicit-algorithm MPU.
+// See validateChecksums.getChecksumDataFromMPUHeaders for the source of truth.
+// The implicit-default MPU (isDefault=true) is tested separately because AWS
+// rejects any per-part Checksum<X> field on a default MPU with InvalidPart,
+// regardless of value or algorithm.
+const MATRIX = [
+    { algorithm: 'crc32', type: 'COMPOSITE' },
+    { algorithm: 'crc32', type: 'FULL_OBJECT' },
+    { algorithm: 'crc32c', type: 'COMPOSITE' },
+    { algorithm: 'crc32c', type: 'FULL_OBJECT' },
+    { algorithm: 'crc64nvme', type: 'FULL_OBJECT' },
+    { algorithm: 'sha1', type: 'COMPOSITE' },
+    { algorithm: 'sha256', type: 'COMPOSITE' },
+];
+
+function makeStoredPart(partNumber, checksum) {
+    const value = {
+        ETag: 'd41d8cd98f00b204e9800998ecf8427e',
+        Size: 5242880,
+        partLocations: [{ key: `data-${partNumber}`, dataStoreName: 'us-east-1' }],
+    };
+    if (checksum) {
+        value.ChecksumAlgorithm = checksum.algorithm;
+        value.ChecksumValue = checksum.value;
+    }
+    return {
+        key: `${UPLOAD_ID}${splitter}${partNumber}`,
+        value,
+    };
+}
+
+function makeJsonPart(partNumber, eTag, checksums) {
+    const part = {
+        PartNumber: [String(partNumber)],
+        ETag: [`"${eTag}"`],
+    };
+    if (checksums) {
+        Object.entries(checksums).forEach(([tag, value]) => {
+            part[tag] = [value];
+        });
+    }
+    return part;
+}
+
+function pickWrongAlgo(algo) {
+    return Object.keys(TAG_BY_ALGO).find(a => a !== algo);
 }
 
 describe('Multipart Upload API', () => {
@@ -3605,4 +3684,453 @@ describe('initiateMultipartUpload checksum headers', () => {
             );
         });
     });
+});
+
+describe('validatePerPartChecksums', () => {
+    describe('AWS combination matrix', () => {
+        MATRIX.forEach(({ algorithm, type, isDefault }) => {
+            const label = `${algorithm}/${type}${isDefault ? ' (default)' : ''}`;
+            const tag = TAG_BY_ALGO[algorithm];
+            const [d1, d2] = SAMPLE_DIGESTS[algorithm];
+            const mpuChecksum = { algorithm, type, isDefault };
+
+            const stored = [makeStoredPart(1, { algorithm, value: d1 }), makeStoredPart(2, { algorithm, value: d2 })];
+
+            describe(label, () => {
+                it('should accept when every part includes the matching checksum', () => {
+                    const jsonList = {
+                        Part: [makeJsonPart(1, 'etag1', { [tag]: d1 }), makeJsonPart(2, 'etag2', { [tag]: d2 })],
+                    };
+                    const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
+                    assert.strictEqual(err, null);
+                });
+
+                it('should return BadDigest when a part uses the wrong checksum field', () => {
+                    const wrongAlgo = pickWrongAlgo(algorithm);
+                    const wrongTag = TAG_BY_ALGO[wrongAlgo];
+                    const wrongDigest = SAMPLE_DIGESTS[wrongAlgo][0];
+                    const jsonList = {
+                        Part: [
+                            makeJsonPart(1, 'etag1', { [wrongTag]: wrongDigest }),
+                            makeJsonPart(2, 'etag2', { [tag]: d2 }),
+                        ],
+                    };
+                    const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
+                    assert(err);
+                    assert.strictEqual(err.is.BadDigest, true);
+                    // AWS-style message: "The {algo} you specified for part {N} did not match what we received."
+                    assert.strictEqual(
+                        err.description,
+                        `The ${wrongAlgo} you specified for part 1 did ` + 'not match what we received.',
+                    );
+                });
+
+                it('should return InvalidPart when the matching field has the wrong value', () => {
+                    const jsonList = {
+                        Part: [makeJsonPart(1, 'etag1', { [tag]: d1 }), makeJsonPart(2, 'etag2', { [tag]: d1 })],
+                    };
+                    const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
+                    assert(err);
+                    assert.strictEqual(err.is.InvalidPart, true);
+                    // AWS reuses its generic InvalidPart message — no algorithm
+                    // or part number in the wording.
+                    assert.strictEqual(
+                        err.description,
+                        'One or more of the specified parts could not be ' +
+                            'found.  The part may not have been uploaded, or ' +
+                            'the specified entity tag may not match the ' +
+                            "part's entity tag.",
+                    );
+                });
+
+                const requiresPerPart = type === 'COMPOSITE' && !isDefault;
+                const missingLabel = requiresPerPart
+                    ? 'should return InvalidRequest when a part is missing its checksum'
+                    : 'should accept a parts list missing per-part checksums';
+                it(missingLabel, () => {
+                    const jsonList = {
+                        Part: [makeJsonPart(1, 'etag1', { [tag]: d1 }), makeJsonPart(2, 'etag2')],
+                    };
+                    const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
+                    if (requiresPerPart) {
+                        assert(err);
+                        assert.strictEqual(err.is.InvalidRequest, true);
+                        assert(err.description.includes(algorithm));
+                        assert(err.description.includes('part 2 in the request'));
+                    } else {
+                        assert.strictEqual(err, null);
+                    }
+                });
+            });
+        });
+    });
+
+    describe('legacy MPU (no algorithm configured)', () => {
+        // Pre-feature MPUs have storedMetadata.checksumAlgorithm === undefined.
+        // Pre-PR CompleteMPU silently ignored any per-part Checksum<X> body
+        // elements; preserve that so in-flight uploads across the upgrade
+        // boundary don't start failing with BadDigest.
+        const mpuChecksum = { algorithm: undefined, type: undefined, isDefault: undefined };
+        const stored = [makeStoredPart(1), makeStoredPart(2)];
+
+        it('should accept when no parts include a checksum field', () => {
+            const jsonList = { Part: [makeJsonPart(1, 'etag1'), makeJsonPart(2, 'etag2')] };
+            const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
+            assert.strictEqual(err, null);
+        });
+
+        it('should accept when a part includes a single Checksum<X> field', () => {
+            const jsonList = {
+                Part: [
+                    makeJsonPart(1, 'etag1', { ChecksumSHA256: SAMPLE_DIGESTS.sha256[0] }),
+                    makeJsonPart(2, 'etag2'),
+                ],
+            };
+            const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
+            assert.strictEqual(err, null);
+        });
+
+        it('should accept when parts include multiple Checksum<X> fields', () => {
+            const jsonList = {
+                Part: [
+                    makeJsonPart(1, 'etag1', {
+                        ChecksumSHA256: SAMPLE_DIGESTS.sha256[0],
+                        ChecksumCRC32: SAMPLE_DIGESTS.crc32[0],
+                    }),
+                    makeJsonPart(2, 'etag2', { ChecksumCRC64NVME: SAMPLE_DIGESTS.crc64nvme[1] }),
+                ],
+            };
+            const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
+            assert.strictEqual(err, null);
+        });
+    });
+    describe('edge cases', () => {
+        it('should accept an empty parts list', () => {
+            const mpuChecksum = {
+                algorithm: 'sha256',
+                type: 'COMPOSITE',
+                isDefault: false,
+            };
+            const err = validatePerPartChecksums({ Part: [] }, [], splitter, mpuChecksum);
+            assert.strictEqual(err, null);
+        });
+
+        it('should accept a parts list with no Part array (treated as empty)', () => {
+            const mpuChecksum = {
+                algorithm: 'crc64nvme',
+                type: 'FULL_OBJECT',
+                isDefault: true,
+            };
+            const err = validatePerPartChecksums({}, [], splitter, mpuChecksum);
+            assert.strictEqual(err, null);
+        });
+
+        it('should accept a FULL_OBJECT mixed list (one part with checksum, one without)', () => {
+            const mpuChecksum = {
+                algorithm: 'crc32',
+                type: 'FULL_OBJECT',
+                isDefault: false,
+            };
+            const [d1, d2] = SAMPLE_DIGESTS.crc32;
+            const stored = [
+                makeStoredPart(1, { algorithm: 'crc32', value: d1 }),
+                makeStoredPart(2, { algorithm: 'crc32', value: d2 }),
+            ];
+            const jsonList = {
+                Part: [makeJsonPart(1, 'etag1', { ChecksumCRC32: d1 }), makeJsonPart(2, 'etag2')],
+            };
+            const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
+            assert.strictEqual(err, null);
+        });
+
+        it('should not enforce per-part presence when MPU algorithm is unknown', () => {
+            // CreateMPU should never let this state through, but guard against
+            // an "InvalidRequest: using a undefined checksum" error if it did.
+            const mpuChecksum = {
+                algorithm: undefined,
+                type: 'COMPOSITE',
+                isDefault: false,
+            };
+            const stored = [makeStoredPart(1, null), makeStoredPart(2, null)];
+            const jsonList = {
+                Part: [makeJsonPart(1, 'etag1'), makeJsonPart(2, 'etag2')],
+            };
+            const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
+            assert.strictEqual(err, null);
+        });
+
+        it('should return InvalidPart when stored part has no checksum but request does', () => {
+            const mpuChecksum = {
+                algorithm: 'sha256',
+                type: 'COMPOSITE',
+                isDefault: false,
+            };
+            const stored = [makeStoredPart(1, null)];
+            const jsonList = {
+                Part: [
+                    makeJsonPart(1, 'etag1', {
+                        ChecksumSHA256: SAMPLE_DIGESTS.sha256[0],
+                    }),
+                ],
+            };
+            const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
+            assert(err);
+            assert.strictEqual(err.is.InvalidPart, true);
+        });
+    });
+});
+
+describe('CompleteMultipartUpload x-amz-checksum-type header', () => {
+    const log = new DummyRequestLogger();
+    const authInfo = makeAuthInfo('accessKey1');
+    const namespace = 'default';
+    const bucketName = 'bucketname-checksum-type';
+    const objectKey = 'testObject';
+
+    const bucketPutRequest = {
+        bucketName,
+        namespace,
+        headers: { host: `${bucketName}.s3.amazonaws.com` },
+        url: '/',
+        post:
+            '<CreateBucketConfiguration ' +
+            'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+            '<LocationConstraint>scality-internal-mem</LocationConstraint>' +
+            '</CreateBucketConfiguration >',
+        actionImplicitDenies: false,
+    };
+
+    function setupMpu(initiateHeaders, cb) {
+        async.waterfall(
+            [
+                next => bucketPut(authInfo, bucketPutRequest, log, next),
+                (corsHeaders, next) => {
+                    const initiateRequest = {
+                        bucketName,
+                        namespace,
+                        objectKey,
+                        headers: {
+                            host: `${bucketName}.s3.amazonaws.com`,
+                            ...initiateHeaders,
+                        },
+                        url: `/${objectKey}?uploads`,
+                        actionImplicitDenies: false,
+                    };
+                    initiateMultipartUpload(authInfo, initiateRequest, log, next);
+                },
+                (xml, corsHeaders, next) => parseString(xml, next),
+                (json, next) => {
+                    const uploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                    const partBody = Buffer.from('I am a part\n', 'utf8');
+                    const partHash = crypto.createHash('md5').update(partBody).digest('hex');
+                    const partRequest = new DummyRequest(
+                        {
+                            bucketName,
+                            namespace,
+                            objectKey,
+                            headers: { host: `${bucketName}.s3.amazonaws.com` },
+                            url: `/${objectKey}?partNumber=1&uploadId=${uploadId}`,
+                            query: { partNumber: '1', uploadId },
+                            partHash,
+                            actionImplicitDenies: false,
+                        },
+                        partBody,
+                    );
+                    objectPutPart(authInfo, partRequest, undefined, log, err => next(err, uploadId, partHash));
+                },
+            ],
+            cb,
+        );
+    }
+
+    function makeCompleteRequest(uploadId, partHash, extraHeaders) {
+        const completeBody =
+            '<CompleteMultipartUpload>' +
+            '<Part>' +
+            '<PartNumber>1</PartNumber>' +
+            `<ETag>"${partHash}"</ETag>` +
+            '</Part>' +
+            '</CompleteMultipartUpload>';
+        return {
+            bucketName,
+            namespace,
+            objectKey,
+            parsedHost: 's3.amazonaws.com',
+            url: `/${objectKey}?uploadId=${uploadId}`,
+            headers: {
+                host: `${bucketName}.s3.amazonaws.com`,
+                ...extraHeaders,
+            },
+            query: { uploadId },
+            post: completeBody,
+            actionImplicitDenies: false,
+        };
+    }
+
+    beforeEach(() => cleanup());
+
+    it('should accept CompleteMPU when no x-amz-checksum-type header is sent', done => {
+        const initiateHeaders = {
+            'x-amz-checksum-algorithm': 'CRC32',
+            'x-amz-checksum-type': 'FULL_OBJECT',
+        };
+        setupMpu(initiateHeaders, (err, uploadId, partHash) => {
+            assert.ifError(err);
+            const req = makeCompleteRequest(uploadId, partHash, {});
+            completeMultipartUpload(authInfo, req, log, completeErr => {
+                assert.ifError(completeErr);
+                done();
+            });
+        });
+    });
+
+    it('should accept CompleteMPU when x-amz-checksum-type matches the MPU type', done => {
+        const initiateHeaders = {
+            'x-amz-checksum-algorithm': 'CRC32',
+            'x-amz-checksum-type': 'FULL_OBJECT',
+        };
+        setupMpu(initiateHeaders, (err, uploadId, partHash) => {
+            assert.ifError(err);
+            const req = makeCompleteRequest(uploadId, partHash, {
+                'x-amz-checksum-type': 'FULL_OBJECT',
+            });
+            completeMultipartUpload(authInfo, req, log, completeErr => {
+                assert.ifError(completeErr);
+                done();
+            });
+        });
+    });
+
+    it('should reject CompleteMPU with InvalidRequest when x-amz-checksum-type does not match the MPU type', done => {
+        const initiateHeaders = {
+            'x-amz-checksum-algorithm': 'CRC32',
+            'x-amz-checksum-type': 'FULL_OBJECT',
+        };
+        setupMpu(initiateHeaders, (err, uploadId, partHash) => {
+            assert.ifError(err);
+            const req = makeCompleteRequest(uploadId, partHash, {
+                'x-amz-checksum-type': 'COMPOSITE',
+            });
+            completeMultipartUpload(authInfo, req, log, completeErr => {
+                assert(completeErr);
+                assert.strictEqual(completeErr.is.InvalidRequest, true);
+                // AWS-style mode-mismatch wording.
+                assert.strictEqual(
+                    completeErr.description,
+                    'The upload was created using the FULL_OBJECT checksum ' +
+                        'mode. The complete request must use the same checksum ' +
+                        'mode.',
+                );
+                done();
+            });
+        });
+    });
+
+    it('should reject CompleteMPU with InvalidRequest when x-amz-checksum-type value is bogus', done => {
+        const initiateHeaders = {
+            'x-amz-checksum-algorithm': 'CRC32',
+            'x-amz-checksum-type': 'FULL_OBJECT',
+        };
+        setupMpu(initiateHeaders, (err, uploadId, partHash) => {
+            assert.ifError(err);
+            const req = makeCompleteRequest(uploadId, partHash, {
+                'x-amz-checksum-type': 'BOGUS',
+            });
+            completeMultipartUpload(authInfo, req, log, completeErr => {
+                assert(completeErr);
+                assert.strictEqual(completeErr.is.InvalidRequest, true);
+                assert.strictEqual(completeErr.description, 'Value for x-amz-checksum-type header is invalid.');
+                done();
+            });
+        });
+    });
+
+    it('should compare x-amz-checksum-type case-insensitively', done => {
+        const initiateHeaders = {
+            'x-amz-checksum-algorithm': 'CRC32',
+            'x-amz-checksum-type': 'FULL_OBJECT',
+        };
+        setupMpu(initiateHeaders, (err, uploadId, partHash) => {
+            assert.ifError(err);
+            const req = makeCompleteRequest(uploadId, partHash, {
+                'x-amz-checksum-type': 'full_object',
+            });
+            completeMultipartUpload(authInfo, req, log, completeErr => {
+                assert.ifError(completeErr);
+                done();
+            });
+        });
+    });
+
+    it('should reject CompleteMPU with a dedicated message when the MPU has no checksum mode', done => {
+        const original = services.metadataValidateMultipart;
+        const stub = sinon.stub(services, 'metadataValidateMultipart').callsFake((params, cb) =>
+            original.call(services, params, (validateErr, mpuBucket, mpuOverview, storedMetadata) => {
+                if (storedMetadata) {
+                    // eslint-disable-next-line no-param-reassign
+                    delete storedMetadata.checksumType;
+                }
+                cb(validateErr, mpuBucket, mpuOverview, storedMetadata);
+            }),
+        );
+        setupMpu({}, (err, uploadId, partHash) => {
+            assert.ifError(err);
+            const req = makeCompleteRequest(uploadId, partHash, {
+                'x-amz-checksum-type': 'FULL_OBJECT',
+            });
+            completeMultipartUpload(authInfo, req, log, completeErr => {
+                stub.restore();
+                assert(completeErr);
+                assert.strictEqual(completeErr.is.InvalidRequest, true);
+                assert.strictEqual(
+                    completeErr.description,
+                    'The upload was not created with a checksum mode. ' +
+                        'The complete request must not include a x-amz-checksum-type header.',
+                );
+                done();
+            });
+        });
+    });
+});
+
+describe('CompleteMultipartUpload body-checksum bypass', () => {
+    const log = new DummyRequestLogger();
+
+    it(
+        'validateMethodChecksumNoChunking returns null for completeMultipartUpload ' +
+            'even when x-amz-checksum-sha256 does not match the body digest',
+        async () => {
+            const body = Buffer.from(
+                '<CompleteMultipartUpload><Part><PartNumber>1</PartNumber>' +
+                    '<ETag>"abc"</ETag></Part></CompleteMultipartUpload>',
+            );
+            // A syntactically valid SHA256 base64 digest that is NOT the digest of `body`
+            // (it's the digest of the empty string). On CompleteMPU this header carries
+            // the expected final-object checksum, not a body checksum, so pre-validation
+            // must skip it.
+            const finalObjectChecksum = '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';
+            const request = {
+                apiMethod: 'completeMultipartUpload',
+                headers: { 'x-amz-checksum-sha256': finalObjectChecksum },
+            };
+            const err = await validateMethodChecksumNoChunking(request, body, log);
+            assert.strictEqual(err, null);
+        },
+    );
+
+    it(
+        'validateMethodChecksumNoChunking still rejects body mismatch for methods ' +
+            'that remain in checksumedMethods (sanity check)',
+        async () => {
+            const body = Buffer.from('{"Objects":[]}');
+            const finalObjectChecksum = '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';
+            const request = {
+                apiMethod: 'multiObjectDelete',
+                headers: { 'x-amz-checksum-sha256': finalObjectChecksum },
+            };
+            const err = await validateMethodChecksumNoChunking(request, body, log);
+            assert(err, 'expected an error for body checksum mismatch');
+            assert.strictEqual(err.is.BadDigest, true);
+        },
+    );
 });

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -3688,11 +3688,11 @@ describe('initiateMultipartUpload checksum headers', () => {
 
 describe('validatePerPartChecksums', () => {
     describe('AWS combination matrix', () => {
-        MATRIX.forEach(({ algorithm, type, isDefault }) => {
-            const label = `${algorithm}/${type}${isDefault ? ' (default)' : ''}`;
+        MATRIX.forEach(({ algorithm, type }) => {
+            const label = `${algorithm}/${type}`;
             const tag = TAG_BY_ALGO[algorithm];
             const [d1, d2] = SAMPLE_DIGESTS[algorithm];
-            const mpuChecksum = { algorithm, type, isDefault };
+            const mpuChecksum = { algorithm, type, isDefault: false };
 
             const stored = [makeStoredPart(1, { algorithm, value: d1 }), makeStoredPart(2, { algorithm, value: d2 })];
 
@@ -3743,7 +3743,7 @@ describe('validatePerPartChecksums', () => {
                     );
                 });
 
-                const requiresPerPart = type === 'COMPOSITE' && !isDefault;
+                const requiresPerPart = type === 'COMPOSITE';
                 const missingLabel = requiresPerPart
                     ? 'should return InvalidRequest when a part is missing its checksum'
                     : 'should accept a parts list missing per-part checksums';
@@ -3762,6 +3762,60 @@ describe('validatePerPartChecksums', () => {
                     }
                 });
             });
+        });
+    });
+
+    describe('default MPU (isDefault=true)', () => {
+        // AWS S3 rejects any per-part
+        // Checksum<X> field on a default MPU with InvalidPart — even when
+        // the field matches the implicit CRC64NVME algorithm and the value
+        // is the same one the part was stored with.
+        const mpuChecksum = { algorithm: 'crc64nvme', type: 'FULL_OBJECT', isDefault: true };
+        const [d1, d2] = SAMPLE_DIGESTS.crc64nvme;
+        const stored = [
+            makeStoredPart(1, { algorithm: 'crc64nvme', value: d1 }),
+            makeStoredPart(2, { algorithm: 'crc64nvme', value: d2 }),
+        ];
+        const invalidPartMessage =
+            'One or more of the specified parts could not be ' +
+            'found.  The part may not have been uploaded, or ' +
+            'the specified entity tag may not match the ' +
+            "part's entity tag.";
+
+        it('should accept when no parts include a checksum field', () => {
+            const jsonList = { Part: [makeJsonPart(1, 'etag1'), makeJsonPart(2, 'etag2')] };
+            const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
+            assert.strictEqual(err, null);
+        });
+
+        it('should return InvalidPart when a part includes the matching field (correct value)', () => {
+            const jsonList = {
+                Part: [makeJsonPart(1, 'etag1', { ChecksumCRC64NVME: d1 }), makeJsonPart(2, 'etag2')],
+            };
+            const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
+            assert(err);
+            assert.strictEqual(err.is.InvalidPart, true);
+            assert.strictEqual(err.description, invalidPartMessage);
+        });
+
+        it('should return InvalidPart when a part includes the matching field (wrong value)', () => {
+            const jsonList = {
+                Part: [makeJsonPart(1, 'etag1', { ChecksumCRC64NVME: d2 }), makeJsonPart(2, 'etag2')],
+            };
+            const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
+            assert(err);
+            assert.strictEqual(err.is.InvalidPart, true);
+            assert.strictEqual(err.description, invalidPartMessage);
+        });
+
+        it('should return InvalidPart when a part includes a non-matching algorithm field', () => {
+            const jsonList = {
+                Part: [makeJsonPart(1, 'etag1', { ChecksumCRC32: SAMPLE_DIGESTS.crc32[0] }), makeJsonPart(2, 'etag2')],
+            };
+            const err = validatePerPartChecksums(jsonList, stored, splitter, mpuChecksum);
+            assert(err);
+            assert.strictEqual(err.is.InvalidPart, true);
+            assert.strictEqual(err.description, invalidPartMessage);
         });
     });
 

--- a/tests/unit/utils/mpuUtils.js
+++ b/tests/unit/utils/mpuUtils.js
@@ -4,14 +4,13 @@ const crypto = require('crypto');
 const xml2js = require('xml2js');
 
 const DummyRequest = require('../DummyRequest');
-const initiateMultipartUpload
-    = require('../../../lib/api/initiateMultipartUpload');
+const { bucketPut } = require('../../../lib/api/bucketPut');
+const initiateMultipartUpload = require('../../../lib/api/initiateMultipartUpload');
 const objectPutPart = require('../../../lib/api/objectPutPart');
-const completeMultipartUpload
-    = require('../../../lib/api/completeMultipartUpload');
+const completeMultipartUpload = require('../../../lib/api/completeMultipartUpload');
+const metadataswitch = require('../metadataswitch');
 
-const { makeAuthInfo }
-    = require('../helpers');
+const { makeAuthInfo } = require('../helpers');
 
 const canonicalID = 'accessKey1';
 const authInfo = makeAuthInfo(canonicalID);
@@ -21,12 +20,27 @@ const partBody = Buffer.from('I am a part\n', 'utf8');
 const md5Hash = crypto.createHash('md5').update(partBody);
 const calculatedHash = md5Hash.digest('hex');
 
-function createinitiateMPURequest(namespace, bucketName, objectKey) {
+function createBucketPutRequest(namespace, bucketName, location = 'scality-internal-mem') {
+    return {
+        bucketName,
+        namespace,
+        headers: { host: `${bucketName}.s3.amazonaws.com` },
+        url: '/',
+        post:
+            '<CreateBucketConfiguration ' +
+            'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+            `<LocationConstraint>${location}</LocationConstraint>` +
+            '</CreateBucketConfiguration >',
+        actionImplicitDenies: false,
+    };
+}
+
+function createinitiateMPURequest(namespace, bucketName, objectKey, extraHeaders = {}) {
     const request = {
         bucketName,
         namespace,
         objectKey,
-        headers: { host: `${bucketName}.s3.amazonaws.com` },
+        headers: { host: `${bucketName}.s3.amazonaws.com`, ...extraHeaders },
         url: `/${objectKey}?uploads`,
         actionImplicitDenies: false,
     };
@@ -34,32 +48,37 @@ function createinitiateMPURequest(namespace, bucketName, objectKey) {
     return request;
 }
 
-function createPutPartRequest(namespace, bucketName, objectKey, partNumber, testUploadId) {
-    const request = new DummyRequest({
-        bucketName,
-        namespace,
-        objectKey,
-        headers: { host: `${bucketName}.s3.amazonaws.com` },
-        url: `/${objectKey}?partNumber=${partNumber}&uploadId=${testUploadId}`,
-        query: {
-            partNumber,
-            uploadId: testUploadId,
+function createPutPartRequest(namespace, bucketName, objectKey, partNumber, testUploadId, extraHeaders = {}) {
+    const request = new DummyRequest(
+        {
+            bucketName,
+            namespace,
+            objectKey,
+            headers: { host: `${bucketName}.s3.amazonaws.com`, ...extraHeaders },
+            url: `/${objectKey}?partNumber=${partNumber}&uploadId=${testUploadId}`,
+            query: {
+                partNumber,
+                uploadId: testUploadId,
+            },
+            calculatedHash,
+            actionImplicitDenies: false,
         },
-        calculatedHash,
-        actionImplicitDenies: false,
-    }, partBody);
+        partBody,
+    );
 
     return request;
 }
 
-function createCompleteRequest(namespace, bucketName, objectKey, testUploadId) {
-  // only suports a single part for now
-    const completeBody = '<CompleteMultipartUpload>' +
-                         '<Part>' +
-                         '<PartNumber>1</PartNumber>' +
-                         `<ETag>"${calculatedHash}"</ETag>` +
-                         '</Part>' +
-                         '</CompleteMultipartUpload>';
+function createCompleteRequest(namespace, bucketName, objectKey, testUploadId, opts = {}) {
+    const { extraHeaders = {}, partChecksumXml = '' } = opts;
+    // only supports a single part for now
+    const completeBody =
+        '<CompleteMultipartUpload>' +
+        '<Part>' +
+        '<PartNumber>1</PartNumber>' +
+        `<ETag>"${calculatedHash}"</ETag>${partChecksumXml}` +
+        '</Part>' +
+        '</CompleteMultipartUpload>';
 
     const request = {
         bucketName,
@@ -67,7 +86,7 @@ function createCompleteRequest(namespace, bucketName, objectKey, testUploadId) {
         objectKey,
         parsedHost: 's3.amazonaws.com',
         url: `/${objectKey}?uploadId=${testUploadId}`,
-        headers: { host: `${bucketName}.s3.amazonaws.com` },
+        headers: { host: `${bucketName}.s3.amazonaws.com`, ...extraHeaders },
         query: { uploadId: testUploadId },
         post: completeBody,
         actionImplicitDenies: false,
@@ -78,36 +97,97 @@ function createCompleteRequest(namespace, bucketName, objectKey, testUploadId) {
 
 function createMPU(namespace, bucketName, objectKey, logger, cb) {
     let testUploadId;
-    async.waterfall([
-        next => {
-            const initiateMPURequest = createinitiateMPURequest(namespace,
-                                                                bucketName,
-                                                                objectKey);
-            initiateMultipartUpload(authInfo, initiateMPURequest, logger, next);
+    async.waterfall(
+        [
+            next => {
+                const initiateMPURequest = createinitiateMPURequest(namespace, bucketName, objectKey);
+                initiateMultipartUpload(authInfo, initiateMPURequest, logger, next);
+            },
+            (result, corsHeaders, next) => xml2js.parseString(result, next),
+            (json, next) => {
+                testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+                const partRequest = createPutPartRequest(namespace, bucketName, objectKey, 1, testUploadId);
+                objectPutPart(authInfo, partRequest, undefined, logger, next);
+            },
+            (hexDigest, corsHeaders, next) => {
+                const completeRequest = createCompleteRequest(namespace, bucketName, objectKey, testUploadId);
+                completeMultipartUpload(authInfo, completeRequest, logger, next);
+            },
+        ],
+        err => {
+            assert.ifError(err);
+            cb(null, testUploadId);
         },
-        (result, corsHeaders, next) => xml2js.parseString(result, next),
-        (json, next) => {
-            testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
-            const partRequest =
-            createPutPartRequest(namespace, bucketName, objectKey, 1, testUploadId);
-            objectPutPart(authInfo, partRequest, undefined, logger, next);
-        },
-        (hexDigest, corsHeaders, next) => {
-            const completeRequest =
-                createCompleteRequest(namespace, bucketName, objectKey, testUploadId);
-            completeMultipartUpload(authInfo, completeRequest, logger, next);
-        },
-    ], err => {
-        assert.ifError(err);
-        cb(null, testUploadId);
-    });
+    );
 
     return testUploadId;
 }
 
+function bucketPutP(bucketName, namespace, logger, location) {
+    return new Promise((resolve, reject) => {
+        bucketPut(authInfo, createBucketPutRequest(namespace, bucketName, location), logger, err =>
+            err ? reject(err) : resolve(),
+        );
+    });
+}
+
+function initiateMpuP(bucketName, namespace, objectKey, logger, extraHeaders) {
+    return new Promise((resolve, reject) => {
+        const req = createinitiateMPURequest(namespace, bucketName, objectKey, extraHeaders);
+        initiateMultipartUpload(authInfo, req, logger, (err, xml) => {
+            if (err) {
+                return reject(err);
+            }
+            return xml2js.parseString(xml, (parseErr, json) =>
+                parseErr ? reject(parseErr) : resolve(json.InitiateMultipartUploadResult.UploadId[0]),
+            );
+        });
+    });
+}
+
+function uploadPartP(bucketName, namespace, objectKey, uploadId, logger, extraHeaders) {
+    return new Promise((resolve, reject) => {
+        const req = createPutPartRequest(namespace, bucketName, objectKey, 1, uploadId, extraHeaders);
+        objectPutPart(authInfo, req, undefined, logger, err => (err ? reject(err) : resolve()));
+    });
+}
+
+// Resolves with { xml, headers } so callers can inspect the response body and
+// headers (e.g. to assert which checksum-related fields the response carries).
+function completeMpuP(bucketName, namespace, objectKey, uploadId, logger, opts) {
+    return new Promise((resolve, reject) => {
+        const req = createCompleteRequest(namespace, bucketName, objectKey, uploadId, opts);
+        completeMultipartUpload(authInfo, req, logger, (err, xml, headers) =>
+            err ? reject(err) : resolve({ xml, headers }),
+        );
+    });
+}
+
+function getObjectMDP(bucketName, objectKey, logger) {
+    return new Promise((resolve, reject) =>
+        metadataswitch.getObjectMD(bucketName, objectKey, {}, logger, (err, md) => (err ? reject(err) : resolve(md))),
+    );
+}
+
+function parseXmlP(xmlStr) {
+    return new Promise((resolve, reject) =>
+        xml2js.parseString(xmlStr, (err, json) => (err ? reject(err) : resolve(json))),
+    );
+}
 
 module.exports = {
+    authInfo,
+    partBody,
+    calculatedHash,
+    createBucketPutRequest,
+    createinitiateMPURequest,
     createPutPartRequest,
     createCompleteRequest,
     createMPU,
+    bucketPutP,
+    initiateMpuP,
+    uploadPartP,
+    completeMpuP,
+    getObjectMDP,
+    parseXmlP,
 };


### PR DESCRIPTION
- Calculate and compare the final object checksum with the one sent by the headers
- Check that all parts have the correct checksum and checksum type
- stores the final checksum when FULL_OBJECT (COMPOSITE are going to be stored by https://scality.atlassian.net/browse/S3C-10399)
- lint `tests/unit/api/multipartUpload.js`