### PR TITLE
CLDSRV-908: CopyObject handle checksums

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -81,6 +81,15 @@ Parse `$ARGUMENTS` to extract the repo and PR number:
       at top of file (never inside `describe` or functions).
     - **Test prefix** — Name of tests using the `it()` Mocha test function
       should start with `should`. Only raise this criteria once per file.
+    - **Prefer assert.match** — Where possible in tests prefer
+      `assert.match` over `includes` to test that a string contains a
+      substring. That way we get a diff and more details when the test
+      fails.
+    - **Prefer asserting error messages** — When testing errors prefer
+      comparing the error message
+      `assert.strictEqual(err.message, 'InvalidRequest');`, instead of
+      using `.is` like `assert.strictEqual(err.is.InvalidRequest, true);`,
+      so a failure shows the actual error name.
 
 4. **Deliver your review:**
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: review-pr
 description: >-
-  Review a PR on cloudserver (S3-compatible object
-  storage server in Node.js)
+    Review a PR on cloudserver (S3-compatible object
+    storage server in Node.js)
 argument-hint: <pr-number-or-url>
 disable-model-invocation: true
 allowed-tools: >-
-  Bash(gh repo view *), Bash(gh pr view *),
-  Bash(gh pr diff *), Bash(gh pr comment *),
-  Bash(gh api *), Bash(git diff *),
-  Bash(git log *), Bash(git show *)
+    Bash(gh repo view *), Bash(gh pr view *),
+    Bash(gh pr diff *), Bash(gh pr comment *),
+    Bash(gh api *), Bash(git diff *),
+    Bash(git log *), Bash(git show *)
 ---
 
 # Review GitHub PR
@@ -48,7 +48,6 @@ Parse `$ARGUMENTS` to extract the repo and PR number:
    change (not just the diff hunks).
 
 3. **Analyze the changes** against these criteria:
-
     - **Async error handling** — uncaught promise rejections, missing
       error callbacks, swallowed errors in streams. Double callbacks
       in try/catch blocks (callback called in try then again in catch).
@@ -122,23 +121,23 @@ Each inline comment must:
 - When the fix is a concrete line change (not architectural), include
   a GitHub suggestion block so the author can apply it in one click:
 
-  ````text
-  ```suggestion
-  corrected-line-here
-  ```
-  ````
+    ````text
+    ```suggestion
+    corrected-line-here
+    ```
+    ````
 
-  Only suggest when you can show the exact replacement. For
-  architectural or design issues, just describe the problem.
-  Example with a suggestion block:
+    Only suggest when you can show the exact replacement. For
+    architectural or design issues, just describe the problem.
+    Example with a suggestion block:
 
-  ```bash
-  gh api ... -f body=$'Missing the update.\
-  <br><br>\n```suggestion\n\
-  /plugin update shared-guidelines@hub\n\
-  /plugin update scality-skills@hub\n\
-  ```\n<br><br>— Claude Code' ...
-  ```
+    ````bash
+    gh api ... -f body=$'Missing the update.\
+    <br><br>\n```suggestion\n\
+    /plugin update shared-guidelines@hub\n\
+    /plugin update scality-skills@hub\n\
+    ```\n<br><br>— Claude Code' ...
+    ````
 
 - When the comment contains a suggestion block, use `$'...'` quoting
   with `\n` for code fence boundaries. Escape single quotes as `\'`

--- a/lib/api/apiUtils/integrity/validateChecksums.js
+++ b/lib/api/apiUtils/integrity/validateChecksums.js
@@ -38,6 +38,13 @@ const errMPUTypeWithoutAlgo = errorInstances.InvalidRequest.customizeDescription
     'The x-amz-checksum-type header can only be used with the x-amz-checksum-algorithm header.',
 );
 
+// TODO(S3C-11278): Update with 'MD5', 'SHA512', 'XXHASH128', 'XXHASH3', 'XXHASH64' when they are introduced.
+// https://scality.atlassian.net/browse/S3C-11278
+const errCopyChecksumAlgoNotSupported = errorInstances.InvalidRequest.customizeDescription(
+    'Checksum algorithm provided is unsupported. Please try again with any of the valid types: ' +
+        '[CRC32, CRC32C, CRC64NVME, SHA1, SHA256]',
+);
+
 // Methods that validate BOTH Content-MD5 and x-amz-checksum-* against the
 // buffered request body. For these, x-amz-checksum-* is the body digest.
 const checksumedMethods = Object.freeze({
@@ -90,6 +97,7 @@ const ChecksumError = Object.freeze({
     MPUTypeInvalid: 'MPUTypeInvalid',
     MPUTypeWithoutAlgo: 'MPUTypeWithoutAlgo',
     MPUInvalidCombination: 'MPUInvalidCombination',
+    CopyChecksumAlgoNotSupported: 'CopyChecksumAlgoNotSupported',
 });
 
 const base64Regex = /^[A-Za-z0-9+/]*={0,2}$/;
@@ -438,6 +446,8 @@ function arsenalErrorFromChecksumError(err) {
                 `The ${err.details.type} checksum type cannot be used ` +
                     `with the ${err.details.algorithm.toUpperCase()} checksum algorithm.`,
             );
+        case ChecksumError.CopyChecksumAlgoNotSupported:
+            return errCopyChecksumAlgoNotSupported;
         default:
             return ArsenalErrors.BadDigest;
     }
@@ -699,6 +709,31 @@ function computeFullObjectMPUChecksum(algorithm, parts) {
     return { checksum: combinePartCrcs(parts, params.polyReversed, params.dim), error: null };
 }
 
+/**
+ * Read and validate the x-amz-checksum-algorithm header for CopyObject.
+ *
+ * @param {object} headers - request headers
+ * @returns {{ error: null, algorithm: string|null }
+ *   | { error: { error: string, details: { algorithm: string } }, algorithm: null }}
+ */
+function getCopyObjectChecksumAlgorithm(headers) {
+    const requested = headers['x-amz-checksum-algorithm'];
+    if (requested === undefined) {
+        return { error: null, algorithm: null };
+    }
+    const algorithm = requested.toLowerCase();
+    if (!algorithms[algorithm]) {
+        return {
+            error: {
+                error: ChecksumError.CopyChecksumAlgoNotSupported,
+                details: { algorithm: requested },
+            },
+            algorithm: null,
+        };
+    }
+    return { error: null, algorithm };
+}
+
 module.exports = {
     ChecksumError,
     defaultChecksumData,
@@ -712,4 +747,5 @@ module.exports = {
     computeCompositeMPUChecksum,
     computeFullObjectMPUChecksum,
     validateCompleteMultipartUploadChecksum,
+    getCopyObjectChecksumAlgorithm,
 };

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -36,6 +36,31 @@ const externalVersioningErrorMessage = 'We do not currently support putting ' +
 'a versioned object to a location-constraint of type AWS or Azure or GCP.';
 
 /**
+ * Compute the prior data locations that are orphaned.
+ *
+ * @param {Array} dataToDelete - prior data locations from versioningPreprocessing
+ * @param {Array} newDataGetInfo - new data locations stored in the new metadata
+ * @returns {Array|null} orphaned entries to batchDelete, or null if none
+ */
+function _orphanedDataLocations(dataToDelete, newDataGetInfo) {
+    // Identity is (dataStoreName, key): the same key under a different
+    // dataStoreName points to a different backend slot, so the old slot
+    // is an orphan even when the key string collides. dataStoreName is a
+    // location-constraint name (never contains '|'), so the delimiter is
+    // unambiguous.
+
+    // We need to normalize to support old legacy location names.
+    const normalize = loc => (typeof loc === 'string' ? { key: loc } : loc);
+    const locId = loc => {
+        const n = normalize(loc);
+        return `${n.dataStoreName}|${n.key}`;
+    };
+    const newIds = new Set((newDataGetInfo || []).map(locId));
+    const orphans = (dataToDelete || []).filter(loc => !newIds.has(locId(loc)));
+    return orphans.length > 0 ? orphans : null;
+}
+
+/**
  * Preps metadata to be saved (based on copy or replace request header)
  * @param {object} request - request
  * @param {object} sourceObjMD - object md of source object
@@ -547,7 +572,8 @@ function objectCopy(authInfo, request, sourceBucket,
                     if (options.extraMD) {
                         Object.assign(storeMetadataParams, options.extraMD);
                     }
-                    const dataToDelete = options.dataToDelete;
+                    const dataToDelete = _orphanedDataLocations(
+                        options.dataToDelete, destDataGetInfoArr);
                     return next(null, storeMetadataParams, destDataGetInfoArr,
                         destObjMD, serverSideEncryption, destBucketMD,
                         dataToDelete);
@@ -589,11 +615,7 @@ function objectCopy(authInfo, request, sourceBucket,
         function deleteExistingData(dataToDelete, storingNewMdResult,
             destBucketMD, storeMetadataParams, serverSideEncryption,
             sourceObjSize, destObjPrevSize, next) {
-            // Clean up any potential orphans in data if object
-            // put is an overwrite of already existing
-            // object with same name, so long as the source is not
-            // the same as the destination
-            if (!sourceIsDestination && dataToDelete) {
+            if (dataToDelete) {
                 const newDataStoreName = storeMetadataParams.dataStoreName;
                 return data.batchDelete(dataToDelete, request.method,
                     newDataStoreName, log, err => {
@@ -688,3 +710,5 @@ function objectCopy(authInfo, request, sourceBucket,
 }
 
 module.exports = objectCopy;
+// Exposed for unit testing only.
+module.exports._orphanedDataLocations = _orphanedDataLocations;

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -32,6 +32,7 @@ const { initializeInternalLogRequestQueue, queueInternalLogRequest } = require('
 const { algorithms, arsenalErrorFromChecksumError, getCopyObjectChecksumAlgorithm } =
     require('./apiUtils/integrity/validateChecksums');
 const ChecksumTransform = require('../auth/streamingV4/ChecksumTransform');
+const ChecksumWritable = require('../auth/streamingV4/ChecksumWritable');
 const kms = require('../kms/wrapper');
 
 const versionIdUtils = versioning.VersionID;
@@ -146,11 +147,12 @@ function _getCopyObjectChecksumAlgorithm(requestedAlgo, sourceObjMD) {
 }
 
 /**
- * Recompute the destination's checksum by streaming the source bytes
- * through a ChecksumTransform. When the bytes don't have to move
- * (copy-to-self, same location, no SSE, not versioned) the source is GET'ed
- * solely to compute the new digest; the bytes are then discarded and the
+ * Recompute the destination's checksum by streaming the source bytes through
+ * a checksum stream. When the bytes don't have to move (copy-to-self, same
+ * location, no SSE, not versioned) the source is GET'ed solely to compute the
+ * new digest via a ChecksumWritable sink; the bytes are then discarded and the
  * existing data location is reused — only cloudserver's metadata is updated.
+ * Otherwise the source is piped through a ChecksumTransform into a single put.
  *
  * @param {object} log - request logger
  * @param {object} request - HTTP request
@@ -177,19 +179,19 @@ function _recomputeChecksumAndStore(log, request, requestedAlgo, sourceObjMD, da
     const wrapChecksumErr = err => Object.assign(err, { checksumStream: { algorithm: algoName } });
 
     // Copy-to-self where the bytes don't have to move (same location, no SSE
-    // change, not versioned): GET the source through a ChecksumTransform to
-    // compute the new digest, discard the bytes, and reuse the existing data
-    // locations. No PUT, no DELETE — only the metadata gets updated.
+    // change, not versioned): GET the source into a ChecksumWritable to compute
+    // the new digest, discard the bytes, and reuse the existing data locations.
+    // No PUT, no DELETE — only the metadata gets updated.
     if (sourceIsDestination && storeMetadataParams.locationMatch
         && !needsEncryption && !isVersionedObj) {
         log.debug('computing checksum on copy-to-self without rewriting data',
             { algorithm: algoName, size: storeMetadataParams.size });
         const sourceStream = _pipeSourcePartsThrough(dataLocator, log);
-        const checksumStream = new ChecksumTransform(algoName, undefined, false, log);
+        const checksumSink = new ChecksumWritable(algoName, log);
         const finish = jsutil.once(err => {
             if (err) {
                 sourceStream.destroy(err);
-                checksumStream.destroy(err);
+                checksumSink.destroy(err);
                 if (request.sourceServerAccessLog) {
                     // eslint-disable-next-line no-param-reassign
                     request.sourceServerAccessLog.error = err;
@@ -199,17 +201,16 @@ function _recomputeChecksumAndStore(log, request, requestedAlgo, sourceObjMD, da
             // eslint-disable-next-line no-param-reassign
             storeMetadataParams.checksum = {
                 algorithm: algoName,
-                value: checksumStream.digest,
+                value: checksumSink.digest,
                 type: 'FULL_OBJECT',
             };
             return next(null, storeMetadataParams, dataLocator, destObjMD,
                 serverSideEncryption, destBucketMD);
         });
         sourceStream.once('error', finish);
-        checksumStream.once('error', err => finish(wrapChecksumErr(err)));
-        checksumStream.on('data', () => {});
-        checksumStream.once('end', () => finish());
-        sourceStream.pipe(checksumStream);
+        checksumSink.once('error', err => finish(wrapChecksumErr(err)));
+        checksumSink.once('finish', () => finish());
+        sourceStream.pipe(checksumSink);
         return undefined;
     }
 

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -8,18 +8,15 @@ const validateHeaders = s3middleware.validateConditionalHeaders;
 
 const constants = require('../../constants');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
-const locationConstraintCheck
-    = require('./apiUtils/object/locationConstraintCheck');
-const { checkQueryVersionId, versioningPreprocessing, decodeVID }
-    = require('./apiUtils/object/versioning');
+const locationConstraintCheck = require('./apiUtils/object/locationConstraintCheck');
+const { checkQueryVersionId, versioningPreprocessing, decodeVID } = require('./apiUtils/object/versioning');
 const getReplicationInfo = require('./apiUtils/object/getReplicationInfo');
 const { data } = require('../data/wrapper');
 const services = require('../services');
 const { pushMetric } = require('../utapi/utilities');
 const removeAWSChunked = require('./apiUtils/object/removeAWSChunked');
 const { standardMetadataValidateBucketAndObj } = require('../metadata/metadataUtils');
-const validateWebsiteHeader = require('./apiUtils/object/websiteServing')
-    .validateWebsiteHeader;
+const validateWebsiteHeader = require('./apiUtils/object/websiteServing').validateWebsiteHeader;
 const { config } = require('../Config');
 const monitoring = require('../utilities/monitoringHandler');
 const applyZenkoUserMD = require('./apiUtils/object/applyZenkoUserMD');
@@ -29,8 +26,11 @@ const { verifyColdObjectAvailable } = require('./apiUtils/object/coldStorage');
 const { setSSEHeaders } = require('./apiUtils/object/sseHeaders');
 const { updateEncryption } = require('./apiUtils/bucket/updateEncryption');
 const { initializeInternalLogRequestQueue, queueInternalLogRequest } = require('../utilities/serverAccessLogger');
-const { algorithms, arsenalErrorFromChecksumError, getCopyObjectChecksumAlgorithm } =
-    require('./apiUtils/integrity/validateChecksums');
+const {
+    algorithms,
+    arsenalErrorFromChecksumError,
+    getCopyObjectChecksumAlgorithm,
+} = require('./apiUtils/integrity/validateChecksums');
 const ChecksumTransform = require('../auth/streamingV4/ChecksumTransform');
 const ChecksumWritable = require('../auth/streamingV4/ChecksumWritable');
 const kms = require('../kms/wrapper');
@@ -38,8 +38,8 @@ const kms = require('../kms/wrapper');
 const versionIdUtils = versioning.VersionID;
 const locationHeader = constants.objectLocationConstraintHeader;
 const versioningNotImplBackends = constants.versioningNotImplBackends;
-const externalVersioningErrorMessage = 'We do not currently support putting ' +
-'a versioned object to a location-constraint of type AWS or Azure or GCP.';
+const externalVersioningErrorMessage =
+    'We do not currently support putting ' + 'a versioned object to a location-constraint of type AWS or Azure or GCP.';
 
 /**
  * Compute the prior data locations that are orphaned.
@@ -78,43 +78,48 @@ function _orphanedDataLocations(dataToDelete, newDataGetInfo) {
  */
 function _pipeSourcePartsThrough(dataLocator, log) {
     const passthrough = new PassThrough();
-    const wrapErr = (err, part) => Object.assign(err, {
-        copyPart: { key: part.key, dataStoreName: part.dataStoreName, dataStoreType: part.dataStoreType },
-    });
-    async.eachSeries(dataLocator, (part, cb) => {
-        const done = jsutil.once(cb);
-        if (part.dataStoreType === 'azure') {
-            // Azure's data.get writes part bytes into the provided writable
-            // instead of returning a Readable. Pipe a per-part PassThrough
-            // into the master passthrough and use its 'end' as the completion
-            // signal — same pattern arsenal's data.copyObject uses.
-            const perPart = new PassThrough();
-            perPart.once('error', err => done(wrapErr(err, part)));
-            perPart.once('end', () => done());
-            perPart.pipe(passthrough, { end: false });
-            return data.get(part, perPart, log, err => {
-                if (err) {
-                    perPart.destroy(err);
-                    done(wrapErr(err, part));
-                }
-            });
-        }
-        return data.get(part, null, log, (err, partStream) => {
-            if (err) {
-                return done(wrapErr(err, part));
-            }
-            partStream.once('error', err => done(wrapErr(err, part)));
-            partStream.once('end', () => done());
-            partStream.pipe(passthrough, { end: false });
-            return undefined;
+    const wrapErr = (err, part) =>
+        Object.assign(err, {
+            copyPart: { key: part.key, dataStoreName: part.dataStoreName, dataStoreType: part.dataStoreType },
         });
-    }, err => {
-        if (err) {
-            passthrough.destroy(err);
-        } else {
-            passthrough.end();
-        }
-    });
+    async.eachSeries(
+        dataLocator,
+        (part, cb) => {
+            const done = jsutil.once(cb);
+            if (part.dataStoreType === 'azure') {
+                // Azure's data.get writes part bytes into the provided writable
+                // instead of returning a Readable. Pipe a per-part PassThrough
+                // into the master passthrough and use its 'end' as the completion
+                // signal — same pattern arsenal's data.copyObject uses.
+                const perPart = new PassThrough();
+                perPart.once('error', err => done(wrapErr(err, part)));
+                perPart.once('end', () => done());
+                perPart.pipe(passthrough, { end: false });
+                return data.get(part, perPart, log, err => {
+                    if (err) {
+                        perPart.destroy(err);
+                        done(wrapErr(err, part));
+                    }
+                });
+            }
+            return data.get(part, null, log, (err, partStream) => {
+                if (err) {
+                    return done(wrapErr(err, part));
+                }
+                partStream.once('error', err => done(wrapErr(err, part)));
+                partStream.once('end', () => done());
+                partStream.pipe(passthrough, { end: false });
+                return undefined;
+            });
+        },
+        err => {
+            if (err) {
+                passthrough.destroy(err);
+            } else {
+                passthrough.end();
+            }
+        },
+    );
     return passthrough;
 }
 
@@ -128,8 +133,10 @@ function _pipeSourcePartsThrough(dataLocator, log) {
  */
 function _shouldRecomputeChecksum(headers, sourceObjMD) {
     const requestedAlgo = headers['x-amz-checksum-algorithm']?.toLowerCase();
-    if (sourceObjMD.checksum?.checksumType === 'FULL_OBJECT'
-        && (!requestedAlgo || requestedAlgo === sourceObjMD.checksum.checksumAlgorithm)) {
+    if (
+        sourceObjMD.checksum?.checksumType === 'FULL_OBJECT' &&
+        (!requestedAlgo || requestedAlgo === sourceObjMD.checksum.checksumAlgorithm)
+    ) {
         return false;
     }
     return true;
@@ -171,10 +178,23 @@ function _getCopyObjectChecksumAlgorithm(requestedAlgo, sourceObjMD) {
  * @param {function} next - waterfall callback
  * @return {undefined}
  */
-function _recomputeChecksumAndStore(log, request, requestedAlgo, sourceObjMD, dataLocator,
-    sourceIsDestination, isVersionedObj, needsEncryption,
-    storeMetadataParams, destObjMD, destBucketMD, serverSideEncryption,
-    dataStoreContext, backendInfoDest, next) {
+function _recomputeChecksumAndStore(
+    log,
+    request,
+    requestedAlgo,
+    sourceObjMD,
+    dataLocator,
+    sourceIsDestination,
+    isVersionedObj,
+    needsEncryption,
+    storeMetadataParams,
+    destObjMD,
+    destBucketMD,
+    serverSideEncryption,
+    dataStoreContext,
+    backendInfoDest,
+    next,
+) {
     const algoName = _getCopyObjectChecksumAlgorithm(requestedAlgo, sourceObjMD);
     const wrapChecksumErr = err => Object.assign(err, { checksumStream: { algorithm: algoName } });
 
@@ -182,10 +202,11 @@ function _recomputeChecksumAndStore(log, request, requestedAlgo, sourceObjMD, da
     // change, not versioned): GET the source into a ChecksumWritable to compute
     // the new digest, discard the bytes, and reuse the existing data locations.
     // No PUT, no DELETE — only the metadata gets updated.
-    if (sourceIsDestination && storeMetadataParams.locationMatch
-        && !needsEncryption && !isVersionedObj) {
-        log.debug('computing checksum on copy-to-self without rewriting data',
-            { algorithm: algoName, size: storeMetadataParams.size });
+    if (sourceIsDestination && storeMetadataParams.locationMatch && !needsEncryption && !isVersionedObj) {
+        log.debug('computing checksum on copy-to-self without rewriting data', {
+            algorithm: algoName,
+            size: storeMetadataParams.size,
+        });
         const sourceStream = _pipeSourcePartsThrough(dataLocator, log);
         const checksumSink = new ChecksumWritable(algoName, log);
         const finish = jsutil.once(err => {
@@ -204,8 +225,7 @@ function _recomputeChecksumAndStore(log, request, requestedAlgo, sourceObjMD, da
                 value: checksumSink.digest,
                 type: 'FULL_OBJECT',
             };
-            return next(null, storeMetadataParams, dataLocator, destObjMD,
-                serverSideEncryption, destBucketMD);
+            return next(null, storeMetadataParams, dataLocator, destObjMD, serverSideEncryption, destBucketMD);
         });
         sourceStream.once('error', finish);
         checksumSink.once('error', err => finish(wrapChecksumErr(err)));
@@ -233,47 +253,50 @@ function _recomputeChecksumAndStore(log, request, requestedAlgo, sourceObjMD, da
     sourceStream.once('error', done);
     checksumStream.once('error', err => done(wrapChecksumErr(err)));
     sourceStream.pipe(checksumStream);
-    const doPut = cipherBundle => data.put(
-        cipherBundle, checksumStream, storeMetadataParams.size,
-        dataStoreContext, backendInfoDest, log,
-        (err, dataRetrievalInfo, hashedStream) => {
-            if (err) {
-                return done(err);
-            }
-            // eslint-disable-next-line no-param-reassign
-            storeMetadataParams.checksum = {
-                algorithm: algoName,
-                value: checksumStream.digest,
-                type: 'FULL_OBJECT',
-            };
-            // Prefix the part number like createAndStoreObject does, so
-            // partNumber-based reads see the copy as a single-part object.
-            const dataStoreETag = dataRetrievalInfo.dataStoreETag || hashedStream?.completedHash;
-            const putResult = {
-                key: dataRetrievalInfo.key,
-                size: storeMetadataParams.size,
-                start: 0,
-                dataStoreName: dataRetrievalInfo.dataStoreName,
-                dataStoreType: dataRetrievalInfo.dataStoreType,
-                dataStoreETag: dataStoreETag ? `1:${dataStoreETag}` : undefined,
-                dataStoreVersionId:
-                    dataRetrievalInfo.dataStoreVersionId,
-            };
-            if (cipherBundle) {
-                putResult.cryptoScheme = cipherBundle.cryptoScheme;
-                putResult.cipheredDataKey =
-                    cipherBundle.cipheredDataKey;
-            }
-            return done(null, [putResult]);
-        });
-    if (serverSideEncryption?.algorithm) {
-        return kms.createCipherBundle(serverSideEncryption, log,
-            (err, cipherBundle) => {
+    const doPut = cipherBundle =>
+        data.put(
+            cipherBundle,
+            checksumStream,
+            storeMetadataParams.size,
+            dataStoreContext,
+            backendInfoDest,
+            log,
+            (err, dataRetrievalInfo, hashedStream) => {
                 if (err) {
                     return done(err);
                 }
-                return doPut(cipherBundle);
-            });
+                // eslint-disable-next-line no-param-reassign
+                storeMetadataParams.checksum = {
+                    algorithm: algoName,
+                    value: checksumStream.digest,
+                    type: 'FULL_OBJECT',
+                };
+                // Prefix the part number like createAndStoreObject does, so
+                // partNumber-based reads see the copy as a single-part object.
+                const dataStoreETag = dataRetrievalInfo.dataStoreETag || hashedStream?.completedHash;
+                const putResult = {
+                    key: dataRetrievalInfo.key,
+                    size: storeMetadataParams.size,
+                    start: 0,
+                    dataStoreName: dataRetrievalInfo.dataStoreName,
+                    dataStoreType: dataRetrievalInfo.dataStoreType,
+                    dataStoreETag: dataStoreETag ? `1:${dataStoreETag}` : undefined,
+                    dataStoreVersionId: dataRetrievalInfo.dataStoreVersionId,
+                };
+                if (cipherBundle) {
+                    putResult.cryptoScheme = cipherBundle.cryptoScheme;
+                    putResult.cipheredDataKey = cipherBundle.cipheredDataKey;
+                }
+                return done(null, [putResult]);
+            },
+        );
+    if (serverSideEncryption?.algorithm) {
+        return kms.createCipherBundle(serverSideEncryption, log, (err, cipherBundle) => {
+            if (err) {
+                return done(err);
+            }
+            return doPut(cipherBundle);
+        });
     }
     return doPut(null);
 }
@@ -296,8 +319,18 @@ function _recomputeChecksumAndStore(log, request, requestedAlgo, sourceObjMD, da
  * - sourceLocationConstraintName {string} - location type of the source
  * - OR error
  */
-function _prepMetadata(request, sourceObjMD, headers, sourceIsDestination,
-    authInfo, objectKey, sourceBucketMD, destBucketMD, sourceVersionId, log) {
+function _prepMetadata(
+    request,
+    sourceObjMD,
+    headers,
+    sourceIsDestination,
+    authInfo,
+    objectKey,
+    sourceBucketMD,
+    destBucketMD,
+    sourceVersionId,
+    log,
+) {
     let whichMetadata = headers['x-amz-metadata-directive'];
     // Default is COPY
     whichMetadata = whichMetadata === undefined ? 'COPY' : whichMetadata;
@@ -308,45 +341,47 @@ function _prepMetadata(request, sourceObjMD, headers, sourceIsDestination,
     // Default is COPY
     whichTagging = whichTagging === undefined ? 'COPY' : whichTagging;
     if (whichTagging !== 'COPY' && whichTagging !== 'REPLACE') {
-        return { error: errorInstances.InvalidArgument
-          .customizeDescription('Unknown tagging directive') };
+        return { error: errorInstances.InvalidArgument.customizeDescription('Unknown tagging directive') };
     }
     const overrideMetadata = {};
     if (headers['x-amz-server-side-encryption']) {
-        overrideMetadata['x-amz-server-side-encryption'] =
-            headers['x-amz-server-side-encryption'];
+        overrideMetadata['x-amz-server-side-encryption'] = headers['x-amz-server-side-encryption'];
     }
-    if (headers['x-amz-storage-class']) {  // TODO: remove in CLDSRV-639
-        overrideMetadata['x-amz-storage-class'] =
-            headers['x-amz-storage-class'];
+    if (headers['x-amz-storage-class']) {
+        // TODO: remove in CLDSRV-639
+        overrideMetadata['x-amz-storage-class'] = headers['x-amz-storage-class'];
     }
     if (headers['x-amz-website-redirect-location']) {
-        overrideMetadata['x-amz-website-redirect-location'] =
-            headers['x-amz-website-redirect-location'];
+        overrideMetadata['x-amz-website-redirect-location'] = headers['x-amz-website-redirect-location'];
     }
-    const retentionHeaders = headers['x-amz-object-lock-mode']
-        && headers['x-amz-object-lock-retain-until-date'];
+    const retentionHeaders = headers['x-amz-object-lock-mode'] && headers['x-amz-object-lock-retain-until-date'];
     const legalHoldHeader = headers['x-amz-object-lock-legal-hold'];
-    if ((retentionHeaders || legalHoldHeader)
-        && !destBucketMD.isObjectLockEnabled()) {
-        return { error: errorInstances.InvalidRequest.customizeDescription(
-            'Bucket is missing ObjectLockConfiguration') };
+    if ((retentionHeaders || legalHoldHeader) && !destBucketMD.isObjectLockEnabled()) {
+        return {
+            error: errorInstances.InvalidRequest.customizeDescription('Bucket is missing ObjectLockConfiguration'),
+        };
     }
     // Cannot copy from same source and destination if no MD
     // changed and no source version id
-    if (sourceIsDestination && whichMetadata === 'COPY' &&
-        Object.keys(overrideMetadata).length === 0 && !sourceVersionId) {
-        return { error: errorInstances.InvalidRequest.customizeDescription('This copy' +
-            ' request is illegal because it is trying to copy an ' +
-            'object to itself without changing the object\'s metadata, ' +
-            'storage class, website redirect location or encryption ' +
-            'attributes.') };
+    if (
+        sourceIsDestination &&
+        whichMetadata === 'COPY' &&
+        Object.keys(overrideMetadata).length === 0 &&
+        !sourceVersionId
+    ) {
+        return {
+            error: errorInstances.InvalidRequest.customizeDescription(
+                'This copy' +
+                    ' request is illegal because it is trying to copy an ' +
+                    "object to itself without changing the object's metadata, " +
+                    'storage class, website redirect location or encryption ' +
+                    'attributes.',
+            ),
+        };
     }
     // If COPY, pull all x-amz-meta keys/values from source object
     // Otherwise, pull all x-amz-meta keys/values from request headers
-    const userMetadata = whichMetadata === 'COPY' ?
-        getMetaHeaders(sourceObjMD) :
-        getMetaHeaders(headers);
+    const userMetadata = whichMetadata === 'COPY' ? getMetaHeaders(sourceObjMD) : getMetaHeaders(headers);
     if (userMetadata instanceof Error) {
         log.debug('user metadata validation failed', {
             error: userMetadata,
@@ -360,28 +395,23 @@ function _prepMetadata(request, sourceObjMD, headers, sourceIsDestination,
     // If metadataDirective is:
     // - 'COPY' and source object has a location constraint in its metadata
     // we use the bucket destination location constraint
-    if (whichMetadata === 'COPY'
-        && userMetadata[locationHeader]
-        && destBucketMD.getLocationConstraint()) {
+    if (whichMetadata === 'COPY' && userMetadata[locationHeader] && destBucketMD.getLocationConstraint()) {
         userMetadata[locationHeader] = destBucketMD.getLocationConstraint();
     }
-    const backendInfoObjSource = locationConstraintCheck(request,
-        sourceObjMD, sourceBucketMD, log);
+    const backendInfoObjSource = locationConstraintCheck(request, sourceObjMD, sourceBucketMD, log);
     if (backendInfoObjSource.err) {
         return { error: backendInfoObjSource.err };
     }
     const sourceLocationConstraintName = backendInfoObjSource.controllingLC;
 
-    const backendInfoObjDest = locationConstraintCheck(request,
-        userMetadata, destBucketMD, log);
+    const backendInfoObjDest = locationConstraintCheck(request, userMetadata, destBucketMD, log);
     if (backendInfoObjDest.err) {
         return { error: backendInfoObjDest.err };
     }
     const destLocationConstraintName = backendInfoObjDest.controllingLC;
 
     // If location constraint header is not included, locations match
-    const locationMatch =
-    sourceLocationConstraintName === destLocationConstraintName;
+    const locationMatch = sourceLocationConstraintName === destLocationConstraintName;
 
     // If tagging directive is REPLACE but you don't specify any
     // tags in the request, the destination object will
@@ -398,8 +428,7 @@ function _prepMetadata(request, sourceObjMD, headers, sourceIsDestination,
 
     // If COPY, pull the necessary headers from source object
     // Otherwise, pull them from request headers
-    const headersToStoreSource = whichMetadata === 'COPY' ?
-        sourceObjMD : headers;
+    const headersToStoreSource = whichMetadata === 'COPY' ? sourceObjMD : headers;
 
     const storeMetadataParams = {
         objectKey,
@@ -412,16 +441,14 @@ function _prepMetadata(request, sourceObjMD, headers, sourceIsDestination,
         contentMD5: sourceObjMD['content-md5'],
         cacheControl: headersToStoreSource['cache-control'],
         contentDisposition: headersToStoreSource['content-disposition'],
-        contentEncoding:
-            removeAWSChunked(headersToStoreSource['content-encoding']),
+        contentEncoding: removeAWSChunked(headersToStoreSource['content-encoding']),
         dataStoreName: destLocationConstraintName,
         expires: headersToStoreSource.expires,
         overrideMetadata,
         lastModifiedDate: new Date().toJSON(),
         tagging,
         taggingCopy,
-        replicationInfo: getReplicationInfo(config,
-            objectKey, destBucketMD, false, sourceObjMD['content-length']),
+        replicationInfo: getReplicationInfo(config, objectKey, destBucketMD, false, sourceObjMD['content-length']),
         locationMatch,
         originOp: 's3:ObjectCreated:Copy',
     };
@@ -449,8 +476,7 @@ function _prepMetadata(request, sourceObjMD, headers, sourceIsDestination,
         storeMetadataParams.bucketOwnerId = destBucketMD.getOwner();
     }
 
-    return { storeMetadataParams, sourceLocationConstraintName,
-      backendInfoDest: backendInfoObjDest.backendInfo };
+    return { storeMetadataParams, sourceLocationConstraintName, backendInfoDest: backendInfoObjDest.backendInfo };
 }
 
 /**
@@ -466,8 +492,7 @@ function _prepMetadata(request, sourceObjMD, headers, sourceIsDestination,
  * @param {function} callback - final callback to call with the result
  * @return {undefined}
  */
-function objectCopy(authInfo, request, sourceBucket,
-    sourceObject, sourceVersionId, log, callback) {
+function objectCopy(authInfo, request, sourceBucket, sourceObject, sourceVersionId, log, callback) {
     log.debug('processing request', { method: 'objectCopy' });
     const destBucketName = request.bucketName;
     const destObjectKey = request.objectKey;
@@ -477,8 +502,7 @@ function objectCopy(authInfo, request, sourceBucket,
         return callback(keyLengthError);
     }
 
-    const sourceIsDestination =
-        destBucketName === sourceBucket && destObjectKey === sourceObject;
+    const sourceIsDestination = destBucketName === sourceBucket && destObjectKey === sourceObject;
     const valGetParams = {
         authInfo,
         bucketName: sourceBucket,
@@ -510,23 +534,21 @@ function objectCopy(authInfo, request, sourceBucket,
         namespace: request.namespace,
         objectKey: destObjectKey,
     };
-    const websiteRedirectHeader =
-        request.headers['x-amz-website-redirect-location'];
+    const websiteRedirectHeader = request.headers['x-amz-website-redirect-location'];
     const responseHeaders = {};
 
-    if (request.headers['x-amz-storage-class'] &&
-        !constants.validStorageClasses.includes(request.headers['x-amz-storage-class'])) {
+    if (
+        request.headers['x-amz-storage-class'] &&
+        !constants.validStorageClasses.includes(request.headers['x-amz-storage-class'])
+    ) {
         log.trace('invalid storage-class header');
-        monitoring.promMetrics('PUT', destBucketName,
-            errorInstances.InvalidStorageClass.code, 'copyObject');
+        monitoring.promMetrics('PUT', destBucketName, errorInstances.InvalidStorageClass.code, 'copyObject');
         return callback(errors.InvalidStorageClass);
     }
     if (!validateWebsiteHeader(websiteRedirectHeader)) {
         const err = errors.InvalidRedirectLocation;
-        log.debug('invalid x-amz-website-redirect-location' +
-            `value ${websiteRedirectHeader}`, { error: err });
-        monitoring.promMetrics(
-            'PUT', destBucketName, err.code, 'copyObject');
+        log.debug('invalid x-amz-website-redirect-location' + `value ${websiteRedirectHeader}`, { error: err });
+        monitoring.promMetrics('PUT', destBucketName, err.code, 'copyObject');
         return callback(err);
     }
     const { error: checksumAlgoErr, algorithm: requestedAlgo } = getCopyObjectChecksumAlgorithm(request.headers);
@@ -540,440 +562,609 @@ function objectCopy(authInfo, request, sourceBucket,
     if (queryContainsVersionId instanceof Error) {
         return callback(queryContainsVersionId);
     }
-    return async.waterfall([
-        function checkDestAuth(next) {
-            return standardMetadataValidateBucketAndObj(valPutParams, request.actionImplicitDenies, log,
-                (err, destBucketMD, destObjMD) =>
-                    updateEncryption(err, destBucketMD, destObjMD, destObjectKey, log, { skipObject: true },
-                (err, destBucketMD, destObjMD) => {
-                    if (err) {
-                        log.debug('error validating put part of request',
-                        { error: err });
-                        return next(err, destBucketMD);
-                    }
-                    const flag = destBucketMD.hasDeletedFlag()
-                        || destBucketMD.hasTransientFlag();
-                    if (flag) {
-                        log.trace('deleted flag or transient flag ' +
-                        'on destination bucket', { flag });
-                        return next(errors.NoSuchBucket);
-                    }
-                    return next(null, destBucketMD, destObjMD);
-                }));
-        },
-        function checkSourceAuthorization(destBucketMD, destObjMD, next) {
-            return standardMetadataValidateBucketAndObj({
-                ...valGetParams,
-                destObjMD,
-                serverAccessLogOptions: { copySource: true },
-            }, request.actionImplicitDenies, log,
-                (err, sourceBucketMD, sourceObjMD) => {
-                    if (err) {
-                        log.debug('error validating get part of request',
-                        { error: err });
-                        // eslint-disable-next-line no-param-reassign
-                        request.sourceServerAccessLog && (request.sourceServerAccessLog.error = err);
-                        return next(err, null, destBucketMD);
-                    }
-                    if (!sourceObjMD) {
-                        const err = sourceVersionId ? errors.NoSuchVersion :
-                            errors.NoSuchKey;
-                        log.debug('no source object', { sourceObject });
-                        // eslint-disable-next-line no-param-reassign
-                        request.sourceServerAccessLog && (request.sourceServerAccessLog.error = err);
-                        return next(err, null, destBucketMD);
-                    }
-                    // check if object data is in a cold storage
-                    const coldErr = verifyColdObjectAvailable(sourceObjMD);
-                    if (coldErr) {
-                        // eslint-disable-next-line no-param-reassign
-                        request.sourceServerAccessLog && (request.sourceServerAccessLog.error = coldErr);
-                        return next(coldErr, null);
-                    }
-                    if (sourceObjMD.isDeleteMarker) {
-                        log.debug('delete marker on source object',
-                        { sourceObject });
-                        let err;
-                        if (sourceVersionId) {
-                            err = errorInstances.InvalidRequest
-                            .customizeDescription('The source of a copy ' +
-                            'request may not specifically refer to a delete' +
-                            'marker by version id.');
-                        } else {
-                            // if user specifies a key in a versioned source bucket
-                            // without specifying a version, and the object has
-                            // a delete marker, return NoSuchKey
-                            err = errors.NoSuchKey;
-                        }
-                        // eslint-disable-next-line no-param-reassign
-                        request.sourceServerAccessLog && (request.sourceServerAccessLog.error = err);
-                        return next(err, destBucketMD);
-                    }
-                    const headerValResult =
-                        validateHeaders(request.headers,
-                        sourceObjMD['last-modified'],
-                        sourceObjMD['content-md5']);
-                    if (headerValResult.error) {
-                        request.sourceServerAccessLog
-                            // eslint-disable-next-line no-param-reassign
-                            && (request.sourceServerAccessLog.error = errors.PreconditionFailed);
-                        return next(errors.PreconditionFailed, destBucketMD);
-                    }
-                    const { storeMetadataParams, error: metadataError,
-                    sourceLocationConstraintName, backendInfoDest } =
-                        _prepMetadata(request, sourceObjMD, request.headers,
-                            sourceIsDestination, authInfo, destObjectKey,
-                            sourceBucketMD, destBucketMD, sourceVersionId, log);
-                    if (metadataError) {
-                        // eslint-disable-next-line no-param-reassign
-                        request.sourceServerAccessLog && (request.sourceServerAccessLog.error = metadataError);
-                        return next(metadataError, destBucketMD);
-                    }
-                    if (storeMetadataParams.metaHeaders) {
-                        dataStoreContext.metaHeaders =
-                          storeMetadataParams.metaHeaders;
-                    }
-
-                    storeMetadataParams.overheadField = constants.overheadField;
-
-                    let dataLocator;
-                    // If 0 byte object just set dataLocator to empty array
-                    if (!sourceObjMD.location) {
-                        dataLocator = [];
-                    } else {
-                        // To provide for backwards compatibility before
-                        // md-model-version 2, need to handle cases where
-                        // objMD.location is just a string
-                        dataLocator = Array.isArray(sourceObjMD.location) ?
-                        sourceObjMD.location : [{ key: sourceObjMD.location }];
-                    }
-
-                    if (sourceObjMD['x-amz-server-side-encryption']) {
-                        for (let i = 0; i < dataLocator.length; i++) {
-                            dataLocator[i].masterKeyId = sourceObjMD[
-                                'x-amz-server-side-encryption-aws-kms-key-id'];
-                            dataLocator[i].algorithm =
-                                sourceObjMD['x-amz-server-side-encryption'];
-                        }
-                    }
-
-                    // If the destination key already exists
-                    if (destObjMD) {
-                        // Re-use creation-time if we can
-                        if (destObjMD['creation-time']) {
-                            storeMetadataParams.creationTime =
-                                destObjMD['creation-time'];
-                        // Otherwise fallback to last-modified
-                        } else {
-                            storeMetadataParams.creationTime =
-                                destObjMD['last-modified'];
-                        }
-                    // If this is a new key, create a new timestamp
-                    } else {
-                        storeMetadataParams.creationTime = new Date().toJSON();
-                    }
-
-                    return next(null, storeMetadataParams, dataLocator,
-                        sourceBucketMD, destBucketMD, destObjMD,
-                        sourceLocationConstraintName, backendInfoDest, sourceObjMD);
-                });
-        },
-        function getSSEConfiguration(storeMetadataParams, dataLocator, sourceBucketMD,
-            destBucketMD, destObjMD, sourceLocationConstraintName,
-            backendInfoDest, sourceObjMD, next) {
-            getObjectSSEConfiguration(
-                    request.headers,
-                    destBucketMD,
+    return async.waterfall(
+        [
+            function checkDestAuth(next) {
+                return standardMetadataValidateBucketAndObj(
+                    valPutParams,
+                    request.actionImplicitDenies,
                     log,
-                    (err, sseConfig) =>
-                        next(err, storeMetadataParams, dataLocator, sourceBucketMD,
-                            destBucketMD, destObjMD, sourceLocationConstraintName,
-                            backendInfoDest, sseConfig, sourceObjMD));
-        },
-        function goGetData(storeMetadataParams, dataLocator, sourceBucketMD,
-            destBucketMD, destObjMD, sourceLocationConstraintName,
-            backendInfoDest, serverSideEncryption, sourceObjMD, next) {
-            const vcfg = destBucketMD.getVersioningConfiguration();
-            const isVersionedObj = vcfg && vcfg.Status === 'Enabled';
-            const destLocationConstraintName =
-                storeMetadataParams.dataStoreName;
-            const needsEncryption = serverSideEncryption && !!serverSideEncryption.algo;
-            const shouldRecomputeChecksum = _shouldRecomputeChecksum(request.headers, sourceObjMD);
-            let destLocationConstraintType;
-            if (config.backends.data === 'multiple') {
-                destLocationConstraintType = config.getLocationConstraintType(destLocationConstraintName);
-            }
-            // skip if source and dest and location constraint the same and
-            // versioning is not enabled, unless we need to recompute a
-            // checksum (which requires streaming the bytes through us).
-            if (sourceIsDestination && storeMetadataParams.locationMatch
-                && !isVersionedObj && !needsEncryption
-                && !shouldRecomputeChecksum) {
-                return next(null, storeMetadataParams, dataLocator, destObjMD,
-                    serverSideEncryption, destBucketMD);
-            }
-
-            // also skip if 0 byte object, unless location constraint is an
-            // external backend and differs from source, in which case put
-            // metadata to backend
-            if (destLocationConstraintType &&
-              versioningNotImplBackends[destLocationConstraintType]
-                && isVersionedObj) {
-                log.debug(externalVersioningErrorMessage,
-                    { method: 'multipleBackendGateway',
-                        error: errors.NotImplemented });
-                return next(errorInstances.NotImplemented.customizeDescription(
-                  externalVersioningErrorMessage), destBucketMD);
-            }
-            if (dataLocator.length === 0) {
-                const finishZeroByte = () => {
-                    if (!storeMetadataParams.locationMatch && destLocationConstraintType
-                        && constants.externalBackends[destLocationConstraintType]) {
-                        return data.put(null, null, storeMetadataParams.size,
-                            dataStoreContext, backendInfoDest,
-                            log, (error, objectRetrievalInfo) => {
-                                if (error) {
-                                    return next(error, destBucketMD);
+                    (err, destBucketMD, destObjMD) =>
+                        updateEncryption(
+                            err,
+                            destBucketMD,
+                            destObjMD,
+                            destObjectKey,
+                            log,
+                            { skipObject: true },
+                            (err, destBucketMD, destObjMD) => {
+                                if (err) {
+                                    log.debug('error validating put part of request', { error: err });
+                                    return next(err, destBucketMD);
                                 }
-                                const putResult = {
-                                    key: objectRetrievalInfo.key,
-                                    dataStoreName: objectRetrievalInfo.dataStoreName,
-                                    dataStoreType: objectRetrievalInfo.dataStoreType,
-                                    size: storeMetadataParams.size,
-                                };
-                                return next(null, storeMetadataParams, [putResult],
-                                    destObjMD, serverSideEncryption, destBucketMD);
-                            });
-                    }
-                    return next(null, storeMetadataParams, dataLocator, destObjMD,
-                        serverSideEncryption, destBucketMD);
-                };
-                if (shouldRecomputeChecksum) {
-                    // No bytes to stream, but AWS still writes the empty-bytes digest of the chosen algorithm.
-                    const algoName = _getCopyObjectChecksumAlgorithm(requestedAlgo, sourceObjMD);
-                    return Promise.resolve(algorithms[algoName].digest(Buffer.alloc(0)))
-                        .then(digest => {
+                                const flag = destBucketMD.hasDeletedFlag() || destBucketMD.hasTransientFlag();
+                                if (flag) {
+                                    log.trace('deleted flag or transient flag ' + 'on destination bucket', { flag });
+                                    return next(errors.NoSuchBucket);
+                                }
+                                return next(null, destBucketMD, destObjMD);
+                            },
+                        ),
+                );
+            },
+            function checkSourceAuthorization(destBucketMD, destObjMD, next) {
+                return standardMetadataValidateBucketAndObj(
+                    {
+                        ...valGetParams,
+                        destObjMD,
+                        serverAccessLogOptions: { copySource: true },
+                    },
+                    request.actionImplicitDenies,
+                    log,
+                    (err, sourceBucketMD, sourceObjMD) => {
+                        if (err) {
+                            log.debug('error validating get part of request', { error: err });
                             // eslint-disable-next-line no-param-reassign
-                            storeMetadataParams.checksum = {
-                                algorithm: algoName,
-                                value: digest,
-                                type: 'FULL_OBJECT',
-                            };
-                            return finishZeroByte();
-                        }, err => {
-                            log.error('failed to compute empty checksum digest',
-                                { algorithm: algoName, error: err });
-                            return next(errors.InternalError, destBucketMD);
-                        });
-                }
-                return finishZeroByte();
-            }
-            if (shouldRecomputeChecksum) {
-                return _recomputeChecksumAndStore(log, request, requestedAlgo, sourceObjMD, dataLocator,
-                    sourceIsDestination, isVersionedObj, needsEncryption,
-                    storeMetadataParams, destObjMD, destBucketMD, serverSideEncryption,
-                    dataStoreContext, backendInfoDest, next);
-            }
-            const originalIdentityImpDenies = request.actionImplicitDenies;
-            // eslint-disable-next-line no-param-reassign
-            delete request.actionImplicitDenies;
-            return data.copyObject(request, sourceLocationConstraintName,
-              storeMetadataParams, dataLocator, dataStoreContext,
-              backendInfoDest, sourceBucketMD, destBucketMD, serverSideEncryption, log,
-            (err, results) => {
-                // eslint-disable-next-line no-param-reassign
-                request.actionImplicitDenies = originalIdentityImpDenies;
-                if (err) {
-                    // eslint-disable-next-line no-param-reassign
-                    request.sourceServerAccessLog && (request.sourceServerAccessLog.error = err);
-                    return next(err, destBucketMD);
-                }
-                return next(null, storeMetadataParams, results,
-                    destObjMD, serverSideEncryption, destBucketMD);
-            });
-        },
-        function getVersioningInfo(storeMetadataParams, destDataGetInfoArr,
-            destObjMD, serverSideEncryption, destBucketMD, next) {
-            if (!destBucketMD.isVersioningEnabled() && destObjMD?.archive?.archiveInfo) {
-                // Ensure we trigger a "delete" event in the oplog for the previously archived object
-                // eslint-disable-next-line
-                storeMetadataParams.needOplogUpdate = 's3:ReplaceArchivedObject';
-            }
-            return versioningPreprocessing(destBucketName,
-                destBucketMD, destObjectKey, destObjMD, log,
-                (err, options) => {
-                    if (err) {
-                        log.debug('error processing versioning info',
-                        { error: err });
-                        return next(err, null, destBucketMD);
-                    }
-
-                    const location = destDataGetInfoArr?.[0]?.dataStoreName;
-                    if (location === destBucketMD.getLocationConstraint() && destBucketMD.isIngestionBucket()) {
-                        // If the object is being written to the "ingested" storage location, keep the same
-                        // versionId for consistency and to avoid creating an extra version when it gets
-                        // ingested
-                        const backendVersionId = decodeVID(destDataGetInfoArr[0].dataStoreVersionId);
-                        if (!(backendVersionId instanceof Error)) {
-                            options.versionId = backendVersionId; // eslint-disable-line no-param-reassign
+                            request.sourceServerAccessLog && (request.sourceServerAccessLog.error = err);
+                            return next(err, null, destBucketMD);
                         }
-                    }
+                        if (!sourceObjMD) {
+                            const err = sourceVersionId ? errors.NoSuchVersion : errors.NoSuchKey;
+                            log.debug('no source object', { sourceObject });
+                            // eslint-disable-next-line no-param-reassign
+                            request.sourceServerAccessLog && (request.sourceServerAccessLog.error = err);
+                            return next(err, null, destBucketMD);
+                        }
+                        // check if object data is in a cold storage
+                        const coldErr = verifyColdObjectAvailable(sourceObjMD);
+                        if (coldErr) {
+                            // eslint-disable-next-line no-param-reassign
+                            request.sourceServerAccessLog && (request.sourceServerAccessLog.error = coldErr);
+                            return next(coldErr, null);
+                        }
+                        if (sourceObjMD.isDeleteMarker) {
+                            log.debug('delete marker on source object', { sourceObject });
+                            let err;
+                            if (sourceVersionId) {
+                                err = errorInstances.InvalidRequest.customizeDescription(
+                                    'The source of a copy ' +
+                                        'request may not specifically refer to a delete' +
+                                        'marker by version id.',
+                                );
+                            } else {
+                                // if user specifies a key in a versioned source bucket
+                                // without specifying a version, and the object has
+                                // a delete marker, return NoSuchKey
+                                err = errors.NoSuchKey;
+                            }
+                            // eslint-disable-next-line no-param-reassign
+                            request.sourceServerAccessLog && (request.sourceServerAccessLog.error = err);
+                            return next(err, destBucketMD);
+                        }
+                        const headerValResult = validateHeaders(
+                            request.headers,
+                            sourceObjMD['last-modified'],
+                            sourceObjMD['content-md5'],
+                        );
+                        if (headerValResult.error) {
+                            request.sourceServerAccessLog &&
+                                // eslint-disable-next-line no-param-reassign
+                                (request.sourceServerAccessLog.error = errors.PreconditionFailed);
+                            return next(errors.PreconditionFailed, destBucketMD);
+                        }
+                        const {
+                            storeMetadataParams,
+                            error: metadataError,
+                            sourceLocationConstraintName,
+                            backendInfoDest,
+                        } = _prepMetadata(
+                            request,
+                            sourceObjMD,
+                            request.headers,
+                            sourceIsDestination,
+                            authInfo,
+                            destObjectKey,
+                            sourceBucketMD,
+                            destBucketMD,
+                            sourceVersionId,
+                            log,
+                        );
+                        if (metadataError) {
+                            // eslint-disable-next-line no-param-reassign
+                            request.sourceServerAccessLog && (request.sourceServerAccessLog.error = metadataError);
+                            return next(metadataError, destBucketMD);
+                        }
+                        if (storeMetadataParams.metaHeaders) {
+                            dataStoreContext.metaHeaders = storeMetadataParams.metaHeaders;
+                        }
 
-                    // eslint-disable-next-line
-                    storeMetadataParams.versionId = options.versionId;
-                    // eslint-disable-next-line
-                    storeMetadataParams.versioning = options.versioning;
-                    // eslint-disable-next-line
-                    storeMetadataParams.isNull = options.isNull;
-                    if (options.extraMD) {
-                        Object.assign(storeMetadataParams, options.extraMD);
-                    }
-                    const dataToDelete = _orphanedDataLocations(
-                        options.dataToDelete, destDataGetInfoArr);
-                    return next(null, storeMetadataParams, destDataGetInfoArr,
-                        destObjMD, serverSideEncryption, destBucketMD,
-                        dataToDelete);
-                });
-        },
-        function storeNewMetadata(storeMetadataParams, destDataGetInfoArr,
-            destObjMD, serverSideEncryption, destBucketMD, dataToDelete, next) {
-            if (destObjMD && destObjMD.uploadId) {
-                // eslint-disable-next-line
-                storeMetadataParams.oldReplayId = destObjMD.uploadId;
-            }
+                        storeMetadataParams.overheadField = constants.overheadField;
 
-            return services.metadataStoreObject(destBucketName,
-                destDataGetInfoArr, serverSideEncryption,
-                storeMetadataParams, (err, result) => {
-                    if (err) {
-                        log.debug('error storing new metadata', { error: err });
-                        return next(err, null, destBucketMD);
-                    }
-                    const sourceObjSize = storeMetadataParams.size;
-                    const destObjPrevSize = (destObjMD &&
-                        destObjMD['content-length'] !== undefined) ?
-                        destObjMD['content-length'] : null;
+                        let dataLocator;
+                        // If 0 byte object just set dataLocator to empty array
+                        if (!sourceObjMD.location) {
+                            dataLocator = [];
+                        } else {
+                            // To provide for backwards compatibility before
+                            // md-model-version 2, need to handle cases where
+                            // objMD.location is just a string
+                            dataLocator = Array.isArray(sourceObjMD.location)
+                                ? sourceObjMD.location
+                                : [{ key: sourceObjMD.location }];
+                        }
 
-                    setExpirationHeaders(responseHeaders, {
-                        lifecycleConfig: destBucketMD.getLifecycleConfiguration(),
-                        objectParams: {
-                            key: destObjectKey,
-                            date: result.lastModified,
-                            tags: result.tags,
-                        },
+                        if (sourceObjMD['x-amz-server-side-encryption']) {
+                            for (let i = 0; i < dataLocator.length; i++) {
+                                dataLocator[i].masterKeyId = sourceObjMD['x-amz-server-side-encryption-aws-kms-key-id'];
+                                dataLocator[i].algorithm = sourceObjMD['x-amz-server-side-encryption'];
+                            }
+                        }
+
+                        // If the destination key already exists
+                        if (destObjMD) {
+                            // Re-use creation-time if we can
+                            if (destObjMD['creation-time']) {
+                                storeMetadataParams.creationTime = destObjMD['creation-time'];
+                                // Otherwise fallback to last-modified
+                            } else {
+                                storeMetadataParams.creationTime = destObjMD['last-modified'];
+                            }
+                            // If this is a new key, create a new timestamp
+                        } else {
+                            storeMetadataParams.creationTime = new Date().toJSON();
+                        }
+
+                        return next(
+                            null,
+                            storeMetadataParams,
+                            dataLocator,
+                            sourceBucketMD,
+                            destBucketMD,
+                            destObjMD,
+                            sourceLocationConstraintName,
+                            backendInfoDest,
+                            sourceObjMD,
+                        );
+                    },
+                );
+            },
+            function getSSEConfiguration(
+                storeMetadataParams,
+                dataLocator,
+                sourceBucketMD,
+                destBucketMD,
+                destObjMD,
+                sourceLocationConstraintName,
+                backendInfoDest,
+                sourceObjMD,
+                next,
+            ) {
+                getObjectSSEConfiguration(request.headers, destBucketMD, log, (err, sseConfig) =>
+                    next(
+                        err,
+                        storeMetadataParams,
+                        dataLocator,
+                        sourceBucketMD,
+                        destBucketMD,
+                        destObjMD,
+                        sourceLocationConstraintName,
+                        backendInfoDest,
+                        sseConfig,
+                        sourceObjMD,
+                    ),
+                );
+            },
+            function goGetData(
+                storeMetadataParams,
+                dataLocator,
+                sourceBucketMD,
+                destBucketMD,
+                destObjMD,
+                sourceLocationConstraintName,
+                backendInfoDest,
+                serverSideEncryption,
+                sourceObjMD,
+                next,
+            ) {
+                const vcfg = destBucketMD.getVersioningConfiguration();
+                const isVersionedObj = vcfg && vcfg.Status === 'Enabled';
+                const destLocationConstraintName = storeMetadataParams.dataStoreName;
+                const needsEncryption = serverSideEncryption && !!serverSideEncryption.algo;
+                const shouldRecomputeChecksum = _shouldRecomputeChecksum(request.headers, sourceObjMD);
+                let destLocationConstraintType;
+                if (config.backends.data === 'multiple') {
+                    destLocationConstraintType = config.getLocationConstraintType(destLocationConstraintName);
+                }
+                // skip if source and dest and location constraint the same and
+                // versioning is not enabled, unless we need to recompute a
+                // checksum (which requires streaming the bytes through us).
+                if (
+                    sourceIsDestination &&
+                    storeMetadataParams.locationMatch &&
+                    !isVersionedObj &&
+                    !needsEncryption &&
+                    !shouldRecomputeChecksum
+                ) {
+                    return next(null, storeMetadataParams, dataLocator, destObjMD, serverSideEncryption, destBucketMD);
+                }
+
+                // also skip if 0 byte object, unless location constraint is an
+                // external backend and differs from source, in which case put
+                // metadata to backend
+                if (
+                    destLocationConstraintType &&
+                    versioningNotImplBackends[destLocationConstraintType] &&
+                    isVersionedObj
+                ) {
+                    log.debug(externalVersioningErrorMessage, {
+                        method: 'multipleBackendGateway',
+                        error: errors.NotImplemented,
                     });
+                    return next(
+                        errorInstances.NotImplemented.customizeDescription(externalVersioningErrorMessage),
+                        destBucketMD,
+                    );
+                }
+                if (dataLocator.length === 0) {
+                    const finishZeroByte = () => {
+                        if (
+                            !storeMetadataParams.locationMatch &&
+                            destLocationConstraintType &&
+                            constants.externalBackends[destLocationConstraintType]
+                        ) {
+                            return data.put(
+                                null,
+                                null,
+                                storeMetadataParams.size,
+                                dataStoreContext,
+                                backendInfoDest,
+                                log,
+                                (error, objectRetrievalInfo) => {
+                                    if (error) {
+                                        return next(error, destBucketMD);
+                                    }
+                                    const putResult = {
+                                        key: objectRetrievalInfo.key,
+                                        dataStoreName: objectRetrievalInfo.dataStoreName,
+                                        dataStoreType: objectRetrievalInfo.dataStoreType,
+                                        size: storeMetadataParams.size,
+                                    };
+                                    return next(
+                                        null,
+                                        storeMetadataParams,
+                                        [putResult],
+                                        destObjMD,
+                                        serverSideEncryption,
+                                        destBucketMD,
+                                    );
+                                },
+                            );
+                        }
+                        return next(
+                            null,
+                            storeMetadataParams,
+                            dataLocator,
+                            destObjMD,
+                            serverSideEncryption,
+                            destBucketMD,
+                        );
+                    };
+                    if (shouldRecomputeChecksum) {
+                        // No bytes to stream, but AWS still writes the empty-bytes digest of the chosen algorithm.
+                        const algoName = _getCopyObjectChecksumAlgorithm(requestedAlgo, sourceObjMD);
+                        return Promise.resolve(algorithms[algoName].digest(Buffer.alloc(0))).then(
+                            digest => {
+                                // eslint-disable-next-line no-param-reassign
+                                storeMetadataParams.checksum = {
+                                    algorithm: algoName,
+                                    value: digest,
+                                    type: 'FULL_OBJECT',
+                                };
+                                return finishZeroByte();
+                            },
+                            err => {
+                                log.error('failed to compute empty checksum digest', {
+                                    algorithm: algoName,
+                                    error: err,
+                                });
+                                return next(errors.InternalError, destBucketMD);
+                            },
+                        );
+                    }
+                    return finishZeroByte();
+                }
+                if (shouldRecomputeChecksum) {
+                    return _recomputeChecksumAndStore(
+                        log,
+                        request,
+                        requestedAlgo,
+                        sourceObjMD,
+                        dataLocator,
+                        sourceIsDestination,
+                        isVersionedObj,
+                        needsEncryption,
+                        storeMetadataParams,
+                        destObjMD,
+                        destBucketMD,
+                        serverSideEncryption,
+                        dataStoreContext,
+                        backendInfoDest,
+                        next,
+                    );
+                }
+                const originalIdentityImpDenies = request.actionImplicitDenies;
+                // eslint-disable-next-line no-param-reassign
+                delete request.actionImplicitDenies;
+                return data.copyObject(
+                    request,
+                    sourceLocationConstraintName,
+                    storeMetadataParams,
+                    dataLocator,
+                    dataStoreContext,
+                    backendInfoDest,
+                    sourceBucketMD,
+                    destBucketMD,
+                    serverSideEncryption,
+                    log,
+                    (err, results) => {
+                        // eslint-disable-next-line no-param-reassign
+                        request.actionImplicitDenies = originalIdentityImpDenies;
+                        if (err) {
+                            // eslint-disable-next-line no-param-reassign
+                            request.sourceServerAccessLog && (request.sourceServerAccessLog.error = err);
+                            return next(err, destBucketMD);
+                        }
+                        return next(null, storeMetadataParams, results, destObjMD, serverSideEncryption, destBucketMD);
+                    },
+                );
+            },
+            function getVersioningInfo(
+                storeMetadataParams,
+                destDataGetInfoArr,
+                destObjMD,
+                serverSideEncryption,
+                destBucketMD,
+                next,
+            ) {
+                if (!destBucketMD.isVersioningEnabled() && destObjMD?.archive?.archiveInfo) {
+                    // Ensure we trigger a "delete" event in the oplog for the previously archived object
+                    // eslint-disable-next-line
+                    storeMetadataParams.needOplogUpdate = 's3:ReplaceArchivedObject';
+                }
+                return versioningPreprocessing(
+                    destBucketName,
+                    destBucketMD,
+                    destObjectKey,
+                    destObjMD,
+                    log,
+                    (err, options) => {
+                        if (err) {
+                            log.debug('error processing versioning info', { error: err });
+                            return next(err, null, destBucketMD);
+                        }
 
-                    return next(null, dataToDelete, result, destBucketMD,
-                        storeMetadataParams, serverSideEncryption,
-                        sourceObjSize, destObjPrevSize);
-                });
-        },
-        function deleteExistingData(dataToDelete, storingNewMdResult,
-            destBucketMD, storeMetadataParams, serverSideEncryption,
-            sourceObjSize, destObjPrevSize, next) {
-            if (dataToDelete) {
-                const newDataStoreName = storeMetadataParams.dataStoreName;
-                return data.batchDelete(dataToDelete, request.method,
-                    newDataStoreName, log, err => {
+                        const location = destDataGetInfoArr?.[0]?.dataStoreName;
+                        if (location === destBucketMD.getLocationConstraint() && destBucketMD.isIngestionBucket()) {
+                            // If the object is being written to the "ingested" storage location, keep the same
+                            // versionId for consistency and to avoid creating an extra version when it gets
+                            // ingested
+                            const backendVersionId = decodeVID(destDataGetInfoArr[0].dataStoreVersionId);
+                            if (!(backendVersionId instanceof Error)) {
+                                options.versionId = backendVersionId; // eslint-disable-line no-param-reassign
+                            }
+                        }
+
+                        // eslint-disable-next-line
+                        storeMetadataParams.versionId = options.versionId;
+                        // eslint-disable-next-line
+                        storeMetadataParams.versioning = options.versioning;
+                        // eslint-disable-next-line
+                        storeMetadataParams.isNull = options.isNull;
+                        if (options.extraMD) {
+                            Object.assign(storeMetadataParams, options.extraMD);
+                        }
+                        const dataToDelete = _orphanedDataLocations(options.dataToDelete, destDataGetInfoArr);
+                        return next(
+                            null,
+                            storeMetadataParams,
+                            destDataGetInfoArr,
+                            destObjMD,
+                            serverSideEncryption,
+                            destBucketMD,
+                            dataToDelete,
+                        );
+                    },
+                );
+            },
+            function storeNewMetadata(
+                storeMetadataParams,
+                destDataGetInfoArr,
+                destObjMD,
+                serverSideEncryption,
+                destBucketMD,
+                dataToDelete,
+                next,
+            ) {
+                if (destObjMD && destObjMD.uploadId) {
+                    // eslint-disable-next-line
+                    storeMetadataParams.oldReplayId = destObjMD.uploadId;
+                }
+
+                return services.metadataStoreObject(
+                    destBucketName,
+                    destDataGetInfoArr,
+                    serverSideEncryption,
+                    storeMetadataParams,
+                    (err, result) => {
+                        if (err) {
+                            log.debug('error storing new metadata', { error: err });
+                            return next(err, null, destBucketMD);
+                        }
+                        const sourceObjSize = storeMetadataParams.size;
+                        const destObjPrevSize =
+                            destObjMD && destObjMD['content-length'] !== undefined ? destObjMD['content-length'] : null;
+
+                        setExpirationHeaders(responseHeaders, {
+                            lifecycleConfig: destBucketMD.getLifecycleConfiguration(),
+                            objectParams: {
+                                key: destObjectKey,
+                                date: result.lastModified,
+                                tags: result.tags,
+                            },
+                        });
+
+                        return next(
+                            null,
+                            dataToDelete,
+                            result,
+                            destBucketMD,
+                            storeMetadataParams,
+                            serverSideEncryption,
+                            sourceObjSize,
+                            destObjPrevSize,
+                        );
+                    },
+                );
+            },
+            function deleteExistingData(
+                dataToDelete,
+                storingNewMdResult,
+                destBucketMD,
+                storeMetadataParams,
+                serverSideEncryption,
+                sourceObjSize,
+                destObjPrevSize,
+                next,
+            ) {
+                if (dataToDelete) {
+                    const newDataStoreName = storeMetadataParams.dataStoreName;
+                    return data.batchDelete(dataToDelete, request.method, newDataStoreName, log, err => {
                         if (err) {
                             // if error, log the error and move on as it is not
                             // relevant to the client as the client's
                             // object already succeeded putting data, metadata
-                            log.error('error deleting existing data',
-                                { error: err });
+                            log.error('error deleting existing data', { error: err });
                         }
-                        next(null,
-                        storingNewMdResult, destBucketMD, storeMetadataParams,
-                        serverSideEncryption, sourceObjSize, destObjPrevSize);
+                        next(
+                            null,
+                            storingNewMdResult,
+                            destBucketMD,
+                            storeMetadataParams,
+                            serverSideEncryption,
+                            sourceObjSize,
+                            destObjPrevSize,
+                        );
                     });
+                }
+                return next(
+                    null,
+                    storingNewMdResult,
+                    destBucketMD,
+                    storeMetadataParams,
+                    serverSideEncryption,
+                    sourceObjSize,
+                    destObjPrevSize,
+                );
+            },
+        ],
+        (
+            err,
+            storingNewMdResult,
+            destBucketMD,
+            storeMetadataParams,
+            serverSideEncryption,
+            sourceObjSize,
+            destObjPrevSize,
+        ) => {
+            const corsHeaders = collectCorsHeaders(request.headers.origin, request.method, destBucketMD);
+
+            // Store full object size for server access logs
+            if (request.serverAccessLog) {
+                // eslint-disable-next-line no-param-reassign
+                request.serverAccessLog.objectSize = sourceObjSize;
             }
-            return next(null,
-                storingNewMdResult, destBucketMD, storeMetadataParams,
-                serverSideEncryption, sourceObjSize, destObjPrevSize);
-        },
-    ], (err, storingNewMdResult, destBucketMD, storeMetadataParams,
-        serverSideEncryption, sourceObjSize, destObjPrevSize) => {
-        const corsHeaders = collectCorsHeaders(request.headers.origin,
-            request.method, destBucketMD);
 
-        // Store full object size for server access logs
-        if (request.serverAccessLog) {
-            // eslint-disable-next-line no-param-reassign
-            request.serverAccessLog.objectSize = sourceObjSize;
-        }
+            // Initialize the queue for internal log request logging
+            initializeInternalLogRequestQueue(request);
+            // Queue the source-side access log (REST.COPY.OBJECT_GET)
+            queueInternalLogRequest(request, {
+                operation: 'REST.COPY.OBJECT_GET',
+                sourceBucket,
+                sourceObject,
+                objectSize: sourceObjSize || null,
+            });
 
-        // Initialize the queue for internal log request logging
-        initializeInternalLogRequestQueue(request);
-        // Queue the source-side access log (REST.COPY.OBJECT_GET)
-        queueInternalLogRequest(request, {
-            operation: 'REST.COPY.OBJECT_GET',
-            sourceBucket,
-            sourceObject,
-            objectSize: sourceObjSize || null,
-        });
+            if (err) {
+                monitoring.promMetrics('PUT', destBucketName, err.code, 'copyObject');
+                return callback(err, null, corsHeaders);
+            }
+            let checksumXml = '';
+            const checksum = storeMetadataParams?.checksum;
+            const checksumAlgo = checksum && algorithms[checksum.algorithm];
+            if (checksum && checksumAlgo) {
+                checksumXml =
+                    `<${checksumAlgo.xmlTag}>${checksum.value}</${checksumAlgo.xmlTag}>` +
+                    `<ChecksumType>${checksum.type}</ChecksumType>`;
+            } else if (checksum) {
+                log.error('unknown checksum algorithm in source object metadata', { algorithm: checksum.algorithm });
+            }
+            const xml = [
+                '<?xml version="1.0" encoding="UTF-8"?>',
+                '<CopyObjectResult>',
+                '<LastModified>',
+                new Date(storeMetadataParams.lastModifiedDate).toISOString(),
+                '</LastModified>',
+                '<ETag>&quot;',
+                storeMetadataParams.contentMD5,
+                '&quot;</ETag>',
+                checksumXml,
+                '</CopyObjectResult>',
+            ].join('');
+            const additionalHeaders = corsHeaders || {};
+            if (serverSideEncryption) {
+                setSSEHeaders(
+                    additionalHeaders,
+                    serverSideEncryption.algorithm,
+                    serverSideEncryption.configuredMasterKeyId || serverSideEncryption.masterKeyId,
+                );
+            }
+            if (sourceVersionId) {
+                additionalHeaders['x-amz-copy-source-version-id'] = versionIdUtils.encode(sourceVersionId);
+            }
+            const isVersioned = storingNewMdResult && storingNewMdResult.versionId;
+            if (isVersioned) {
+                additionalHeaders['x-amz-version-id'] = versionIdUtils.encode(storingNewMdResult.versionId);
+            }
 
-        if (err) {
+            Object.assign(responseHeaders, additionalHeaders);
+
+            // Only pre-existing non-versioned objects get 0 all others use 1
+            const numberOfObjects = !isVersioned && destObjPrevSize !== null ? 0 : 1;
+
+            pushMetric('copyObject', log, {
+                authInfo,
+                canonicalID: destBucketMD.getOwner(),
+                bucket: destBucketName,
+                keys: [destObjectKey],
+                newByteLength: sourceObjSize,
+                oldByteLength: isVersioned ? null : destObjPrevSize,
+                location: storeMetadataParams.dataStoreName,
+                versionId: isVersioned ? storingNewMdResult.versionId : undefined,
+                numberOfObjects,
+            });
             monitoring.promMetrics(
-                'PUT', destBucketName, err.code, 'copyObject');
-            return callback(err, null, corsHeaders);
-        }
-        let checksumXml = '';
-        const checksum = storeMetadataParams?.checksum;
-        const checksumAlgo = checksum && algorithms[checksum.algorithm];
-        if (checksum && checksumAlgo) {
-            checksumXml =
-                `<${checksumAlgo.xmlTag}>${checksum.value}</${checksumAlgo.xmlTag}>` +
-                `<ChecksumType>${checksum.type}</ChecksumType>`;
-        } else if (checksum) {
-            log.error('unknown checksum algorithm in source object metadata', { algorithm: checksum.algorithm });
-        }
-        const xml = [
-            '<?xml version="1.0" encoding="UTF-8"?>',
-            '<CopyObjectResult>',
-            '<LastModified>', new Date(storeMetadataParams.lastModifiedDate)
-                .toISOString(), '</LastModified>',
-            '<ETag>&quot;', storeMetadataParams.contentMD5, '&quot;</ETag>',
-            checksumXml,
-            '</CopyObjectResult>',
-        ].join('');
-        const additionalHeaders = corsHeaders || {};
-        if (serverSideEncryption) {
-            setSSEHeaders(additionalHeaders,
-                serverSideEncryption.algorithm,
-                serverSideEncryption.configuredMasterKeyId || serverSideEncryption.masterKeyId
+                'PUT',
+                destBucketName,
+                '200',
+                'copyObject',
+                sourceObjSize,
+                destObjPrevSize,
+                isVersioned,
             );
-        }
-        if (sourceVersionId) {
-            additionalHeaders['x-amz-copy-source-version-id'] =
-                versionIdUtils.encode(sourceVersionId);
-        }
-        const isVersioned = storingNewMdResult && storingNewMdResult.versionId;
-        if (isVersioned) {
-            additionalHeaders['x-amz-version-id'] =
-                versionIdUtils.encode(storingNewMdResult.versionId);
-        }
-
-        Object.assign(responseHeaders, additionalHeaders);
-
-        // Only pre-existing non-versioned objects get 0 all others use 1
-        const numberOfObjects = !isVersioned && destObjPrevSize !== null ? 0 : 1;
-
-        pushMetric('copyObject', log, {
-            authInfo,
-            canonicalID: destBucketMD.getOwner(),
-            bucket: destBucketName,
-            keys: [destObjectKey],
-            newByteLength: sourceObjSize,
-            oldByteLength: isVersioned ? null : destObjPrevSize,
-            location: storeMetadataParams.dataStoreName,
-            versionId: isVersioned ? storingNewMdResult.versionId : undefined,
-            numberOfObjects,
-        });
-        monitoring.promMetrics('PUT', destBucketName, '200',
-                'copyObject', sourceObjSize, destObjPrevSize, isVersioned);
-        // Add expiration header if lifecycle enabled
-        return callback(null, xml, responseHeaders);
-    });
+            // Add expiration header if lifecycle enabled
+            return callback(null, xml, responseHeaders);
+        },
+    );
 }
 
 module.exports = objectCopy;

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -78,11 +78,26 @@ function _orphanedDataLocations(dataToDelete, newDataGetInfo) {
 function _pipeSourcePartsThrough(dataLocator, log) {
     const passthrough = new PassThrough();
     async.eachSeries(dataLocator, (part, cb) => {
-        data.get(part, null, log, (err, partStream) => {
+        const done = jsutil.once(cb);
+        if (part.dataStoreType === 'azure') {
+            // Azure's data.get writes part bytes into the provided writable
+            // instead of returning a Readable. Pipe a per-part PassThrough
+            // into the master passthrough and use its 'end' as the completion
+            // signal — same pattern arsenal's data.copyObject uses.
+            const perPart = new PassThrough();
+            perPart.once('error', done);
+            perPart.once('end', () => done());
+            perPart.pipe(passthrough, { end: false });
+            return data.get(part, perPart, log, err => {
+                if (err) {
+                    done(err);
+                }
+            });
+        }
+        return data.get(part, null, log, (err, partStream) => {
             if (err) {
-                return cb(err);
+                return done(err);
             }
-            const done = jsutil.once(cb);
             partStream.once('error', done);
             partStream.once('end', () => done());
             partStream.pipe(passthrough, { end: false });

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -39,7 +39,7 @@ const versionIdUtils = versioning.VersionID;
 const locationHeader = constants.objectLocationConstraintHeader;
 const versioningNotImplBackends = constants.versioningNotImplBackends;
 const externalVersioningErrorMessage =
-    'We do not currently support putting ' + 'a versioned object to a location-constraint of type AWS or Azure or GCP.';
+    'We do not currently support putting a versioned object to a location-constraint of type AWS or Azure or GCP.';
 
 /**
  * Compute the prior data locations that are orphaned.
@@ -547,7 +547,7 @@ function objectCopy(authInfo, request, sourceBucket, sourceObject, sourceVersion
     }
     if (!validateWebsiteHeader(websiteRedirectHeader)) {
         const err = errors.InvalidRedirectLocation;
-        log.debug('invalid x-amz-website-redirect-location' + `value ${websiteRedirectHeader}`, { error: err });
+        log.debug(`invalid x-amz-website-redirect-location value ${websiteRedirectHeader}`, { error: err });
         monitoring.promMetrics('PUT', destBucketName, err.code, 'copyObject');
         return callback(err);
     }
@@ -584,7 +584,7 @@ function objectCopy(authInfo, request, sourceBucket, sourceObject, sourceVersion
                                 }
                                 const flag = destBucketMD.hasDeletedFlag() || destBucketMD.hasTransientFlag();
                                 if (flag) {
-                                    log.trace('deleted flag or transient flag ' + 'on destination bucket', { flag });
+                                    log.trace('deleted flag or transient flag on destination bucket', { flag });
                                     return next(errors.NoSuchBucket);
                                 }
                                 return next(null, destBucketMD, destObjMD);

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -1,6 +1,7 @@
 const async = require('async');
+const { PassThrough } = require('stream');
 
-const { errors, errorInstances, versioning, s3middleware, s3routes } = require('arsenal');
+const { errors, errorInstances, jsutil, versioning, s3middleware, s3routes } = require('arsenal');
 const { validateObjectKeyLength } = s3routes.routesUtils;
 const getMetaHeaders = s3middleware.userMetadata.getMetaHeaders;
 const validateHeaders = s3middleware.validateConditionalHeaders;
@@ -28,6 +29,10 @@ const { verifyColdObjectAvailable } = require('./apiUtils/object/coldStorage');
 const { setSSEHeaders } = require('./apiUtils/object/sseHeaders');
 const { updateEncryption } = require('./apiUtils/bucket/updateEncryption');
 const { initializeInternalLogRequestQueue, queueInternalLogRequest } = require('../utilities/serverAccessLogger');
+const { algorithms, arsenalErrorFromChecksumError, getCopyObjectChecksumAlgorithm } =
+    require('./apiUtils/integrity/validateChecksums');
+const ChecksumTransform = require('../auth/streamingV4/ChecksumTransform');
+const kms = require('../kms/wrapper');
 
 const versionIdUtils = versioning.VersionID;
 const locationHeader = constants.objectLocationConstraintHeader;
@@ -58,6 +63,196 @@ function _orphanedDataLocations(dataToDelete, newDataGetInfo) {
     const newIds = new Set((newDataGetInfo || []).map(locId));
     const orphans = (dataToDelete || []).filter(loc => !newIds.has(locId(loc)));
     return orphans.length > 0 ? orphans : null;
+}
+
+/**
+ * Concatenate the source object's parts into a single Readable stream by
+ * reading them sequentially through `data.get`. Returns the PassThrough
+ * immediately; consumers should pipe it to the next stage and observe
+ * `error` on this stream for any read failure along the way.
+ *
+ * @param {Array} dataLocator - ordered source parts
+ * @param {object} log - request logger
+ * @return {PassThrough}
+ */
+function _pipeSourcePartsThrough(dataLocator, log) {
+    const passthrough = new PassThrough();
+    async.eachSeries(dataLocator, (part, cb) => {
+        data.get(part, null, log, (err, partStream) => {
+            if (err) {
+                return cb(err);
+            }
+            const done = jsutil.once(cb);
+            partStream.once('error', done);
+            partStream.once('end', () => done());
+            partStream.pipe(passthrough, { end: false });
+            return undefined;
+        });
+    }, err => {
+        if (err) {
+            passthrough.destroy(err);
+        } else {
+            passthrough.end();
+        }
+    });
+    return passthrough;
+}
+
+/**
+ * Decide whether the destination's checksum needs to be recomputed by
+ * streaming the source bytes through a ChecksumTransform.
+ *
+ * @param {object} headers - request headers
+ * @param {object} sourceObjMD - source object metadata
+ * @returns {boolean}
+ */
+function _shouldRecomputeChecksum(headers, sourceObjMD) {
+    const requestedAlgo = headers['x-amz-checksum-algorithm']?.toLowerCase();
+    if (sourceObjMD.checksum?.checksumType === 'FULL_OBJECT'
+        && (!requestedAlgo || requestedAlgo === sourceObjMD.checksum.checksumAlgorithm)) {
+        return false;
+    }
+    return true;
+}
+
+/**
+ * Pick the checksum algorithm to write on CopyObject. Defaults to CRC64NVME when the source object has no checksum.
+ *
+ * @param {string|null} requestedAlgo - validated request algorithm
+ * @param {object} sourceObjMD - source object metadata
+ * @returns {string}
+ */
+function _getCopyObjectChecksumAlgorithm(requestedAlgo, sourceObjMD) {
+    return requestedAlgo || sourceObjMD.checksum?.checksumAlgorithm || 'crc64nvme';
+}
+
+/**
+ * Recompute the destination's checksum by streaming the source bytes
+ * through a ChecksumTransform. When the bytes don't have to move
+ * (copy-to-self, same location, no SSE, not versioned) the source is GET'ed
+ * solely to compute the new digest; the bytes are then discarded and the
+ * existing data location is reused — only cloudserver's metadata is updated.
+ *
+ * @param {object} log - request logger
+ * @param {object} request - HTTP request
+ * @param {string|null} requestedAlgo - client-requested algorithm, lowercase
+ * @param {object} sourceObjMD - source object metadata
+ * @param {Array} dataLocator - ordered source parts
+ * @param {boolean} sourceIsDestination - source key == destination key
+ * @param {boolean} isVersionedObj - destination bucket has versioning enabled
+ * @param {boolean} needsEncryption - destination requires SSE
+ * @param {object} storeMetadataParams - mutable carrier for destination metadata
+ * @param {object} destObjMD - existing destination object metadata
+ * @param {object} destBucketMD - destination bucket metadata
+ * @param {object} serverSideEncryption - SSE config for the destination
+ * @param {object} dataStoreContext - context passed to data.put
+ * @param {object} backendInfoDest - backend info for the destination
+ * @param {function} next - waterfall callback
+ * @return {undefined}
+ */
+function _recomputeChecksumAndStore(log, request, requestedAlgo, sourceObjMD, dataLocator,
+    sourceIsDestination, isVersionedObj, needsEncryption,
+    storeMetadataParams, destObjMD, destBucketMD, serverSideEncryption,
+    dataStoreContext, backendInfoDest, next) {
+    const algoName = _getCopyObjectChecksumAlgorithm(requestedAlgo, sourceObjMD);
+    const wrapChecksumErr = err => Object.assign(err, { checksumStream: { algorithm: algoName } });
+
+    // Copy-to-self where the bytes don't have to move (same location, no SSE
+    // change, not versioned): GET the source through a ChecksumTransform to
+    // compute the new digest, discard the bytes, and reuse the existing data
+    // locations. No PUT, no DELETE — only the metadata gets updated.
+    if (sourceIsDestination && storeMetadataParams.locationMatch
+        && !needsEncryption && !isVersionedObj) {
+        log.debug('computing checksum on copy-to-self without rewriting data',
+            { algorithm: algoName, size: storeMetadataParams.size });
+        const sourceStream = _pipeSourcePartsThrough(dataLocator, log);
+        const checksumStream = new ChecksumTransform(algoName, undefined, false, log);
+        const finish = jsutil.once(err => {
+            if (err) {
+                sourceStream.destroy(err);
+                checksumStream.destroy(err);
+                if (request.sourceServerAccessLog) {
+                    // eslint-disable-next-line no-param-reassign
+                    request.sourceServerAccessLog.error = err;
+                }
+                return next(err, destBucketMD);
+            }
+            // eslint-disable-next-line no-param-reassign
+            storeMetadataParams.checksum = {
+                algorithm: algoName,
+                value: checksumStream.digest,
+                type: 'FULL_OBJECT',
+            };
+            return next(null, storeMetadataParams, dataLocator, destObjMD,
+                serverSideEncryption, destBucketMD);
+        });
+        sourceStream.once('error', finish);
+        checksumStream.once('error', err => finish(wrapChecksumErr(err)));
+        checksumStream.on('data', () => {});
+        checksumStream.once('end', () => finish());
+        sourceStream.pipe(checksumStream);
+        return undefined;
+    }
+
+    // Stream source bytes through a ChecksumTransform and write them out as a single put.
+    log.debug('recomputing checksum on CopyObject', { algorithm: algoName, size: storeMetadataParams.size });
+    const sourceStream = _pipeSourcePartsThrough(dataLocator, log);
+    const checksumStream = new ChecksumTransform(algoName, undefined, false, log);
+    const done = jsutil.once((err, results) => {
+        if (err) {
+            sourceStream.destroy(err);
+            checksumStream.destroy(err);
+            if (request.sourceServerAccessLog) {
+                // eslint-disable-next-line no-param-reassign
+                request.sourceServerAccessLog.error = err;
+            }
+            return next(err, destBucketMD);
+        }
+        return next(null, storeMetadataParams, results, destObjMD, serverSideEncryption, destBucketMD);
+    });
+    sourceStream.once('error', done);
+    checksumStream.once('error', err => done(wrapChecksumErr(err)));
+    sourceStream.pipe(checksumStream);
+    const doPut = cipherBundle => data.put(
+        cipherBundle, checksumStream, storeMetadataParams.size,
+        dataStoreContext, backendInfoDest, log,
+        (err, dataRetrievalInfo) => {
+            if (err) {
+                return done(err);
+            }
+            // eslint-disable-next-line no-param-reassign
+            storeMetadataParams.checksum = {
+                algorithm: algoName,
+                value: checksumStream.digest,
+                type: 'FULL_OBJECT',
+            };
+            const putResult = {
+                key: dataRetrievalInfo.key,
+                size: storeMetadataParams.size,
+                start: 0,
+                dataStoreName: dataRetrievalInfo.dataStoreName,
+                dataStoreType: dataRetrievalInfo.dataStoreType,
+                dataStoreETag: dataRetrievalInfo.dataStoreETag,
+                dataStoreVersionId:
+                    dataRetrievalInfo.dataStoreVersionId,
+            };
+            if (cipherBundle) {
+                putResult.cryptoScheme = cipherBundle.cryptoScheme;
+                putResult.cipheredDataKey =
+                    cipherBundle.cipheredDataKey;
+            }
+            return done(null, [putResult]);
+        });
+    if (serverSideEncryption?.algorithm) {
+        return kms.createCipherBundle(serverSideEncryption, log,
+            (err, cipherBundle) => {
+                if (err) {
+                    return done(err);
+                }
+                return doPut(cipherBundle);
+            });
+    }
+    return doPut(null);
 }
 
 /**
@@ -213,6 +408,14 @@ function _prepMetadata(request, sourceObjMD, headers, sourceIsDestination,
         storeMetadataParams.defaultRetention = defaultRetentionConfig;
     }
 
+    if (sourceObjMD.checksum && !_shouldRecomputeChecksum(headers, sourceObjMD)) {
+        storeMetadataParams.checksum = {
+            algorithm: sourceObjMD.checksum.checksumAlgorithm,
+            value: sourceObjMD.checksum.checksumValue,
+            type: sourceObjMD.checksum.checksumType,
+        };
+    }
+
     // In case whichMetadata === 'REPLACE' but contentType is undefined in copy
     // request headers, make sure to keep the original header instead
     if (!storeMetadataParams.contentType) {
@@ -301,6 +504,13 @@ function objectCopy(authInfo, request, sourceBucket,
             `value ${websiteRedirectHeader}`, { error: err });
         monitoring.promMetrics(
             'PUT', destBucketName, err.code, 'copyObject');
+        return callback(err);
+    }
+    const { error: checksumAlgoErr, algorithm: requestedAlgo } = getCopyObjectChecksumAlgorithm(request.headers);
+    if (checksumAlgoErr) {
+        const err = arsenalErrorFromChecksumError(checksumAlgoErr);
+        log.debug('invalid x-amz-checksum-algorithm', { error: checksumAlgoErr });
+        monitoring.promMetrics('PUT', destBucketName, err.code, 'copyObject');
         return callback(err);
     }
     const queryContainsVersionId = checkQueryVersionId(request.query);
@@ -442,12 +652,12 @@ function objectCopy(authInfo, request, sourceBucket,
 
                     return next(null, storeMetadataParams, dataLocator,
                         sourceBucketMD, destBucketMD, destObjMD,
-                        sourceLocationConstraintName, backendInfoDest);
+                        sourceLocationConstraintName, backendInfoDest, sourceObjMD);
                 });
         },
         function getSSEConfiguration(storeMetadataParams, dataLocator, sourceBucketMD,
             destBucketMD, destObjMD, sourceLocationConstraintName,
-            backendInfoDest, next) {
+            backendInfoDest, sourceObjMD, next) {
             getObjectSSEConfiguration(
                     request.headers,
                     destBucketMD,
@@ -455,22 +665,27 @@ function objectCopy(authInfo, request, sourceBucket,
                     (err, sseConfig) =>
                         next(err, storeMetadataParams, dataLocator, sourceBucketMD,
                             destBucketMD, destObjMD, sourceLocationConstraintName,
-                            backendInfoDest, sseConfig));
+                            backendInfoDest, sseConfig, sourceObjMD));
         },
         function goGetData(storeMetadataParams, dataLocator, sourceBucketMD,
             destBucketMD, destObjMD, sourceLocationConstraintName,
-            backendInfoDest, serverSideEncryption, next) {
+            backendInfoDest, serverSideEncryption, sourceObjMD, next) {
             const vcfg = destBucketMD.getVersioningConfiguration();
             const isVersionedObj = vcfg && vcfg.Status === 'Enabled';
             const destLocationConstraintName =
                 storeMetadataParams.dataStoreName;
             const needsEncryption = serverSideEncryption && !!serverSideEncryption.algo;
+            const shouldRecomputeChecksum = _shouldRecomputeChecksum(request.headers, sourceObjMD);
+            let destLocationConstraintType;
+            if (config.backends.data === 'multiple') {
+                destLocationConstraintType = config.getLocationConstraintType(destLocationConstraintName);
+            }
             // skip if source and dest and location constraint the same and
-            // versioning is not enabled
-            // still send along serverSideEncryption info so algo
-            // and masterKeyId stored properly in metadata
+            // versioning is not enabled, unless we need to recompute a
+            // checksum (which requires streaming the bytes through us).
             if (sourceIsDestination && storeMetadataParams.locationMatch
-                && !isVersionedObj && !needsEncryption) {
+                && !isVersionedObj && !needsEncryption
+                && !shouldRecomputeChecksum) {
                 return next(null, storeMetadataParams, dataLocator, destObjMD,
                     serverSideEncryption, destBucketMD);
             }
@@ -478,11 +693,6 @@ function objectCopy(authInfo, request, sourceBucket,
             // also skip if 0 byte object, unless location constraint is an
             // external backend and differs from source, in which case put
             // metadata to backend
-            let destLocationConstraintType;
-            if (config.backends.data === 'multiple') {
-                destLocationConstraintType =
-                config.getLocationConstraintType(destLocationConstraintName);
-            }
             if (destLocationConstraintType &&
               versioningNotImplBackends[destLocationConstraintType]
                 && isVersionedObj) {
@@ -493,9 +703,8 @@ function objectCopy(authInfo, request, sourceBucket,
                   externalVersioningErrorMessage), destBucketMD);
             }
             if (dataLocator.length === 0) {
-                if (!storeMetadataParams.locationMatch &&
-                destLocationConstraintType &&
-                constants.externalBackends[destLocationConstraintType]) {
+                if (!storeMetadataParams.locationMatch && destLocationConstraintType
+                    && constants.externalBackends[destLocationConstraintType]) {
                     return data.put(null, null, storeMetadataParams.size,
                         dataStoreContext, backendInfoDest,
                         log, (error, objectRetrievalInfo) => {
@@ -504,19 +713,22 @@ function objectCopy(authInfo, request, sourceBucket,
                             }
                             const putResult = {
                                 key: objectRetrievalInfo.key,
-                                dataStoreName: objectRetrievalInfo.
-                                    dataStoreName,
-                                dataStoreType: objectRetrievalInfo.
-                                    dataStoreType,
+                                dataStoreName: objectRetrievalInfo.dataStoreName,
+                                dataStoreType: objectRetrievalInfo.dataStoreType,
                                 size: storeMetadataParams.size,
                             };
-                            const putResultArr = [putResult];
-                            return next(null, storeMetadataParams, putResultArr,
+                            return next(null, storeMetadataParams, [putResult],
                                 destObjMD, serverSideEncryption, destBucketMD);
                         });
                 }
                 return next(null, storeMetadataParams, dataLocator, destObjMD,
                     serverSideEncryption, destBucketMD);
+            }
+            if (shouldRecomputeChecksum) {
+                return _recomputeChecksumAndStore(log, request, requestedAlgo, sourceObjMD, dataLocator,
+                    sourceIsDestination, isVersionedObj, needsEncryption,
+                    storeMetadataParams, destObjMD, destBucketMD, serverSideEncryption,
+                    dataStoreContext, backendInfoDest, next);
             }
             const originalIdentityImpDenies = request.actionImplicitDenies;
             // eslint-disable-next-line no-param-reassign
@@ -661,12 +873,23 @@ function objectCopy(authInfo, request, sourceBucket,
                 'PUT', destBucketName, err.code, 'copyObject');
             return callback(err, null, corsHeaders);
         }
+        let checksumXml = '';
+        const checksum = storeMetadataParams?.checksum;
+        const checksumAlgo = checksum && algorithms[checksum.algorithm];
+        if (checksum && checksumAlgo) {
+            checksumXml =
+                `<${checksumAlgo.xmlTag}>${checksum.value}</${checksumAlgo.xmlTag}>` +
+                `<ChecksumType>${checksum.type}</ChecksumType>`;
+        } else if (checksum) {
+            log.error('unknown checksum algorithm in source object metadata', { algorithm: checksum.algorithm });
+        }
         const xml = [
             '<?xml version="1.0" encoding="UTF-8"?>',
             '<CopyObjectResult>',
             '<LastModified>', new Date(storeMetadataParams.lastModifiedDate)
                 .toISOString(), '</LastModified>',
             '<ETag>&quot;', storeMetadataParams.contentMD5, '&quot;</ETag>',
+            checksumXml,
             '</CopyObjectResult>',
         ].join('');
         const additionalHeaders = corsHeaders || {};

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -703,26 +703,47 @@ function objectCopy(authInfo, request, sourceBucket,
                   externalVersioningErrorMessage), destBucketMD);
             }
             if (dataLocator.length === 0) {
-                if (!storeMetadataParams.locationMatch && destLocationConstraintType
-                    && constants.externalBackends[destLocationConstraintType]) {
-                    return data.put(null, null, storeMetadataParams.size,
-                        dataStoreContext, backendInfoDest,
-                        log, (error, objectRetrievalInfo) => {
-                            if (error) {
-                                return next(error, destBucketMD);
-                            }
-                            const putResult = {
-                                key: objectRetrievalInfo.key,
-                                dataStoreName: objectRetrievalInfo.dataStoreName,
-                                dataStoreType: objectRetrievalInfo.dataStoreType,
-                                size: storeMetadataParams.size,
+                const finishZeroByte = () => {
+                    if (!storeMetadataParams.locationMatch && destLocationConstraintType
+                        && constants.externalBackends[destLocationConstraintType]) {
+                        return data.put(null, null, storeMetadataParams.size,
+                            dataStoreContext, backendInfoDest,
+                            log, (error, objectRetrievalInfo) => {
+                                if (error) {
+                                    return next(error, destBucketMD);
+                                }
+                                const putResult = {
+                                    key: objectRetrievalInfo.key,
+                                    dataStoreName: objectRetrievalInfo.dataStoreName,
+                                    dataStoreType: objectRetrievalInfo.dataStoreType,
+                                    size: storeMetadataParams.size,
+                                };
+                                return next(null, storeMetadataParams, [putResult],
+                                    destObjMD, serverSideEncryption, destBucketMD);
+                            });
+                    }
+                    return next(null, storeMetadataParams, dataLocator, destObjMD,
+                        serverSideEncryption, destBucketMD);
+                };
+                if (shouldRecomputeChecksum) {
+                    // No bytes to stream, but AWS still writes the empty-bytes digest of the chosen algorithm.
+                    const algoName = _getCopyObjectChecksumAlgorithm(requestedAlgo, sourceObjMD);
+                    return Promise.resolve(algorithms[algoName].digest(Buffer.alloc(0)))
+                        .then(digest => {
+                            // eslint-disable-next-line no-param-reassign
+                            storeMetadataParams.checksum = {
+                                algorithm: algoName,
+                                value: digest,
+                                type: 'FULL_OBJECT',
                             };
-                            return next(null, storeMetadataParams, [putResult],
-                                destObjMD, serverSideEncryption, destBucketMD);
+                            return finishZeroByte();
+                        }, err => {
+                            log.error('failed to compute empty checksum digest',
+                                { algorithm: algoName, error: err });
+                            return next(errors.InternalError, destBucketMD);
                         });
                 }
-                return next(null, storeMetadataParams, dataLocator, destObjMD,
-                    serverSideEncryption, destBucketMD);
+                return finishZeroByte();
             }
             if (shouldRecomputeChecksum) {
                 return _recomputeChecksumAndStore(log, request, requestedAlgo, sourceObjMD, dataLocator,

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -235,7 +235,7 @@ function _recomputeChecksumAndStore(log, request, requestedAlgo, sourceObjMD, da
     const doPut = cipherBundle => data.put(
         cipherBundle, checksumStream, storeMetadataParams.size,
         dataStoreContext, backendInfoDest, log,
-        (err, dataRetrievalInfo) => {
+        (err, dataRetrievalInfo, hashedStream) => {
             if (err) {
                 return done(err);
             }
@@ -245,13 +245,16 @@ function _recomputeChecksumAndStore(log, request, requestedAlgo, sourceObjMD, da
                 value: checksumStream.digest,
                 type: 'FULL_OBJECT',
             };
+            // Prefix the part number like createAndStoreObject does, so
+            // partNumber-based reads see the copy as a single-part object.
+            const dataStoreETag = dataRetrievalInfo.dataStoreETag || hashedStream?.completedHash;
             const putResult = {
                 key: dataRetrievalInfo.key,
                 size: storeMetadataParams.size,
                 start: 0,
                 dataStoreName: dataRetrievalInfo.dataStoreName,
                 dataStoreType: dataRetrievalInfo.dataStoreType,
-                dataStoreETag: dataRetrievalInfo.dataStoreETag,
+                dataStoreETag: dataStoreETag ? `1:${dataStoreETag}` : undefined,
                 dataStoreVersionId:
                     dataRetrievalInfo.dataStoreVersionId,
             };

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -77,6 +77,9 @@ function _orphanedDataLocations(dataToDelete, newDataGetInfo) {
  */
 function _pipeSourcePartsThrough(dataLocator, log) {
     const passthrough = new PassThrough();
+    const wrapErr = (err, part) => Object.assign(err, {
+        copyPart: { key: part.key, dataStoreName: part.dataStoreName, dataStoreType: part.dataStoreType },
+    });
     async.eachSeries(dataLocator, (part, cb) => {
         const done = jsutil.once(cb);
         if (part.dataStoreType === 'azure') {
@@ -85,20 +88,21 @@ function _pipeSourcePartsThrough(dataLocator, log) {
             // into the master passthrough and use its 'end' as the completion
             // signal — same pattern arsenal's data.copyObject uses.
             const perPart = new PassThrough();
-            perPart.once('error', done);
+            perPart.once('error', err => done(wrapErr(err, part)));
             perPart.once('end', () => done());
             perPart.pipe(passthrough, { end: false });
             return data.get(part, perPart, log, err => {
                 if (err) {
-                    done(err);
+                    perPart.destroy(err);
+                    done(wrapErr(err, part));
                 }
             });
         }
         return data.get(part, null, log, (err, partStream) => {
             if (err) {
-                return done(err);
+                return done(wrapErr(err, part));
             }
-            partStream.once('error', done);
+            partStream.once('error', err => done(wrapErr(err, part)));
             partStream.once('end', () => done());
             partStream.pipe(passthrough, { end: false });
             return undefined;

--- a/lib/auth/streamingV4/ChecksumWritable.js
+++ b/lib/auth/streamingV4/ChecksumWritable.js
@@ -1,0 +1,38 @@
+const { errors } = require('arsenal');
+const { algorithms } = require('../../api/apiUtils/integrity/validateChecksums');
+const { Writable } = require('stream');
+
+/**
+ * Writable sink that hashes everything written to it and discards the bytes.
+ *
+ * The computed digest is available on `.digest` once the 'finish' event fires.
+ */
+class ChecksumWritable extends Writable {
+    constructor(algoName, log) {
+        super({});
+        this.log = log;
+        this.algoName = algoName;
+        this.algo = algorithms[algoName];
+        this.hash = this.algo.createHash();
+        this.digest = undefined;
+    }
+
+    _write(chunk, encoding, callback) {
+        const input = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        this.hash.update(input);
+        callback();
+    }
+
+    _final(callback) {
+        Promise.resolve(this.algo.digestFromHash(this.hash))
+            .then(digest => {
+                this.digest = digest;
+                callback();
+            }, err => {
+                this.log.error('failed to compute checksum digest', { error: err, algorithm: this.algoName });
+                callback(errors.InternalError);
+            });
+    }
+}
+
+module.exports = ChecksumWritable;

--- a/lib/auth/streamingV4/ChecksumWritable.js
+++ b/lib/auth/streamingV4/ChecksumWritable.js
@@ -24,14 +24,16 @@ class ChecksumWritable extends Writable {
     }
 
     _final(callback) {
-        Promise.resolve(this.algo.digestFromHash(this.hash))
-            .then(digest => {
+        Promise.resolve(this.algo.digestFromHash(this.hash)).then(
+            digest => {
                 this.digest = digest;
                 callback();
-            }, err => {
+            },
+            err => {
                 this.log.error('failed to compute checksum digest', { error: err, algorithm: this.algoName });
                 callback(errors.InternalError);
-            });
+            },
+        );
     }
 }
 

--- a/tests/functional/aws-node-sdk/test/object/objectCopy.js
+++ b/tests/functional/aws-node-sdk/test/object/objectCopy.js
@@ -18,6 +18,8 @@ const { taggingTests } = require('../../lib/utility/tagging');
 const genMaxSizeMetaHeaders
     = require('../../lib/utility/genMaxSizeMetaHeaders');
 const constants = require('../../../../../constants');
+const { algorithms } =
+    require('../../../../../lib/api/apiUtils/integrity/validateChecksums');
 
 const sourceBucketName = 'supersourcebucket8102016';
 const sourceObjName = 'supersourceobject';
@@ -1534,4 +1536,168 @@ describe('Object Copy with object lock enabled on both destination ' +
             });
         });
 
+});
+
+describe('Object Copy checksum behavior', () => {
+    withV4(sigCfg => {
+        let bucketUtil;
+        let s3;
+
+        before(async () => {
+            try {
+                bucketUtil = new BucketUtility('default', sigCfg);
+                s3 = bucketUtil.s3;
+                await bucketUtil.empty(sourceBucketName);
+                await bucketUtil.empty(destBucketName);
+                await bucketUtil.deleteMany([sourceBucketName, destBucketName]);
+            } catch (err) {
+                if (err.name !== 'NoSuchBucket') {
+                    throw err;
+                }
+            }
+            await bucketUtil.createOne(sourceBucketName);
+            await bucketUtil.createOne(destBucketName);
+        });
+
+        afterEach(async () => {
+            await bucketUtil.empty(sourceBucketName, true);
+            await bucketUtil.empty(destBucketName, true);
+        });
+
+        after(async () => bucketUtil.deleteMany([sourceBucketName, destBucketName]));
+
+        const checksumFixtures = [
+            { algo: 'crc32', header: 'CRC32', key: 'ChecksumCRC32' },
+            { algo: 'crc32c', header: 'CRC32C', key: 'ChecksumCRC32C' },
+            { algo: 'crc64nvme', header: 'CRC64NVME', key: 'ChecksumCRC64NVME' },
+            { algo: 'sha1', header: 'SHA1', key: 'ChecksumSHA1' },
+            { algo: 'sha256', header: 'SHA256', key: 'ChecksumSHA256' },
+        ];
+
+        const propagateBody = 'checksum-propagate-body';
+        const recomputeBody = 'recompute-different-algo-body';
+
+        checksumFixtures.forEach(({ algo, header, key }) => {
+            it(`should propagate a FULL_OBJECT ${algo} checksum on CopyObject`, async () => {
+                const putRes = await s3.send(new PutObjectCommand({
+                    Bucket: sourceBucketName,
+                    Key: sourceObjName,
+                    Body: propagateBody,
+                    ChecksumAlgorithm: header,
+                }));
+                const sourceValue = putRes[key];
+                assert(sourceValue, `PutObject response should carry ${key}`);
+
+                const copyRes = await s3.send(new CopyObjectCommand({
+                    Bucket: destBucketName,
+                    Key: destObjName,
+                    CopySource: `${sourceBucketName}/${sourceObjName}`,
+                }));
+                assert.strictEqual(copyRes.CopyObjectResult[key], sourceValue);
+                assert.strictEqual(copyRes.CopyObjectResult.ChecksumType, 'FULL_OBJECT');
+
+                const headRes = await s3.send(new HeadObjectCommand({
+                    Bucket: destBucketName,
+                    Key: destObjName,
+                    ChecksumMode: 'ENABLED',
+                }));
+                assert.strictEqual(headRes[key], sourceValue);
+                assert.strictEqual(headRes.ChecksumType, 'FULL_OBJECT');
+            });
+        });
+
+        // Recompute path: every (source algo, requested algo) pair where the
+        // two differ should produce the requested algo's digest of the body.
+        checksumFixtures.forEach(({ algo: sourceAlgo, header: sourceHeader }) => {
+            checksumFixtures.forEach(({ algo, header, key }) => {
+                if (sourceAlgo === algo) {
+                    return; // same-algo is the propagation case, covered above
+                }
+                it(`should recompute ${algo} when source is ${sourceAlgo} and ${header} requested`, async () => {
+                    await s3.send(new PutObjectCommand({
+                        Bucket: sourceBucketName,
+                        Key: sourceObjName,
+                        Body: recomputeBody,
+                        ChecksumAlgorithm: sourceHeader,
+                    }));
+                    const expectedDigest = await Promise.resolve(
+                        algorithms[algo].digest(Buffer.from(recomputeBody)));
+
+                    const copyRes = await s3.send(new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        ChecksumAlgorithm: header,
+                    }));
+                    assert.strictEqual(copyRes.CopyObjectResult[key], expectedDigest);
+                    assert.strictEqual(copyRes.CopyObjectResult.ChecksumType, 'FULL_OBJECT');
+
+                    const headRes = await s3.send(new HeadObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        ChecksumMode: 'ENABLED',
+                    }));
+                    assert.strictEqual(headRes[key], expectedDigest);
+                    assert.strictEqual(headRes.ChecksumType, 'FULL_OBJECT');
+                });
+            });
+        });
+
+        // 0-byte source: each requested algo produces the empty-bytes digest.
+        // Source algo doesn't matter (empty body has the same content
+        // regardless), so we pivot on CRC32 ↔ SHA256 to force recompute.
+        checksumFixtures.forEach(({ algo, header, key }) => {
+            const sourceHeader = header === 'CRC32' ? 'SHA256' : 'CRC32';
+            it(`should compute empty-bytes ${algo} digest on a 0-byte source recompute`, async () => {
+                await s3.send(new PutObjectCommand({
+                    Bucket: sourceBucketName,
+                    Key: sourceObjName,
+                    Body: '',
+                    ChecksumAlgorithm: sourceHeader,
+                }));
+                const expectedDigest = await Promise.resolve(
+                    algorithms[algo].digest(Buffer.alloc(0)));
+
+                const copyRes = await s3.send(new CopyObjectCommand({
+                    Bucket: destBucketName,
+                    Key: destObjName,
+                    CopySource: `${sourceBucketName}/${sourceObjName}`,
+                    ChecksumAlgorithm: header,
+                }));
+                assert.strictEqual(copyRes.CopyObjectResult[key], expectedDigest);
+                assert.strictEqual(copyRes.CopyObjectResult.ChecksumType, 'FULL_OBJECT');
+
+                const headRes = await s3.send(new HeadObjectCommand({
+                    Bucket: destBucketName,
+                    Key: destObjName,
+                    ChecksumMode: 'ENABLED',
+                }));
+                assert.strictEqual(headRes[key], expectedDigest);
+                assert.strictEqual(headRes.ChecksumType, 'FULL_OBJECT');
+            });
+        });
+
+        it('should reject an unknown ChecksumAlgorithm with InvalidRequest', async () => {
+            await s3.send(new PutObjectCommand({
+                Bucket: sourceBucketName,
+                Key: sourceObjName,
+                Body: 'whatever',
+            }));
+            try {
+                await s3.send(new CopyObjectCommand({
+                    Bucket: destBucketName,
+                    Key: destObjName,
+                    CopySource: `${sourceBucketName}/${sourceObjName}`,
+                    ChecksumAlgorithm: 'GARBAGE',
+                }));
+                throw new Error('Expected 400 InvalidRequest');
+            } catch (err) {
+                checkError(err, 'InvalidRequest', 400);
+                const expected = 'Checksum algorithm provided is unsupported. '
+                    + 'Please try again with any of the valid types: '
+                    + '[CRC32, CRC32C, CRC64NVME, SHA1, SHA256]';
+                assert.strictEqual(err.message, expected);
+            }
+        });
+    });
 });

--- a/tests/functional/aws-node-sdk/test/object/objectCopy.js
+++ b/tests/functional/aws-node-sdk/test/object/objectCopy.js
@@ -232,7 +232,7 @@ describe('Object Copy', () => {
             },
         );
 
-        it('should return 400 InvalidArgument if invalid tagging ' + 'directive', done => {
+        it('should return 400 InvalidArgument if invalid tagging directive', done => {
             s3.send(
                 new CopyObjectCommand({
                     Bucket: destBucketName,
@@ -434,7 +434,7 @@ describe('Object Copy', () => {
                                 checkError(err, taggingTest.error, taggingTest.code);
                                 return done();
                             }
-                            assert.equal(err, null, 'Expected success, ' + `got error ${JSON.stringify(err)}`);
+                            assert.equal(err, null, `Expected success, got error ${JSON.stringify(err)}`);
                             return checkSuccessTagging(taggingTest.tag.key, taggingTest.tag.value, done);
                         });
                 });
@@ -476,7 +476,7 @@ describe('Object Copy', () => {
             },
         );
 
-        it('should copy an object from a source bucket to a different ' + 'key in the same bucket', async () => {
+        it('should copy an object from a source bucket to a different key in the same bucket', async () => {
             const res = await s3.send(
                 new CopyObjectCommand({
                     Bucket: sourceBucketName,
@@ -488,40 +488,37 @@ describe('Object Copy', () => {
         });
 
         // TODO: see S3C-3482, figure out why this test fails in Integration builds
-        itSkipIfE2E(
-            'should not return error if copying object w/ > ' + '2KB user-defined md and COPY directive',
-            done => {
-                const metadata = genMaxSizeMetaHeaders();
-                const params = {
-                    Bucket: destBucketName,
-                    Key: destObjName,
-                    CopySource: `${sourceBucketName}/${sourceObjName}`,
-                    MetadataDirective: 'COPY',
-                    Metadata: metadata,
-                };
-                s3.send(new CopyObjectCommand(params))
-                    .then(() => {
-                        // add one more byte to be over the limit
-                        metadata.header0 = `${metadata.header0}${'0'}`;
-                        s3.send(new CopyObjectCommand(params))
-                            .then(() => {
-                                done();
-                            })
-                            .catch(err => {
-                                assert.strictEqual(err, null, `Unexpected err: ${err}`);
-                                done(err);
-                            });
-                    })
-                    .catch(err => {
-                        assert.strictEqual(err, null, `Unexpected err: ${err}`);
-                        done(err);
-                    });
-            },
-        );
+        itSkipIfE2E('should not return error if copying object w/ > 2KB user-defined md and COPY directive', done => {
+            const metadata = genMaxSizeMetaHeaders();
+            const params = {
+                Bucket: destBucketName,
+                Key: destObjName,
+                CopySource: `${sourceBucketName}/${sourceObjName}`,
+                MetadataDirective: 'COPY',
+                Metadata: metadata,
+            };
+            s3.send(new CopyObjectCommand(params))
+                .then(() => {
+                    // add one more byte to be over the limit
+                    metadata.header0 = `${metadata.header0}${'0'}`;
+                    s3.send(new CopyObjectCommand(params))
+                        .then(() => {
+                            done();
+                        })
+                        .catch(err => {
+                            assert.strictEqual(err, null, `Unexpected err: ${err}`);
+                            done(err);
+                        });
+                })
+                .catch(err => {
+                    assert.strictEqual(err, null, `Unexpected err: ${err}`);
+                    done(err);
+                });
+        });
 
         // TODO: see S3C-3482, figure out why this test fails in Integration builds
         itSkipIfE2E(
-            'should return error if copying object w/ > 2KB ' + 'user-defined md and REPLACE directive',
+            'should return error if copying object w/ > 2KB user-defined md and REPLACE directive',
             async () => {
                 try {
                     const metadata = genMaxSizeMetaHeaders();
@@ -544,7 +541,7 @@ describe('Object Copy', () => {
             },
         );
 
-        it('should copy an object from a source to the same destination ' + '(update metadata)', async () => {
+        it('should copy an object from a source to the same destination (update metadata)', async () => {
             const res = await s3.send(
                 new CopyObjectCommand({
                     Bucket: sourceBucketName,
@@ -931,25 +928,22 @@ describe('Object Copy', () => {
             },
         );
 
-        it(
-            'should return Not Implemented error for obj. encryption using ' + 'customer-provided encryption keys',
-            done => {
-                const params = {
-                    Bucket: destBucketName,
-                    Key: 'key',
-                    CopySource: `${sourceBucketName}/${sourceObjName}`,
-                    SSECustomerAlgorithm: 'AES256',
-                };
-                s3.send(new CopyObjectCommand(params))
-                    .then(() => {
-                        throw Error('Expected NotImplemented error');
-                    })
-                    .catch(err => {
-                        assert.strictEqual(err.name, 'NotImplemented');
-                        done();
-                    });
-            },
-        );
+        it('should return Not Implemented error for obj. encryption using customer-provided encryption keys', done => {
+            const params = {
+                Bucket: destBucketName,
+                Key: 'key',
+                CopySource: `${sourceBucketName}/${sourceObjName}`,
+                SSECustomerAlgorithm: 'AES256',
+            };
+            s3.send(new CopyObjectCommand(params))
+                .then(() => {
+                    throw Error('Expected NotImplemented error');
+                })
+                .catch(err => {
+                    assert.strictEqual(err.name, 'NotImplemented');
+                    done();
+                });
+        });
 
         it('should copy an object and set the acl on the new object', done => {
             s3.send(
@@ -972,7 +966,7 @@ describe('Object Copy', () => {
                             assert.strictEqual(res.Grants[1].Permission, 'READ');
                             assert.strictEqual(
                                 res.Grants[1].Grantee.URI,
-                                'http://acs.amazonaws.com/groups/' + 'global/AuthenticatedUsers',
+                                'http://acs.amazonaws.com/groups/global/AuthenticatedUsers',
                             );
                             done();
                         })
@@ -1034,7 +1028,7 @@ describe('Object Copy', () => {
         );
 
         it(
-            'should return an error if attempt to copy with same source as' +
+            'should return an error if attempt to copy with same source as ' +
                 'destination and do not change any metadata',
             done => {
                 s3.send(
@@ -1215,26 +1209,23 @@ describe('Object Copy', () => {
                     .then(() => otherAccountBucketUtility.deleteOne(otherAccountBucket)),
             );
 
-            it(
-                'should not allow an account without read persmission on the ' + 'source object to copy the object',
-                done => {
-                    otherAccountS3
-                        .send(
-                            new CopyObjectCommand({
-                                Bucket: otherAccountBucket,
-                                Key: otherAccountKey,
-                                CopySource: `${sourceBucketName}/${sourceObjName}`,
-                            }),
-                        )
-                        .then(() => {
-                            done();
-                        })
-                        .catch(err => {
-                            checkError(err, 'AccessDenied', 403);
-                            done();
-                        });
-                },
-            );
+            it('should not allow an account without read persmission on the source object to copy the object', done => {
+                otherAccountS3
+                    .send(
+                        new CopyObjectCommand({
+                            Bucket: otherAccountBucket,
+                            Key: otherAccountKey,
+                            CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        }),
+                    )
+                    .then(() => {
+                        done();
+                    })
+                    .catch(err => {
+                        checkError(err, 'AccessDenied', 403);
+                        done();
+                    });
+            });
 
             it(
                 'should not allow an account without write persmission on the ' +
@@ -1282,28 +1273,28 @@ describe('Object Copy', () => {
             );
         });
 
-        it('If-Match: returns no error when ETag match, with double quotes ' + 'around ETag', done => {
+        it('If-Match: returns no error when ETag match, with double quotes around ETag', done => {
             requestCopy({ CopySourceIfMatch: etag }, err => {
                 checkNoError(err);
                 done();
             });
         });
 
-        it('If-Match: returns no error when one of ETags match, with double ' + 'quotes around ETag', done => {
+        it('If-Match: returns no error when one of ETags match, with double quotes around ETag', done => {
             requestCopy({ CopySourceIfMatch: `non-matching,${etag}` }, err => {
                 checkNoError(err);
                 done();
             });
         });
 
-        it('If-Match: returns no error when ETag match, without double ' + 'quotes around ETag', done => {
+        it('If-Match: returns no error when ETag match, without double quotes around ETag', done => {
             requestCopy({ CopySourceIfMatch: etagTrim }, err => {
                 checkNoError(err);
                 done();
             });
         });
 
-        it('If-Match: returns no error when one of ETags match, without ' + 'double quotes around ETag', done => {
+        it('If-Match: returns no error when one of ETags match, without double quotes around ETag', done => {
             requestCopy({ CopySourceIfMatch: `non-matching,${etagTrim}` }, err => {
                 checkNoError(err);
                 done();
@@ -1343,7 +1334,7 @@ describe('Object Copy', () => {
             );
         });
 
-        it('If-None-Match: returns PreconditionFailed when ETag match, with' + 'double quotes around ETag', done => {
+        it('If-None-Match: returns PreconditionFailed when ETag match, with double quotes around ETag', done => {
             requestCopy({ CopySourceIfNoneMatch: etag }, err => {
                 checkError(err, 'PreconditionFailed', 412);
                 done();
@@ -1365,15 +1356,12 @@ describe('Object Copy', () => {
             },
         );
 
-        it(
-            'If-None-Match: returns PreconditionFailed when ETag match, ' + 'without double quotes around ETag',
-            done => {
-                requestCopy({ CopySourceIfNoneMatch: etagTrim }, err => {
-                    checkError(err, 'PreconditionFailed', 412);
-                    done();
-                });
-            },
-        );
+        it('If-None-Match: returns PreconditionFailed when ETag match, without double quotes around ETag', done => {
+            requestCopy({ CopySourceIfNoneMatch: etagTrim }, err => {
+                checkError(err, 'PreconditionFailed', 412);
+                done();
+            });
+        });
 
         it(
             'If-None-Match: returns PreconditionFailed when one of ETags ' + 'match, without double quotes around ETag',
@@ -1390,7 +1378,7 @@ describe('Object Copy', () => {
             },
         );
 
-        it('If-Modified-Since: returns no error if Last modified date is ' + 'greater', done => {
+        it('If-Modified-Since: returns no error if Last modified date is greater', done => {
             requestCopy({ CopySourceIfModifiedSince: dateFromNow(-1) }, err => {
                 checkNoError(err);
                 done();
@@ -1399,56 +1387,53 @@ describe('Object Copy', () => {
 
         // Skipping this test, because real AWS does not provide error as
         // expected
-        it.skip('If-Modified-Since: returns PreconditionFailed if Last ' + 'modified date is lesser', done => {
+        it.skip('If-Modified-Since: returns PreconditionFailed if Last modified date is lesser', done => {
             requestCopy({ CopySourceIfModifiedSince: dateFromNow(1) }, err => {
                 checkError(err, 'PreconditionFailed', 412);
                 done();
             });
         });
 
-        it('If-Modified-Since: returns PreconditionFailed if Last modified ' + 'date is equal', done => {
+        it('If-Modified-Since: returns PreconditionFailed if Last modified date is equal', done => {
             requestCopy({ CopySourceIfModifiedSince: dateConvert(lastModified) }, err => {
                 checkError(err, 'PreconditionFailed', 412);
                 done();
             });
         });
 
-        it('If-Unmodified-Since: returns no error when lastModified date is ' + 'greater', done => {
+        it('If-Unmodified-Since: returns no error when lastModified date is greater', done => {
             requestCopy({ CopySourceIfUnmodifiedSince: dateFromNow(1) }, err => {
                 checkNoError(err);
                 done();
             });
         });
 
-        it('If-Unmodified-Since: returns no error when lastModified ' + 'date is equal', done => {
+        it('If-Unmodified-Since: returns no error when lastModified date is equal', done => {
             requestCopy({ CopySourceIfUnmodifiedSince: dateConvert(lastModified) }, err => {
                 checkNoError(err);
                 done();
             });
         });
 
-        it('If-Unmodified-Since: returns PreconditionFailed when ' + 'lastModified date is lesser', done => {
+        it('If-Unmodified-Since: returns PreconditionFailed when lastModified date is lesser', done => {
             requestCopy({ CopySourceIfUnmodifiedSince: dateFromNow(-1) }, err => {
                 checkError(err, 'PreconditionFailed', 412);
                 done();
             });
         });
 
-        it(
-            'If-Match & If-Unmodified-Since: returns no error when match Etag ' + 'and lastModified is greater',
-            done => {
-                requestCopy(
-                    {
-                        CopySourceIfMatch: etagTrim,
-                        CopySourceIfUnmodifiedSince: dateFromNow(-1),
-                    },
-                    err => {
-                        checkNoError(err);
-                        done();
-                    },
-                );
-            },
-        );
+        it('If-Match & If-Unmodified-Since: returns no error when match Etag and lastModified is greater', done => {
+            requestCopy(
+                {
+                    CopySourceIfMatch: etagTrim,
+                    CopySourceIfUnmodifiedSince: dateFromNow(-1),
+                },
+                err => {
+                    checkNoError(err);
+                    done();
+                },
+            );
+        });
 
         it('If-Match match & If-Unmodified-Since match', done => {
             requestCopy(
@@ -1766,7 +1751,7 @@ describe('Object Copy', () => {
     });
 });
 
-describe('Object Copy with object lock enabled on both destination ' + 'bucket and source bucket', () => {
+describe('Object Copy with object lock enabled on both destination bucket and source bucket', () => {
     withV4(sigCfg => {
         let bucketUtil;
         let s3;

--- a/tests/functional/aws-node-sdk/test/object/objectCopy.js
+++ b/tests/functional/aws-node-sdk/test/object/objectCopy.js
@@ -11,15 +11,13 @@ const {
     GetObjectTaggingCommand,
     PutObjectCommand,
     GetObjectAclCommand,
-    PutObjectAclCommand
+    PutObjectAclCommand,
 } = require('@aws-sdk/client-s3');
 
 const { taggingTests } = require('../../lib/utility/tagging');
-const genMaxSizeMetaHeaders
-    = require('../../lib/utility/genMaxSizeMetaHeaders');
+const genMaxSizeMetaHeaders = require('../../lib/utility/genMaxSizeMetaHeaders');
 const constants = require('../../../../../constants');
-const { algorithms } =
-    require('../../../../../lib/api/apiUtils/integrity/validateChecksums');
+const { algorithms } = require('../../../../../lib/api/apiUtils/integrity/validateChecksums');
 
 const sourceBucketName = 'supersourcebucket8102016';
 const sourceObjName = 'supersourceobject';
@@ -60,8 +58,7 @@ const otherAccountS3 = otherAccountBucketUtility.s3;
 const itSkipIfE2E = process.env.S3_END_TO_END ? it.skip : it;
 
 function checkNoError(err) {
-    assert.equal(err, null,
-        `Expected success, got error ${JSON.stringify(err)}`);
+    assert.equal(err, null, `Expected success, got error ${JSON.stringify(err)}`);
 }
 
 function dateFromNow(diff) {
@@ -74,7 +71,6 @@ function dateConvert(d) {
     return new Date(d);
 }
 
-
 describe('Object Copy', () => {
     withV4(sigCfg => {
         let bucketUtil;
@@ -82,7 +78,6 @@ describe('Object Copy', () => {
         let etag;
         let etagTrim;
         let lastModified;
-
 
         before(async () => {
             try {
@@ -101,26 +96,35 @@ describe('Object Copy', () => {
             await bucketUtil.createOne(destBucketName);
         });
 
-        beforeEach(() => s3.send(new PutObjectCommand({
-            Bucket: sourceBucketName,
-            Key: sourceObjName,
-            Body: content,
-            Metadata: originalMetadata,
-            CacheControl: originalCacheControl,
-            ContentDisposition: originalContentDisposition,
-            ContentEncoding: originalContentEncoding,
-            Expires: originalExpires,
-            Tagging: originalTagging,
-        })).then(res => {
-            etag = res.ETag;
-            etagTrim = etag.substring(1, etag.length - 1);
-            return s3.send(new HeadObjectCommand({
-                Bucket: sourceBucketName,
-                Key: sourceObjName,
-            }));
-        }).then(res => {
-            lastModified = res.LastModified;
-        }));
+        beforeEach(() =>
+            s3
+                .send(
+                    new PutObjectCommand({
+                        Bucket: sourceBucketName,
+                        Key: sourceObjName,
+                        Body: content,
+                        Metadata: originalMetadata,
+                        CacheControl: originalCacheControl,
+                        ContentDisposition: originalContentDisposition,
+                        ContentEncoding: originalContentEncoding,
+                        Expires: originalExpires,
+                        Tagging: originalTagging,
+                    }),
+                )
+                .then(res => {
+                    etag = res.ETag;
+                    etagTrim = etag.substring(1, etag.length - 1);
+                    return s3.send(
+                        new HeadObjectCommand({
+                            Bucket: sourceBucketName,
+                            Key: sourceObjName,
+                        }),
+                    );
+                })
+                .then(res => {
+                    lastModified = res.LastModified;
+                }),
+        );
 
         afterEach(async () => {
             await bucketUtil.empty(sourceBucketName, true);
@@ -130,24 +134,35 @@ describe('Object Copy', () => {
         after(async () => await bucketUtil.deleteMany([sourceBucketName, destBucketName]));
 
         function requestCopy(fields, cb) {
-            s3.send(new CopyObjectCommand(Object.assign({
-                Bucket: destBucketName,
-                Key: destObjName,
-                CopySource: `${sourceBucketName}/${sourceObjName}`,
-            }, fields))).then(res => {
-                cb(null, res);
-            }).catch(cb);
+            s3.send(
+                new CopyObjectCommand(
+                    Object.assign(
+                        {
+                            Bucket: destBucketName,
+                            Key: destObjName,
+                            CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        },
+                        fields,
+                    ),
+                ),
+            )
+                .then(res => {
+                    cb(null, res);
+                })
+                .catch(cb);
         }
 
         async function successCopyCheck(error, response, copyVersionMetadata, destBucketName, destObjName) {
             checkNoError(error);
             assert.strictEqual(response.ETag, etag);
             const copyLastModified = new Date(response.LastModified).toGMTString();
-            
-            const res = await s3.send(new GetObjectCommand({ 
-                Bucket: destBucketName,
-                Key: destObjName 
-            }));
+
+            const res = await s3.send(
+                new GetObjectCommand({
+                    Bucket: destBucketName,
+                    Key: destObjName,
+                }),
+            );
             assert.strictEqual(res.StorageClass, undefined);
             const bodyString = await res.Body.transformToString();
             assert.strictEqual(bodyString, content);
@@ -156,157 +171,248 @@ describe('Object Copy', () => {
         }
 
         function checkSuccessTagging(key, value, cb) {
-            s3.send(new GetObjectTaggingCommand({ Bucket: destBucketName, Key: destObjName })).then(data => {
-                assert.strictEqual(data.TagSet[0].Key, key);
-                assert.strictEqual(data.TagSet[0].Value, value);
-                cb();
-            }).catch(err => {
-                checkNoError(err);
-                cb(err);
-            });
+            s3.send(new GetObjectTaggingCommand({ Bucket: destBucketName, Key: destObjName }))
+                .then(data => {
+                    assert.strictEqual(data.TagSet[0].Key, key);
+                    assert.strictEqual(data.TagSet[0].Value, value);
+                    cb();
+                })
+                .catch(err => {
+                    checkNoError(err);
+                    cb(err);
+                });
         }
 
         function checkNoTagging(cb) {
-            s3.send(new GetObjectTaggingCommand({ Bucket: destBucketName, Key: destObjName })).then(data => {
-                assert.strictEqual(data.TagSet.length, 0);
-                cb();
-            }).catch(err => {
-                checkNoError(err);
-                cb(err);
-            });
+            s3.send(new GetObjectTaggingCommand({ Bucket: destBucketName, Key: destObjName }))
+                .then(data => {
+                    assert.strictEqual(data.TagSet.length, 0);
+                    cb();
+                })
+                .catch(err => {
+                    checkNoError(err);
+                    cb(err);
+                });
         }
 
-        it('should copy an object from a source bucket to a different ' +
-            'destination bucket and copy the metadata if no metadata directive ' +
-            'header provided', async () => {
-            const res = await s3.send(new CopyObjectCommand({ 
-                Bucket: destBucketName, 
-                Key: destObjName,
-                CopySource: `${sourceBucketName}/${sourceObjName}` 
-            }));
-            await successCopyCheck(null, res.CopyObjectResult, originalMetadata,
-                destBucketName, destObjName);
-        });
+        it(
+            'should copy an object from a source bucket to a different ' +
+                'destination bucket and copy the metadata if no metadata directive ' +
+                'header provided',
+            async () => {
+                const res = await s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                    }),
+                );
+                await successCopyCheck(null, res.CopyObjectResult, originalMetadata, destBucketName, destObjName);
+            },
+        );
 
-        it('should copy an object from a source bucket to a different ' +
-            'destination bucket and copy the tag set if no tagging directive' +
-            'header provided', done => {
-            s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                CopySource: `${sourceBucketName}/${sourceObjName}` })).then(() => {
-                    checkSuccessTagging(originalTagKey, originalTagValue, done);
-                }).catch(err => {
-                    checkNoError(err);
-                });
-        });
+        it(
+            'should copy an object from a source bucket to a different ' +
+                'destination bucket and copy the tag set if no tagging directive' +
+                'header provided',
+            done => {
+                s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                    }),
+                )
+                    .then(() => {
+                        checkSuccessTagging(originalTagKey, originalTagValue, done);
+                    })
+                    .catch(err => {
+                        checkNoError(err);
+                    });
+            },
+        );
 
-        it('should return 400 InvalidArgument if invalid tagging ' +
-        'directive', done => {
-            s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                CopySource: `${sourceBucketName}/${sourceObjName}`,
-                TaggingDirective: 'COCO' })).then(() => {
+        it('should return 400 InvalidArgument if invalid tagging ' + 'directive', done => {
+            s3.send(
+                new CopyObjectCommand({
+                    Bucket: destBucketName,
+                    Key: destObjName,
+                    CopySource: `${sourceBucketName}/${sourceObjName}`,
+                    TaggingDirective: 'COCO',
+                }),
+            )
+                .then(() => {
                     done(new Error('Expected 400 InvalidArgument error'));
-                }).catch(err => {
+                })
+                .catch(err => {
                     checkError(err, 'InvalidArgument', 400);
                     done();
                 });
         });
 
         it('should return 400 KeyTooLong if key is longer than 915 bytes', done => {
-            s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: 'a'.repeat(916),
-                CopySource: `${sourceBucketName}/${sourceObjName}` })).then(() => {
+            s3.send(
+                new CopyObjectCommand({
+                    Bucket: destBucketName,
+                    Key: 'a'.repeat(916),
+                    CopySource: `${sourceBucketName}/${sourceObjName}`,
+                }),
+            )
+                .then(() => {
                     done(new Error('Expected 400 KeyTooLong error'));
-                }).catch(err => {
+                })
+                .catch(err => {
                     checkError(err, 'KeyTooLong', 400);
                     done();
                 });
         });
 
-        it('should copy an object from a source bucket to a different ' +
-            'destination bucket and copy the tag set if COPY tagging ' +
-            'directive header provided', done => {
-            s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                CopySource: `${sourceBucketName}/${sourceObjName}`,
-                TaggingDirective: 'COPY' })).then(() => {
-                    checkSuccessTagging(originalTagKey, originalTagValue, done);
-                }).catch(err => {
-                    checkNoError(err);
-                });
-        });
+        it(
+            'should copy an object from a source bucket to a different ' +
+                'destination bucket and copy the tag set if COPY tagging ' +
+                'directive header provided',
+            done => {
+                s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        TaggingDirective: 'COPY',
+                    }),
+                )
+                    .then(() => {
+                        checkSuccessTagging(originalTagKey, originalTagValue, done);
+                    })
+                    .catch(err => {
+                        checkNoError(err);
+                    });
+            },
+        );
 
-        it('should copy an object and tag set if COPY ' +
-            'included as tag directive header (and ignore any new ' +
-            'tag set sent with copy request)', done => {
-            s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                CopySource: `${sourceBucketName}/${sourceObjName}`,
-                TaggingDirective: 'COPY',
-                Tagging: newTagging,
-            })).then(() => {
-                s3.send(new GetObjectCommand({ Bucket: destBucketName,
-                    Key: destObjName })).then(res => {
-                    assert.deepStrictEqual(res.Metadata, originalMetadata);
-                    done();
-                }).catch(err => {
-                    checkNoError(err);
-                    done(err);
-                });
-            }).catch(err => {
-                checkNoError(err);
-            });
-        });
+        it(
+            'should copy an object and tag set if COPY ' +
+                'included as tag directive header (and ignore any new ' +
+                'tag set sent with copy request)',
+            done => {
+                s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        TaggingDirective: 'COPY',
+                        Tagging: newTagging,
+                    }),
+                )
+                    .then(() => {
+                        s3.send(new GetObjectCommand({ Bucket: destBucketName, Key: destObjName }))
+                            .then(res => {
+                                assert.deepStrictEqual(res.Metadata, originalMetadata);
+                                done();
+                            })
+                            .catch(err => {
+                                checkNoError(err);
+                                done(err);
+                            });
+                    })
+                    .catch(err => {
+                        checkNoError(err);
+                    });
+            },
+        );
 
-        it('should copy an object from a source to the same destination ' +
-        'updating tag if REPLACE tagging directive header provided',
-        done => {
-            s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                CopySource: `${sourceBucketName}/${sourceObjName}`,
-                TaggingDirective: 'REPLACE', Tagging: newTagging })).then(() => {
-                    checkSuccessTagging(newTagKey, newTagValue, done);
-                }).catch(err => {
-                    checkNoError(err);
-                    done(err);
-                });
-        });
+        it(
+            'should copy an object from a source to the same destination ' +
+                'updating tag if REPLACE tagging directive header provided',
+            done => {
+                s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        TaggingDirective: 'REPLACE',
+                        Tagging: newTagging,
+                    }),
+                )
+                    .then(() => {
+                        checkSuccessTagging(newTagKey, newTagValue, done);
+                    })
+                    .catch(err => {
+                        checkNoError(err);
+                        done(err);
+                    });
+            },
+        );
 
-        it('should copy an object from a source to the same destination ' +
-        'return no tag if REPLACE tagging directive header provided but ' +
-        '"x-amz-tagging" header is not specified', done => {
-            s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                CopySource: `${sourceBucketName}/${sourceObjName}`,
-                TaggingDirective: 'REPLACE' })).then(() => {
-                    checkNoTagging(done);
-                }).catch(err => {
-                    checkNoError(err);
-                    done(err);
-                });
-        });
+        it(
+            'should copy an object from a source to the same destination ' +
+                'return no tag if REPLACE tagging directive header provided but ' +
+                '"x-amz-tagging" header is not specified',
+            done => {
+                s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        TaggingDirective: 'REPLACE',
+                    }),
+                )
+                    .then(() => {
+                        checkNoTagging(done);
+                    })
+                    .catch(err => {
+                        checkNoError(err);
+                        done(err);
+                    });
+            },
+        );
 
-        it('should copy an object from a source to the same destination ' +
-        'return no tag if COPY tagging directive header but provided from ' +
-        'an empty object', done => {
-            s3.send(new PutObjectCommand({ Bucket: sourceBucketName, Key: 'emptyobject' })).then(() => {
-                s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                    CopySource: `${sourceBucketName}/emptyobject`,
-                    TaggingDirective: 'COPY' })).then(() => {
-                    checkNoTagging(done);
-                }).catch(err => {
-                    checkNoError(err);
-                    done(err);
+        it(
+            'should copy an object from a source to the same destination ' +
+                'return no tag if COPY tagging directive header but provided from ' +
+                'an empty object',
+            done => {
+                s3.send(new PutObjectCommand({ Bucket: sourceBucketName, Key: 'emptyobject' })).then(() => {
+                    s3.send(
+                        new CopyObjectCommand({
+                            Bucket: destBucketName,
+                            Key: destObjName,
+                            CopySource: `${sourceBucketName}/emptyobject`,
+                            TaggingDirective: 'COPY',
+                        }),
+                    )
+                        .then(() => {
+                            checkNoTagging(done);
+                        })
+                        .catch(err => {
+                            checkNoError(err);
+                            done(err);
+                        });
                 });
-            });
-        });
+            },
+        );
 
-        it('should copy an object from a source to the same destination ' +
-        'updating tag if REPLACE tagging directive header provided',
-        done => {
-            s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                CopySource: `${sourceBucketName}/${sourceObjName}`,
-                TaggingDirective: 'REPLACE', Tagging: newTagging })).then(() => {
-                    checkSuccessTagging(newTagKey, newTagValue, done);
-                }).catch(err => {
-                    checkNoError(err);
-                    done(err);
-                });
-        });
+        it(
+            'should copy an object from a source to the same destination ' +
+                'updating tag if REPLACE tagging directive header provided',
+            done => {
+                s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        TaggingDirective: 'REPLACE',
+                        Tagging: newTagging,
+                    }),
+                )
+                    .then(() => {
+                        checkSuccessTagging(newTagKey, newTagValue, done);
+                    })
+                    .catch(err => {
+                        checkNoError(err);
+                        done(err);
+                    });
+            },
+        );
 
         describe('Copy object updating tag set', () => {
             taggingTests.forEach(taggingTest => {
@@ -314,63 +420,77 @@ describe('Object Copy', () => {
                     const key = encodeURIComponent(taggingTest.tag.key);
                     const value = encodeURIComponent(taggingTest.tag.value);
                     const tagging = `${key}=${value}`;
-                    const params = { Bucket: destBucketName, Key: destObjName,
+                    const params = {
+                        Bucket: destBucketName,
+                        Key: destObjName,
                         CopySource: `${sourceBucketName}/${sourceObjName}`,
-                        TaggingDirective: 'REPLACE', Tagging: tagging };
-                    s3.send(new CopyObjectCommand(params)).then(() => checkSuccessTagging(taggingTest.tag.key,
-                          taggingTest.tag.value, done)).catch(err => {
-                        if (taggingTest.error) {
-                            checkError(err, taggingTest.error, taggingTest.code);
-                            return done();
-                        }
-                        assert.equal(err, null, 'Expected success, ' +
-                        `got error ${JSON.stringify(err)}`);
-                        return checkSuccessTagging(taggingTest.tag.key,
-                          taggingTest.tag.value, done);
-                    });
+                        TaggingDirective: 'REPLACE',
+                        Tagging: tagging,
+                    };
+                    s3.send(new CopyObjectCommand(params))
+                        .then(() => checkSuccessTagging(taggingTest.tag.key, taggingTest.tag.value, done))
+                        .catch(err => {
+                            if (taggingTest.error) {
+                                checkError(err, taggingTest.error, taggingTest.code);
+                                return done();
+                            }
+                            assert.equal(err, null, 'Expected success, ' + `got error ${JSON.stringify(err)}`);
+                            return checkSuccessTagging(taggingTest.tag.key, taggingTest.tag.value, done);
+                        });
                 });
             });
         });
 
-        it('should also copy additional headers (CacheControl, ' +
-            'ContentDisposition, ContentEncoding, Expires) when copying an ' +
-            'object from a source bucket to a different destination bucket', done => {
-              s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                  CopySource: `${sourceBucketName}/${sourceObjName}` })).then(() => {
-                      s3.send(new GetObjectCommand({ Bucket: destBucketName, Key: destObjName })).then(res => {
-                          assert.strictEqual(res.CacheControl,
-                              originalCacheControl);
-                            assert.strictEqual(res.ContentDisposition,
-                              originalContentDisposition);
-                            // Should remove V4 streaming value 'aws-chunked'
-                            // to be compatible with AWS behavior
-                            assert.strictEqual(res.ContentEncoding,
-                              'base64,'
-                            );
-                            assert.strictEqual(res.Expires.toGMTString(),
-                                originalExpires.toGMTString());
-                            done();
-                        }).catch(err => {
-                            checkNoError(err);
-                            done(err);
-                        });
-                    }).catch(err => {
+        it(
+            'should also copy additional headers (CacheControl, ' +
+                'ContentDisposition, ContentEncoding, Expires) when copying an ' +
+                'object from a source bucket to a different destination bucket',
+            done => {
+                s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                    }),
+                )
+                    .then(() => {
+                        s3.send(new GetObjectCommand({ Bucket: destBucketName, Key: destObjName }))
+                            .then(res => {
+                                assert.strictEqual(res.CacheControl, originalCacheControl);
+                                assert.strictEqual(res.ContentDisposition, originalContentDisposition);
+                                // Should remove V4 streaming value 'aws-chunked'
+                                // to be compatible with AWS behavior
+                                assert.strictEqual(res.ContentEncoding, 'base64,');
+                                assert.strictEqual(res.Expires.toGMTString(), originalExpires.toGMTString());
+                                done();
+                            })
+                            .catch(err => {
+                                checkNoError(err);
+                                done(err);
+                            });
+                    })
+                    .catch(err => {
                         checkNoError(err);
                         done(err);
                     });
-            });
+            },
+        );
 
-        it('should copy an object from a source bucket to a different ' +
-            'key in the same bucket', async () => {
-                const res = await s3.send(new CopyObjectCommand({ Bucket: sourceBucketName, Key: destObjName,
-                    CopySource: `${sourceBucketName}/${sourceObjName}` }));
-                await successCopyCheck(null, res.CopyObjectResult, originalMetadata,
-                    sourceBucketName, destObjName);
-            });
+        it('should copy an object from a source bucket to a different ' + 'key in the same bucket', async () => {
+            const res = await s3.send(
+                new CopyObjectCommand({
+                    Bucket: sourceBucketName,
+                    Key: destObjName,
+                    CopySource: `${sourceBucketName}/${sourceObjName}`,
+                }),
+            );
+            await successCopyCheck(null, res.CopyObjectResult, originalMetadata, sourceBucketName, destObjName);
+        });
 
         // TODO: see S3C-3482, figure out why this test fails in Integration builds
-        itSkipIfE2E('should not return error if copying object w/ > ' +
-            '2KB user-defined md and COPY directive', done => {
+        itSkipIfE2E(
+            'should not return error if copying object w/ > ' + '2KB user-defined md and COPY directive',
+            done => {
                 const metadata = genMaxSizeMetaHeaders();
                 const params = {
                     Bucket: destBucketName,
@@ -379,198 +499,261 @@ describe('Object Copy', () => {
                     MetadataDirective: 'COPY',
                     Metadata: metadata,
                 };
-                s3.send(new CopyObjectCommand(params)).then(() => {
-                    // add one more byte to be over the limit
-                    metadata.header0 = `${metadata.header0}${'0'}`;
-                    s3.send(new CopyObjectCommand(params)).then(() => {
-                        done();
-                    }).catch(err => {
+                s3.send(new CopyObjectCommand(params))
+                    .then(() => {
+                        // add one more byte to be over the limit
+                        metadata.header0 = `${metadata.header0}${'0'}`;
+                        s3.send(new CopyObjectCommand(params))
+                            .then(() => {
+                                done();
+                            })
+                            .catch(err => {
+                                assert.strictEqual(err, null, `Unexpected err: ${err}`);
+                                done(err);
+                            });
+                    })
+                    .catch(err => {
                         assert.strictEqual(err, null, `Unexpected err: ${err}`);
                         done(err);
                     });
-                }).catch(err => {
-                    assert.strictEqual(err, null, `Unexpected err: ${err}`);
-                    done(err);
-                });
-            });
+            },
+        );
 
         // TODO: see S3C-3482, figure out why this test fails in Integration builds
-        itSkipIfE2E('should return error if copying object w/ > 2KB ' +
-            'user-defined md and REPLACE directive', async () => {
+        itSkipIfE2E(
+            'should return error if copying object w/ > 2KB ' + 'user-defined md and REPLACE directive',
+            async () => {
                 try {
                     const metadata = genMaxSizeMetaHeaders();
                     const params = {
                         Bucket: destBucketName,
                         Key: destObjName,
                         CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        MetadataDirective: 'REPLACE',
+                        Metadata: metadata,
+                    };
+                    await s3.send(new CopyObjectCommand(params));
+                    // add one more byte to be over the limit
+                    metadata.header0 = `${metadata.header0}${'0'}`;
+                    await s3.send(new CopyObjectCommand(params));
+                    assert.fail('Expected MetadataTooLarge error');
+                } catch (err) {
+                    assert.strictEqual(err.name, 'MetadataTooLarge');
+                    assert.strictEqual(err.$metadata.httpStatusCode, 400);
+                }
+            },
+        );
+
+        it('should copy an object from a source to the same destination ' + '(update metadata)', async () => {
+            const res = await s3.send(
+                new CopyObjectCommand({
+                    Bucket: sourceBucketName,
+                    Key: sourceObjName,
+                    CopySource: `${sourceBucketName}/${sourceObjName}`,
                     MetadataDirective: 'REPLACE',
-                    Metadata: metadata,
-                };
-                await s3.send(new CopyObjectCommand(params));
-                // add one more byte to be over the limit
-                metadata.header0 = `${metadata.header0}${'0'}`;
-                await s3.send(new CopyObjectCommand(params));
-                assert.fail('Expected MetadataTooLarge error');
-            } catch (err) {
-                assert.strictEqual(err.name, 'MetadataTooLarge');
-                assert.strictEqual(err.$metadata.httpStatusCode, 400);
-            }
+                    Metadata: newMetadata,
+                }),
+            );
+            await successCopyCheck(null, res.CopyObjectResult, newMetadata, sourceBucketName, sourceObjName);
         });
 
-        it('should copy an object from a source to the same destination ' +
-            '(update metadata)', async () => {
-            const res = await s3.send(new CopyObjectCommand({ Bucket: sourceBucketName, Key: sourceObjName,
-                CopySource: `${sourceBucketName}/${sourceObjName}`,
-                MetadataDirective: 'REPLACE',
-                Metadata: newMetadata }));
-            await successCopyCheck(null, res.CopyObjectResult, newMetadata,
-                sourceBucketName, sourceObjName);
-        });
+        it(
+            'should copy an object and replace the metadata if replace ' + 'included as metadata directive header',
+            async () => {
+                const res = await s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        MetadataDirective: 'REPLACE',
+                        Metadata: newMetadata,
+                    }),
+                );
+                await successCopyCheck(null, res.CopyObjectResult, newMetadata, destBucketName, destObjName);
+            },
+        );
 
-        it('should copy an object and replace the metadata if replace ' +
-            'included as metadata directive header', async () => {
-            const res = await s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                CopySource: `${sourceBucketName}/${sourceObjName}`,
-                MetadataDirective: 'REPLACE',
-                Metadata: newMetadata }));
-            await successCopyCheck(null, res.CopyObjectResult, newMetadata,
-                destBucketName, destObjName);
-        });
+        it(
+            'should copy an object and replace ContentType if replace ' +
+                'included as a metadata directive header, and new ContentType is ' +
+                'provided',
+            async () => {
+                await s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        MetadataDirective: 'REPLACE',
+                        ContentType: 'image',
+                    }),
+                );
+                const res = await s3.send(new GetObjectCommand({ Bucket: destBucketName, Key: destObjName }));
+                assert.strictEqual(res.ContentType, 'image');
+            },
+        );
 
-        it('should copy an object and replace ContentType if replace ' +
-            'included as a metadata directive header, and new ContentType is ' +
-            'provided', async () => {
-            await s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                CopySource: `${sourceBucketName}/${sourceObjName}`,
-                MetadataDirective: 'REPLACE',
-                ContentType: 'image',
-            }));
-            const res = await s3.send(new GetObjectCommand({ Bucket: destBucketName,
-                Key: destObjName }));
-            assert.strictEqual(res.ContentType, 'image');
-        });
-
-        it('should copy an object and keep ContentType if replace ' +
-            'included as a metadata directive header, but no new ContentType ' +
-            'is provided', done => {
-            s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                CopySource: `${sourceBucketName}/${sourceObjName}`,
-                MetadataDirective: 'REPLACE',
-            })).then(() => {
-                s3.send(new GetObjectCommand({ Bucket: destBucketName,
-                    Key: destObjName })).then(res => {
-                    assert.strictEqual(res.ContentType, 'application/octet-stream');
-                    done();
-                }).catch(err => {
-                    checkNoError(err);
-                    done(err);
+        it(
+            'should copy an object and keep ContentType if replace ' +
+                'included as a metadata directive header, but no new ContentType ' +
+                'is provided',
+            done => {
+                s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        MetadataDirective: 'REPLACE',
+                    }),
+                ).then(() => {
+                    s3.send(new GetObjectCommand({ Bucket: destBucketName, Key: destObjName }))
+                        .then(res => {
+                            assert.strictEqual(res.ContentType, 'application/octet-stream');
+                            done();
+                        })
+                        .catch(err => {
+                            checkNoError(err);
+                            done(err);
+                        });
                 });
-            });
-        });
+            },
+        );
 
-        it('should also replace additional headers if replace ' +
-            'included as metadata directive header and new headers are ' +
-            'specified', done => {
-            s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                CopySource: `${sourceBucketName}/${sourceObjName}`,
-                MetadataDirective: 'REPLACE',
-                CacheControl: newCacheControl,
-                ContentDisposition: newContentDisposition,
-                ContentEncoding: newContentEncoding,
-                Expires: newExpires,
-            })).then(() => {
-                s3.send(new GetObjectCommand({ Bucket: destBucketName,
-                    Key: destObjName })).then(res => {
-                    assert.strictEqual(res.CacheControl, newCacheControl);
-                    assert.strictEqual(res.ContentDisposition,
-                      newContentDisposition);
-                    // Should remove V4 streaming value 'aws-chunked'
-                    // to be compatible with AWS behavior
-                    assert.strictEqual(res.ContentEncoding, 'gzip,');
-                    assert.strictEqual(res.Expires.toGMTString(),
-                        newExpires.toGMTString());
-                    done();
-                }).catch(err => {
-                    checkNoError(err);
-                    done(err); 
-                });
-            }).catch(err => {
-                checkNoError(err);
-                done(err);
-            });
-        });
-
-        it('should copy an object and the metadata if copy ' +
-            'included as metadata directive header (and ignore any new ' +
-            'metadata sent with copy request)', done => {
-            s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                CopySource: `${sourceBucketName}/${sourceObjName}`,
-                MetadataDirective: 'COPY',
-                Metadata: newMetadata,
-            })).then(() => {
-                    s3.send(new GetObjectCommand({ Bucket: destBucketName,
-                        Key: destObjName })).then(res => {
-                        assert.deepStrictEqual(res.Metadata, originalMetadata);
-                        done();
-                    }).catch(err => {
+        it(
+            'should also replace additional headers if replace ' +
+                'included as metadata directive header and new headers are ' +
+                'specified',
+            done => {
+                s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        MetadataDirective: 'REPLACE',
+                        CacheControl: newCacheControl,
+                        ContentDisposition: newContentDisposition,
+                        ContentEncoding: newContentEncoding,
+                        Expires: newExpires,
+                    }),
+                )
+                    .then(() => {
+                        s3.send(new GetObjectCommand({ Bucket: destBucketName, Key: destObjName }))
+                            .then(res => {
+                                assert.strictEqual(res.CacheControl, newCacheControl);
+                                assert.strictEqual(res.ContentDisposition, newContentDisposition);
+                                // Should remove V4 streaming value 'aws-chunked'
+                                // to be compatible with AWS behavior
+                                assert.strictEqual(res.ContentEncoding, 'gzip,');
+                                assert.strictEqual(res.Expires.toGMTString(), newExpires.toGMTString());
+                                done();
+                            })
+                            .catch(err => {
+                                checkNoError(err);
+                                done(err);
+                            });
+                    })
+                    .catch(err => {
                         checkNoError(err);
                         done(err);
                     });
-            }).catch(err => {
-                checkNoError(err);
-                done(err);
-            });
-        });
+            },
+        );
 
-        it('should copy an object and its additional headers if copy ' +
-            'included as metadata directive header (and ignore any new ' +
-            'headers sent with copy request)', done => {
-            s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                CopySource: `${sourceBucketName}/${sourceObjName}`,
-                MetadataDirective: 'COPY',
-                Metadata: newMetadata,
-                CacheControl: newCacheControl,
-                ContentDisposition: newContentDisposition,
-                ContentEncoding: newContentEncoding,
-                Expires: newExpires,
-            })).then(() => {
-                s3.send(new GetObjectCommand({ Bucket: destBucketName, Key: destObjName })).then(res => {
-                    assert.strictEqual(res.CacheControl,
-                        originalCacheControl);
-                      assert.strictEqual(res.ContentDisposition,
-                        originalContentDisposition);
-                      assert.strictEqual(res.ContentEncoding,
-                        'base64,');
-                      assert.strictEqual(res.Expires.toGMTString(),
-                        originalExpires.toGMTString());
-                      done();
-                  });
-            });
-        });
+        it(
+            'should copy an object and the metadata if copy ' +
+                'included as metadata directive header (and ignore any new ' +
+                'metadata sent with copy request)',
+            done => {
+                s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        MetadataDirective: 'COPY',
+                        Metadata: newMetadata,
+                    }),
+                )
+                    .then(() => {
+                        s3.send(new GetObjectCommand({ Bucket: destBucketName, Key: destObjName }))
+                            .then(res => {
+                                assert.deepStrictEqual(res.Metadata, originalMetadata);
+                                done();
+                            })
+                            .catch(err => {
+                                checkNoError(err);
+                                done(err);
+                            });
+                    })
+                    .catch(err => {
+                        checkNoError(err);
+                        done(err);
+                    });
+            },
+        );
+
+        it(
+            'should copy an object and its additional headers if copy ' +
+                'included as metadata directive header (and ignore any new ' +
+                'headers sent with copy request)',
+            done => {
+                s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        MetadataDirective: 'COPY',
+                        Metadata: newMetadata,
+                        CacheControl: newCacheControl,
+                        ContentDisposition: newContentDisposition,
+                        ContentEncoding: newContentEncoding,
+                        Expires: newExpires,
+                    }),
+                ).then(() => {
+                    s3.send(new GetObjectCommand({ Bucket: destBucketName, Key: destObjName })).then(res => {
+                        assert.strictEqual(res.CacheControl, originalCacheControl);
+                        assert.strictEqual(res.ContentDisposition, originalContentDisposition);
+                        assert.strictEqual(res.ContentEncoding, 'base64,');
+                        assert.strictEqual(res.Expires.toGMTString(), originalExpires.toGMTString());
+                        done();
+                    });
+                });
+            },
+        );
 
         it('should copy a 0 byte object to different destination', done => {
             const emptyFileETag = '"d41d8cd98f00b204e9800998ecf8427e"';
-            s3.send(new PutObjectCommand({ Bucket: sourceBucketName, Key: sourceObjName,
-                Body: '', Metadata: originalMetadata })).then(() => {
-                s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                    CopySource: `${sourceBucketName}/${sourceObjName}`,
-                })).then(res => {
-                        assert.strictEqual(res.CopyObjectResult.ETag, emptyFileETag);
-                        s3.send(new GetObjectCommand({ Bucket: destBucketName,
-                            Key: destObjName })).then(res => {
-                            assert.deepStrictEqual(res.Metadata,
-                                originalMetadata);
-                            assert.strictEqual(res.ETag, emptyFileETag);
-                            done();
+            s3.send(
+                new PutObjectCommand({
+                    Bucket: sourceBucketName,
+                    Key: sourceObjName,
+                    Body: '',
+                    Metadata: originalMetadata,
+                }),
+            )
+                .then(() => {
+                    s3.send(
+                        new CopyObjectCommand({
+                            Bucket: destBucketName,
+                            Key: destObjName,
+                            CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        }),
+                    )
+                        .then(res => {
+                            assert.strictEqual(res.CopyObjectResult.ETag, emptyFileETag);
+                            s3.send(new GetObjectCommand({ Bucket: destBucketName, Key: destObjName })).then(res => {
+                                assert.deepStrictEqual(res.Metadata, originalMetadata);
+                                assert.strictEqual(res.ETag, emptyFileETag);
+                                done();
+                            });
+                        })
+                        .catch(err => {
+                            checkNoError(err);
+                            done(err);
                         });
-                    }).catch(err => {
-                        checkNoError(err);
-                        done(err);
-                    });
-            }).catch(err => {
-                checkNoError(err);
-                done(err);
-            });
+                })
+                .catch(err => {
+                    checkNoError(err);
+                    done(err);
+                });
         });
 
         // TODO: remove (or update to use different location constraint) in CLDSRV-639
@@ -578,403 +761,554 @@ describe('Object Copy', () => {
             it('should copy a 0 byte object to same destination', done => {
                 const emptyFileETag = '"d41d8cd98f00b204e9800998ecf8427e"';
                 s3.send(new PutObjectCommand({ Bucket: sourceBucketName, Key: sourceObjName, Body: '' })).then(() => {
-                    s3.send(new CopyObjectCommand({ Bucket: sourceBucketName, Key: sourceObjName,
-                        CopySource: `${sourceBucketName}/${sourceObjName}`,
-                        StorageClass: 'REDUCED_REDUNDANCY',
-                    })).then(res => {
-                        assert.strictEqual(res.CopyObjectResult.ETag, emptyFileETag);
-                        s3.send(new GetObjectCommand({ Bucket: sourceBucketName,
-                            Key: sourceObjName })).then(res => {
-                            assert.deepStrictEqual(res.Metadata,
-                                {});
-                            assert.deepStrictEqual(res.StorageClass,
-                                'REDUCED_REDUNDANCY');
-                            assert.strictEqual(res.ETag, emptyFileETag);
-                            done();
-                        }).catch(err => {
+                    s3.send(
+                        new CopyObjectCommand({
+                            Bucket: sourceBucketName,
+                            Key: sourceObjName,
+                            CopySource: `${sourceBucketName}/${sourceObjName}`,
+                            StorageClass: 'REDUCED_REDUNDANCY',
+                        }),
+                    )
+                        .then(res => {
+                            assert.strictEqual(res.CopyObjectResult.ETag, emptyFileETag);
+                            s3.send(new GetObjectCommand({ Bucket: sourceBucketName, Key: sourceObjName }))
+                                .then(res => {
+                                    assert.deepStrictEqual(res.Metadata, {});
+                                    assert.deepStrictEqual(res.StorageClass, 'REDUCED_REDUNDANCY');
+                                    assert.strictEqual(res.ETag, emptyFileETag);
+                                    done();
+                                })
+                                .catch(err => {
+                                    checkNoError(err);
+                                    done(err);
+                                });
+                        })
+                        .catch(err => {
                             checkNoError(err);
                             done(err);
                         });
-                    }).catch(err => {
-                        checkNoError(err);
-                        done(err);
-                    });
                 });
             });
 
-            it('should copy an object to a different destination and change ' +
-                'the storage class if storage class header provided', done => {
-                s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                    CopySource: `${sourceBucketName}/${sourceObjName}`,
-                    StorageClass: 'REDUCED_REDUNDANCY',
-                })).then(() => {
-                    s3.send(new GetObjectCommand({ Bucket: destBucketName,
-                        Key: destObjName })).then(res => {
-                        assert.strictEqual(res.StorageClass,
-                            'REDUCED_REDUNDANCY');
-                        done();
-                    }).catch(err => {
-                        checkNoError(err);
-                        done(err);
-                    });
-                }).catch(err => {
-                    checkNoError(err);
-                    done(err);
-                });
-            });
+            it(
+                'should copy an object to a different destination and change ' +
+                    'the storage class if storage class header provided',
+                done => {
+                    s3.send(
+                        new CopyObjectCommand({
+                            Bucket: destBucketName,
+                            Key: destObjName,
+                            CopySource: `${sourceBucketName}/${sourceObjName}`,
+                            StorageClass: 'REDUCED_REDUNDANCY',
+                        }),
+                    )
+                        .then(() => {
+                            s3.send(new GetObjectCommand({ Bucket: destBucketName, Key: destObjName }))
+                                .then(res => {
+                                    assert.strictEqual(res.StorageClass, 'REDUCED_REDUNDANCY');
+                                    done();
+                                })
+                                .catch(err => {
+                                    checkNoError(err);
+                                    done(err);
+                                });
+                        })
+                        .catch(err => {
+                            checkNoError(err);
+                            done(err);
+                        });
+                },
+            );
 
-            it('should copy an object to the same destination and change the ' +
-                'storage class if the storage class header provided', done => {
-                s3.send(new CopyObjectCommand({ Bucket: sourceBucketName, Key: sourceObjName,
-                    CopySource: `${sourceBucketName}/${sourceObjName}`,
-                    StorageClass: 'REDUCED_REDUNDANCY',
-                })).then(() => {
-                    s3.send(new GetObjectCommand({ Bucket: sourceBucketName,
-                        Key: sourceObjName })).then(res => {
-                        assert.strictEqual(res.StorageClass,
-                            'REDUCED_REDUNDANCY');
-                        done();
-                    }).catch(err => {
-                        checkNoError(err);
-                        done(err);
-                    });
-                }).catch(err => {
-                    checkNoError(err);
-                    done(err);
-                });
-            });
+            it(
+                'should copy an object to the same destination and change the ' +
+                    'storage class if the storage class header provided',
+                done => {
+                    s3.send(
+                        new CopyObjectCommand({
+                            Bucket: sourceBucketName,
+                            Key: sourceObjName,
+                            CopySource: `${sourceBucketName}/${sourceObjName}`,
+                            StorageClass: 'REDUCED_REDUNDANCY',
+                        }),
+                    )
+                        .then(() => {
+                            s3.send(new GetObjectCommand({ Bucket: sourceBucketName, Key: sourceObjName }))
+                                .then(res => {
+                                    assert.strictEqual(res.StorageClass, 'REDUCED_REDUNDANCY');
+                                    done();
+                                })
+                                .catch(err => {
+                                    checkNoError(err);
+                                    done(err);
+                                });
+                        })
+                        .catch(err => {
+                            checkNoError(err);
+                            done(err);
+                        });
+                },
+            );
         }
 
-        it('should copy an object to a new bucket and overwrite an already ' +
-            'existing object in the destination bucket', done => {
-            s3.send(new PutObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                Body: 'overwrite me', Metadata: originalMetadata })).then(() => {
-                s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                    CopySource: `${sourceBucketName}/${sourceObjName}`,
-                    MetadataDirective: 'REPLACE',
-                    Metadata: newMetadata,
-                })).then(res => {
-                        assert.strictEqual(res.CopyObjectResult.ETag, etag);
-                        s3.send(new GetObjectCommand({ Bucket: destBucketName,
-                            Key: destObjName })).then(async res => {
-                            assert.deepStrictEqual(res.Metadata,
-                                newMetadata);
-                            assert.strictEqual(res.ETag, etag);
-                            const bodyString = await res.Body.transformToString();
-                            assert.strictEqual(bodyString, content);
-                            done();
-                        }).catch(err => {
-                            checkNoError(err);
-                            done(err);
-                        });
-                    }).catch(err => {
+        it(
+            'should copy an object to a new bucket and overwrite an already ' +
+                'existing object in the destination bucket',
+            done => {
+                s3.send(
+                    new PutObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        Body: 'overwrite me',
+                        Metadata: originalMetadata,
+                    }),
+                )
+                    .then(() => {
+                        s3.send(
+                            new CopyObjectCommand({
+                                Bucket: destBucketName,
+                                Key: destObjName,
+                                CopySource: `${sourceBucketName}/${sourceObjName}`,
+                                MetadataDirective: 'REPLACE',
+                                Metadata: newMetadata,
+                            }),
+                        )
+                            .then(res => {
+                                assert.strictEqual(res.CopyObjectResult.ETag, etag);
+                                s3.send(new GetObjectCommand({ Bucket: destBucketName, Key: destObjName }))
+                                    .then(async res => {
+                                        assert.deepStrictEqual(res.Metadata, newMetadata);
+                                        assert.strictEqual(res.ETag, etag);
+                                        const bodyString = await res.Body.transformToString();
+                                        assert.strictEqual(bodyString, content);
+                                        done();
+                                    })
+                                    .catch(err => {
+                                        checkNoError(err);
+                                        done(err);
+                                    });
+                            })
+                            .catch(err => {
+                                checkNoError(err);
+                                done(err);
+                            });
+                    })
+                    .catch(err => {
                         checkNoError(err);
                         done(err);
                     });
-                }).catch(err => {
-                    checkNoError(err);
-                    done(err);
-                }
-            );
-        });
+            },
+        );
 
         // skipping test as object level encryption is not implemented yet
-        it.skip('should copy an object and change the server side encryption' +
-            'option if server side encryption header provided', done => {
-            s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                CopySource: `${sourceBucketName}/${sourceObjName}`,
-                ServerSideEncryption: 'AES256',
-            })).then(() => {
-                s3.send(new GetObjectCommand({ Bucket: destBucketName,
-                    Key: destObjName })).then(res => {
-                    assert.strictEqual(res.ServerSideEncryption,
-                        'AES256');
-                    done();
-                }).catch(err => {
-                    checkNoError(err);
-                    done(err);
-                });
-            }).catch(err => {
-                checkNoError(err);
-                done(err);
-            });
-        });
-
-        it('should return Not Implemented error for obj. encryption using ' +
-            'customer-provided encryption keys', done => {
-            const params = { Bucket: destBucketName, Key: 'key',
-                CopySource: `${sourceBucketName}/${sourceObjName}`,
-                SSECustomerAlgorithm: 'AES256' };
-            s3.send(new CopyObjectCommand(params)).then(() => {
-                throw Error('Expected NotImplemented error');
-            }).catch(err => {
-                assert.strictEqual(err.name, 'NotImplemented');
-                done();
-            });
-        });
-
-        it('should copy an object and set the acl on the new object', done => {
-            s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                CopySource: `${sourceBucketName}/${sourceObjName}`,
-                ACL: 'authenticated-read',
-            })).then(() => {
-                    s3.send(new GetObjectAclCommand({ Bucket: destBucketName,
-                        Key: destObjName })).then(res => {
-                        // With authenticated-read ACL, there are two
-                        // grants:
-                        // (1) FULL_CONTROL to the object owner
-                        // (2) READ to the authenticated-read
-                        assert.strictEqual(res.Grants.length, 2);
-                        assert.strictEqual(res.Grants[0].Permission,
-                            'FULL_CONTROL');
-                        assert.strictEqual(res.Grants[1].Permission,
-                            'READ');
-                        assert.strictEqual(res.Grants[1].Grantee.URI,
-                            'http://acs.amazonaws.com/groups/' +
-                            'global/AuthenticatedUsers');
-                        done();
-                    }).catch(err => {
+        it.skip(
+            'should copy an object and change the server side encryption' +
+                'option if server side encryption header provided',
+            done => {
+                s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        ServerSideEncryption: 'AES256',
+                    }),
+                )
+                    .then(() => {
+                        s3.send(new GetObjectCommand({ Bucket: destBucketName, Key: destObjName }))
+                            .then(res => {
+                                assert.strictEqual(res.ServerSideEncryption, 'AES256');
+                                done();
+                            })
+                            .catch(err => {
+                                checkNoError(err);
+                                done(err);
+                            });
+                    })
+                    .catch(err => {
                         checkNoError(err);
                         done(err);
                     });
-            }).catch(err => {
-                checkNoError(err);
-                done(err);
-            });
-        });
+            },
+        );
 
-        it('should copy an object and default the acl on the new object ' +
-            'to private even if the copied object had a ' +
-            'different acl', done => {
-            s3.send(new PutObjectAclCommand({ Bucket: sourceBucketName, Key: sourceObjName,
-                ACL: 'authenticated-read' })).then(() => {
-                s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
+        it(
+            'should return Not Implemented error for obj. encryption using ' + 'customer-provided encryption keys',
+            done => {
+                const params = {
+                    Bucket: destBucketName,
+                    Key: 'key',
                     CopySource: `${sourceBucketName}/${sourceObjName}`,
-                })).then(() => {
-                        s3.send(new GetObjectAclCommand({ Bucket: destBucketName,
-                            Key: destObjName })).then(res => {
-                            // With private ACL, there is only one grant
-                            // of FULL_CONTROL to the object owner
-                            assert.strictEqual(res.Grants.length, 1);
-                            assert.strictEqual(res.Grants[0].Permission,
-                                'FULL_CONTROL');
-                            done();
-                        }).catch(err => {
-                            checkNoError(err);
-                            done(err);
-                        });
-                }).catch(err => {
-                    checkNoError(err);
-                    done(err);
-                });
-            }).catch(err => {
-                checkNoError(err);
-                done(err);
-            });
-        });
+                    SSECustomerAlgorithm: 'AES256',
+                };
+                s3.send(new CopyObjectCommand(params))
+                    .then(() => {
+                        throw Error('Expected NotImplemented error');
+                    })
+                    .catch(err => {
+                        assert.strictEqual(err.name, 'NotImplemented');
+                        done();
+                    });
+            },
+        );
 
-        it('should return an error if attempt to copy with same source as' +
-            'destination and do not change any metadata', done => {
-            s3.send(new CopyObjectCommand({ Bucket: sourceBucketName, Key: sourceObjName,
-                CopySource: `${sourceBucketName}/${sourceObjName}`,
-            })).then(() => {
-                done();
-            }).catch(err => {
-                checkError(err, 'InvalidRequest', 400);
-                done();
-            });
-        });
-
-        it('should return an error if attempt to copy from nonexistent bucket',
-            done => {
-                s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                    CopySource: `nobucket453234/${sourceObjName}`,
-                })).then(() => {
-                    done();
-                }).catch(err => {
-                    checkError(err, 'NoSuchBucket', 404);
-                    done();
-                });
-            });
-
-        it('should return an error if use invalid redirect location',
-            done => {
-                s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                    CopySource: `${sourceBucketName}/${sourceObjName}`,
-                    WebsiteRedirectLocation: 'google.com',
-                })).then(() => {
-                    done();
-                }).catch(err => {
-                    checkError(err, 'InvalidRedirectLocation', 400);
-                    done();
-                });
-            });
-
-        it('should return an error if copy request has object lock legal ' +
-            'hold header but object lock is not enabled on destination bucket',
-            done => {
-                s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                    CopySource: `${sourceBucketName}/${sourceObjName}`,
-                    ObjectLockLegalHoldStatus: 'ON',
-                })).then(() => {
-                    done();
-                }).catch(err => {
-                    checkError(err, 'InvalidRequest', 400);
-                    done();
-                });
-            });
-
-        it('should return an error if copy request has retention headers ' +
-            'but object lock is not enabled on destination bucket',
-            done => {
-                const mockDate = new Date(2050, 10, 12);
-                s3.send(new CopyObjectCommand({
+        it('should copy an object and set the acl on the new object', done => {
+            s3.send(
+                new CopyObjectCommand({
                     Bucket: destBucketName,
                     Key: destObjName,
                     CopySource: `${sourceBucketName}/${sourceObjName}`,
-                    ObjectLockMode: 'GOVERNANCE',
-                    ObjectLockRetainUntilDate: mockDate,
-                })).then(() => {
-                    done();
-                }).catch(err => {
-                    checkError(err, 'InvalidRequest', 400);
-                    done();
+                    ACL: 'authenticated-read',
+                }),
+            )
+                .then(() => {
+                    s3.send(new GetObjectAclCommand({ Bucket: destBucketName, Key: destObjName }))
+                        .then(res => {
+                            // With authenticated-read ACL, there are two
+                            // grants:
+                            // (1) FULL_CONTROL to the object owner
+                            // (2) READ to the authenticated-read
+                            assert.strictEqual(res.Grants.length, 2);
+                            assert.strictEqual(res.Grants[0].Permission, 'FULL_CONTROL');
+                            assert.strictEqual(res.Grants[1].Permission, 'READ');
+                            assert.strictEqual(
+                                res.Grants[1].Grantee.URI,
+                                'http://acs.amazonaws.com/groups/' + 'global/AuthenticatedUsers',
+                            );
+                            done();
+                        })
+                        .catch(err => {
+                            checkNoError(err);
+                            done(err);
+                        });
+                })
+                .catch(err => {
+                    checkNoError(err);
+                    done(err);
                 });
-            });
+        });
 
-        it('should return an error if attempt to copy to nonexistent bucket',
+        it(
+            'should copy an object and default the acl on the new object ' +
+                'to private even if the copied object had a ' +
+                'different acl',
             done => {
-                s3.send(new CopyObjectCommand({ Bucket: 'nobucket453234', Key: destObjName,
-                    CopySource: `${sourceBucketName}/${sourceObjName}`,
-                })).then(() => {
+                s3.send(
+                    new PutObjectAclCommand({
+                        Bucket: sourceBucketName,
+                        Key: sourceObjName,
+                        ACL: 'authenticated-read',
+                    }),
+                )
+                    .then(() => {
+                        s3.send(
+                            new CopyObjectCommand({
+                                Bucket: destBucketName,
+                                Key: destObjName,
+                                CopySource: `${sourceBucketName}/${sourceObjName}`,
+                            }),
+                        )
+                            .then(() => {
+                                s3.send(new GetObjectAclCommand({ Bucket: destBucketName, Key: destObjName }))
+                                    .then(res => {
+                                        // With private ACL, there is only one grant
+                                        // of FULL_CONTROL to the object owner
+                                        assert.strictEqual(res.Grants.length, 1);
+                                        assert.strictEqual(res.Grants[0].Permission, 'FULL_CONTROL');
+                                        done();
+                                    })
+                                    .catch(err => {
+                                        checkNoError(err);
+                                        done(err);
+                                    });
+                            })
+                            .catch(err => {
+                                checkNoError(err);
+                                done(err);
+                            });
+                    })
+                    .catch(err => {
+                        checkNoError(err);
+                        done(err);
+                    });
+            },
+        );
+
+        it(
+            'should return an error if attempt to copy with same source as' +
+                'destination and do not change any metadata',
+            done => {
+                s3.send(
+                    new CopyObjectCommand({
+                        Bucket: sourceBucketName,
+                        Key: sourceObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                    }),
+                )
+                    .then(() => {
+                        done();
+                    })
+                    .catch(err => {
+                        checkError(err, 'InvalidRequest', 400);
+                        done();
+                    });
+            },
+        );
+
+        it('should return an error if attempt to copy from nonexistent bucket', done => {
+            s3.send(
+                new CopyObjectCommand({
+                    Bucket: destBucketName,
+                    Key: destObjName,
+                    CopySource: `nobucket453234/${sourceObjName}`,
+                }),
+            )
+                .then(() => {
                     done();
-                }).catch(err => {
+                })
+                .catch(err => {
                     checkError(err, 'NoSuchBucket', 404);
                     done();
                 });
-            });
+        });
 
-        it('should return an error if attempt to copy nonexistent object',
-            done => {
-                s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
-                    CopySource: `${sourceBucketName}/nokey`,
-                })).then(() => {
+        it('should return an error if use invalid redirect location', done => {
+            s3.send(
+                new CopyObjectCommand({
+                    Bucket: destBucketName,
+                    Key: destObjName,
+                    CopySource: `${sourceBucketName}/${sourceObjName}`,
+                    WebsiteRedirectLocation: 'google.com',
+                }),
+            )
+                .then(() => {
                     done();
-                }).catch(err => {
+                })
+                .catch(err => {
+                    checkError(err, 'InvalidRedirectLocation', 400);
+                    done();
+                });
+        });
+
+        it(
+            'should return an error if copy request has object lock legal ' +
+                'hold header but object lock is not enabled on destination bucket',
+            done => {
+                s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        ObjectLockLegalHoldStatus: 'ON',
+                    }),
+                )
+                    .then(() => {
+                        done();
+                    })
+                    .catch(err => {
+                        checkError(err, 'InvalidRequest', 400);
+                        done();
+                    });
+            },
+        );
+
+        it(
+            'should return an error if copy request has retention headers ' +
+                'but object lock is not enabled on destination bucket',
+            done => {
+                const mockDate = new Date(2050, 10, 12);
+                s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        ObjectLockMode: 'GOVERNANCE',
+                        ObjectLockRetainUntilDate: mockDate,
+                    }),
+                )
+                    .then(() => {
+                        done();
+                    })
+                    .catch(err => {
+                        checkError(err, 'InvalidRequest', 400);
+                        done();
+                    });
+            },
+        );
+
+        it('should return an error if attempt to copy to nonexistent bucket', done => {
+            s3.send(
+                new CopyObjectCommand({
+                    Bucket: 'nobucket453234',
+                    Key: destObjName,
+                    CopySource: `${sourceBucketName}/${sourceObjName}`,
+                }),
+            )
+                .then(() => {
+                    done();
+                })
+                .catch(err => {
+                    checkError(err, 'NoSuchBucket', 404);
+                    done();
+                });
+        });
+
+        it('should return an error if attempt to copy nonexistent object', done => {
+            s3.send(
+                new CopyObjectCommand({
+                    Bucket: destBucketName,
+                    Key: destObjName,
+                    CopySource: `${sourceBucketName}/nokey`,
+                }),
+            )
+                .then(() => {
+                    done();
+                })
+                .catch(err => {
                     checkError(err, 'NoSuchKey', 404);
                     done();
                 });
-            });
+        });
 
-        it('should return an error if attempt to copy nonexistent object',
-            done => {
-                s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
+        it('should return an error if attempt to copy nonexistent object', done => {
+            s3.send(
+                new CopyObjectCommand({
+                    Bucket: destBucketName,
+                    Key: destObjName,
                     CopySource: `${sourceBucketName}/nokey`,
-                })).then(() => {
+                }),
+            )
+                .then(() => {
                     done();
-                }).catch(err => {
+                })
+                .catch(err => {
                     checkError(err, 'NoSuchKey', 404);
                     done();
                 });
-            });
+        });
 
-        it('should return an error if send invalid metadata directive header',
-            done => {
-                s3.send(new CopyObjectCommand({ Bucket: destBucketName, Key: destObjName,
+        it('should return an error if send invalid metadata directive header', done => {
+            s3.send(
+                new CopyObjectCommand({
+                    Bucket: destBucketName,
+                    Key: destObjName,
                     CopySource: `${sourceBucketName}/${sourceObjName}`,
                     MetadataDirective: 'copyHalf',
-                })).then(() => {
+                }),
+            )
+                .then(() => {
                     done();
-                }).catch(err => {
+                })
+                .catch(err => {
                     checkError(err, 'InvalidArgument', 400);
                     done();
                 });
-            });
+        });
 
         describe('copying by another account', () => {
             const otherAccountBucket = 'otheraccountbucket42342342342';
             const otherAccountKey = 'key';
-            beforeEach(() => otherAccountBucketUtility
-                .createOne(otherAccountBucket)
+            beforeEach(() => otherAccountBucketUtility.createOne(otherAccountBucket));
+
+            afterEach(() =>
+                otherAccountBucketUtility
+                    .empty(otherAccountBucket)
+                    .then(() => otherAccountBucketUtility.deleteOne(otherAccountBucket)),
             );
 
-            afterEach(() => otherAccountBucketUtility.empty(otherAccountBucket)
-                .then(() => otherAccountBucketUtility
-                .deleteOne(otherAccountBucket))
+            it(
+                'should not allow an account without read persmission on the ' + 'source object to copy the object',
+                done => {
+                    otherAccountS3
+                        .send(
+                            new CopyObjectCommand({
+                                Bucket: otherAccountBucket,
+                                Key: otherAccountKey,
+                                CopySource: `${sourceBucketName}/${sourceObjName}`,
+                            }),
+                        )
+                        .then(() => {
+                            done();
+                        })
+                        .catch(err => {
+                            checkError(err, 'AccessDenied', 403);
+                            done();
+                        });
+                },
             );
 
-            it('should not allow an account without read persmission on the ' +
-                'source object to copy the object', done => {
-                otherAccountS3.send(new CopyObjectCommand({ Bucket: otherAccountBucket,
-                    Key: otherAccountKey,
-                    CopySource: `${sourceBucketName}/${sourceObjName}`,
-                })).then(() => {
-                    done();
-                }).catch(err => {
-                    checkError(err, 'AccessDenied', 403);
-                        done();
-                    });
-            });
+            it(
+                'should not allow an account without write persmission on the ' +
+                    'destination bucket to copy the object',
+                () =>
+                    otherAccountS3
+                        .send(new PutObjectCommand({ Bucket: otherAccountBucket, Key: otherAccountKey, Body: '' }))
+                        .then(() =>
+                            otherAccountS3
+                                .send(
+                                    new CopyObjectCommand({
+                                        Bucket: destBucketName,
+                                        Key: destObjName,
+                                        CopySource: `${otherAccountBucket}/${otherAccountKey}`,
+                                    }),
+                                )
+                                .catch(err => {
+                                    checkError(err, 'AccessDenied', 403);
+                                }),
+                        ),
+            );
 
-            it('should not allow an account without write persmission on the ' +
-                'destination bucket to copy the object', () => otherAccountS3.send(new PutObjectCommand(
-                    { Bucket: otherAccountBucket,
-                    Key: otherAccountKey, Body: '' })).then(() => otherAccountS3.send(new CopyObjectCommand(
-                        { Bucket: destBucketName,
-                        Key: destObjName,
-                        CopySource: `${otherAccountBucket}/${otherAccountKey}`,
-                    })).catch(err => {
-                        checkError(err, 'AccessDenied', 403);
-                    })));
-
-
-            it('should allow an account with read permission on the ' +
-                'source object and write permission on the destination ' +
-                'bucket to copy the object', () => s3.send(new PutObjectAclCommand({ Bucket: sourceBucketName,
-                    Key: sourceObjName, ACL: 'public-read' })).then(() => otherAccountS3.send(new CopyObjectCommand(
-                        { Bucket: otherAccountBucket,
-                        Key: otherAccountKey,
-                        CopySource: `${sourceBucketName}/${sourceObjName}`,
-                    }))));
+            it(
+                'should allow an account with read permission on the ' +
+                    'source object and write permission on the destination ' +
+                    'bucket to copy the object',
+                () =>
+                    s3
+                        .send(
+                            new PutObjectAclCommand({
+                                Bucket: sourceBucketName,
+                                Key: sourceObjName,
+                                ACL: 'public-read',
+                            }),
+                        )
+                        .then(() =>
+                            otherAccountS3.send(
+                                new CopyObjectCommand({
+                                    Bucket: otherAccountBucket,
+                                    Key: otherAccountKey,
+                                    CopySource: `${sourceBucketName}/${sourceObjName}`,
+                                }),
+                            ),
+                        ),
+            );
         });
 
-        it('If-Match: returns no error when ETag match, with double quotes ' +
-            'around ETag',
-            done => {
-                requestCopy({ CopySourceIfMatch: etag }, err => {
-                    checkNoError(err);
-                    done();
-                });
+        it('If-Match: returns no error when ETag match, with double quotes ' + 'around ETag', done => {
+            requestCopy({ CopySourceIfMatch: etag }, err => {
+                checkNoError(err);
+                done();
             });
+        });
 
-        it('If-Match: returns no error when one of ETags match, with double ' +
-            'quotes around ETag',
-            done => {
-                requestCopy({ CopySourceIfMatch:
-                    `non-matching,${etag}` }, err => {
-                    checkNoError(err);
-                    done();
-                });
+        it('If-Match: returns no error when one of ETags match, with double ' + 'quotes around ETag', done => {
+            requestCopy({ CopySourceIfMatch: `non-matching,${etag}` }, err => {
+                checkNoError(err);
+                done();
             });
+        });
 
-        it('If-Match: returns no error when ETag match, without double ' +
-            'quotes around ETag',
-            done => {
-                requestCopy({ CopySourceIfMatch: etagTrim }, err => {
-                    checkNoError(err);
-                    done();
-                });
+        it('If-Match: returns no error when ETag match, without double ' + 'quotes around ETag', done => {
+            requestCopy({ CopySourceIfMatch: etagTrim }, err => {
+                checkNoError(err);
+                done();
             });
+        });
 
-        it('If-Match: returns no error when one of ETags match, without ' +
-            'double quotes around ETag',
-            done => {
-                requestCopy({ CopySourceIfMatch:
-                    `non-matching,${etagTrim}` }, err => {
-                    checkNoError(err);
-                    done();
-                });
+        it('If-Match: returns no error when one of ETags match, without ' + 'double quotes around ETag', done => {
+            requestCopy({ CopySourceIfMatch: `non-matching,${etagTrim}` }, err => {
+                checkNoError(err);
+                done();
             });
+        });
 
         it('If-Match: returns no error when ETag match with *', done => {
             requestCopy({ CopySourceIfMatch: '*' }, err => {
@@ -983,13 +1317,12 @@ describe('Object Copy', () => {
             });
         });
 
-        it('If-Match: returns PreconditionFailed when ETag does not match',
-            done => {
-                requestCopy({ CopySourceIfMatch: 'non-matching ETag' }, err => {
-                    checkError(err, 'PreconditionFailed', 412);
-                    done();
-                });
+        it('If-Match: returns PreconditionFailed when ETag does not match', done => {
+            requestCopy({ CopySourceIfMatch: 'non-matching ETag' }, err => {
+                checkError(err, 'PreconditionFailed', 412);
+                done();
             });
+        });
 
         it('If-None-Match: returns no error when ETag does not match', done => {
             requestCopy({ CopySourceIfNoneMatch: 'non-matching' }, err => {
@@ -998,342 +1331,402 @@ describe('Object Copy', () => {
             });
         });
 
-        it('If-None-Match: returns no error when all ETags do not match',
-            done => {
-                requestCopy({
+        it('If-None-Match: returns no error when all ETags do not match', done => {
+            requestCopy(
+                {
                     CopySourceIfNoneMatch: 'non-matching,non-matching-either',
-                }, err => {
+                },
+                err => {
                     checkNoError(err);
                     done();
-                });
-            });
+                },
+            );
+        });
 
-        it('If-None-Match: returns PreconditionFailed when ETag match, with' +
-            'double quotes around ETag',
+        it('If-None-Match: returns PreconditionFailed when ETag match, with' + 'double quotes around ETag', done => {
+            requestCopy({ CopySourceIfNoneMatch: etag }, err => {
+                checkError(err, 'PreconditionFailed', 412);
+                done();
+            });
+        });
+
+        it(
+            'If-None-Match: returns PreconditionFailed when one of ETags ' + 'match, with double quotes around ETag',
             done => {
-                requestCopy({ CopySourceIfNoneMatch: etag }, err => {
-                    checkError(err, 'PreconditionFailed', 412);
-                    done();
-                });
-            });
+                requestCopy(
+                    {
+                        CopySourceIfNoneMatch: `non-matching,${etag}`,
+                    },
+                    err => {
+                        checkError(err, 'PreconditionFailed', 412);
+                        done();
+                    },
+                );
+            },
+        );
 
-        it('If-None-Match: returns PreconditionFailed when one of ETags ' +
-            'match, with double quotes around ETag',
-            done => {
-                requestCopy({
-                    CopySourceIfNoneMatch: `non-matching,${etag}`,
-                }, err => {
-                    checkError(err, 'PreconditionFailed', 412);
-                    done();
-                });
-            });
-
-        it('If-None-Match: returns PreconditionFailed when ETag match, ' +
-            'without double quotes around ETag',
+        it(
+            'If-None-Match: returns PreconditionFailed when ETag match, ' + 'without double quotes around ETag',
             done => {
                 requestCopy({ CopySourceIfNoneMatch: etagTrim }, err => {
                     checkError(err, 'PreconditionFailed', 412);
                     done();
                 });
-            });
+            },
+        );
 
-        it('If-None-Match: returns PreconditionFailed when one of ETags ' +
-            'match, without double quotes around ETag',
+        it(
+            'If-None-Match: returns PreconditionFailed when one of ETags ' + 'match, without double quotes around ETag',
             done => {
-                requestCopy({
-                    CopySourceIfNoneMatch: `non-matching,${etagTrim}`,
-                }, err => {
-                    checkError(err, 'PreconditionFailed', 412);
-                    done();
-                });
-            });
-
-        it('If-Modified-Since: returns no error if Last modified date is ' +
-            'greater',
-            done => {
-                requestCopy({ CopySourceIfModifiedSince: dateFromNow(-1) },
-                    err => {
-                        checkNoError(err);
-                        done();
-                    });
-            });
-
-        // Skipping this test, because real AWS does not provide error as
-        // expected
-        it.skip('If-Modified-Since: returns PreconditionFailed if Last ' +
-            'modified date is lesser',
-            done => {
-                requestCopy({ CopySourceIfModifiedSince: dateFromNow(1) },
+                requestCopy(
+                    {
+                        CopySourceIfNoneMatch: `non-matching,${etagTrim}`,
+                    },
                     err => {
                         checkError(err, 'PreconditionFailed', 412);
                         done();
-                    });
-            });
+                    },
+                );
+            },
+        );
 
-        it('If-Modified-Since: returns PreconditionFailed if Last modified ' +
-            'date is equal',
-            done => {
-                requestCopy({ CopySourceIfModifiedSince:
-                    dateConvert(lastModified) },
-                    err => {
-                        checkError(err, 'PreconditionFailed', 412);
-                        done();
-                    });
-            });
-
-        it('If-Unmodified-Since: returns no error when lastModified date is ' +
-            'greater',
-            done => {
-                requestCopy({ CopySourceIfUnmodifiedSince: dateFromNow(1) },
-                err => {
-                    checkNoError(err);
-                    done();
-                });
-            });
-
-        it('If-Unmodified-Since: returns no error when lastModified ' +
-            'date is equal',
-            done => {
-                requestCopy({ CopySourceIfUnmodifiedSince:
-                    dateConvert(lastModified) },
-                    err => {
-                        checkNoError(err);
-                        done();
-                    });
-            });
-
-        it('If-Unmodified-Since: returns PreconditionFailed when ' +
-            'lastModified date is lesser',
-            done => {
-                requestCopy({ CopySourceIfUnmodifiedSince: dateFromNow(-1) },
-                err => {
-                    checkError(err, 'PreconditionFailed', 412);
-                    done();
-                });
-            });
-
-        it('If-Match & If-Unmodified-Since: returns no error when match Etag ' +
-            'and lastModified is greater',
-            done => {
-                requestCopy({
-                    CopySourceIfMatch: etagTrim,
-                    CopySourceIfUnmodifiedSince: dateFromNow(-1),
-                }, err => {
-                    checkNoError(err);
-                    done();
-                });
-            });
-
-        it('If-Match match & If-Unmodified-Since match', done => {
-            requestCopy({
-                CopySourceIfMatch: etagTrim,
-                CopySourceIfUnmodifiedSince: dateFromNow(1),
-            }, err => {
+        it('If-Modified-Since: returns no error if Last modified date is ' + 'greater', done => {
+            requestCopy({ CopySourceIfModifiedSince: dateFromNow(-1) }, err => {
                 checkNoError(err);
                 done();
             });
         });
 
-        it('If-Match not match & If-Unmodified-Since not match', done => {
-            requestCopy({
-                CopySourceIfMatch: 'non-matching',
-                CopySourceIfUnmodifiedSince: dateFromNow(-1),
-            }, err => {
+        // Skipping this test, because real AWS does not provide error as
+        // expected
+        it.skip('If-Modified-Since: returns PreconditionFailed if Last ' + 'modified date is lesser', done => {
+            requestCopy({ CopySourceIfModifiedSince: dateFromNow(1) }, err => {
                 checkError(err, 'PreconditionFailed', 412);
                 done();
             });
         });
 
-        it('If-Match not match & If-Unmodified-Since match', done => {
-            requestCopy({
-                CopySourceIfMatch: 'non-matching',
-                CopySourceIfUnmodifiedSince: dateFromNow(1),
-            }, err => {
-                checkError(err, 'PreconditionFailed');
+        it('If-Modified-Since: returns PreconditionFailed if Last modified ' + 'date is equal', done => {
+            requestCopy({ CopySourceIfModifiedSince: dateConvert(lastModified) }, err => {
+                checkError(err, 'PreconditionFailed', 412);
                 done();
             });
+        });
+
+        it('If-Unmodified-Since: returns no error when lastModified date is ' + 'greater', done => {
+            requestCopy({ CopySourceIfUnmodifiedSince: dateFromNow(1) }, err => {
+                checkNoError(err);
+                done();
+            });
+        });
+
+        it('If-Unmodified-Since: returns no error when lastModified ' + 'date is equal', done => {
+            requestCopy({ CopySourceIfUnmodifiedSince: dateConvert(lastModified) }, err => {
+                checkNoError(err);
+                done();
+            });
+        });
+
+        it('If-Unmodified-Since: returns PreconditionFailed when ' + 'lastModified date is lesser', done => {
+            requestCopy({ CopySourceIfUnmodifiedSince: dateFromNow(-1) }, err => {
+                checkError(err, 'PreconditionFailed', 412);
+                done();
+            });
+        });
+
+        it(
+            'If-Match & If-Unmodified-Since: returns no error when match Etag ' + 'and lastModified is greater',
+            done => {
+                requestCopy(
+                    {
+                        CopySourceIfMatch: etagTrim,
+                        CopySourceIfUnmodifiedSince: dateFromNow(-1),
+                    },
+                    err => {
+                        checkNoError(err);
+                        done();
+                    },
+                );
+            },
+        );
+
+        it('If-Match match & If-Unmodified-Since match', done => {
+            requestCopy(
+                {
+                    CopySourceIfMatch: etagTrim,
+                    CopySourceIfUnmodifiedSince: dateFromNow(1),
+                },
+                err => {
+                    checkNoError(err);
+                    done();
+                },
+            );
+        });
+
+        it('If-Match not match & If-Unmodified-Since not match', done => {
+            requestCopy(
+                {
+                    CopySourceIfMatch: 'non-matching',
+                    CopySourceIfUnmodifiedSince: dateFromNow(-1),
+                },
+                err => {
+                    checkError(err, 'PreconditionFailed', 412);
+                    done();
+                },
+            );
+        });
+
+        it('If-Match not match & If-Unmodified-Since match', done => {
+            requestCopy(
+                {
+                    CopySourceIfMatch: 'non-matching',
+                    CopySourceIfUnmodifiedSince: dateFromNow(1),
+                },
+                err => {
+                    checkError(err, 'PreconditionFailed');
+                    done();
+                },
+            );
         });
 
         // Skipping this test, because real AWS does not provide error as
         // expected
         it.skip('If-Match match & If-Modified-Since not match', done => {
-            requestCopy({
-                CopySourceIfMatch: etagTrim,
-                CopySourceIfModifiedSince: dateFromNow(1),
-            }, err => {
-                checkNoError(err);
-                done();
-            });
+            requestCopy(
+                {
+                    CopySourceIfMatch: etagTrim,
+                    CopySourceIfModifiedSince: dateFromNow(1),
+                },
+                err => {
+                    checkNoError(err);
+                    done();
+                },
+            );
         });
 
         it('If-Match match & If-Modified-Since match', done => {
-            requestCopy({
-                CopySourceIfMatch: etagTrim,
-                CopySourceIfModifiedSince: dateFromNow(-1),
-            }, err => {
-                checkNoError(err);
-                done();
-            });
+            requestCopy(
+                {
+                    CopySourceIfMatch: etagTrim,
+                    CopySourceIfModifiedSince: dateFromNow(-1),
+                },
+                err => {
+                    checkNoError(err);
+                    done();
+                },
+            );
         });
 
         it('If-Match not match & If-Modified-Since not match', done => {
-            requestCopy({
-                CopySourceIfMatch: 'non-matching',
-                CopySourceIfModifiedSince: dateFromNow(1),
-            }, err => {
-                checkError(err, 'PreconditionFailed', 412);
-                done();
-            });
+            requestCopy(
+                {
+                    CopySourceIfMatch: 'non-matching',
+                    CopySourceIfModifiedSince: dateFromNow(1),
+                },
+                err => {
+                    checkError(err, 'PreconditionFailed', 412);
+                    done();
+                },
+            );
         });
 
         it('If-Match not match & If-Modified-Since match', done => {
-            requestCopy({
-                CopySourceIfMatch: 'non-matching',
-                CopySourceIfModifiedSince: dateFromNow(-1),
-            }, err => {
-                checkError(err, 'PreconditionFailed', 412);
-                done();
-            });
-        });
-
-        it('If-None-Match & If-Modified-Since: returns PreconditionFailed ' +
-            'when Etag does not match and lastModified is greater',
-            done => {
-                requestCopy({
-                    CopySourceIfNoneMatch: etagTrim,
+            requestCopy(
+                {
+                    CopySourceIfMatch: 'non-matching',
                     CopySourceIfModifiedSince: dateFromNow(-1),
-                }, err => {
+                },
+                err => {
                     checkError(err, 'PreconditionFailed', 412);
                     done();
-                });
-            });
+                },
+            );
+        });
+
+        it(
+            'If-None-Match & If-Modified-Since: returns PreconditionFailed ' +
+                'when Etag does not match and lastModified is greater',
+            done => {
+                requestCopy(
+                    {
+                        CopySourceIfNoneMatch: etagTrim,
+                        CopySourceIfModifiedSince: dateFromNow(-1),
+                    },
+                    err => {
+                        checkError(err, 'PreconditionFailed', 412);
+                        done();
+                    },
+                );
+            },
+        );
 
         it('If-None-Match not match & If-Modified-Since not match', done => {
-            requestCopy({
-                CopySourceIfNoneMatch: etagTrim,
-                CopySourceIfModifiedSince: dateFromNow(1),
-            }, err => {
-                checkError(err, 'PreconditionFailed', 412);
-                done();
-            });
+            requestCopy(
+                {
+                    CopySourceIfNoneMatch: etagTrim,
+                    CopySourceIfModifiedSince: dateFromNow(1),
+                },
+                err => {
+                    checkError(err, 'PreconditionFailed', 412);
+                    done();
+                },
+            );
         });
 
         it('If-None-Match match & If-Modified-Since match', done => {
-            requestCopy({
-                CopySourceIfNoneMatch: 'non-matching',
-                CopySourceIfModifiedSince: dateFromNow(-1),
-            }, err => {
-                checkNoError(err);
-                done();
-            });
+            requestCopy(
+                {
+                    CopySourceIfNoneMatch: 'non-matching',
+                    CopySourceIfModifiedSince: dateFromNow(-1),
+                },
+                err => {
+                    checkNoError(err);
+                    done();
+                },
+            );
         });
 
         // Skipping this test, because real AWS does not provide error as
         // expected
         it.skip('If-None-Match match & If-Modified-Since not match', done => {
-            requestCopy({
-                CopySourceIfNoneMatch: 'non-matching',
-                CopySourceIfModifiedSince: dateFromNow(1),
-            }, err => {
-                checkError(err, 'PreconditionFailed', 412);
-                done();
-            });
+            requestCopy(
+                {
+                    CopySourceIfNoneMatch: 'non-matching',
+                    CopySourceIfModifiedSince: dateFromNow(1),
+                },
+                err => {
+                    checkError(err, 'PreconditionFailed', 412);
+                    done();
+                },
+            );
         });
 
         it('If-None-Match match & If-Unmodified-Since match', done => {
-            requestCopy({
-                CopySourceIfNoneMatch: 'non-matching',
-                CopySourceIfUnmodifiedSince: dateFromNow(1),
-            }, err => {
-                checkNoError(err);
-                done();
-            });
+            requestCopy(
+                {
+                    CopySourceIfNoneMatch: 'non-matching',
+                    CopySourceIfUnmodifiedSince: dateFromNow(1),
+                },
+                err => {
+                    checkNoError(err);
+                    done();
+                },
+            );
         });
 
         it('If-None-Match match & If-Unmodified-Since not match', done => {
-            requestCopy({
-                CopySourceIfNoneMatch: 'non-matching',
-                CopySourceIfUnmodifiedSince: dateFromNow(-1),
-            }, err => {
-                checkError(err, 'PreconditionFailed', 412);
-                done();
-            });
+            requestCopy(
+                {
+                    CopySourceIfNoneMatch: 'non-matching',
+                    CopySourceIfUnmodifiedSince: dateFromNow(-1),
+                },
+                err => {
+                    checkError(err, 'PreconditionFailed', 412);
+                    done();
+                },
+            );
         });
 
         it('If-None-Match not match & If-Unmodified-Since match', done => {
-            requestCopy({
-                CopySourceIfNoneMatch: etagTrim,
-                CopySourceIfUnmodifiedSince: dateFromNow(1),
-            }, err => {
-                checkError(err, 'PreconditionFailed', 412);
-                done();
-            });
+            requestCopy(
+                {
+                    CopySourceIfNoneMatch: etagTrim,
+                    CopySourceIfUnmodifiedSince: dateFromNow(1),
+                },
+                err => {
+                    checkError(err, 'PreconditionFailed', 412);
+                    done();
+                },
+            );
         });
 
         it('If-None-Match not match & If-Unmodified-Since not match', done => {
-            requestCopy({
-                CopySourceIfNoneMatch: etagTrim,
-                CopySourceIfUnmodifiedSince: dateFromNow(-1),
-            }, err => {
-                checkError(err, 'PreconditionFailed', 412);
-                done();
-            });
+            requestCopy(
+                {
+                    CopySourceIfNoneMatch: etagTrim,
+                    CopySourceIfUnmodifiedSince: dateFromNow(-1),
+                },
+                err => {
+                    checkError(err, 'PreconditionFailed', 412);
+                    done();
+                },
+            );
         });
 
-        it('should return InvalidStorageClass error when x-amz-storage-class header is provided ' +
-        'and not equal to STANDARD', done => {
-            s3.send(new CopyObjectCommand({
-                Bucket: destBucketName,
-                Key: destObjName,
-                CopySource: `${sourceBucketName}/${sourceObjName}`,
-                StorageClass: 'COLD',
-            })).then(() => {
-                throw new Error('Expected InvalidStorageClass error');
-            }).catch(err => {
-                assert.strictEqual(err.name, 'InvalidStorageClass');
-                assert.strictEqual(err.$metadata.httpStatusCode, 400);
-                done();
-            });
-        });
+        it(
+            'should return InvalidStorageClass error when x-amz-storage-class header is provided ' +
+                'and not equal to STANDARD',
+            done => {
+                s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        StorageClass: 'COLD',
+                    }),
+                )
+                    .then(() => {
+                        throw new Error('Expected InvalidStorageClass error');
+                    })
+                    .catch(err => {
+                        assert.strictEqual(err.name, 'InvalidStorageClass');
+                        assert.strictEqual(err.$metadata.httpStatusCode, 400);
+                        done();
+                    });
+            },
+        );
 
         it('should not copy a cold object', done => {
             const archive = {
                 archiveInfo: {
                     archiveId: '97a71dfe-49c1-4cca-840a-69199e0b0322',
-                    archiveVersion: 5577006791947779
+                    archiveVersion: 5577006791947779,
                 },
             };
             fakeMetadataArchive(sourceBucketName, sourceObjName, undefined, archive, err => {
                 assert.ifError(err);
-                s3.send(new CopyObjectCommand({
-                    Bucket: destBucketName,
-                    Key: destObjName,
-                    CopySource: `${sourceBucketName}/${sourceObjName}`,
-                })).then(() => {
-                throw new Error('Expected InvalidObjectState error');
-            }).catch(err => {
-                assert.strictEqual(err.name, 'InvalidObjectState');
-                assert.strictEqual(err.$metadata.httpStatusCode, 403);
-                done();
-                });
+                s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                    }),
+                )
+                    .then(() => {
+                        throw new Error('Expected InvalidObjectState error');
+                    })
+                    .catch(err => {
+                        assert.strictEqual(err.name, 'InvalidObjectState');
+                        assert.strictEqual(err.$metadata.httpStatusCode, 403);
+                        done();
+                    });
             });
         });
 
-        it('should copy an object when it\'s transitioning to cold', done => {
+        it("should copy an object when it's transitioning to cold", done => {
             fakeMetadataTransition(sourceBucketName, sourceObjName, undefined, err => {
                 assert.ifError(err);
-                s3.send(new CopyObjectCommand({
-                    Bucket: destBucketName,
-                    Key: destObjName,
-                    CopySource: `${sourceBucketName}/${sourceObjName}`,
-                })).then(async res => {
-                    await successCopyCheck(null, res.CopyObjectResult, originalMetadata,
-                        destBucketName, destObjName);
-                    done();
-                }).catch(err => {
-                    checkNoError(err);
-                    done();
-                });
+                s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                    }),
+                )
+                    .then(async res => {
+                        await successCopyCheck(
+                            null,
+                            res.CopyObjectResult,
+                            originalMetadata,
+                            destBucketName,
+                            destObjName,
+                        );
+                        done();
+                    })
+                    .catch(err => {
+                        checkNoError(err);
+                        done();
+                    });
             });
         });
 
@@ -1343,30 +1736,37 @@ describe('Object Copy', () => {
                 restoreRequestedAt: new Date(0),
                 restoreRequestedDays: 5,
                 restoreCompletedAt: new Date(10),
-                restoreWillExpireAt: new Date(10 + (5 * 24 * 60 * 60 * 1000)),
+                restoreWillExpireAt: new Date(10 + 5 * 24 * 60 * 60 * 1000),
             };
             fakeMetadataArchive(sourceBucketName, sourceObjName, undefined, archiveCompleted, err => {
                 assert.ifError(err);
-                s3.send(new CopyObjectCommand({
-                    Bucket: destBucketName,
-                    Key: destObjName,
-                    CopySource: `${sourceBucketName}/${sourceObjName}`,
-                })).then(async res => {
-                    await successCopyCheck(null, res.CopyObjectResult, originalMetadata,
-                        destBucketName, destObjName);
-                    done();
-                }).catch(err => {
-                    checkNoError(err);
-                    done();
-                });
+                s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                    }),
+                )
+                    .then(async res => {
+                        await successCopyCheck(
+                            null,
+                            res.CopyObjectResult,
+                            originalMetadata,
+                            destBucketName,
+                            destObjName,
+                        );
+                        done();
+                    })
+                    .catch(err => {
+                        checkNoError(err);
+                        done();
+                    });
             });
         });
     });
 });
 
-
-describe('Object Copy with object lock enabled on both destination ' +
-    'bucket and source bucket', () => {
+describe('Object Copy with object lock enabled on both destination ' + 'bucket and source bucket', () => {
     withV4(sigCfg => {
         let bucketUtil;
         let s3;
@@ -1375,10 +1775,10 @@ describe('Object Copy with object lock enabled on both destination ' +
         before(() => {
             bucketUtil = new BucketUtility('default', sigCfg);
             s3 = bucketUtil.s3;
-            return bucketUtil.empty(sourceBucketName, true)
+            return bucketUtil
+                .empty(sourceBucketName, true)
                 .then(() => bucketUtil.empty(destBucketName))
-                .then(() =>
-                    bucketUtil.deleteMany([sourceBucketName, destBucketName]))
+                .then(() => bucketUtil.deleteMany([sourceBucketName, destBucketName]))
                 .catch(err => {
                     if (err.name !== 'NoSuchBucket') {
                         process.stdout.write(`${err}\n`);
@@ -1392,20 +1792,28 @@ describe('Object Copy with object lock enabled on both destination ' +
                 });
         });
 
-        beforeEach(() => s3.send(new PutObjectCommand({
-            Bucket: sourceBucketName,
-            Key: sourceObjName,
-            Body: content,
-            Metadata: originalMetadata,
-            ObjectLockMode: 'GOVERNANCE',
-            ObjectLockRetainUntilDate: new Date(2050, 1, 1),
-        })).then(res => {
-            versionId = res.VersionId;
-            s3.send(new HeadObjectCommand({
-                Bucket: sourceBucketName,
-                Key: sourceObjName,
-            }));
-        }));
+        beforeEach(() =>
+            s3
+                .send(
+                    new PutObjectCommand({
+                        Bucket: sourceBucketName,
+                        Key: sourceObjName,
+                        Body: content,
+                        Metadata: originalMetadata,
+                        ObjectLockMode: 'GOVERNANCE',
+                        ObjectLockRetainUntilDate: new Date(2050, 1, 1),
+                    }),
+                )
+                .then(res => {
+                    versionId = res.VersionId;
+                    s3.send(
+                        new HeadObjectCommand({
+                            Bucket: sourceBucketName,
+                            Key: sourceObjName,
+                        }),
+                    );
+                }),
+        );
 
         afterEach(async () => {
             await bucketUtil.empty(sourceBucketName);
@@ -1414,128 +1822,150 @@ describe('Object Copy with object lock enabled on both destination ' +
 
         after(async () => await bucketUtil.deleteMany([sourceBucketName, destBucketName]));
 
-        it('should not copy default retention info of the destination ' +
-            'bucket if legal hold header is passed with copy object request',
+        it(
+            'should not copy default retention info of the destination ' +
+                'bucket if legal hold header is passed with copy object request',
             done => {
-                s3.send(new CopyObjectCommand({
-                    Bucket: destBucketName,
-                    Key: destObjName,
-                    CopySource: `${sourceBucketName}/${sourceObjName}`,
-                    ObjectLockLegalHoldStatus: 'ON',
-                })).then(() => {
-                    s3.send(new GetObjectCommand({ Bucket: destBucketName, Key: destObjName }))
-                        .then(res => {
-                            assert.strictEqual(res.ObjectLockMode, undefined);
-                            assert.strictEqual(res.ObjectLockRetainUntilDate,
-                                undefined);
-                            assert.strictEqual(res.ObjectLockLegalHoldStatus,
-                                'ON');
-                            const removeLockObjs = [
-                                {
-                                    bucket: sourceBucketName,
-                                    key: sourceObjName,
-                                    versionId,
-                                }, {
-                                    bucket: destBucketName,
-                                    key: destObjName,
-                                    versionId: res.VersionId,
-                                },
-                            ];
-                            new Promise((resolve, reject) => {
-                                changeObjectLock(removeLockObjs, '', err => {
-                                    if (err) {
-                                        reject(err);
-                                    } else {
-                                        resolve();
-                                    }
-                                });
-                            }).then(done).catch(err => {
+                s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        ObjectLockLegalHoldStatus: 'ON',
+                    }),
+                )
+                    .then(() => {
+                        s3.send(new GetObjectCommand({ Bucket: destBucketName, Key: destObjName }))
+                            .then(res => {
+                                assert.strictEqual(res.ObjectLockMode, undefined);
+                                assert.strictEqual(res.ObjectLockRetainUntilDate, undefined);
+                                assert.strictEqual(res.ObjectLockLegalHoldStatus, 'ON');
+                                const removeLockObjs = [
+                                    {
+                                        bucket: sourceBucketName,
+                                        key: sourceObjName,
+                                        versionId,
+                                    },
+                                    {
+                                        bucket: destBucketName,
+                                        key: destObjName,
+                                        versionId: res.VersionId,
+                                    },
+                                ];
+                                new Promise((resolve, reject) => {
+                                    changeObjectLock(removeLockObjs, '', err => {
+                                        if (err) {
+                                            reject(err);
+                                        } else {
+                                            resolve();
+                                        }
+                                    });
+                                })
+                                    .then(done)
+                                    .catch(err => {
+                                        assert.ifError(err);
+                                        done(err);
+                                    });
+                            })
+                            .catch(err => {
                                 assert.ifError(err);
                                 done(err);
                             });
-                        }).catch(err => {
-                    assert.ifError(err);
-                    done(err);
-                });
-            }).catch(err => {
-                assert.ifError(err);
-                done(err);
-            });
-        });
+                    })
+                    .catch(err => {
+                        assert.ifError(err);
+                        done(err);
+                    });
+            },
+        );
 
-        it('should not copy default retention info of the destination ' +
-            'bucket if legal hold header is passed with copy object request',
+        it(
+            'should not copy default retention info of the destination ' +
+                'bucket if legal hold header is passed with copy object request',
             done => {
-                s3.send(new CopyObjectCommand({
-                    Bucket: destBucketName,
-                    Key: destObjName,
-                    CopySource: `${sourceBucketName}/${sourceObjName}`,
-                    ObjectLockLegalHoldStatus: 'on',
-                })).then(() => {
-                    s3.send(new GetObjectCommand({ Bucket: destBucketName, Key: destObjName }))
-                        .then(res => {
-                            assert.strictEqual(res.ObjectLockMode, undefined);
-                            assert.strictEqual(res.ObjectLockMode, undefined);
-                            assert.strictEqual(res.ObjectLockRetainUntilDate,
-                                undefined);
-                            assert.strictEqual(res.ObjectLockLegalHoldStatus,
-                                'OFF');
-                            const removeLockObjs = [
-                                {
-                                    bucket: sourceBucketName,
-                                    key: sourceObjName,
-                                    versionId,
-                                },
-                            ];
-                            changeObjectLock(removeLockObjs, '', done);
-                        }).catch(err => {
-                            assert.ifError(err);
-                            done(err);
-                        });
-                }).catch(err => {
-                    assert.ifError(err);
-                    done(err);
-                });
-            });
+                s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        ObjectLockLegalHoldStatus: 'on',
+                    }),
+                )
+                    .then(() => {
+                        s3.send(new GetObjectCommand({ Bucket: destBucketName, Key: destObjName }))
+                            .then(res => {
+                                assert.strictEqual(res.ObjectLockMode, undefined);
+                                assert.strictEqual(res.ObjectLockMode, undefined);
+                                assert.strictEqual(res.ObjectLockRetainUntilDate, undefined);
+                                assert.strictEqual(res.ObjectLockLegalHoldStatus, 'OFF');
+                                const removeLockObjs = [
+                                    {
+                                        bucket: sourceBucketName,
+                                        key: sourceObjName,
+                                        versionId,
+                                    },
+                                ];
+                                changeObjectLock(removeLockObjs, '', done);
+                            })
+                            .catch(err => {
+                                assert.ifError(err);
+                                done(err);
+                            });
+                    })
+                    .catch(err => {
+                        assert.ifError(err);
+                        done(err);
+                    });
+            },
+        );
 
-        it('should overwrite default retention info of the destination ' +
-            'bucket if retention headers passed with copy object request',
+        it(
+            'should overwrite default retention info of the destination ' +
+                'bucket if retention headers passed with copy object request',
             done => {
-                s3.send(new CopyObjectCommand({
-                    Bucket: destBucketName,
-                    Key: destObjName,
-                    CopySource: `${sourceBucketName}/${sourceObjName}`,
-                    ObjectLockMode: 'COMPLIANCE',
-                    ObjectLockRetainUntilDate: new Date(2055, 2, 3),
-                })).then(() => {
-                    s3.send(new GetObjectCommand({ Bucket: destBucketName, Key: destObjName }))
-                        .then(res => {
-                            assert.strictEqual(res.ObjectLockMode, 'COMPLIANCE');
-                            assert.strictEqual(res.ObjectLockRetainUntilDate.toGMTString(),
-                                new Date(2055, 2, 3).toGMTString());
-                            const removeLockObjs = [
-                                {
-                                    bucket: sourceBucketName,
-                                    key: sourceObjName,
-                                    versionId,
-                                }, {
-                                    bucket: destBucketName,
-                                    key: destObjName,
-                                    versionId: res.VersionId,
-                                },
-                            ];
-                            changeObjectLock(removeLockObjs, '', done);
-                        }).catch(err => {
-                            assert.ifError(err);
-                            done(err);
-                        });
-                }).catch(err => {
-                    assert.ifError(err);
-                    done(err);
-                });
-            });
-        });
-
+                s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        ObjectLockMode: 'COMPLIANCE',
+                        ObjectLockRetainUntilDate: new Date(2055, 2, 3),
+                    }),
+                )
+                    .then(() => {
+                        s3.send(new GetObjectCommand({ Bucket: destBucketName, Key: destObjName }))
+                            .then(res => {
+                                assert.strictEqual(res.ObjectLockMode, 'COMPLIANCE');
+                                assert.strictEqual(
+                                    res.ObjectLockRetainUntilDate.toGMTString(),
+                                    new Date(2055, 2, 3).toGMTString(),
+                                );
+                                const removeLockObjs = [
+                                    {
+                                        bucket: sourceBucketName,
+                                        key: sourceObjName,
+                                        versionId,
+                                    },
+                                    {
+                                        bucket: destBucketName,
+                                        key: destObjName,
+                                        versionId: res.VersionId,
+                                    },
+                                ];
+                                changeObjectLock(removeLockObjs, '', done);
+                            })
+                            .catch(err => {
+                                assert.ifError(err);
+                                done(err);
+                            });
+                    })
+                    .catch(err => {
+                        assert.ifError(err);
+                        done(err);
+                    });
+            },
+        );
+    });
 });
 
 describe('Object Copy checksum behavior', () => {
@@ -1579,28 +2009,34 @@ describe('Object Copy checksum behavior', () => {
 
         checksumFixtures.forEach(({ algo, header, key }) => {
             it(`should propagate a FULL_OBJECT ${algo} checksum on CopyObject`, async () => {
-                const putRes = await s3.send(new PutObjectCommand({
-                    Bucket: sourceBucketName,
-                    Key: sourceObjName,
-                    Body: propagateBody,
-                    ChecksumAlgorithm: header,
-                }));
+                const putRes = await s3.send(
+                    new PutObjectCommand({
+                        Bucket: sourceBucketName,
+                        Key: sourceObjName,
+                        Body: propagateBody,
+                        ChecksumAlgorithm: header,
+                    }),
+                );
                 const sourceValue = putRes[key];
                 assert(sourceValue, `PutObject response should carry ${key}`);
 
-                const copyRes = await s3.send(new CopyObjectCommand({
-                    Bucket: destBucketName,
-                    Key: destObjName,
-                    CopySource: `${sourceBucketName}/${sourceObjName}`,
-                }));
+                const copyRes = await s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                    }),
+                );
                 assert.strictEqual(copyRes.CopyObjectResult[key], sourceValue);
                 assert.strictEqual(copyRes.CopyObjectResult.ChecksumType, 'FULL_OBJECT');
 
-                const headRes = await s3.send(new HeadObjectCommand({
-                    Bucket: destBucketName,
-                    Key: destObjName,
-                    ChecksumMode: 'ENABLED',
-                }));
+                const headRes = await s3.send(
+                    new HeadObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        ChecksumMode: 'ENABLED',
+                    }),
+                );
                 assert.strictEqual(headRes[key], sourceValue);
                 assert.strictEqual(headRes.ChecksumType, 'FULL_OBJECT');
             });
@@ -1614,29 +2050,34 @@ describe('Object Copy checksum behavior', () => {
                     return; // same-algo is the propagation case, covered above
                 }
                 it(`should recompute ${algo} when source is ${sourceAlgo} and ${header} requested`, async () => {
-                    await s3.send(new PutObjectCommand({
-                        Bucket: sourceBucketName,
-                        Key: sourceObjName,
-                        Body: recomputeBody,
-                        ChecksumAlgorithm: sourceHeader,
-                    }));
-                    const expectedDigest = await Promise.resolve(
-                        algorithms[algo].digest(Buffer.from(recomputeBody)));
+                    await s3.send(
+                        new PutObjectCommand({
+                            Bucket: sourceBucketName,
+                            Key: sourceObjName,
+                            Body: recomputeBody,
+                            ChecksumAlgorithm: sourceHeader,
+                        }),
+                    );
+                    const expectedDigest = await Promise.resolve(algorithms[algo].digest(Buffer.from(recomputeBody)));
 
-                    const copyRes = await s3.send(new CopyObjectCommand({
-                        Bucket: destBucketName,
-                        Key: destObjName,
-                        CopySource: `${sourceBucketName}/${sourceObjName}`,
-                        ChecksumAlgorithm: header,
-                    }));
+                    const copyRes = await s3.send(
+                        new CopyObjectCommand({
+                            Bucket: destBucketName,
+                            Key: destObjName,
+                            CopySource: `${sourceBucketName}/${sourceObjName}`,
+                            ChecksumAlgorithm: header,
+                        }),
+                    );
                     assert.strictEqual(copyRes.CopyObjectResult[key], expectedDigest);
                     assert.strictEqual(copyRes.CopyObjectResult.ChecksumType, 'FULL_OBJECT');
 
-                    const headRes = await s3.send(new HeadObjectCommand({
-                        Bucket: destBucketName,
-                        Key: destObjName,
-                        ChecksumMode: 'ENABLED',
-                    }));
+                    const headRes = await s3.send(
+                        new HeadObjectCommand({
+                            Bucket: destBucketName,
+                            Key: destObjName,
+                            ChecksumMode: 'ENABLED',
+                        }),
+                    );
                     assert.strictEqual(headRes[key], expectedDigest);
                     assert.strictEqual(headRes.ChecksumType, 'FULL_OBJECT');
                 });
@@ -1649,53 +2090,63 @@ describe('Object Copy checksum behavior', () => {
         checksumFixtures.forEach(({ algo, header, key }) => {
             const sourceHeader = header === 'CRC32' ? 'SHA256' : 'CRC32';
             it(`should compute empty-bytes ${algo} digest on a 0-byte source recompute`, async () => {
-                await s3.send(new PutObjectCommand({
-                    Bucket: sourceBucketName,
-                    Key: sourceObjName,
-                    Body: '',
-                    ChecksumAlgorithm: sourceHeader,
-                }));
-                const expectedDigest = await Promise.resolve(
-                    algorithms[algo].digest(Buffer.alloc(0)));
+                await s3.send(
+                    new PutObjectCommand({
+                        Bucket: sourceBucketName,
+                        Key: sourceObjName,
+                        Body: '',
+                        ChecksumAlgorithm: sourceHeader,
+                    }),
+                );
+                const expectedDigest = await Promise.resolve(algorithms[algo].digest(Buffer.alloc(0)));
 
-                const copyRes = await s3.send(new CopyObjectCommand({
-                    Bucket: destBucketName,
-                    Key: destObjName,
-                    CopySource: `${sourceBucketName}/${sourceObjName}`,
-                    ChecksumAlgorithm: header,
-                }));
+                const copyRes = await s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        ChecksumAlgorithm: header,
+                    }),
+                );
                 assert.strictEqual(copyRes.CopyObjectResult[key], expectedDigest);
                 assert.strictEqual(copyRes.CopyObjectResult.ChecksumType, 'FULL_OBJECT');
 
-                const headRes = await s3.send(new HeadObjectCommand({
-                    Bucket: destBucketName,
-                    Key: destObjName,
-                    ChecksumMode: 'ENABLED',
-                }));
+                const headRes = await s3.send(
+                    new HeadObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        ChecksumMode: 'ENABLED',
+                    }),
+                );
                 assert.strictEqual(headRes[key], expectedDigest);
                 assert.strictEqual(headRes.ChecksumType, 'FULL_OBJECT');
             });
         });
 
         it('should reject an unknown ChecksumAlgorithm with InvalidRequest', async () => {
-            await s3.send(new PutObjectCommand({
-                Bucket: sourceBucketName,
-                Key: sourceObjName,
-                Body: 'whatever',
-            }));
+            await s3.send(
+                new PutObjectCommand({
+                    Bucket: sourceBucketName,
+                    Key: sourceObjName,
+                    Body: 'whatever',
+                }),
+            );
             try {
-                await s3.send(new CopyObjectCommand({
-                    Bucket: destBucketName,
-                    Key: destObjName,
-                    CopySource: `${sourceBucketName}/${sourceObjName}`,
-                    ChecksumAlgorithm: 'GARBAGE',
-                }));
+                await s3.send(
+                    new CopyObjectCommand({
+                        Bucket: destBucketName,
+                        Key: destObjName,
+                        CopySource: `${sourceBucketName}/${sourceObjName}`,
+                        ChecksumAlgorithm: 'GARBAGE',
+                    }),
+                );
                 throw new Error('Expected 400 InvalidRequest');
             } catch (err) {
                 checkError(err, 'InvalidRequest', 400);
-                const expected = 'Checksum algorithm provided is unsupported. '
-                    + 'Please try again with any of the valid types: '
-                    + '[CRC32, CRC32C, CRC64NVME, SHA1, SHA256]';
+                const expected =
+                    'Checksum algorithm provided is unsupported. ' +
+                    'Please try again with any of the valid types: ' +
+                    '[CRC32, CRC32C, CRC64NVME, SHA1, SHA256]';
                 assert.strictEqual(err.message, expected);
             }
         });

--- a/tests/unit/api/apiUtils/integrity/validateChecksums.js
+++ b/tests/unit/api/apiUtils/integrity/validateChecksums.js
@@ -11,6 +11,7 @@ const {
     arsenalErrorFromChecksumError,
     getChecksumDataFromMPUHeaders,
     validateCompleteMultipartUploadChecksum,
+    getCopyObjectChecksumAlgorithm,
 } = require('../../../../../lib/api/apiUtils/integrity/validateChecksums');
 const { errors: ArsenalErrors } = require('arsenal');
 const { config } = require('../../../../../lib/Config');
@@ -755,6 +756,19 @@ describe('arsenalErrorFromChecksumError', () => {
         assert.strictEqual(result.message, 'InvalidRequest');
     });
 
+    it('should return InvalidRequest with the AWS-shaped message for CopyChecksumAlgoNotSupported', () => {
+        const result = arsenalErrorFromChecksumError({
+            error: ChecksumError.CopyChecksumAlgoNotSupported,
+            details: { algorithm: 'GARBAGE' },
+        });
+        assert.strictEqual(result.message, 'InvalidRequest');
+        assert.match(
+            result.description,
+            /Checksum algorithm provided is unsupported/,
+            'expected AWS-shaped error description',
+        );
+    });
+
     it('should return InvalidRequest for MissingCorresponding', () => {
         const result = arsenalErrorFromChecksumError({
             error: ChecksumError.MissingCorresponding,
@@ -1221,5 +1235,66 @@ describe('validateCompleteMultipartUploadChecksum', () => {
         assert(err);
         assert.strictEqual(err.error, ChecksumError.AlgoNotSupported);
         assert.strictEqual(err.details.algorithm, 'md5');
+    });
+});
+
+describe('getCopyObjectChecksumAlgorithm', () => {
+    it('should return algorithm null and no error when the header is absent', () => {
+        const result = getCopyObjectChecksumAlgorithm({});
+        assert.strictEqual(result.error, null);
+        assert.strictEqual(result.algorithm, null);
+    });
+
+    it('should ignore unrelated headers', () => {
+        const result = getCopyObjectChecksumAlgorithm({
+            'content-type': 'application/octet-stream',
+            host: 'example.com',
+        });
+        assert.strictEqual(result.error, null);
+        assert.strictEqual(result.algorithm, null);
+    });
+
+    const validAlgorithms = [
+        ['CRC32', 'crc32'],
+        ['CRC32C', 'crc32c'],
+        ['CRC64NVME', 'crc64nvme'],
+        ['SHA1', 'sha1'],
+        ['SHA256', 'sha256'],
+        // mixed-case input is lowercased
+        ['Sha256', 'sha256'],
+        // already-lowercase input is accepted as-is
+        ['crc32', 'crc32'],
+    ];
+
+    for (const [header, normalized] of validAlgorithms) {
+        it(`should return algorithm '${normalized}' for header '${header}'`, () => {
+            const result = getCopyObjectChecksumAlgorithm({
+                'x-amz-checksum-algorithm': header,
+            });
+            assert.strictEqual(result.error, null);
+            assert.strictEqual(result.algorithm, normalized);
+        });
+    }
+
+    it('should return CopyChecksumAlgoNotSupported for an unknown algorithm', () => {
+        const result = getCopyObjectChecksumAlgorithm({
+            'x-amz-checksum-algorithm': 'GARBAGE',
+        });
+        assert.strictEqual(result.algorithm, null);
+        assert(result.error);
+        assert.strictEqual(result.error.error, ChecksumError.CopyChecksumAlgoNotSupported);
+        assert.strictEqual(result.error.details.algorithm, 'GARBAGE');
+    });
+
+    it('should reject algorithms AWS may know about but cloudserver does not support', () => {
+        // AWS error message lists MD5/SHA512/XXHASH* as known names; we only
+        // accept the five FULL_OBJECT-capable algorithms.
+        for (const algo of ['MD5', 'SHA512', 'XXHASH128', 'XXHASH3', 'XXHASH64']) {
+            const result = getCopyObjectChecksumAlgorithm({
+                'x-amz-checksum-algorithm': algo,
+            });
+            assert.strictEqual(result.algorithm, null, `expected null algorithm for ${algo}`);
+            assert.strictEqual(result.error.error, ChecksumError.CopyChecksumAlgoNotSupported);
+        }
     });
 });

--- a/tests/unit/api/objectCopy.js
+++ b/tests/unit/api/objectCopy.js
@@ -679,14 +679,19 @@ function setSourceEmptyBody(cb) {
     });
 }
 
+const escapeRegExp = str => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+function assertXmlContains(xml, substr, message) {
+    assert.match(xml, new RegExp(escapeRegExp(substr)), message);
+}
+
 // Builds the objectCopy callback that asserts a successful FULL_OBJECT recompute:
 // response XML and destination metadata both carry the expected algo and digest.
 function assertRecomputed(algo, xmlTag, expectedDigest, done) {
     return (err, xml) => {
         assert.ifError(err);
-        assert(xml.includes(`<${xmlTag}>${expectedDigest}</${xmlTag}>`),
+        assertXmlContains(xml, `<${xmlTag}>${expectedDigest}</${xmlTag}>`,
             `XML should contain ${xmlTag}=${expectedDigest}`);
-        assert(xml.includes('<ChecksumType>FULL_OBJECT</ChecksumType>'),
+        assertXmlContains(xml, '<ChecksumType>FULL_OBJECT</ChecksumType>',
             'XML should contain ChecksumType FULL_OBJECT');
         metadata.getObjectMD(destBucketName, objectKey, {}, log, (err, md) => {
             assert.ifError(err);
@@ -710,7 +715,10 @@ describe('objectCopy checksum propagation', () => {
         ], done);
     });
 
-    afterEach(() => cleanup());
+    afterEach(() => {
+        sinon.restore();
+        cleanup();
+    });
 
     const algorithmFixtures = [
         { algo: 'crc32', header: 'CRC32', xmlTag: 'ChecksumCRC32', value: 'AAAAAA==' },
@@ -731,8 +739,8 @@ describe('objectCopy checksum propagation', () => {
         };
 
         function assertPropagated(xml, cb) {
-            assert(xml.includes(`<${xmlTag}>${value}</${xmlTag}>`), `XML should contain ${xmlTag}`);
-            assert(xml.includes('<ChecksumType>FULL_OBJECT</ChecksumType>'), 'XML should contain ChecksumType');
+            assertXmlContains(xml, `<${xmlTag}>${value}</${xmlTag}>`, `XML should contain ${xmlTag}`);
+            assertXmlContains(xml, '<ChecksumType>FULL_OBJECT</ChecksumType>', 'XML should contain ChecksumType');
             metadata.getObjectMD(destBucketName, objectKey, {}, log,
                 (err, md) => {
                     assert.ifError(err);
@@ -799,7 +807,10 @@ describe('objectCopy checksum recompute', () => {
         ], done);
     });
 
-    afterEach(() => cleanup());
+    afterEach(() => {
+        sinon.restore();
+        cleanup();
+    });
 
     const recomputeFixtures = [
         { algo: 'crc32', header: 'CRC32', xmlTag: 'ChecksumCRC32' },
@@ -904,7 +915,7 @@ describe('objectCopy checksum recompute', () => {
         const partB = Buffer.from('part-b-bytes-longer', 'utf8');
         const fullBody = Buffer.concat([partA, partB]);
         const parts = { 'mpart-a': partA, 'mpart-b': partB };
-        const dataGetStub = sinon.stub(data, 'get').callsFake((info, _response, _l, cb) => {
+        sinon.stub(data, 'get').callsFake((info, _response, _l, cb) => {
             const buf = parts[info.key];
             return cb(null, Readable.from(buf));
         });
@@ -925,11 +936,9 @@ describe('objectCopy checksum recompute', () => {
                     });
                     objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log,
                         (err, xml) => {
-                            dataGetStub.restore();
                             assertRecomputed('sha256', 'ChecksumSHA256', expectedDigest, done)(err, xml);
                         });
                 }, err => {
-                    dataGetStub.restore();
                     done(err);
                 });
             });
@@ -949,8 +958,6 @@ describe('objectCopy checksum recompute', () => {
             });
             objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log,
                 assertRecomputed('sha256', 'ChecksumSHA256', expectedDigest, err => {
-                    cipherBundleSpy.restore();
-                    dataPutSpy.restore();
                     if (err) {
                         return done(err);
                     }
@@ -1000,7 +1007,7 @@ describe('objectCopy checksum recompute', () => {
         });
         objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, err => {
             assert(err);
-            assert.strictEqual(err.is.InvalidRequest, true);
+            assert.strictEqual(err.message, 'InvalidRequest');
             done();
         });
     });
@@ -1010,7 +1017,7 @@ describe('objectCopy checksum recompute', () => {
         // Azure-flagged parts so the test exercises the Azure branch end-to-end
         // without a real Azure backend.
         const originalGet = data.get;
-        const dataGetStub = sinon.stub(data, 'get').callsFake((info, response, l, cb) => {
+        sinon.stub(data, 'get').callsFake((info, response, l, cb) => {
             if (info?.dataStoreType === 'azure') {
                 // Simulate Azure: write the (already-known) source bytes to the
                 // provided writable, end it, and signal completion.
@@ -1035,11 +1042,9 @@ describe('objectCopy checksum recompute', () => {
                     });
                     objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log,
                         (err, xml) => {
-                            dataGetStub.restore();
                             assertRecomputed('sha256', 'ChecksumSHA256', expectedDigest, done)(err, xml);
                         });
                 }, err => {
-                    dataGetStub.restore();
                     done(err);
                 });
             });
@@ -1074,12 +1079,10 @@ describe('objectCopy checksum recompute', () => {
                         socket: {},
                     });
                     objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, (err, xml) => {
-                        dataPutSpy.restore();
-                        batchDeleteSpy.restore();
                         assert.ifError(err);
                         assert(!dataPutSpy.called, 'data.put should NOT be called');
                         assert(!batchDeleteSpy.called, 'data.batchDelete should NOT be called');
-                        assert(xml.includes(`<${xmlTag}>${expectedDigest}</${xmlTag}>`),
+                        assertXmlContains(xml, `<${xmlTag}>${expectedDigest}</${xmlTag}>`,
                             'response XML should carry the new checksum');
                         metadata.getObjectMD(sourceBucketName, objectKey, {}, log, (err, md) => {
                             assert.ifError(err);
@@ -1129,14 +1132,12 @@ describe('objectCopy checksum recompute', () => {
                         socket: {},
                     });
                     objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, (err, xml) => {
-                        dataPutSpy.restore();
-                        batchDeleteSpy.restore();
                         assert.ifError(err);
                         assert(!dataPutSpy.called, 'data.put should NOT be called (location reused)');
                         assert(!batchDeleteSpy.called, 'data.batchDelete should NOT be called');
-                        assert(xml.includes(`<${xmlTag}>${expectedDigest}</${xmlTag}>`),
+                        assertXmlContains(xml, `<${xmlTag}>${expectedDigest}</${xmlTag}>`,
                             'response XML should carry the recomputed FULL_OBJECT digest');
-                        assert(xml.includes('<ChecksumType>FULL_OBJECT</ChecksumType>'),
+                        assertXmlContains(xml, '<ChecksumType>FULL_OBJECT</ChecksumType>',
                             'response XML must say FULL_OBJECT, never COMPOSITE');
                         metadata.getObjectMD(sourceBucketName, objectKey, {}, log, (err, md) => {
                             assert.ifError(err);
@@ -1173,7 +1174,6 @@ describe('objectCopy checksum recompute', () => {
                 socket: {},
             });
             objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, err => {
-                dataPutSpy.restore();
                 assert.ifError(err);
                 assert(dataPutSpy.called,
                     'data.put should be called because versioning forces a new version write');
@@ -1209,7 +1209,10 @@ describe('objectCopy checksum recompute on external backends', () => {
         ], done);
     });
 
-    afterEach(() => cleanup());
+    afterEach(() => {
+        sinon.restore();
+        cleanup();
+    });
 
     it('should recompute the checksum on a cross-key copy on an external backend', done => {
         // A recompute streams the source through CloudServer (GET + PUT) and
@@ -1220,11 +1223,10 @@ describe('objectCopy checksum recompute on external backends', () => {
                 'x-amz-checksum-algorithm': 'SHA256',
             });
             objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, (err, xml) => {
-                copyObjectSpy.restore();
                 assert.ifError(err);
                 assert(!copyObjectSpy.called,
                     'data.copyObject should NOT be called (recompute streams instead)');
-                assert(xml.includes(`<ChecksumSHA256>${expectedDigest}</ChecksumSHA256>`),
+                assertXmlContains(xml, `<ChecksumSHA256>${expectedDigest}</ChecksumSHA256>`,
                     'response XML should carry the recomputed checksum');
                 metadata.getObjectMD(destBucketName, objectKey, {}, log, (err, md) => {
                     assert.ifError(err);
@@ -1247,11 +1249,10 @@ describe('objectCopy checksum recompute on external backends', () => {
                 'x-amz-meta-scal-location-constraint': 'us-east-2',
             });
             objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, (err, xml) => {
-                copyObjectSpy.restore();
                 assert.ifError(err);
                 assert(!copyObjectSpy.called,
                     'data.copyObject should NOT be called (recompute streams instead)');
-                assert(xml.includes(`<ChecksumSHA256>${expectedDigest}</ChecksumSHA256>`),
+                assertXmlContains(xml, `<ChecksumSHA256>${expectedDigest}</ChecksumSHA256>`,
                     'response XML should carry the recomputed checksum');
                 done();
             });
@@ -1276,12 +1277,10 @@ describe('objectCopy checksum recompute on external backends', () => {
                 socket: {},
             });
             objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, (err, xml) => {
-                copyObjectSpy.restore();
-                dataPutSpy.restore();
                 assert.ifError(err);
                 assert(!copyObjectSpy.called, 'data.copyObject should NOT be called (location reused)');
                 assert(!dataPutSpy.called, 'data.put should NOT be called (location reused)');
-                assert(xml.includes(`<ChecksumSHA256>${expectedDigest}</ChecksumSHA256>`),
+                assertXmlContains(xml, `<ChecksumSHA256>${expectedDigest}</ChecksumSHA256>`,
                     'response XML should carry the recomputed checksum');
                 metadata.getObjectMD(sourceBucketName, objectKey, {}, log, (err, md) => {
                     assert.ifError(err);
@@ -1308,7 +1307,10 @@ describe('objectCopy checksum recompute on 0-byte source', () => {
         ], done);
     });
 
-    afterEach(() => cleanup());
+    afterEach(() => {
+        sinon.restore();
+        cleanup();
+    });
 
     const recomputeFixtures = [
         { algo: 'crc32', header: 'CRC32', xmlTag: 'ChecksumCRC32' },
@@ -1363,8 +1365,8 @@ describe('objectCopy checksum recompute on 0-byte source', () => {
             const req = _createObjectCopyRequest(destBucketName);
             objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, (err, xml) => {
                 assert.ifError(err);
-                assert(xml.includes('<ChecksumCRC32>AAAAAA==</ChecksumCRC32>'));
-                assert(xml.includes('<ChecksumType>FULL_OBJECT</ChecksumType>'));
+                assertXmlContains(xml, '<ChecksumCRC32>AAAAAA==</ChecksumCRC32>');
+                assertXmlContains(xml, '<ChecksumType>FULL_OBJECT</ChecksumType>');
                 metadata.getObjectMD(destBucketName, objectKey, {}, log, (err, md) => {
                     assert.ifError(err);
                     assert.strictEqual(md.checksum.checksumAlgorithm, 'crc32');
@@ -1416,7 +1418,10 @@ describe('objectCopy data orphan cleanup on cross-backend copy-to-self', () => {
         ], done);
     });
 
-    afterEach(() => cleanup());
+    afterEach(() => {
+        sinon.restore();
+        cleanup();
+    });
 
     it('should reclaim the old location on copy-to-self that lands at a different backend key', done => {
         // Copy-to-self where the new metadata points to a different data key
@@ -1424,7 +1429,7 @@ describe('objectCopy data orphan cleanup on cross-backend copy-to-self', () => {
         // location-constraint). The old key is no longer referenced and must
         // be batchDeleted — guards against a pre-existing orphan bug.
         const batchDeleteSpy = sinon.spy(data, 'batchDelete');
-        const copyObjectStub = sinon.stub(data, 'copyObject').callsFake(
+        sinon.stub(data, 'copyObject').callsFake(
             (req, srcLoc, sMP, dataLocator, ctx, backendInfo, srcBM, dstBM, sse, l, cb) =>
                 cb(null, [{ key: 'new-backend-key', dataStoreName: 'us-east-2', size: objData[0].length, start: 0 }]));
         metadata.getObjectMD(sourceBucketName, objectKey, {}, log, (err, srcMd) => {
@@ -1442,8 +1447,6 @@ describe('objectCopy data orphan cleanup on cross-backend copy-to-self', () => {
                 socket: {},
             });
             objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, err => {
-                batchDeleteSpy.restore();
-                copyObjectStub.restore();
                 assert.ifError(err);
                 assert(batchDeleteSpy.calledOnce,
                     'data.batchDelete should reclaim the old data location');
@@ -1465,7 +1468,7 @@ describe('objectCopy data orphan cleanup on cross-backend copy-to-self', () => {
         metadata.getObjectMD(sourceBucketName, objectKey, {}, log, (err, srcMd) => {
             assert.ifError(err);
             const oldLoc = srcMd.location[0];
-            const copyObjectStub = sinon.stub(data, 'copyObject').callsFake(
+            sinon.stub(data, 'copyObject').callsFake(
                 (req, srcLoc, sMP, dataLocator, ctx, backendInfo, srcBM, dstBM, sse, l, cb) =>
                     cb(null, [{ key: oldLoc.key, dataStoreName: 'us-east-2',
                         size: objData[0].length, start: 0 }]));
@@ -1481,8 +1484,6 @@ describe('objectCopy data orphan cleanup on cross-backend copy-to-self', () => {
                 socket: {},
             });
             objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, err => {
-                batchDeleteSpy.restore();
-                copyObjectStub.restore();
                 assert.ifError(err);
                 assert(batchDeleteSpy.calledOnce,
                     'data.batchDelete should reclaim the old slot even when the backend key matches');
@@ -1507,7 +1508,10 @@ describe('objectCopy legacy string-location copy-to-self', () => {
         ], done);
     });
 
-    afterEach(() => cleanup());
+    afterEach(() => {
+        sinon.restore();
+        cleanup();
+    });
 
     it('should not delete the reused location on copy-to-self with a legacy string location', done => {
         // Pre-md-model-version-2 objects store `location` as a bare string;
@@ -1535,7 +1539,6 @@ describe('objectCopy legacy string-location copy-to-self', () => {
                     socket: {},
                 });
                 objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, err => {
-                    batchDeleteSpy.restore();
                     assert.ifError(err);
                     assert(batchDeleteSpy.notCalled,
                         'the reused legacy string location must not be treated as an orphan');

--- a/tests/unit/api/objectCopy.js
+++ b/tests/unit/api/objectCopy.js
@@ -984,6 +984,48 @@ describe('objectCopy checksum recompute', () => {
             done();
         });
     });
+    it('should recompute checksum on an Azure source via the per-part PassThrough path', done => {
+        // The mem backend's data.get returns a Readable; Azure backend's data.get
+        // instead writes part bytes into the response writable. Stub data.get for
+        // Azure-flagged parts so the test exercises the Azure branch end-to-end
+        // without a real Azure backend.
+        const originalGet = data.get;
+        const dataGetStub = sinon.stub(data, 'get').callsFake((info, response, l, cb) => {
+            if (info?.dataStoreType === 'azure') {
+                // Simulate Azure: write the (already-known) source bytes to the
+                // provided writable, end it, and signal completion.
+                setImmediate(() => {
+                    response.write(objData[0]);
+                    response.end();
+                    cb(null);
+                });
+                return;
+            }
+            originalGet.call(data, info, response, l, cb);
+        });
+        metadata.getObjectMD(sourceBucketName, objectKey, {}, log, (err, md) => {
+            assert.ifError(err);
+            // eslint-disable-next-line no-param-reassign
+            md.location = [{ ...md.location[0], dataStoreType: 'azure' }];
+            metadata.putObjectMD(sourceBucketName, objectKey, md, {}, log, err => {
+                assert.ifError(err);
+                Promise.resolve(algorithms.sha256.digest(objData[0])).then(expectedDigest => {
+                    const req = _createObjectCopyRequest(destBucketName, {
+                        'x-amz-checksum-algorithm': 'SHA256',
+                    });
+                    objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log,
+                        (err, xml) => {
+                            dataGetStub.restore();
+                            assertRecomputed('sha256', 'ChecksumSHA256', expectedDigest, done)(err, xml);
+                        });
+                }, err => {
+                    dataGetStub.restore();
+                    done(err);
+                });
+            });
+        });
+    });
+
     const copyToSelfFixtures = [
         { algo: 'crc32', header: 'CRC32', xmlTag: 'ChecksumCRC32' },
         { algo: 'crc32c', header: 'CRC32C', xmlTag: 'ChecksumCRC32C' },

--- a/tests/unit/api/objectCopy.js
+++ b/tests/unit/api/objectCopy.js
@@ -11,21 +11,17 @@ const bucketPutPolicy = require('../../../lib/api/bucketPutPolicy');
 const objectPut = require('../../../lib/api/objectPut');
 const objectCopy = require('../../../lib/api/objectCopy');
 const DummyRequest = require('../DummyRequest');
-const { cleanup, DummyRequestLogger, makeAuthInfo, versioningTestUtils }
-    = require('../helpers');
+const { cleanup, DummyRequestLogger, makeAuthInfo, versioningTestUtils } = require('../helpers');
 const mpuUtils = require('../utils/mpuUtils');
 const metadata = require('../metadataswitch');
 const { data } = require('../../../lib/data/wrapper');
 const kms = require('../../../lib/kms/wrapper');
 const { objectLocationConstraintHeader } = require('../../../constants');
-const { algorithms } =
-    require('../../../lib/api/apiUtils/integrity/validateChecksums');
+const { algorithms } = require('../../../lib/api/apiUtils/integrity/validateChecksums');
 const { fakeMetadataArchive } = require('../../functional/aws-node-sdk/test/utils/init');
 const { config } = require('../../../lib/Config');
 
-const {
-    LOCATION_NAME_CRR,
-} = require('../../constants');
+const { LOCATION_NAME_CRR } = require('../../constants');
 
 const any = sinon.match.any;
 
@@ -63,50 +59,41 @@ function _createObjectCopyRequest(destBucketName, headers = {}) {
 
 const putDestBucketRequest = _createBucketPutRequest(destBucketName);
 const putSourceBucketRequest = _createBucketPutRequest(sourceBucketName);
-const enableVersioningRequest = versioningTestUtils
-    .createBucketPutVersioningReq(destBucketName, 'Enabled');
-const suspendVersioningRequest = versioningTestUtils
-    .createBucketPutVersioningReq(destBucketName, 'Suspended');
-const objData = ['foo0', 'foo1', 'foo2'].map(str =>
-    Buffer.from(str, 'utf8'));
-
+const enableVersioningRequest = versioningTestUtils.createBucketPutVersioningReq(destBucketName, 'Enabled');
+const suspendVersioningRequest = versioningTestUtils.createBucketPutVersioningReq(destBucketName, 'Suspended');
+const objData = ['foo0', 'foo1', 'foo2'].map(str => Buffer.from(str, 'utf8'));
 
 describe('objectCopy with versioning', () => {
-    const testPutObjectRequests = objData.slice(0, 2).map(data =>
-        versioningTestUtils.createPutObjectRequest(destBucketName, objectKey,
-            data));
-    testPutObjectRequests.push(versioningTestUtils
-        .createPutObjectRequest(sourceBucketName, objectKey, objData[2]));
+    const testPutObjectRequests = objData
+        .slice(0, 2)
+        .map(data => versioningTestUtils.createPutObjectRequest(destBucketName, objectKey, data));
+    testPutObjectRequests.push(versioningTestUtils.createPutObjectRequest(sourceBucketName, objectKey, objData[2]));
 
     before(done => {
         cleanup();
         sinon.spy(metadata, 'putObjectMD');
-        async.series([
-            callback => bucketPut(authInfo, putDestBucketRequest, log,
-                callback),
-            callback => bucketPut(authInfo, putSourceBucketRequest, log,
-                callback),
-            // putting null version: put obj before versioning configured
-            // in dest bucket
-            callback => objectPut(authInfo, testPutObjectRequests[0],
-                undefined, log, callback),
-            callback => bucketPutVersioning(authInfo,
-                enableVersioningRequest, log, callback),
-            // put another version in dest bucket:
-            callback => objectPut(authInfo, testPutObjectRequests[1],
-                undefined, log, callback),
-            callback => bucketPutVersioning(authInfo,
-                suspendVersioningRequest, log, callback),
-            // put source object in source bucket
-            callback => objectPut(authInfo, testPutObjectRequests[2],
-                undefined, log, callback),
-        ], err => {
-            if (err) {
-                return done(err);
-            }
-            versioningTestUtils.assertDataStoreValues(ds, objData);
-            return done();
-        });
+        async.series(
+            [
+                callback => bucketPut(authInfo, putDestBucketRequest, log, callback),
+                callback => bucketPut(authInfo, putSourceBucketRequest, log, callback),
+                // putting null version: put obj before versioning configured
+                // in dest bucket
+                callback => objectPut(authInfo, testPutObjectRequests[0], undefined, log, callback),
+                callback => bucketPutVersioning(authInfo, enableVersioningRequest, log, callback),
+                // put another version in dest bucket:
+                callback => objectPut(authInfo, testPutObjectRequests[1], undefined, log, callback),
+                callback => bucketPutVersioning(authInfo, suspendVersioningRequest, log, callback),
+                // put source object in source bucket
+                callback => objectPut(authInfo, testPutObjectRequests[2], undefined, log, callback),
+            ],
+            err => {
+                if (err) {
+                    return done(err);
+                }
+                versioningTestUtils.assertDataStoreValues(ds, objData);
+                return done();
+            },
+        );
     });
 
     after(() => {
@@ -114,13 +101,14 @@ describe('objectCopy with versioning', () => {
         cleanup();
     });
 
-    it('should delete null version when creating new null version, ' +
-    'even when null version is not the latest version', done => {
-        // will have another copy of last object in datastore after objectCopy
-        const expectedValues = [undefined, objData[1], objData[2], objData[2]];
-        const testObjectCopyRequest = _createObjectCopyRequest(destBucketName);
-        objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey,
-            undefined, log, err => {
+    it(
+        'should delete null version when creating new null version, ' +
+            'even when null version is not the latest version',
+        done => {
+            // will have another copy of last object in datastore after objectCopy
+            const expectedValues = [undefined, objData[1], objData[2], objData[2]];
+            const testObjectCopyRequest = _createObjectCopyRequest(destBucketName);
+            objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey, undefined, log, err => {
                 assert.ifError(err, `Unexpected err: ${err}`);
                 sinon.assert.calledWith(
                     metadata.putObjectMD.lastCall,
@@ -129,44 +117,42 @@ describe('objectCopy with versioning', () => {
                     sinon.match({ _data: { originOp: 's3:ObjectCreated:Copy' } }),
                     sinon.match.any,
                     sinon.match.any,
-                    sinon.match.any
+                    sinon.match.any,
                 );
                 setImmediate(() => {
-                    versioningTestUtils
-                        .assertDataStoreValues(ds, expectedValues);
+                    versioningTestUtils.assertDataStoreValues(ds, expectedValues);
                     done();
                 });
             });
-    });
+        },
+    );
 
     it('should not copy object with storage-class header not equal to STANDARD', done => {
         const testObjectCopyRequest = _createObjectCopyRequest(destBucketName);
         testObjectCopyRequest.headers['x-amz-storage-class'] = 'COLD';
-        objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey,
-            undefined, log, err => {
-                setImmediate(() => {
-                    assert.strictEqual(err.is.InvalidStorageClass, true);
-                    done();
-                });
+        objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey, undefined, log, err => {
+            setImmediate(() => {
+                assert.strictEqual(err.is.InvalidStorageClass, true);
+                done();
             });
+        });
     });
 
     it('should not set bucketOwnerId if requesting account owns dest bucket', done => {
         const testObjectCopyRequest = _createObjectCopyRequest(destBucketName);
-        objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey,
-            undefined, log, err => {
-                assert.ifError(err);
-                sinon.assert.calledWith(
-                    metadata.putObjectMD.lastCall,
-                    destBucketName,
-                    objectKey,
-                    sinon.match({ _data: { bucketOwnerId: sinon.match.typeOf('undefined') } }),
-                    sinon.match.any,
-                    sinon.match.any,
-                    sinon.match.any
-                );
-                done();
-            });
+        objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey, undefined, log, err => {
+            assert.ifError(err);
+            sinon.assert.calledWith(
+                metadata.putObjectMD.lastCall,
+                destBucketName,
+                objectKey,
+                sinon.match({ _data: { bucketOwnerId: sinon.match.typeOf('undefined') } }),
+                sinon.match.any,
+                sinon.match.any,
+                sinon.match.any,
+            );
+            done();
+        });
     });
 
     // TODO: S3C-9965
@@ -189,9 +175,7 @@ describe('objectCopy with versioning', () => {
                         Effect: 'Allow',
                         Principal: { AWS: `arn:aws:iam::${authInfo2.shortid}:root` },
                         Action: ['s3:GetObject'],
-                        Resource: [
-                            `arn:aws:s3:::${sourceBucketName}/*`,
-                        ],
+                        Resource: [`arn:aws:s3:::${sourceBucketName}/*`],
                     },
                 ],
             }),
@@ -210,9 +194,7 @@ describe('objectCopy with versioning', () => {
                         Effect: 'Allow',
                         Principal: { AWS: `arn:aws:iam::${authInfo2.shortid}:root` },
                         Action: ['s3:PutObject'],
-                        Resource: [
-                            `arn:aws:s3:::${destBucketName}/*`,
-                        ],
+                        Resource: [`arn:aws:s3:::${destBucketName}/*`],
                     },
                 ],
             }),
@@ -221,51 +203,47 @@ describe('objectCopy with versioning', () => {
             assert.ifError(err);
             bucketPutPolicy(authInfo, testPutDestPolicyRequest, log, err => {
                 assert.ifError(err);
-                objectCopy(authInfo2, testObjectCopyRequest, sourceBucketName, objectKey,
-                    undefined, log, err => {
-                        sinon.assert.calledWith(
-                            metadata.putObjectMD.lastCall,
-                            destBucketName,
-                            objectKey,
-                            sinon.match({ _data: { bucketOwnerId: authInfo.canonicalID } }),
-                            sinon.match.any,
-                            sinon.match.any,
-                            sinon.match.any
-                        );
-                        assert.ifError(err);
-                        done();
-                    });
+                objectCopy(authInfo2, testObjectCopyRequest, sourceBucketName, objectKey, undefined, log, err => {
+                    sinon.assert.calledWith(
+                        metadata.putObjectMD.lastCall,
+                        destBucketName,
+                        objectKey,
+                        sinon.match({ _data: { bucketOwnerId: authInfo.canonicalID } }),
+                        sinon.match.any,
+                        sinon.match.any,
+                        sinon.match.any,
+                    );
+                    assert.ifError(err);
+                    done();
+                });
             });
         });
     });
 });
 
 describe('non-versioned objectCopy', () => {
-    const testPutObjectRequest = versioningTestUtils
-        .createPutObjectRequest(sourceBucketName, objectKey, objData[0]);
-    const testPutDestObjectRequest = versioningTestUtils
-        .createPutObjectRequest(destBucketName, objectKey, objData[1]);
+    const testPutObjectRequest = versioningTestUtils.createPutObjectRequest(sourceBucketName, objectKey, objData[0]);
+    const testPutDestObjectRequest = versioningTestUtils.createPutObjectRequest(destBucketName, objectKey, objData[1]);
 
     before(done => {
         cleanup();
-        sinon.stub(metadata, 'putObjectMD')
-            .callsFake(originalputObjectMD);
+        sinon.stub(metadata, 'putObjectMD').callsFake(originalputObjectMD);
 
-        async.series([
-            callback => bucketPut(authInfo, putDestBucketRequest, log,
-                callback),
-            callback => bucketPut(authInfo, putSourceBucketRequest, log,
-                callback),
-            // put source object in source bucket
-            callback => objectPut(authInfo, testPutObjectRequest,
-                undefined, log, callback),
-        ], err => {
-            if (err) {
-                return done(err);
-            }
-            versioningTestUtils.assertDataStoreValues(ds, objData.slice(0, 1));
-            return done();
-        });
+        async.series(
+            [
+                callback => bucketPut(authInfo, putDestBucketRequest, log, callback),
+                callback => bucketPut(authInfo, putSourceBucketRequest, log, callback),
+                // put source object in source bucket
+                callback => objectPut(authInfo, testPutObjectRequest, undefined, log, callback),
+            ],
+            err => {
+                if (err) {
+                    return done(err);
+                }
+                versioningTestUtils.assertDataStoreValues(ds, objData.slice(0, 1));
+                return done();
+            },
+        );
     });
 
     after(() => {
@@ -276,91 +254,132 @@ describe('non-versioned objectCopy', () => {
     const testObjectCopyRequest = _createObjectCopyRequest(destBucketName);
 
     it('should not leave orphans in data when overwriting a multipart upload', done => {
-        mpuUtils.createMPU(namespace, destBucketName, objectKey, log,
-        (err, testUploadId) => {
+        mpuUtils.createMPU(namespace, destBucketName, objectKey, log, (err, testUploadId) => {
             assert.ifError(err);
-            objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey,
-                undefined, log, err => {
-                    assert.ifError(err);
-                    sinon.assert.calledWith(metadata.putObjectMD,
-                        any, any, any, sinon.match({ oldReplayId: testUploadId }), any, any);
-                    done();
-                });
+            objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey, undefined, log, err => {
+                assert.ifError(err);
+                sinon.assert.calledWith(
+                    metadata.putObjectMD,
+                    any,
+                    any,
+                    any,
+                    sinon.match({ oldReplayId: testUploadId }),
+                    any,
+                    any,
+                );
+                done();
+            });
         });
     });
 
     it('should not pass needOplogUpdate when creating object', done => {
-        async.series([
-            next => objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey,
-                undefined, log, next),
-            async () => {
-                sinon.assert.calledWith(metadata.putObjectMD.lastCall,
-                    destBucketName, objectKey, sinon.match({
-                        _data: { originOp: 's3:ObjectCreated:Copy' },
-                    }), sinon.match({
-                        needOplogUpdate: undefined,
-                        originOp: undefined,
-                    }), any, any);
-            },
-        ], done);
+        async.series(
+            [
+                next => objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey, undefined, log, next),
+                async () => {
+                    sinon.assert.calledWith(
+                        metadata.putObjectMD.lastCall,
+                        destBucketName,
+                        objectKey,
+                        sinon.match({
+                            _data: { originOp: 's3:ObjectCreated:Copy' },
+                        }),
+                        sinon.match({
+                            needOplogUpdate: undefined,
+                            originOp: undefined,
+                        }),
+                        any,
+                        any,
+                    );
+                },
+            ],
+            done,
+        );
     });
 
     it('should not pass needOplogUpdate when replacing object', done => {
-        async.series([
-            next => objectPut(authInfo, testPutDestObjectRequest, undefined, log, next),
-            next => objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey,
-                undefined, log, next),
-            async () => {
-                sinon.assert.calledWith(metadata.putObjectMD.lastCall,
-                    destBucketName, objectKey, sinon.match({
-                        _data: { originOp: 's3:ObjectCreated:Copy' },
-                    }), sinon.match({
-                        needOplogUpdate: undefined,
-                        originOp: undefined,
-                    }), any, any);
-            },
-        ], done);
+        async.series(
+            [
+                next => objectPut(authInfo, testPutDestObjectRequest, undefined, log, next),
+                next => objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey, undefined, log, next),
+                async () => {
+                    sinon.assert.calledWith(
+                        metadata.putObjectMD.lastCall,
+                        destBucketName,
+                        objectKey,
+                        sinon.match({
+                            _data: { originOp: 's3:ObjectCreated:Copy' },
+                        }),
+                        sinon.match({
+                            needOplogUpdate: undefined,
+                            originOp: undefined,
+                        }),
+                        any,
+                        any,
+                    );
+                },
+            ],
+            done,
+        );
     });
 
     it('should pass needOplogUpdate to metadata when replacing archived object', done => {
         const archived = {
-            archiveInfo: { foo: 0, bar: 'stuff' }
+            archiveInfo: { foo: 0, bar: 'stuff' },
         };
 
-        async.series([
-            next => objectPut(authInfo, testPutDestObjectRequest, undefined, log, next),
-            next => fakeMetadataArchive(destBucketName, objectKey, undefined, archived, next),
-            next => objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey,
-                undefined, log, next),
-            async () => {
-                sinon.assert.calledWith(metadata.putObjectMD.lastCall,
-                    destBucketName, objectKey, any, sinon.match({
-                        needOplogUpdate: true,
-                        originOp: 's3:ReplaceArchivedObject',
-                    }), any, any);
-            },
-        ], done);
+        async.series(
+            [
+                next => objectPut(authInfo, testPutDestObjectRequest, undefined, log, next),
+                next => fakeMetadataArchive(destBucketName, objectKey, undefined, archived, next),
+                next => objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey, undefined, log, next),
+                async () => {
+                    sinon.assert.calledWith(
+                        metadata.putObjectMD.lastCall,
+                        destBucketName,
+                        objectKey,
+                        any,
+                        sinon.match({
+                            needOplogUpdate: true,
+                            originOp: 's3:ReplaceArchivedObject',
+                        }),
+                        any,
+                        any,
+                    );
+                },
+            ],
+            done,
+        );
     });
 
     it('should pass needOplogUpdate to metadata when replacing archived object in version suspended bucket', done => {
         const archived = {
-            archiveInfo: { foo: 0, bar: 'stuff' }
+            archiveInfo: { foo: 0, bar: 'stuff' },
         };
 
-        async.series([
-            next => bucketPutVersioning(authInfo, suspendVersioningRequest, log, next),
-            next => objectPut(authInfo, testPutDestObjectRequest, undefined, log, next),
-            next => fakeMetadataArchive(destBucketName, objectKey, undefined, archived, next),
-            next => objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey,
-                undefined, log, next),
-            async () => {
-                sinon.assert.calledWith(metadata.putObjectMD.lastCall,
-                    destBucketName, objectKey, any, sinon.match({
-                        needOplogUpdate: true,
-                        originOp: 's3:ReplaceArchivedObject',
-                    }), any, any);
-            },
-        ], done);
+        async.series(
+            [
+                next => bucketPutVersioning(authInfo, suspendVersioningRequest, log, next),
+                next => objectPut(authInfo, testPutDestObjectRequest, undefined, log, next),
+                next => fakeMetadataArchive(destBucketName, objectKey, undefined, archived, next),
+                next => objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey, undefined, log, next),
+                async () => {
+                    sinon.assert.calledWith(
+                        metadata.putObjectMD.lastCall,
+                        destBucketName,
+                        objectKey,
+                        any,
+                        sinon.match({
+                            needOplogUpdate: true,
+                            originOp: 's3:ReplaceArchivedObject',
+                        }),
+                        any,
+                        any,
+                    );
+                },
+            ],
+            done,
+        );
     });
 
     it('should fail to copy object when setting a crr location as the locationConstraint', done => {
@@ -369,14 +388,16 @@ describe('non-versioned objectCopy', () => {
             [objectLocationConstraintHeader]: LOCATION_NAME_CRR,
         });
 
-        async.series([
-            next => objectPut(authInfo, testPutDestObjectRequest, undefined, log, next),
-            next => objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey,
-                undefined, log, next),
-        ], err => {
-            assert(err.is.InvalidArgument);
-            done();
-        });
+        async.series(
+            [
+                next => objectPut(authInfo, testPutDestObjectRequest, undefined, log, next),
+                next => objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey, undefined, log, next),
+            ],
+            err => {
+                assert(err.is.InvalidArgument);
+                done();
+            },
+        );
     });
 });
 
@@ -384,10 +405,13 @@ describe('objectCopy overheadField', () => {
     beforeEach(done => {
         cleanup();
         sinon.stub(metadata, 'putObjectMD').callsFake(originalputObjectMD);
-        async.series([
-            next => bucketPut(authInfo, putSourceBucketRequest, log, next),
-            next => bucketPut(authInfo, putDestBucketRequest, log, next),
-        ], done);
+        async.series(
+            [
+                next => bucketPut(authInfo, putSourceBucketRequest, log, next),
+                next => bucketPut(authInfo, putDestBucketRequest, log, next),
+            ],
+            done,
+        );
     });
 
     afterEach(() => {
@@ -396,62 +420,82 @@ describe('objectCopy overheadField', () => {
     });
 
     it('should pass overheadField to metadata.putObjectMD for a non-versioned request', done => {
-        const testPutObjectRequest =
-            versioningTestUtils.createPutObjectRequest(sourceBucketName, objectKey, objData[0]);
+        const testPutObjectRequest = versioningTestUtils.createPutObjectRequest(
+            sourceBucketName,
+            objectKey,
+            objData[0],
+        );
         const testObjectCopyRequest = _createObjectCopyRequest(destBucketName);
         objectPut(authInfo, testPutObjectRequest, undefined, log, err => {
             assert.ifError(err);
-            objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey, undefined, log,
-                err => {
-                    assert.ifError(err);
-                    sinon.assert.calledWith(metadata.putObjectMD.lastCall,
-                        destBucketName, objectKey, any, sinon.match({ overheadField: sinon.match.array }), any, any);
-                    done();
-                }
-            );
+            objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey, undefined, log, err => {
+                assert.ifError(err);
+                sinon.assert.calledWith(
+                    metadata.putObjectMD.lastCall,
+                    destBucketName,
+                    objectKey,
+                    any,
+                    sinon.match({ overheadField: sinon.match.array }),
+                    any,
+                    any,
+                );
+                done();
+            });
         });
     });
 
     it('should pass overheadField to metadata.putObjectMD for a versioned request', done => {
-        const testPutObjectRequest =
-            versioningTestUtils.createPutObjectRequest(sourceBucketName, objectKey, objData[0]);
+        const testPutObjectRequest = versioningTestUtils.createPutObjectRequest(
+            sourceBucketName,
+            objectKey,
+            objData[0],
+        );
         const testObjectCopyRequest = _createObjectCopyRequest(destBucketName);
         objectPut(authInfo, testPutObjectRequest, undefined, log, err => {
             assert.ifError(err);
             bucketPutVersioning(authInfo, enableVersioningRequest, log, err => {
                 assert.ifError(err);
-                objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey, undefined, log,
-                    err => {
-                        assert.ifError(err);
-                        sinon.assert.calledWith(metadata.putObjectMD.lastCall,
-                            destBucketName, objectKey, any,
-                            sinon.match({ overheadField: sinon.match.array }), any, any
-                        );
-                        done();
-                    }
-                );
+                objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey, undefined, log, err => {
+                    assert.ifError(err);
+                    sinon.assert.calledWith(
+                        metadata.putObjectMD.lastCall,
+                        destBucketName,
+                        objectKey,
+                        any,
+                        sinon.match({ overheadField: sinon.match.array }),
+                        any,
+                        any,
+                    );
+                    done();
+                });
             });
         });
     });
 
     it('should pass overheadField to metadata.putObjectMD for a version-suspended request', done => {
-        const testPutObjectRequest =
-            versioningTestUtils.createPutObjectRequest(sourceBucketName, objectKey, objData[0]);
+        const testPutObjectRequest = versioningTestUtils.createPutObjectRequest(
+            sourceBucketName,
+            objectKey,
+            objData[0],
+        );
         const testObjectCopyRequest = _createObjectCopyRequest(destBucketName);
         objectPut(authInfo, testPutObjectRequest, undefined, log, err => {
             assert.ifError(err);
             bucketPutVersioning(authInfo, suspendVersioningRequest, log, err => {
                 assert.ifError(err);
-                objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey, undefined, log,
-                    err => {
-                        assert.ifError(err);
-                        sinon.assert.calledWith(metadata.putObjectMD.lastCall,
-                            destBucketName, objectKey, any,
-                            sinon.match({ overheadField: sinon.match.array }), any, any
-                        );
-                        done();
-                    }
-                );
+                objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey, undefined, log, err => {
+                    assert.ifError(err);
+                    sinon.assert.calledWith(
+                        metadata.putObjectMD.lastCall,
+                        destBucketName,
+                        objectKey,
+                        any,
+                        sinon.match({ overheadField: sinon.match.array }),
+                        any,
+                        any,
+                    );
+                    done();
+                });
             });
         });
     });
@@ -466,10 +510,16 @@ describe('objectCopy in ingestion bucket', () => {
 
     before(() => {
         // Setup multi-backend, this is required for ingestion
-        data.switch(new storage.data.MultipleBackendGateway({
-            'us-east-1': dataClient,
-            'us-east-2': dataClient,
-        }, metadata, data.locStorageCheckFn));
+        data.switch(
+            new storage.data.MultipleBackendGateway(
+                {
+                    'us-east-1': dataClient,
+                    'us-east-2': dataClient,
+                },
+                metadata,
+                data.locStorageCheckFn,
+            ),
+        );
         data.implName = 'multipleBackends';
 
         // "mock" the data location, simulating a backend supporting server-side copy
@@ -502,19 +552,20 @@ describe('objectCopy in ingestion bucket', () => {
         sinon.restore();
     });
 
-    const newPutIngestBucketRequest = location => new DummyRequest({
-        bucketName: destBucketName,
-        namespace,
-        headers: { host: `${destBucketName}.s3.amazonaws.com` },
-        url: '/',
-        post: '<?xml version="1.0" encoding="UTF-8"?>' +
-            '<CreateBucketConfiguration ' +
-            'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
-            `<LocationConstraint>${location}</LocationConstraint>` +
-            '</CreateBucketConfiguration>',
-    });
-    const putSourceObjectRequest = versioningTestUtils.createPutObjectRequest(
-        sourceBucketName, objectKey, objData[0]);
+    const newPutIngestBucketRequest = location =>
+        new DummyRequest({
+            bucketName: destBucketName,
+            namespace,
+            headers: { host: `${destBucketName}.s3.amazonaws.com` },
+            url: '/',
+            post:
+                '<?xml version="1.0" encoding="UTF-8"?>' +
+                '<CreateBucketConfiguration ' +
+                'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+                `<LocationConstraint>${location}</LocationConstraint>` +
+                '</CreateBucketConfiguration>',
+        });
+    const putSourceObjectRequest = versioningTestUtils.createPutObjectRequest(sourceBucketName, objectKey, objData[0]);
     const newPutObjectRequest = params => {
         const { location } = params || {};
         const r = _createObjectCopyRequest(destBucketName);
@@ -531,17 +582,28 @@ describe('objectCopy in ingestion bucket', () => {
         const versionID = versioning.VersionID.encode(versioning.VersionID.generateVersionId('0', ''));
         dataClient.copyObject = sinon.stub().yields(null, objectKey, versionID);
 
-        async.series([
-            next => bucketPut(authInfo, putSourceBucketRequest, log, next),
-            next => bucketPut(authInfo, newPutIngestBucketRequest('us-east-1:ingest'), log, next),
-            next => objectPut(authInfo, putSourceObjectRequest, undefined, log, next),
-            next => objectCopy(authInfo, newPutObjectRequest(), sourceBucketName, objectKey, undefined, log,
-                (err, xml, headers) => {
-                    assert.ifError(err);
-                    assert.strictEqual(headers['x-amz-version-id'], versionID);
-                    next();
-                }),
-        ], done);
+        async.series(
+            [
+                next => bucketPut(authInfo, putSourceBucketRequest, log, next),
+                next => bucketPut(authInfo, newPutIngestBucketRequest('us-east-1:ingest'), log, next),
+                next => objectPut(authInfo, putSourceObjectRequest, undefined, log, next),
+                next =>
+                    objectCopy(
+                        authInfo,
+                        newPutObjectRequest(),
+                        sourceBucketName,
+                        objectKey,
+                        undefined,
+                        log,
+                        (err, xml, headers) => {
+                            assert.ifError(err);
+                            assert.strictEqual(headers['x-amz-version-id'], versionID);
+                            next();
+                        },
+                    ),
+            ],
+            done,
+        );
     });
 
     it('should not use the versionID from the backend when writing in another location', done => {
@@ -549,34 +611,56 @@ describe('objectCopy in ingestion bucket', () => {
         dataClient.copyObject = sinon.stub().yields(null, objectKey, versionID);
 
         const copyObjectRequest = newPutObjectRequest({ location: 'us-east-2' });
-        async.series([
-            next => bucketPut(authInfo, putSourceBucketRequest, log, next),
-            next => bucketPut(authInfo, newPutIngestBucketRequest('us-east-1:ingest'), log, next),
-            next => objectPut(authInfo, putSourceObjectRequest, undefined, log, next),
-            next => objectCopy(authInfo, copyObjectRequest, sourceBucketName, objectKey, undefined, log,
-                (err, xml, headers) => {
-                    assert.ifError(err);
-                    assert.notEqual(headers['x-amz-version-id'], versionID);
-                    next();
-                }),
-        ], done);
+        async.series(
+            [
+                next => bucketPut(authInfo, putSourceBucketRequest, log, next),
+                next => bucketPut(authInfo, newPutIngestBucketRequest('us-east-1:ingest'), log, next),
+                next => objectPut(authInfo, putSourceObjectRequest, undefined, log, next),
+                next =>
+                    objectCopy(
+                        authInfo,
+                        copyObjectRequest,
+                        sourceBucketName,
+                        objectKey,
+                        undefined,
+                        log,
+                        (err, xml, headers) => {
+                            assert.ifError(err);
+                            assert.notEqual(headers['x-amz-version-id'], versionID);
+                            next();
+                        },
+                    ),
+            ],
+            done,
+        );
     });
 
     it('should not use the versionID from the backend when it is not a valid versionID', done => {
         const versionID = undefined;
         dataClient.copyObject = sinon.stub().yields(null, objectKey, versionID);
 
-        async.series([
-            next => bucketPut(authInfo, putSourceBucketRequest, log, next),
-            next => bucketPut(authInfo, newPutIngestBucketRequest('us-east-1:ingest'), log, next),
-            next => objectPut(authInfo, putSourceObjectRequest, undefined, log, next),
-            next => objectCopy(authInfo, newPutObjectRequest(), sourceBucketName, objectKey, undefined, log,
-                (err, xml, headers) => {
-                    assert.ifError(err);
-                    assert.notEqual(headers['x-amz-version-id'], versionID);
-                    next();
-                }),
-        ], done);
+        async.series(
+            [
+                next => bucketPut(authInfo, putSourceBucketRequest, log, next),
+                next => bucketPut(authInfo, newPutIngestBucketRequest('us-east-1:ingest'), log, next),
+                next => objectPut(authInfo, putSourceObjectRequest, undefined, log, next),
+                next =>
+                    objectCopy(
+                        authInfo,
+                        newPutObjectRequest(),
+                        sourceBucketName,
+                        objectKey,
+                        undefined,
+                        log,
+                        (err, xml, headers) => {
+                            assert.ifError(err);
+                            assert.notEqual(headers['x-amz-version-id'], versionID);
+                            next();
+                        },
+                    ),
+            ],
+            done,
+        );
     });
 });
 
@@ -585,12 +669,21 @@ describe('objectCopy with objectKeyByteLimit', () => {
 
     beforeEach(done => {
         cleanup();
-        async.series([
-            next => bucketPut(authInfo, putDestBucketRequest, log, next),
-            next => bucketPut(authInfo, putSourceBucketRequest, log, next),
-            next => objectPut(authInfo, versioningTestUtils.createPutObjectRequest(
-                sourceBucketName, objectKey, objData[0]), undefined, log, next),
-        ], done);
+        async.series(
+            [
+                next => bucketPut(authInfo, putDestBucketRequest, log, next),
+                next => bucketPut(authInfo, putSourceBucketRequest, log, next),
+                next =>
+                    objectPut(
+                        authInfo,
+                        versioningTestUtils.createPutObjectRequest(sourceBucketName, objectKey, objData[0]),
+                        undefined,
+                        log,
+                        next,
+                    ),
+            ],
+            done,
+        );
     });
 
     afterEach(() => {
@@ -603,13 +696,12 @@ describe('objectCopy with objectKeyByteLimit', () => {
         testCopyObjectRequest.objectKey = longDestKey;
         testCopyObjectRequest.url = `/${destBucketName}/${longDestKey}`;
 
-        objectCopy(authInfo, testCopyObjectRequest, sourceBucketName, objectKey,
-            undefined, log, err => {
-                assert(err);
-                assert.strictEqual(err.KeyTooLong, true);
-                assert.match(err.description, /915/);
-                done();
-            });
+        objectCopy(authInfo, testCopyObjectRequest, sourceBucketName, objectKey, undefined, log, err => {
+            assert(err);
+            assert.strictEqual(err.KeyTooLong, true);
+            assert.match(err.description, /915/);
+            done();
+        });
     });
 
     it('should accept destination object key longer than 915 bytes with objectKeyByteLimit', done => {
@@ -620,12 +712,11 @@ describe('objectCopy with objectKeyByteLimit', () => {
         testCopyObjectRequest.objectKey = longDestKey;
         testCopyObjectRequest.url = `/${destBucketName}/${longDestKey}`;
 
-        objectCopy(authInfo, testCopyObjectRequest, sourceBucketName, objectKey,
-            undefined, log, (err, xml) => {
-                assert.ifError(err);
-                assert(xml);
-                done();
-            });
+        objectCopy(authInfo, testCopyObjectRequest, sourceBucketName, objectKey, undefined, log, (err, xml) => {
+            assert.ifError(err);
+            assert(xml);
+            done();
+        });
     });
 
     it('should reject destination object key exceeding objectKeyByteLimit', done => {
@@ -636,13 +727,12 @@ describe('objectCopy with objectKeyByteLimit', () => {
         testCopyObjectRequest.objectKey = longDestKey;
         testCopyObjectRequest.url = `/${destBucketName}/${longDestKey}`;
 
-        objectCopy(authInfo, testCopyObjectRequest, sourceBucketName, objectKey,
-            undefined, log, err => {
-                assert(err);
-                assert.strictEqual(err.KeyTooLong, true);
-                assert.match(err.description, /1024/);
-                done();
-            });
+        objectCopy(authInfo, testCopyObjectRequest, sourceBucketName, objectKey, undefined, log, err => {
+            assert(err);
+            assert.strictEqual(err.KeyTooLong, true);
+            assert.match(err.description, /1024/);
+            done();
+        });
     });
 });
 
@@ -689,10 +779,16 @@ function assertXmlContains(xml, substr, message) {
 function assertRecomputed(algo, xmlTag, expectedDigest, done) {
     return (err, xml) => {
         assert.ifError(err);
-        assertXmlContains(xml, `<${xmlTag}>${expectedDigest}</${xmlTag}>`,
-            `XML should contain ${xmlTag}=${expectedDigest}`);
-        assertXmlContains(xml, '<ChecksumType>FULL_OBJECT</ChecksumType>',
-            'XML should contain ChecksumType FULL_OBJECT');
+        assertXmlContains(
+            xml,
+            `<${xmlTag}>${expectedDigest}</${xmlTag}>`,
+            `XML should contain ${xmlTag}=${expectedDigest}`,
+        );
+        assertXmlContains(
+            xml,
+            '<ChecksumType>FULL_OBJECT</ChecksumType>',
+            'XML should contain ChecksumType FULL_OBJECT',
+        );
         metadata.getObjectMD(destBucketName, objectKey, {}, log, (err, md) => {
             assert.ifError(err);
             assert(md.checksum, 'destination should have a checksum');
@@ -707,12 +803,21 @@ function assertRecomputed(algo, xmlTag, expectedDigest, done) {
 describe('objectCopy checksum propagation', () => {
     beforeEach(done => {
         cleanup();
-        async.series([
-            next => bucketPut(authInfo, putDestBucketRequest, log, next),
-            next => bucketPut(authInfo, putSourceBucketRequest, log, next),
-            next => objectPut(authInfo, versioningTestUtils.createPutObjectRequest(
-                sourceBucketName, objectKey, objData[0]), undefined, log, next),
-        ], done);
+        async.series(
+            [
+                next => bucketPut(authInfo, putDestBucketRequest, log, next),
+                next => bucketPut(authInfo, putSourceBucketRequest, log, next),
+                next =>
+                    objectPut(
+                        authInfo,
+                        versioningTestUtils.createPutObjectRequest(sourceBucketName, objectKey, objData[0]),
+                        undefined,
+                        log,
+                        next,
+                    ),
+            ],
+            done,
+        );
     });
 
     afterEach(() => {
@@ -726,8 +831,10 @@ describe('objectCopy checksum propagation', () => {
         { algo: 'crc64nvme', header: 'CRC64NVME', xmlTag: 'ChecksumCRC64NVME', value: 'AAAAAAAAAAA=' },
         { algo: 'sha1', header: 'SHA1', xmlTag: 'ChecksumSHA1', value: 'AAAAAAAAAAAAAAAAAAAAAAAAAAA=' },
         {
-            algo: 'sha256', header: 'SHA256', xmlTag: 'ChecksumSHA256',
-            value: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+            algo: 'sha256',
+            header: 'SHA256',
+            xmlTag: 'ChecksumSHA256',
+            value: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
         },
     ];
 
@@ -741,44 +848,39 @@ describe('objectCopy checksum propagation', () => {
         function assertPropagated(xml, cb) {
             assertXmlContains(xml, `<${xmlTag}>${value}</${xmlTag}>`, `XML should contain ${xmlTag}`);
             assertXmlContains(xml, '<ChecksumType>FULL_OBJECT</ChecksumType>', 'XML should contain ChecksumType');
-            metadata.getObjectMD(destBucketName, objectKey, {}, log,
-                (err, md) => {
-                    assert.ifError(err);
-                    assert(md.checksum, 'destination should have a checksum');
-                    assert.strictEqual(md.checksum.checksumAlgorithm, algo);
-                    assert.strictEqual(md.checksum.checksumValue, value);
-                    assert.strictEqual(md.checksum.checksumType, 'FULL_OBJECT');
-                    cb();
-                });
+            metadata.getObjectMD(destBucketName, objectKey, {}, log, (err, md) => {
+                assert.ifError(err);
+                assert(md.checksum, 'destination should have a checksum');
+                assert.strictEqual(md.checksum.checksumAlgorithm, algo);
+                assert.strictEqual(md.checksum.checksumValue, value);
+                assert.strictEqual(md.checksum.checksumType, 'FULL_OBJECT');
+                cb();
+            });
         }
 
-        it(`should propagate a FULL_OBJECT ${algo} checksum from source to destination`,
-            done => {
-                setSourceChecksum(sourceChecksum, err => {
+        it(`should propagate a FULL_OBJECT ${algo} checksum from source to destination`, done => {
+            setSourceChecksum(sourceChecksum, err => {
+                assert.ifError(err);
+                const req = _createObjectCopyRequest(destBucketName);
+                objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, (err, xml) => {
                     assert.ifError(err);
-                    const req = _createObjectCopyRequest(destBucketName);
-                    objectCopy(authInfo, req, sourceBucketName, objectKey,
-                        undefined, log, (err, xml) => {
-                            assert.ifError(err);
-                            assertPropagated(xml, done);
-                        });
+                    assertPropagated(xml, done);
                 });
             });
+        });
 
-        it(`should propagate when x-amz-checksum-algorithm matches source ${algo} algorithm`,
-            done => {
-                setSourceChecksum(sourceChecksum, err => {
+        it(`should propagate when x-amz-checksum-algorithm matches source ${algo} algorithm`, done => {
+            setSourceChecksum(sourceChecksum, err => {
+                assert.ifError(err);
+                const req = _createObjectCopyRequest(destBucketName, {
+                    'x-amz-checksum-algorithm': header,
+                });
+                objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, (err, xml) => {
                     assert.ifError(err);
-                    const req = _createObjectCopyRequest(destBucketName, {
-                        'x-amz-checksum-algorithm': header,
-                    });
-                    objectCopy(authInfo, req, sourceBucketName, objectKey,
-                        undefined, log, (err, xml) => {
-                            assert.ifError(err);
-                            assertPropagated(xml, done);
-                        });
+                    assertPropagated(xml, done);
                 });
             });
+        });
     });
 
     it('should default to CRC64NVME when source has no checksum and no algorithm is requested', done => {
@@ -788,9 +890,15 @@ describe('objectCopy checksum propagation', () => {
             }
             return Promise.resolve(algorithms.crc64nvme.digest(objData[0])).then(expectedDigest => {
                 const req = _createObjectCopyRequest(destBucketName);
-                objectCopy(authInfo, req, sourceBucketName, objectKey,
-                    undefined, log,
-                    assertRecomputed('crc64nvme', 'ChecksumCRC64NVME', expectedDigest, done));
+                objectCopy(
+                    authInfo,
+                    req,
+                    sourceBucketName,
+                    objectKey,
+                    undefined,
+                    log,
+                    assertRecomputed('crc64nvme', 'ChecksumCRC64NVME', expectedDigest, done),
+                );
             }, done);
         });
     });
@@ -799,12 +907,21 @@ describe('objectCopy checksum propagation', () => {
 describe('objectCopy checksum recompute', () => {
     beforeEach(done => {
         cleanup();
-        async.series([
-            next => bucketPut(authInfo, putDestBucketRequest, log, next),
-            next => bucketPut(authInfo, putSourceBucketRequest, log, next),
-            next => objectPut(authInfo, versioningTestUtils.createPutObjectRequest(
-                sourceBucketName, objectKey, objData[0]), undefined, log, next),
-        ], done);
+        async.series(
+            [
+                next => bucketPut(authInfo, putDestBucketRequest, log, next),
+                next => bucketPut(authInfo, putSourceBucketRequest, log, next),
+                next =>
+                    objectPut(
+                        authInfo,
+                        versioningTestUtils.createPutObjectRequest(sourceBucketName, objectKey, objData[0]),
+                        undefined,
+                        log,
+                        next,
+                    ),
+            ],
+            done,
+        );
     });
 
     afterEach(() => {
@@ -825,61 +942,14 @@ describe('objectCopy checksum recompute', () => {
             // Seed source with a different algorithm so the request forces a recompute.
             // crc32 ↔ sha256 swap covers both pivots.
             const sourceAlgo = algo === 'crc32' ? 'sha256' : 'crc32';
-            const sourceValue = sourceAlgo === 'crc32'
-                ? 'AAAAAA=='
-                : '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';
-            setSourceChecksum({
-                checksumAlgorithm: sourceAlgo,
-                checksumValue: sourceValue,
-                checksumType: 'FULL_OBJECT',
-            }, err => {
-                if (err) {
-                    return done(err);
-                }
-                return Promise.resolve(algorithms[algo].digest(objData[0])).then(expectedDigest => {
-                    const req = _createObjectCopyRequest(destBucketName, {
-                        'x-amz-checksum-algorithm': header,
-                    });
-                    objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log,
-                        assertRecomputed(algo, xmlTag, expectedDigest, done));
-                }, done);
-            });
-        });
-
-        // CRC64NVME cannot be used as COMPOSITE (AWS rejects it at MPU init); only test
-        // the COMPOSITE-source path for the four other algorithms.
-        if (algo !== 'crc64nvme') {
-            it(`should recompute ${algo} when source is COMPOSITE and no algorithm requested`, done => {
-                setSourceChecksum({
-                    checksumAlgorithm: algo,
-                    // valid-shape placeholder; the test does not depend on the source value
-                    // matching the body — only on the destination digest being recomputed.
-                    checksumValue: 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=',
-                    checksumType: 'COMPOSITE',
-                }, err => {
-                    if (err) {
-                        return done(err);
-                    }
-                    return Promise.resolve(algorithms[algo].digest(objData[0])).then(expectedDigest => {
-                        const req = _createObjectCopyRequest(destBucketName);
-                        objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log,
-                            assertRecomputed(algo, xmlTag, expectedDigest, done));
-                    }, done);
-                });
-            });
-
-            it(`should recompute ${algo} when source is COMPOSITE and different algorithm requested`, done => {
-                // Force a recompute by both source-type (COMPOSITE) and algo mismatch.
-                // Seed source with sha256 COMPOSITE so the requested algo always differs.
-                const sourceAlgo = algo === 'sha256' ? 'sha1' : 'sha256';
-                const sourceValue = sourceAlgo === 'sha1'
-                    ? 'AAAAAAAAAAAAAAAAAAAAAAAAAAA='
-                    : '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';
-                setSourceChecksum({
+            const sourceValue = sourceAlgo === 'crc32' ? 'AAAAAA==' : '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';
+            setSourceChecksum(
+                {
                     checksumAlgorithm: sourceAlgo,
                     checksumValue: sourceValue,
-                    checksumType: 'COMPOSITE',
-                }, err => {
+                    checksumType: 'FULL_OBJECT',
+                },
+                err => {
                     if (err) {
                         return done(err);
                     }
@@ -887,10 +957,86 @@ describe('objectCopy checksum recompute', () => {
                         const req = _createObjectCopyRequest(destBucketName, {
                             'x-amz-checksum-algorithm': header,
                         });
-                        objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log,
-                            assertRecomputed(algo, xmlTag, expectedDigest, done));
+                        objectCopy(
+                            authInfo,
+                            req,
+                            sourceBucketName,
+                            objectKey,
+                            undefined,
+                            log,
+                            assertRecomputed(algo, xmlTag, expectedDigest, done),
+                        );
                     }, done);
-                });
+                },
+            );
+        });
+
+        // CRC64NVME cannot be used as COMPOSITE (AWS rejects it at MPU init); only test
+        // the COMPOSITE-source path for the four other algorithms.
+        if (algo !== 'crc64nvme') {
+            it(`should recompute ${algo} when source is COMPOSITE and no algorithm requested`, done => {
+                setSourceChecksum(
+                    {
+                        checksumAlgorithm: algo,
+                        // valid-shape placeholder; the test does not depend on the source value
+                        // matching the body — only on the destination digest being recomputed.
+                        checksumValue: 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=',
+                        checksumType: 'COMPOSITE',
+                    },
+                    err => {
+                        if (err) {
+                            return done(err);
+                        }
+                        return Promise.resolve(algorithms[algo].digest(objData[0])).then(expectedDigest => {
+                            const req = _createObjectCopyRequest(destBucketName);
+                            objectCopy(
+                                authInfo,
+                                req,
+                                sourceBucketName,
+                                objectKey,
+                                undefined,
+                                log,
+                                assertRecomputed(algo, xmlTag, expectedDigest, done),
+                            );
+                        }, done);
+                    },
+                );
+            });
+
+            it(`should recompute ${algo} when source is COMPOSITE and different algorithm requested`, done => {
+                // Force a recompute by both source-type (COMPOSITE) and algo mismatch.
+                // Seed source with sha256 COMPOSITE so the requested algo always differs.
+                const sourceAlgo = algo === 'sha256' ? 'sha1' : 'sha256';
+                const sourceValue =
+                    sourceAlgo === 'sha1'
+                        ? 'AAAAAAAAAAAAAAAAAAAAAAAAAAA='
+                        : '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';
+                setSourceChecksum(
+                    {
+                        checksumAlgorithm: sourceAlgo,
+                        checksumValue: sourceValue,
+                        checksumType: 'COMPOSITE',
+                    },
+                    err => {
+                        if (err) {
+                            return done(err);
+                        }
+                        return Promise.resolve(algorithms[algo].digest(objData[0])).then(expectedDigest => {
+                            const req = _createObjectCopyRequest(destBucketName, {
+                                'x-amz-checksum-algorithm': header,
+                            });
+                            objectCopy(
+                                authInfo,
+                                req,
+                                sourceBucketName,
+                                objectKey,
+                                undefined,
+                                log,
+                                assertRecomputed(algo, xmlTag, expectedDigest, done),
+                            );
+                        }, done);
+                    },
+                );
             });
         }
 
@@ -903,8 +1049,15 @@ describe('objectCopy checksum recompute', () => {
                     const req = _createObjectCopyRequest(destBucketName, {
                         'x-amz-checksum-algorithm': header,
                     });
-                    objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log,
-                        assertRecomputed(algo, xmlTag, expectedDigest, done));
+                    objectCopy(
+                        authInfo,
+                        req,
+                        sourceBucketName,
+                        objectKey,
+                        undefined,
+                        log,
+                        assertRecomputed(algo, xmlTag, expectedDigest, done),
+                    );
                 }, done);
             });
         });
@@ -930,17 +1083,19 @@ describe('objectCopy checksum recompute', () => {
             md['content-length'] = fullBody.length;
             metadata.putObjectMD(sourceBucketName, objectKey, md, {}, log, err => {
                 assert.ifError(err);
-                Promise.resolve(algorithms.sha256.digest(fullBody)).then(expectedDigest => {
-                    const req = _createObjectCopyRequest(destBucketName, {
-                        'x-amz-checksum-algorithm': 'SHA256',
-                    });
-                    objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log,
-                        (err, xml) => {
+                Promise.resolve(algorithms.sha256.digest(fullBody)).then(
+                    expectedDigest => {
+                        const req = _createObjectCopyRequest(destBucketName, {
+                            'x-amz-checksum-algorithm': 'SHA256',
+                        });
+                        objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, (err, xml) => {
                             assertRecomputed('sha256', 'ChecksumSHA256', expectedDigest, done)(err, xml);
                         });
-                }, err => {
-                    done(err);
-                });
+                    },
+                    err => {
+                        done(err);
+                    },
+                );
             });
         });
     });
@@ -956,29 +1111,32 @@ describe('objectCopy checksum recompute', () => {
                 'x-amz-checksum-algorithm': 'SHA256',
                 'x-amz-server-side-encryption': 'AES256',
             });
-            objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log,
+            objectCopy(
+                authInfo,
+                req,
+                sourceBucketName,
+                objectKey,
+                undefined,
+                log,
                 assertRecomputed('sha256', 'ChecksumSHA256', expectedDigest, err => {
                     if (err) {
                         return done(err);
                     }
                     try {
-                        assert(cipherBundleSpy.calledOnce,
-                            'kms.createCipherBundle should be called once');
+                        assert(cipherBundleSpy.calledOnce, 'kms.createCipherBundle should be called once');
                         const sseConfig = cipherBundleSpy.firstCall.args[0];
                         assert.strictEqual(sseConfig.algorithm, 'AES256');
                         // The data.put call that consumed the checksum stream
                         // (size > 0) should have received a non-null cipherBundle.
-                        const recomputePut = dataPutSpy.getCalls()
-                            .find(call => call.args[1] !== null);
-                        assert(recomputePut,
-                            'expected at least one data.put with a real stream');
-                        assert(recomputePut.args[0],
-                            'cipherBundle should be non-null for SSE recompute');
+                        const recomputePut = dataPutSpy.getCalls().find(call => call.args[1] !== null);
+                        assert(recomputePut, 'expected at least one data.put with a real stream');
+                        assert(recomputePut.args[0], 'cipherBundle should be non-null for SSE recompute');
                         return done();
                     } catch (e) {
                         return done(e);
                     }
-                }));
+                }),
+            );
         }, done);
     });
 
@@ -994,8 +1152,11 @@ describe('objectCopy checksum recompute', () => {
             assert.ifError(err);
             metadata.getObjectMD(destBucketName, objectKey, {}, log, (err, md) => {
                 assert.ifError(err);
-                assert.strictEqual(md.location[0].dataStoreETag, `1:${expectedMD5}`,
-                    'recomputed destination location should carry a 1:-prefixed MD5 dataStoreETag');
+                assert.strictEqual(
+                    md.location[0].dataStoreETag,
+                    `1:${expectedMD5}`,
+                    'recomputed destination location should carry a 1:-prefixed MD5 dataStoreETag',
+                );
                 done();
             });
         });
@@ -1036,17 +1197,19 @@ describe('objectCopy checksum recompute', () => {
             md.location = [{ ...md.location[0], dataStoreType: 'azure' }];
             metadata.putObjectMD(sourceBucketName, objectKey, md, {}, log, err => {
                 assert.ifError(err);
-                Promise.resolve(algorithms.sha256.digest(objData[0])).then(expectedDigest => {
-                    const req = _createObjectCopyRequest(destBucketName, {
-                        'x-amz-checksum-algorithm': 'SHA256',
-                    });
-                    objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log,
-                        (err, xml) => {
+                Promise.resolve(algorithms.sha256.digest(objData[0])).then(
+                    expectedDigest => {
+                        const req = _createObjectCopyRequest(destBucketName, {
+                            'x-amz-checksum-algorithm': 'SHA256',
+                        });
+                        objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, (err, xml) => {
                             assertRecomputed('sha256', 'ChecksumSHA256', expectedDigest, done)(err, xml);
                         });
-                }, err => {
-                    done(err);
-                });
+                    },
+                    err => {
+                        done(err);
+                    },
+                );
             });
         });
     });
@@ -1082,14 +1245,18 @@ describe('objectCopy checksum recompute', () => {
                         assert.ifError(err);
                         assert(!dataPutSpy.called, 'data.put should NOT be called');
                         assert(!batchDeleteSpy.called, 'data.batchDelete should NOT be called');
-                        assertXmlContains(xml, `<${xmlTag}>${expectedDigest}</${xmlTag}>`,
-                            'response XML should carry the new checksum');
+                        assertXmlContains(
+                            xml,
+                            `<${xmlTag}>${expectedDigest}</${xmlTag}>`,
+                            'response XML should carry the new checksum',
+                        );
                         metadata.getObjectMD(sourceBucketName, objectKey, {}, log, (err, md) => {
                             assert.ifError(err);
                             assert.deepStrictEqual(
                                 md.location.map(l => l.key),
                                 sourceLocation.map(l => l.key),
-                                'data location keys should be reused');
+                                'data location keys should be reused',
+                            );
                             assert.strictEqual(md.checksum.checksumAlgorithm, algo);
                             assert.strictEqual(md.checksum.checksumValue, expectedDigest);
                             assert.strictEqual(md.checksum.checksumType, 'FULL_OBJECT');
@@ -1115,50 +1282,64 @@ describe('objectCopy checksum recompute', () => {
             // reusing the data location.
             const dataPutSpy = sinon.spy(data, 'put');
             const batchDeleteSpy = sinon.spy(data, 'batchDelete');
-            setSourceChecksum({
-                checksumAlgorithm: algo,
-                // placeholder COMPOSITE value, distinct from the FULL_OBJECT digest
-                checksumValue: 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=',
-                checksumType: 'COMPOSITE',
-            }, err => {
-                assert.ifError(err);
-                Promise.resolve(algorithms[algo].digest(objData[0])).then(expectedDigest => {
-                    const req = new DummyRequest({
-                        bucketName: sourceBucketName,
-                        namespace,
-                        objectKey,
-                        headers: { 'x-amz-metadata-directive': 'REPLACE' },
-                        url: `/${sourceBucketName}/${objectKey}`,
-                        socket: {},
-                    });
-                    objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, (err, xml) => {
-                        assert.ifError(err);
-                        assert(!dataPutSpy.called, 'data.put should NOT be called (location reused)');
-                        assert(!batchDeleteSpy.called, 'data.batchDelete should NOT be called');
-                        assertXmlContains(xml, `<${xmlTag}>${expectedDigest}</${xmlTag}>`,
-                            'response XML should carry the recomputed FULL_OBJECT digest');
-                        assertXmlContains(xml, '<ChecksumType>FULL_OBJECT</ChecksumType>',
-                            'response XML must say FULL_OBJECT, never COMPOSITE');
-                        metadata.getObjectMD(sourceBucketName, objectKey, {}, log, (err, md) => {
-                            assert.ifError(err);
-                            assert.strictEqual(md.checksum.checksumType, 'FULL_OBJECT',
-                                'stored checksum must be FULL_OBJECT, never COMPOSITE');
-                            assert.strictEqual(md.checksum.checksumAlgorithm, algo);
-                            assert.strictEqual(md.checksum.checksumValue, expectedDigest,
-                                'value must be the recomputed FULL_OBJECT digest, not the source COMPOSITE value');
-                            done();
+            setSourceChecksum(
+                {
+                    checksumAlgorithm: algo,
+                    // placeholder COMPOSITE value, distinct from the FULL_OBJECT digest
+                    checksumValue: 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=',
+                    checksumType: 'COMPOSITE',
+                },
+                err => {
+                    assert.ifError(err);
+                    Promise.resolve(algorithms[algo].digest(objData[0])).then(expectedDigest => {
+                        const req = new DummyRequest({
+                            bucketName: sourceBucketName,
+                            namespace,
+                            objectKey,
+                            headers: { 'x-amz-metadata-directive': 'REPLACE' },
+                            url: `/${sourceBucketName}/${objectKey}`,
+                            socket: {},
                         });
-                    });
-                }, done);
-            });
+                        objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, (err, xml) => {
+                            assert.ifError(err);
+                            assert(!dataPutSpy.called, 'data.put should NOT be called (location reused)');
+                            assert(!batchDeleteSpy.called, 'data.batchDelete should NOT be called');
+                            assertXmlContains(
+                                xml,
+                                `<${xmlTag}>${expectedDigest}</${xmlTag}>`,
+                                'response XML should carry the recomputed FULL_OBJECT digest',
+                            );
+                            assertXmlContains(
+                                xml,
+                                '<ChecksumType>FULL_OBJECT</ChecksumType>',
+                                'response XML must say FULL_OBJECT, never COMPOSITE',
+                            );
+                            metadata.getObjectMD(sourceBucketName, objectKey, {}, log, (err, md) => {
+                                assert.ifError(err);
+                                assert.strictEqual(
+                                    md.checksum.checksumType,
+                                    'FULL_OBJECT',
+                                    'stored checksum must be FULL_OBJECT, never COMPOSITE',
+                                );
+                                assert.strictEqual(md.checksum.checksumAlgorithm, algo);
+                                assert.strictEqual(
+                                    md.checksum.checksumValue,
+                                    expectedDigest,
+                                    'value must be the recomputed FULL_OBJECT digest, not the source COMPOSITE value',
+                                );
+                                done();
+                            });
+                        });
+                    }, done);
+                },
+            );
         });
     });
 
     it('should still PUT on copy-to-self when versioning is enabled (no metadata-only shortcut)', done => {
         // Versioned copies produce a new version-id; the metadata-only path
         // is skipped so the new version gets its own data write.
-        const enableVersioning = versioningTestUtils
-            .createBucketPutVersioningReq(sourceBucketName, 'Enabled');
+        const enableVersioning = versioningTestUtils.createBucketPutVersioningReq(sourceBucketName, 'Enabled');
         bucketPutVersioning(authInfo, enableVersioning, log, err => {
             assert.ifError(err);
             const dataPutSpy = sinon.spy(data, 'put');
@@ -1175,8 +1356,7 @@ describe('objectCopy checksum recompute', () => {
             });
             objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, err => {
                 assert.ifError(err);
-                assert(dataPutSpy.called,
-                    'data.put should be called because versioning forces a new version write');
+                assert(dataPutSpy.called, 'data.put should be called because versioning forces a new version write');
                 done();
             });
         });
@@ -1201,12 +1381,21 @@ describe('objectCopy checksum recompute on external backends', () => {
 
     beforeEach(done => {
         cleanup();
-        async.series([
-            next => bucketPut(authInfo, putDestBucketRequest, log, next),
-            next => bucketPut(authInfo, putSourceBucketRequest, log, next),
-            next => objectPut(authInfo, versioningTestUtils.createPutObjectRequest(
-                sourceBucketName, objectKey, objData[0]), undefined, log, next),
-        ], done);
+        async.series(
+            [
+                next => bucketPut(authInfo, putDestBucketRequest, log, next),
+                next => bucketPut(authInfo, putSourceBucketRequest, log, next),
+                next =>
+                    objectPut(
+                        authInfo,
+                        versioningTestUtils.createPutObjectRequest(sourceBucketName, objectKey, objData[0]),
+                        undefined,
+                        log,
+                        next,
+                    ),
+            ],
+            done,
+        );
     });
 
     afterEach(() => {
@@ -1224,10 +1413,12 @@ describe('objectCopy checksum recompute on external backends', () => {
             });
             objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, (err, xml) => {
                 assert.ifError(err);
-                assert(!copyObjectSpy.called,
-                    'data.copyObject should NOT be called (recompute streams instead)');
-                assertXmlContains(xml, `<ChecksumSHA256>${expectedDigest}</ChecksumSHA256>`,
-                    'response XML should carry the recomputed checksum');
+                assert(!copyObjectSpy.called, 'data.copyObject should NOT be called (recompute streams instead)');
+                assertXmlContains(
+                    xml,
+                    `<ChecksumSHA256>${expectedDigest}</ChecksumSHA256>`,
+                    'response XML should carry the recomputed checksum',
+                );
                 metadata.getObjectMD(destBucketName, objectKey, {}, log, (err, md) => {
                     assert.ifError(err);
                     assert.strictEqual(md.checksum.checksumType, 'FULL_OBJECT');
@@ -1250,10 +1441,12 @@ describe('objectCopy checksum recompute on external backends', () => {
             });
             objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, (err, xml) => {
                 assert.ifError(err);
-                assert(!copyObjectSpy.called,
-                    'data.copyObject should NOT be called (recompute streams instead)');
-                assertXmlContains(xml, `<ChecksumSHA256>${expectedDigest}</ChecksumSHA256>`,
-                    'response XML should carry the recomputed checksum');
+                assert(!copyObjectSpy.called, 'data.copyObject should NOT be called (recompute streams instead)');
+                assertXmlContains(
+                    xml,
+                    `<ChecksumSHA256>${expectedDigest}</ChecksumSHA256>`,
+                    'response XML should carry the recomputed checksum',
+                );
                 done();
             });
         }, done);
@@ -1280,8 +1473,11 @@ describe('objectCopy checksum recompute on external backends', () => {
                 assert.ifError(err);
                 assert(!copyObjectSpy.called, 'data.copyObject should NOT be called (location reused)');
                 assert(!dataPutSpy.called, 'data.put should NOT be called (location reused)');
-                assertXmlContains(xml, `<ChecksumSHA256>${expectedDigest}</ChecksumSHA256>`,
-                    'response XML should carry the recomputed checksum');
+                assertXmlContains(
+                    xml,
+                    `<ChecksumSHA256>${expectedDigest}</ChecksumSHA256>`,
+                    'response XML should carry the recomputed checksum',
+                );
                 metadata.getObjectMD(sourceBucketName, objectKey, {}, log, (err, md) => {
                     assert.ifError(err);
                     assert.strictEqual(md.checksum.checksumType, 'FULL_OBJECT');
@@ -1296,15 +1492,24 @@ describe('objectCopy checksum recompute on external backends', () => {
 describe('objectCopy checksum recompute on 0-byte source', () => {
     beforeEach(done => {
         cleanup();
-        async.series([
-            next => bucketPut(authInfo, putDestBucketRequest, log, next),
-            next => bucketPut(authInfo, putSourceBucketRequest, log, next),
-            next => objectPut(authInfo, versioningTestUtils.createPutObjectRequest(
-                sourceBucketName, objectKey, objData[0]), undefined, log, next),
-            // Truncate the source to 0 bytes (no data location, content-length 0).
-            // Matches the AWS behavior we're exercising: empty source + recompute.
-            next => setSourceEmptyBody(next),
-        ], done);
+        async.series(
+            [
+                next => bucketPut(authInfo, putDestBucketRequest, log, next),
+                next => bucketPut(authInfo, putSourceBucketRequest, log, next),
+                next =>
+                    objectPut(
+                        authInfo,
+                        versioningTestUtils.createPutObjectRequest(sourceBucketName, objectKey, objData[0]),
+                        undefined,
+                        log,
+                        next,
+                    ),
+                // Truncate the source to 0 bytes (no data location, content-length 0).
+                // Matches the AWS behavior we're exercising: empty source + recompute.
+                next => setSourceEmptyBody(next),
+            ],
+            done,
+        );
     });
 
     afterEach(() => {
@@ -1330,8 +1535,15 @@ describe('objectCopy checksum recompute on 0-byte source', () => {
                     const req = _createObjectCopyRequest(destBucketName, {
                         'x-amz-checksum-algorithm': header,
                     });
-                    objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log,
-                        assertRecomputed(algo, xmlTag, expectedDigest, done));
+                    objectCopy(
+                        authInfo,
+                        req,
+                        sourceBucketName,
+                        objectKey,
+                        undefined,
+                        log,
+                        assertRecomputed(algo, xmlTag, expectedDigest, done),
+                    );
                 }, done);
             });
         });
@@ -1340,42 +1552,55 @@ describe('objectCopy checksum recompute on 0-byte source', () => {
     it('should recompute empty-bytes digest on COMPOSITE 0-byte source (no algo header)', done => {
         // COMPOSITE source forces recompute even with no algorithm header.
         // Use sha256 placeholder; the dest digest will be the empty-bytes sha256.
-        setSourceChecksum({
-            checksumAlgorithm: 'sha256',
-            checksumValue: '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=',
-            checksumType: 'COMPOSITE',
-        }, err => {
-            assert.ifError(err);
-            Promise.resolve(algorithms.sha256.digest(Buffer.alloc(0))).then(expectedDigest => {
-                const req = _createObjectCopyRequest(destBucketName);
-                objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log,
-                    assertRecomputed('sha256', 'ChecksumSHA256', expectedDigest, done));
-            }, done);
-        });
+        setSourceChecksum(
+            {
+                checksumAlgorithm: 'sha256',
+                checksumValue: '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=',
+                checksumType: 'COMPOSITE',
+            },
+            err => {
+                assert.ifError(err);
+                Promise.resolve(algorithms.sha256.digest(Buffer.alloc(0))).then(expectedDigest => {
+                    const req = _createObjectCopyRequest(destBucketName);
+                    objectCopy(
+                        authInfo,
+                        req,
+                        sourceBucketName,
+                        objectKey,
+                        undefined,
+                        log,
+                        assertRecomputed('sha256', 'ChecksumSHA256', expectedDigest, done),
+                    );
+                }, done);
+            },
+        );
     });
 
     it('should propagate FULL_OBJECT checksum on 0-byte source (no algo header)', done => {
         // The 0-byte recompute path must not override propagation set by _prepMetadata.
-        setSourceChecksum({
-            checksumAlgorithm: 'crc32',
-            checksumValue: 'AAAAAA==',
-            checksumType: 'FULL_OBJECT',
-        }, err => {
-            assert.ifError(err);
-            const req = _createObjectCopyRequest(destBucketName);
-            objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, (err, xml) => {
+        setSourceChecksum(
+            {
+                checksumAlgorithm: 'crc32',
+                checksumValue: 'AAAAAA==',
+                checksumType: 'FULL_OBJECT',
+            },
+            err => {
                 assert.ifError(err);
-                assertXmlContains(xml, '<ChecksumCRC32>AAAAAA==</ChecksumCRC32>');
-                assertXmlContains(xml, '<ChecksumType>FULL_OBJECT</ChecksumType>');
-                metadata.getObjectMD(destBucketName, objectKey, {}, log, (err, md) => {
+                const req = _createObjectCopyRequest(destBucketName);
+                objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, (err, xml) => {
                     assert.ifError(err);
-                    assert.strictEqual(md.checksum.checksumAlgorithm, 'crc32');
-                    assert.strictEqual(md.checksum.checksumValue, 'AAAAAA==');
-                    assert.strictEqual(md.checksum.checksumType, 'FULL_OBJECT');
-                    done();
+                    assertXmlContains(xml, '<ChecksumCRC32>AAAAAA==</ChecksumCRC32>');
+                    assertXmlContains(xml, '<ChecksumType>FULL_OBJECT</ChecksumType>');
+                    metadata.getObjectMD(destBucketName, objectKey, {}, log, (err, md) => {
+                        assert.ifError(err);
+                        assert.strictEqual(md.checksum.checksumAlgorithm, 'crc32');
+                        assert.strictEqual(md.checksum.checksumValue, 'AAAAAA==');
+                        assert.strictEqual(md.checksum.checksumType, 'FULL_OBJECT');
+                        done();
+                    });
                 });
-            });
-        });
+            },
+        );
     });
 
     it('should compute empty-bytes CRC64NVME on 0-byte source with no source checksum and no algo header', done => {
@@ -1385,8 +1610,15 @@ describe('objectCopy checksum recompute on 0-byte source', () => {
             }
             return Promise.resolve(algorithms.crc64nvme.digest(Buffer.alloc(0))).then(expectedDigest => {
                 const req = _createObjectCopyRequest(destBucketName);
-                objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log,
-                    assertRecomputed('crc64nvme', 'ChecksumCRC64NVME', expectedDigest, done));
+                objectCopy(
+                    authInfo,
+                    req,
+                    sourceBucketName,
+                    objectKey,
+                    undefined,
+                    log,
+                    assertRecomputed('crc64nvme', 'ChecksumCRC64NVME', expectedDigest, done),
+                );
             }, done);
         });
     });
@@ -1411,11 +1643,20 @@ describe('objectCopy data orphan cleanup on cross-backend copy-to-self', () => {
 
     beforeEach(done => {
         cleanup();
-        async.series([
-            next => bucketPut(authInfo, putSourceBucketRequest, log, next),
-            next => objectPut(authInfo, versioningTestUtils.createPutObjectRequest(
-                sourceBucketName, objectKey, objData[0]), undefined, log, next),
-        ], done);
+        async.series(
+            [
+                next => bucketPut(authInfo, putSourceBucketRequest, log, next),
+                next =>
+                    objectPut(
+                        authInfo,
+                        versioningTestUtils.createPutObjectRequest(sourceBucketName, objectKey, objData[0]),
+                        undefined,
+                        log,
+                        next,
+                    ),
+            ],
+            done,
+        );
     });
 
     afterEach(() => {
@@ -1429,9 +1670,11 @@ describe('objectCopy data orphan cleanup on cross-backend copy-to-self', () => {
         // location-constraint). The old key is no longer referenced and must
         // be batchDeleted — guards against a pre-existing orphan bug.
         const batchDeleteSpy = sinon.spy(data, 'batchDelete');
-        sinon.stub(data, 'copyObject').callsFake(
-            (req, srcLoc, sMP, dataLocator, ctx, backendInfo, srcBM, dstBM, sse, l, cb) =>
-                cb(null, [{ key: 'new-backend-key', dataStoreName: 'us-east-2', size: objData[0].length, start: 0 }]));
+        sinon
+            .stub(data, 'copyObject')
+            .callsFake((req, srcLoc, sMP, dataLocator, ctx, backendInfo, srcBM, dstBM, sse, l, cb) =>
+                cb(null, [{ key: 'new-backend-key', dataStoreName: 'us-east-2', size: objData[0].length, start: 0 }]),
+            );
         metadata.getObjectMD(sourceBucketName, objectKey, {}, log, (err, srcMd) => {
             assert.ifError(err);
             const oldKeys = srcMd.location.map(l => l.key);
@@ -1448,12 +1691,14 @@ describe('objectCopy data orphan cleanup on cross-backend copy-to-self', () => {
             });
             objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, err => {
                 assert.ifError(err);
-                assert(batchDeleteSpy.calledOnce,
-                    'data.batchDelete should reclaim the old data location');
+                assert(batchDeleteSpy.calledOnce, 'data.batchDelete should reclaim the old data location');
                 const reclaimed = batchDeleteSpy.firstCall.args[0];
                 const reclaimedKeys = reclaimed.map(l => l.key);
-                assert.deepStrictEqual(reclaimedKeys, oldKeys,
-                    'batchDelete should target the old source key, not the new backend key');
+                assert.deepStrictEqual(
+                    reclaimedKeys,
+                    oldKeys,
+                    'batchDelete should target the old source key, not the new backend key',
+                );
                 done();
             });
         });
@@ -1468,10 +1713,11 @@ describe('objectCopy data orphan cleanup on cross-backend copy-to-self', () => {
         metadata.getObjectMD(sourceBucketName, objectKey, {}, log, (err, srcMd) => {
             assert.ifError(err);
             const oldLoc = srcMd.location[0];
-            sinon.stub(data, 'copyObject').callsFake(
-                (req, srcLoc, sMP, dataLocator, ctx, backendInfo, srcBM, dstBM, sse, l, cb) =>
-                    cb(null, [{ key: oldLoc.key, dataStoreName: 'us-east-2',
-                        size: objData[0].length, start: 0 }]));
+            sinon
+                .stub(data, 'copyObject')
+                .callsFake((req, srcLoc, sMP, dataLocator, ctx, backendInfo, srcBM, dstBM, sse, l, cb) =>
+                    cb(null, [{ key: oldLoc.key, dataStoreName: 'us-east-2', size: objData[0].length, start: 0 }]),
+                );
             const req = new DummyRequest({
                 bucketName: sourceBucketName,
                 namespace,
@@ -1485,12 +1731,17 @@ describe('objectCopy data orphan cleanup on cross-backend copy-to-self', () => {
             });
             objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, err => {
                 assert.ifError(err);
-                assert(batchDeleteSpy.calledOnce,
-                    'data.batchDelete should reclaim the old slot even when the backend key matches');
+                assert(
+                    batchDeleteSpy.calledOnce,
+                    'data.batchDelete should reclaim the old slot even when the backend key matches',
+                );
                 const reclaimed = batchDeleteSpy.firstCall.args[0];
                 assert.strictEqual(reclaimed.length, 1);
-                assert.strictEqual(reclaimed[0].dataStoreName, oldLoc.dataStoreName,
-                    'batchDelete must target the old dataStoreName, not the new one');
+                assert.strictEqual(
+                    reclaimed[0].dataStoreName,
+                    oldLoc.dataStoreName,
+                    'batchDelete must target the old dataStoreName, not the new one',
+                );
                 assert.strictEqual(reclaimed[0].key, oldLoc.key);
                 done();
             });
@@ -1501,11 +1752,20 @@ describe('objectCopy data orphan cleanup on cross-backend copy-to-self', () => {
 describe('objectCopy legacy string-location copy-to-self', () => {
     beforeEach(done => {
         cleanup();
-        async.series([
-            next => bucketPut(authInfo, putSourceBucketRequest, log, next),
-            next => objectPut(authInfo, versioningTestUtils.createPutObjectRequest(
-                sourceBucketName, objectKey, objData[0]), undefined, log, next),
-        ], done);
+        async.series(
+            [
+                next => bucketPut(authInfo, putSourceBucketRequest, log, next),
+                next =>
+                    objectPut(
+                        authInfo,
+                        versioningTestUtils.createPutObjectRequest(sourceBucketName, objectKey, objData[0]),
+                        undefined,
+                        log,
+                        next,
+                    ),
+            ],
+            done,
+        );
     });
 
     afterEach(() => {
@@ -1540,8 +1800,10 @@ describe('objectCopy legacy string-location copy-to-self', () => {
                 });
                 objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, err => {
                     assert.ifError(err);
-                    assert(batchDeleteSpy.notCalled,
-                        'the reused legacy string location must not be treated as an orphan');
+                    assert(
+                        batchDeleteSpy.notCalled,
+                        'the reused legacy string location must not be treated as an orphan',
+                    );
                     done();
                 });
             });
@@ -1582,8 +1844,7 @@ describe('_orphanedDataLocations', () => {
     it('should return only the subset of prior locations that are orphaned', () => {
         const reused = { dataStoreName: 'l1', key: 'keep' };
         const orphan = { dataStoreName: 'l1', key: 'gone' };
-        assert.deepStrictEqual(
-            orphanedDataLocations([reused, orphan], [reused]), [orphan]);
+        assert.deepStrictEqual(orphanedDataLocations([reused, orphan], [reused]), [orphan]);
     });
 
     it('should not flag a key referenced by any of several new locations', () => {
@@ -1597,12 +1858,10 @@ describe('_orphanedDataLocations', () => {
 
     it('should normalize a reused legacy string location (not an orphan)', () => {
         // pre-md-model-version-2 string location reused as { key } by goGetData
-        assert.strictEqual(
-            orphanedDataLocations(['legacyKey'], [{ key: 'legacyKey' }]), null);
+        assert.strictEqual(orphanedDataLocations(['legacyKey'], [{ key: 'legacyKey' }]), null);
     });
 
     it('should flag a legacy string location that is no longer referenced', () => {
-        assert.deepStrictEqual(
-            orphanedDataLocations(['oldKey'], [{ key: 'newKey' }]), ['oldKey']);
+        assert.deepStrictEqual(orphanedDataLocations(['oldKey'], [{ key: 'newKey' }]), ['oldKey']);
     });
 });

--- a/tests/unit/api/objectCopy.js
+++ b/tests/unit/api/objectCopy.js
@@ -662,6 +662,42 @@ function setSourceChecksum(checksum, cb) {
     });
 }
 
+// Truncate the source object to 0 bytes by clearing its data location and
+// content-length. Lets a single beforeEach setup serve both non-empty and
+// empty-source tests without rebuilding the bucket each time.
+function setSourceEmptyBody(cb) {
+    metadata.getObjectMD(sourceBucketName, objectKey, {}, log, (err, md) => {
+        if (err) {
+            return cb(err);
+        }
+        // eslint-disable-next-line no-param-reassign
+        md.location = null;
+        // eslint-disable-next-line no-param-reassign
+        md['content-length'] = 0;
+        return metadata.putObjectMD(sourceBucketName, objectKey, md, {}, log, cb);
+    });
+}
+
+// Builds the objectCopy callback that asserts a successful FULL_OBJECT recompute:
+// response XML and destination metadata both carry the expected algo and digest.
+function assertRecomputed(algo, xmlTag, expectedDigest, done) {
+    return (err, xml) => {
+        assert.ifError(err);
+        assert(xml.includes(`<${xmlTag}>${expectedDigest}</${xmlTag}>`),
+            `XML should contain ${xmlTag}=${expectedDigest}`);
+        assert(xml.includes('<ChecksumType>FULL_OBJECT</ChecksumType>'),
+            'XML should contain ChecksumType FULL_OBJECT');
+        metadata.getObjectMD(destBucketName, objectKey, {}, log, (err, md) => {
+            assert.ifError(err);
+            assert(md.checksum, 'destination should have a checksum');
+            assert.strictEqual(md.checksum.checksumAlgorithm, algo);
+            assert.strictEqual(md.checksum.checksumValue, expectedDigest);
+            assert.strictEqual(md.checksum.checksumType, 'FULL_OBJECT');
+            done();
+        });
+    };
+}
+
 describe('objectCopy checksum propagation', () => {
     beforeEach(done => {
         cleanup();
@@ -763,38 +799,6 @@ describe('objectCopy checksum recompute', () => {
     });
 
     afterEach(() => cleanup());
-
-    // Builds the objectCopy callback that asserts a successful FULL_OBJECT recompute:
-    // response XML and destination metadata both carry the expected algo and digest.
-    function assertRecomputed(algo, xmlTag, expectedDigest, done) {
-        return (err, xml) => {
-            if (err) {
-                return done(err);
-            }
-            try {
-                assert(xml.includes(`<${xmlTag}>${expectedDigest}</${xmlTag}>`),
-                    `XML should contain ${xmlTag}=${expectedDigest}`);
-                assert(xml.includes('<ChecksumType>FULL_OBJECT</ChecksumType>'),
-                    'XML should contain ChecksumType FULL_OBJECT');
-            } catch (e) {
-                return done(e);
-            }
-            return metadata.getObjectMD(destBucketName, objectKey, {}, log, (err, md) => {
-                if (err) {
-                    return done(err);
-                }
-                try {
-                    assert(md.checksum, 'destination should have a checksum');
-                    assert.strictEqual(md.checksum.checksumAlgorithm, algo);
-                    assert.strictEqual(md.checksum.checksumValue, expectedDigest);
-                    assert.strictEqual(md.checksum.checksumType, 'FULL_OBJECT');
-                    return done();
-                } catch (e) {
-                    return done(e);
-                }
-            });
-        };
-    }
 
     const recomputeFixtures = [
         { algo: 'crc32', header: 'CRC32', xmlTag: 'ChecksumCRC32' },
@@ -1225,6 +1229,102 @@ describe('objectCopy checksum recompute on external backends', () => {
                 });
             });
         }, done);
+    });
+});
+
+describe('objectCopy checksum recompute on 0-byte source', () => {
+    beforeEach(done => {
+        cleanup();
+        async.series([
+            next => bucketPut(authInfo, putDestBucketRequest, log, next),
+            next => bucketPut(authInfo, putSourceBucketRequest, log, next),
+            next => objectPut(authInfo, versioningTestUtils.createPutObjectRequest(
+                sourceBucketName, objectKey, objData[0]), undefined, log, next),
+            // Truncate the source to 0 bytes (no data location, content-length 0).
+            // Matches the AWS behavior we're exercising: empty source + recompute.
+            next => setSourceEmptyBody(next),
+        ], done);
+    });
+
+    afterEach(() => cleanup());
+
+    const recomputeFixtures = [
+        { algo: 'crc32', header: 'CRC32', xmlTag: 'ChecksumCRC32' },
+        { algo: 'crc32c', header: 'CRC32C', xmlTag: 'ChecksumCRC32C' },
+        { algo: 'crc64nvme', header: 'CRC64NVME', xmlTag: 'ChecksumCRC64NVME' },
+        { algo: 'sha1', header: 'SHA1', xmlTag: 'ChecksumSHA1' },
+        { algo: 'sha256', header: 'SHA256', xmlTag: 'ChecksumSHA256' },
+    ];
+
+    recomputeFixtures.forEach(({ algo, header, xmlTag }) => {
+        it(`should compute empty-bytes ${algo} digest when source has no checksum`, done => {
+            setSourceChecksum(null, err => {
+                if (err) {
+                    return done(err);
+                }
+                return Promise.resolve(algorithms[algo].digest(Buffer.alloc(0))).then(expectedDigest => {
+                    const req = _createObjectCopyRequest(destBucketName, {
+                        'x-amz-checksum-algorithm': header,
+                    });
+                    objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log,
+                        assertRecomputed(algo, xmlTag, expectedDigest, done));
+                }, done);
+            });
+        });
+    });
+
+    it('should recompute empty-bytes digest on COMPOSITE 0-byte source (no algo header)', done => {
+        // COMPOSITE source forces recompute even with no algorithm header.
+        // Use sha256 placeholder; the dest digest will be the empty-bytes sha256.
+        setSourceChecksum({
+            checksumAlgorithm: 'sha256',
+            checksumValue: '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=',
+            checksumType: 'COMPOSITE',
+        }, err => {
+            assert.ifError(err);
+            Promise.resolve(algorithms.sha256.digest(Buffer.alloc(0))).then(expectedDigest => {
+                const req = _createObjectCopyRequest(destBucketName);
+                objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log,
+                    assertRecomputed('sha256', 'ChecksumSHA256', expectedDigest, done));
+            }, done);
+        });
+    });
+
+    it('should propagate FULL_OBJECT checksum on 0-byte source (no algo header)', done => {
+        // The 0-byte recompute path must not override propagation set by _prepMetadata.
+        setSourceChecksum({
+            checksumAlgorithm: 'crc32',
+            checksumValue: 'AAAAAA==',
+            checksumType: 'FULL_OBJECT',
+        }, err => {
+            assert.ifError(err);
+            const req = _createObjectCopyRequest(destBucketName);
+            objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, (err, xml) => {
+                assert.ifError(err);
+                assert(xml.includes('<ChecksumCRC32>AAAAAA==</ChecksumCRC32>'));
+                assert(xml.includes('<ChecksumType>FULL_OBJECT</ChecksumType>'));
+                metadata.getObjectMD(destBucketName, objectKey, {}, log, (err, md) => {
+                    assert.ifError(err);
+                    assert.strictEqual(md.checksum.checksumAlgorithm, 'crc32');
+                    assert.strictEqual(md.checksum.checksumValue, 'AAAAAA==');
+                    assert.strictEqual(md.checksum.checksumType, 'FULL_OBJECT');
+                    done();
+                });
+            });
+        });
+    });
+
+    it('should compute empty-bytes CRC64NVME on 0-byte source with no source checksum and no algo header', done => {
+        setSourceChecksum(null, err => {
+            if (err) {
+                return done(err);
+            }
+            return Promise.resolve(algorithms.crc64nvme.digest(Buffer.alloc(0))).then(expectedDigest => {
+                const req = _createObjectCopyRequest(destBucketName);
+                objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log,
+                    assertRecomputed('crc64nvme', 'ChecksumCRC64NVME', expectedDigest, done));
+            }, done);
+        });
     });
 });
 

--- a/tests/unit/api/objectCopy.js
+++ b/tests/unit/api/objectCopy.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const async = require('async');
+const crypto = require('crypto');
 const { Readable } = require('stream');
 const { storage, versioning } = require('arsenal');
 const sinon = require('sinon');
@@ -972,6 +973,25 @@ describe('objectCopy checksum recompute', () => {
                     }
                 }));
         }, done);
+    });
+
+    it('should store a part-prefixed dataStoreETag on the recomputed destination location', done => {
+        // The recompute path writes the destination through data.put, which
+        // does not return a dataStoreETag; it must be filled in from the MD5
+        // of the streamed bytes, prefixed like createAndStoreObject does.
+        const expectedMD5 = crypto.createHash('md5').update(objData[0]).digest('hex');
+        const req = _createObjectCopyRequest(destBucketName, {
+            'x-amz-checksum-algorithm': 'SHA256',
+        });
+        objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, err => {
+            assert.ifError(err);
+            metadata.getObjectMD(destBucketName, objectKey, {}, log, (err, md) => {
+                assert.ifError(err);
+                assert.strictEqual(md.location[0].dataStoreETag, `1:${expectedMD5}`,
+                    'recomputed destination location should carry a 1:-prefixed MD5 dataStoreETag');
+                done();
+            });
+        });
     });
 
     it('should reject an unknown x-amz-checksum-algorithm value with InvalidRequest', done => {

--- a/tests/unit/api/objectCopy.js
+++ b/tests/unit/api/objectCopy.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const async = require('async');
+const { Readable } = require('stream');
 const { storage, versioning } = require('arsenal');
 const sinon = require('sinon');
 
@@ -14,7 +15,10 @@ const { cleanup, DummyRequestLogger, makeAuthInfo, versioningTestUtils }
 const mpuUtils = require('../utils/mpuUtils');
 const metadata = require('../metadataswitch');
 const { data } = require('../../../lib/data/wrapper');
+const kms = require('../../../lib/kms/wrapper');
 const { objectLocationConstraintHeader } = require('../../../constants');
+const { algorithms } =
+    require('../../../lib/api/apiUtils/integrity/validateChecksums');
 const { fakeMetadataArchive } = require('../../functional/aws-node-sdk/test/utils/init');
 const { config } = require('../../../lib/Config');
 
@@ -638,6 +642,589 @@ describe('objectCopy with objectKeyByteLimit', () => {
                 assert.match(err.description, /1024/);
                 done();
             });
+    });
+});
+
+// Set or clear the source object's stored checksum directly in metadata.
+function setSourceChecksum(checksum, cb) {
+    metadata.getObjectMD(sourceBucketName, objectKey, {}, log, (err, md) => {
+        if (err) {
+            return cb(err);
+        }
+        if (checksum) {
+            // eslint-disable-next-line no-param-reassign
+            md.checksum = checksum;
+        } else {
+            // eslint-disable-next-line no-param-reassign
+            delete md.checksum;
+        }
+        return metadata.putObjectMD(sourceBucketName, objectKey, md, {}, log, cb);
+    });
+}
+
+describe('objectCopy checksum propagation', () => {
+    beforeEach(done => {
+        cleanup();
+        async.series([
+            next => bucketPut(authInfo, putDestBucketRequest, log, next),
+            next => bucketPut(authInfo, putSourceBucketRequest, log, next),
+            next => objectPut(authInfo, versioningTestUtils.createPutObjectRequest(
+                sourceBucketName, objectKey, objData[0]), undefined, log, next),
+        ], done);
+    });
+
+    afterEach(() => cleanup());
+
+    const algorithmFixtures = [
+        { algo: 'crc32', header: 'CRC32', xmlTag: 'ChecksumCRC32', value: 'AAAAAA==' },
+        { algo: 'crc32c', header: 'CRC32C', xmlTag: 'ChecksumCRC32C', value: 'AAAAAA==' },
+        { algo: 'crc64nvme', header: 'CRC64NVME', xmlTag: 'ChecksumCRC64NVME', value: 'AAAAAAAAAAA=' },
+        { algo: 'sha1', header: 'SHA1', xmlTag: 'ChecksumSHA1', value: 'AAAAAAAAAAAAAAAAAAAAAAAAAAA=' },
+        {
+            algo: 'sha256', header: 'SHA256', xmlTag: 'ChecksumSHA256',
+            value: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+        },
+    ];
+
+    algorithmFixtures.forEach(({ algo, header, xmlTag, value }) => {
+        const sourceChecksum = {
+            checksumAlgorithm: algo,
+            checksumValue: value,
+            checksumType: 'FULL_OBJECT',
+        };
+
+        function assertPropagated(xml, cb) {
+            assert(xml.includes(`<${xmlTag}>${value}</${xmlTag}>`), `XML should contain ${xmlTag}`);
+            assert(xml.includes('<ChecksumType>FULL_OBJECT</ChecksumType>'), 'XML should contain ChecksumType');
+            metadata.getObjectMD(destBucketName, objectKey, {}, log,
+                (err, md) => {
+                    assert.ifError(err);
+                    assert(md.checksum, 'destination should have a checksum');
+                    assert.strictEqual(md.checksum.checksumAlgorithm, algo);
+                    assert.strictEqual(md.checksum.checksumValue, value);
+                    assert.strictEqual(md.checksum.checksumType, 'FULL_OBJECT');
+                    cb();
+                });
+        }
+
+        it(`should propagate a FULL_OBJECT ${algo} checksum from source to destination`,
+            done => {
+                setSourceChecksum(sourceChecksum, err => {
+                    assert.ifError(err);
+                    const req = _createObjectCopyRequest(destBucketName);
+                    objectCopy(authInfo, req, sourceBucketName, objectKey,
+                        undefined, log, (err, xml) => {
+                            assert.ifError(err);
+                            assertPropagated(xml, done);
+                        });
+                });
+            });
+
+        it(`should propagate when x-amz-checksum-algorithm matches source ${algo} algorithm`,
+            done => {
+                setSourceChecksum(sourceChecksum, err => {
+                    assert.ifError(err);
+                    const req = _createObjectCopyRequest(destBucketName, {
+                        'x-amz-checksum-algorithm': header,
+                    });
+                    objectCopy(authInfo, req, sourceBucketName, objectKey,
+                        undefined, log, (err, xml) => {
+                            assert.ifError(err);
+                            assertPropagated(xml, done);
+                        });
+                });
+            });
+    });
+
+    it('should default to CRC64NVME when source has no checksum and no algorithm is requested', done => {
+        setSourceChecksum(null, err => {
+            if (err) {
+                return done(err);
+            }
+            return Promise.resolve(algorithms.crc64nvme.digest(objData[0])).then(expectedDigest => {
+                const req = _createObjectCopyRequest(destBucketName);
+                objectCopy(authInfo, req, sourceBucketName, objectKey,
+                    undefined, log,
+                    assertRecomputed('crc64nvme', 'ChecksumCRC64NVME', expectedDigest, done));
+            }, done);
+        });
+    });
+});
+
+describe('objectCopy checksum recompute', () => {
+    beforeEach(done => {
+        cleanup();
+        async.series([
+            next => bucketPut(authInfo, putDestBucketRequest, log, next),
+            next => bucketPut(authInfo, putSourceBucketRequest, log, next),
+            next => objectPut(authInfo, versioningTestUtils.createPutObjectRequest(
+                sourceBucketName, objectKey, objData[0]), undefined, log, next),
+        ], done);
+    });
+
+    afterEach(() => cleanup());
+
+    // Builds the objectCopy callback that asserts a successful FULL_OBJECT recompute:
+    // response XML and destination metadata both carry the expected algo and digest.
+    function assertRecomputed(algo, xmlTag, expectedDigest, done) {
+        return (err, xml) => {
+            if (err) {
+                return done(err);
+            }
+            try {
+                assert(xml.includes(`<${xmlTag}>${expectedDigest}</${xmlTag}>`),
+                    `XML should contain ${xmlTag}=${expectedDigest}`);
+                assert(xml.includes('<ChecksumType>FULL_OBJECT</ChecksumType>'),
+                    'XML should contain ChecksumType FULL_OBJECT');
+            } catch (e) {
+                return done(e);
+            }
+            return metadata.getObjectMD(destBucketName, objectKey, {}, log, (err, md) => {
+                if (err) {
+                    return done(err);
+                }
+                try {
+                    assert(md.checksum, 'destination should have a checksum');
+                    assert.strictEqual(md.checksum.checksumAlgorithm, algo);
+                    assert.strictEqual(md.checksum.checksumValue, expectedDigest);
+                    assert.strictEqual(md.checksum.checksumType, 'FULL_OBJECT');
+                    return done();
+                } catch (e) {
+                    return done(e);
+                }
+            });
+        };
+    }
+
+    const recomputeFixtures = [
+        { algo: 'crc32', header: 'CRC32', xmlTag: 'ChecksumCRC32' },
+        { algo: 'crc32c', header: 'CRC32C', xmlTag: 'ChecksumCRC32C' },
+        { algo: 'crc64nvme', header: 'CRC64NVME', xmlTag: 'ChecksumCRC64NVME' },
+        { algo: 'sha1', header: 'SHA1', xmlTag: 'ChecksumSHA1' },
+        { algo: 'sha256', header: 'SHA256', xmlTag: 'ChecksumSHA256' },
+    ];
+
+    recomputeFixtures.forEach(({ algo, header, xmlTag }) => {
+        it(`should recompute ${algo} when x-amz-checksum-algorithm differs from source`, done => {
+            // Seed source with a different algorithm so the request forces a recompute.
+            // crc32 ↔ sha256 swap covers both pivots.
+            const sourceAlgo = algo === 'crc32' ? 'sha256' : 'crc32';
+            const sourceValue = sourceAlgo === 'crc32'
+                ? 'AAAAAA=='
+                : '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';
+            setSourceChecksum({
+                checksumAlgorithm: sourceAlgo,
+                checksumValue: sourceValue,
+                checksumType: 'FULL_OBJECT',
+            }, err => {
+                if (err) {
+                    return done(err);
+                }
+                return Promise.resolve(algorithms[algo].digest(objData[0])).then(expectedDigest => {
+                    const req = _createObjectCopyRequest(destBucketName, {
+                        'x-amz-checksum-algorithm': header,
+                    });
+                    objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log,
+                        assertRecomputed(algo, xmlTag, expectedDigest, done));
+                }, done);
+            });
+        });
+
+        // CRC64NVME cannot be used as COMPOSITE (AWS rejects it at MPU init); only test
+        // the COMPOSITE-source path for the four other algorithms.
+        if (algo !== 'crc64nvme') {
+            it(`should recompute ${algo} when source is COMPOSITE and no algorithm requested`, done => {
+                setSourceChecksum({
+                    checksumAlgorithm: algo,
+                    // valid-shape placeholder; the test does not depend on the source value
+                    // matching the body — only on the destination digest being recomputed.
+                    checksumValue: 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=',
+                    checksumType: 'COMPOSITE',
+                }, err => {
+                    if (err) {
+                        return done(err);
+                    }
+                    return Promise.resolve(algorithms[algo].digest(objData[0])).then(expectedDigest => {
+                        const req = _createObjectCopyRequest(destBucketName);
+                        objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log,
+                            assertRecomputed(algo, xmlTag, expectedDigest, done));
+                    }, done);
+                });
+            });
+
+            it(`should recompute ${algo} when source is COMPOSITE and different algorithm requested`, done => {
+                // Force a recompute by both source-type (COMPOSITE) and algo mismatch.
+                // Seed source with sha256 COMPOSITE so the requested algo always differs.
+                const sourceAlgo = algo === 'sha256' ? 'sha1' : 'sha256';
+                const sourceValue = sourceAlgo === 'sha1'
+                    ? 'AAAAAAAAAAAAAAAAAAAAAAAAAAA='
+                    : '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';
+                setSourceChecksum({
+                    checksumAlgorithm: sourceAlgo,
+                    checksumValue: sourceValue,
+                    checksumType: 'COMPOSITE',
+                }, err => {
+                    if (err) {
+                        return done(err);
+                    }
+                    return Promise.resolve(algorithms[algo].digest(objData[0])).then(expectedDigest => {
+                        const req = _createObjectCopyRequest(destBucketName, {
+                            'x-amz-checksum-algorithm': header,
+                        });
+                        objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log,
+                            assertRecomputed(algo, xmlTag, expectedDigest, done));
+                    }, done);
+                });
+            });
+        }
+
+        it(`should compute ${algo} when source has no checksum and algorithm is requested`, done => {
+            setSourceChecksum(null, err => {
+                if (err) {
+                    return done(err);
+                }
+                return Promise.resolve(algorithms[algo].digest(objData[0])).then(expectedDigest => {
+                    const req = _createObjectCopyRequest(destBucketName, {
+                        'x-amz-checksum-algorithm': header,
+                    });
+                    objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log,
+                        assertRecomputed(algo, xmlTag, expectedDigest, done));
+                }, done);
+            });
+        });
+    });
+
+    it('should recompute the checksum across all parts of a multi-part source', done => {
+        const partA = Buffer.from('part-a-bytes', 'utf8');
+        const partB = Buffer.from('part-b-bytes-longer', 'utf8');
+        const fullBody = Buffer.concat([partA, partB]);
+        const parts = { 'mpart-a': partA, 'mpart-b': partB };
+        const dataGetStub = sinon.stub(data, 'get').callsFake((info, _response, _l, cb) => {
+            const buf = parts[info.key];
+            return cb(null, Readable.from(buf));
+        });
+        metadata.getObjectMD(sourceBucketName, objectKey, {}, log, (err, md) => {
+            assert.ifError(err);
+            // eslint-disable-next-line no-param-reassign
+            md.location = [
+                { key: 'mpart-a', dataStoreName: 'us-east-1', size: partA.length, start: 0 },
+                { key: 'mpart-b', dataStoreName: 'us-east-1', size: partB.length, start: partA.length },
+            ];
+            // eslint-disable-next-line no-param-reassign
+            md['content-length'] = fullBody.length;
+            metadata.putObjectMD(sourceBucketName, objectKey, md, {}, log, err => {
+                assert.ifError(err);
+                Promise.resolve(algorithms.sha256.digest(fullBody)).then(expectedDigest => {
+                    const req = _createObjectCopyRequest(destBucketName, {
+                        'x-amz-checksum-algorithm': 'SHA256',
+                    });
+                    objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log,
+                        (err, xml) => {
+                            dataGetStub.restore();
+                            assertRecomputed('sha256', 'ChecksumSHA256', expectedDigest, done)(err, xml);
+                        });
+                }, err => {
+                    dataGetStub.restore();
+                    done(err);
+                });
+            });
+        });
+    });
+
+    it('should recompute the checksum and encrypt the destination when SSE is requested', done => {
+        // Recompute path must create a cipher bundle via kms when SSE is configured.
+        // Confirm the cipher bundle is forwarded to data.put and the checksum is
+        // still over the cleartext bytes.
+        const cipherBundleSpy = sinon.spy(kms, 'createCipherBundle');
+        const dataPutSpy = sinon.spy(data, 'put');
+        Promise.resolve(algorithms.sha256.digest(objData[0])).then(expectedDigest => {
+            const req = _createObjectCopyRequest(destBucketName, {
+                'x-amz-checksum-algorithm': 'SHA256',
+                'x-amz-server-side-encryption': 'AES256',
+            });
+            objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log,
+                assertRecomputed('sha256', 'ChecksumSHA256', expectedDigest, err => {
+                    cipherBundleSpy.restore();
+                    dataPutSpy.restore();
+                    if (err) {
+                        return done(err);
+                    }
+                    try {
+                        assert(cipherBundleSpy.calledOnce,
+                            'kms.createCipherBundle should be called once');
+                        const sseConfig = cipherBundleSpy.firstCall.args[0];
+                        assert.strictEqual(sseConfig.algorithm, 'AES256');
+                        // The data.put call that consumed the checksum stream
+                        // (size > 0) should have received a non-null cipherBundle.
+                        const recomputePut = dataPutSpy.getCalls()
+                            .find(call => call.args[1] !== null);
+                        assert(recomputePut,
+                            'expected at least one data.put with a real stream');
+                        assert(recomputePut.args[0],
+                            'cipherBundle should be non-null for SSE recompute');
+                        return done();
+                    } catch (e) {
+                        return done(e);
+                    }
+                }));
+        }, done);
+    });
+
+    it('should reject an unknown x-amz-checksum-algorithm value with InvalidRequest', done => {
+        const req = _createObjectCopyRequest(destBucketName, {
+            'x-amz-checksum-algorithm': 'GARBAGE',
+        });
+        objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, err => {
+            assert(err);
+            assert.strictEqual(err.is.InvalidRequest, true);
+            done();
+        });
+    });
+    const copyToSelfFixtures = [
+        { algo: 'crc32', header: 'CRC32', xmlTag: 'ChecksumCRC32' },
+        { algo: 'crc32c', header: 'CRC32C', xmlTag: 'ChecksumCRC32C' },
+        { algo: 'crc64nvme', header: 'CRC64NVME', xmlTag: 'ChecksumCRC64NVME' },
+        { algo: 'sha1', header: 'SHA1', xmlTag: 'ChecksumSHA1' },
+        { algo: 'sha256', header: 'SHA256', xmlTag: 'ChecksumSHA256' },
+    ];
+
+    copyToSelfFixtures.forEach(({ algo, header, xmlTag }) => {
+        it(`should compute the ${algo} checksum on copy-to-self without rewriting data`, done => {
+            const dataPutSpy = sinon.spy(data, 'put');
+            const batchDeleteSpy = sinon.spy(data, 'batchDelete');
+            metadata.getObjectMD(sourceBucketName, objectKey, {}, log, (err, srcMd) => {
+                assert.ifError(err);
+                const sourceLocation = srcMd.location;
+                Promise.resolve(algorithms[algo].digest(objData[0])).then(expectedDigest => {
+                    const req = new DummyRequest({
+                        bucketName: sourceBucketName,
+                        namespace,
+                        objectKey,
+                        headers: {
+                            'x-amz-checksum-algorithm': header,
+                            'x-amz-metadata-directive': 'REPLACE',
+                        },
+                        url: `/${sourceBucketName}/${objectKey}`,
+                        socket: {},
+                    });
+                    objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, (err, xml) => {
+                        dataPutSpy.restore();
+                        batchDeleteSpy.restore();
+                        assert.ifError(err);
+                        assert(!dataPutSpy.called, 'data.put should NOT be called');
+                        assert(!batchDeleteSpy.called, 'data.batchDelete should NOT be called');
+                        assert(xml.includes(`<${xmlTag}>${expectedDigest}</${xmlTag}>`),
+                            'response XML should carry the new checksum');
+                        metadata.getObjectMD(sourceBucketName, objectKey, {}, log, (err, md) => {
+                            assert.ifError(err);
+                            assert.deepStrictEqual(
+                                md.location.map(l => l.key),
+                                sourceLocation.map(l => l.key),
+                                'data location keys should be reused');
+                            assert.strictEqual(md.checksum.checksumAlgorithm, algo);
+                            assert.strictEqual(md.checksum.checksumValue, expectedDigest);
+                            assert.strictEqual(md.checksum.checksumType, 'FULL_OBJECT');
+                            done();
+                        });
+                    });
+                }, done);
+            });
+        });
+    });
+
+    const compositeFixtures = [
+        { algo: 'crc32', xmlTag: 'ChecksumCRC32' },
+        { algo: 'crc32c', xmlTag: 'ChecksumCRC32C' },
+        { algo: 'sha1', xmlTag: 'ChecksumSHA1' },
+        { algo: 'sha256', xmlTag: 'ChecksumSHA256' },
+    ];
+
+    compositeFixtures.forEach(({ algo, xmlTag }) => {
+        it(`should recompute a FULL_OBJECT ${algo} checksum on copy-to-self of a COMPOSITE (MPU) source`, done => {
+            // A copy of an MPU/COMPOSITE source must never preserve the COMPOSITE
+            // checksum: it is recomputed as FULL_OBJECT (algorithm carried over),
+            // reusing the data location.
+            const dataPutSpy = sinon.spy(data, 'put');
+            const batchDeleteSpy = sinon.spy(data, 'batchDelete');
+            setSourceChecksum({
+                checksumAlgorithm: algo,
+                // placeholder COMPOSITE value, distinct from the FULL_OBJECT digest
+                checksumValue: 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=',
+                checksumType: 'COMPOSITE',
+            }, err => {
+                assert.ifError(err);
+                Promise.resolve(algorithms[algo].digest(objData[0])).then(expectedDigest => {
+                    const req = new DummyRequest({
+                        bucketName: sourceBucketName,
+                        namespace,
+                        objectKey,
+                        headers: { 'x-amz-metadata-directive': 'REPLACE' },
+                        url: `/${sourceBucketName}/${objectKey}`,
+                        socket: {},
+                    });
+                    objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, (err, xml) => {
+                        dataPutSpy.restore();
+                        batchDeleteSpy.restore();
+                        assert.ifError(err);
+                        assert(!dataPutSpy.called, 'data.put should NOT be called (location reused)');
+                        assert(!batchDeleteSpy.called, 'data.batchDelete should NOT be called');
+                        assert(xml.includes(`<${xmlTag}>${expectedDigest}</${xmlTag}>`),
+                            'response XML should carry the recomputed FULL_OBJECT digest');
+                        assert(xml.includes('<ChecksumType>FULL_OBJECT</ChecksumType>'),
+                            'response XML must say FULL_OBJECT, never COMPOSITE');
+                        metadata.getObjectMD(sourceBucketName, objectKey, {}, log, (err, md) => {
+                            assert.ifError(err);
+                            assert.strictEqual(md.checksum.checksumType, 'FULL_OBJECT',
+                                'stored checksum must be FULL_OBJECT, never COMPOSITE');
+                            assert.strictEqual(md.checksum.checksumAlgorithm, algo);
+                            assert.strictEqual(md.checksum.checksumValue, expectedDigest,
+                                'value must be the recomputed FULL_OBJECT digest, not the source COMPOSITE value');
+                            done();
+                        });
+                    });
+                }, done);
+            });
+        });
+    });
+
+    it('should still PUT on copy-to-self when versioning is enabled (no metadata-only shortcut)', done => {
+        // Versioned copies produce a new version-id; the metadata-only path
+        // is skipped so the new version gets its own data write.
+        const enableVersioning = versioningTestUtils
+            .createBucketPutVersioningReq(sourceBucketName, 'Enabled');
+        bucketPutVersioning(authInfo, enableVersioning, log, err => {
+            assert.ifError(err);
+            const dataPutSpy = sinon.spy(data, 'put');
+            const req = new DummyRequest({
+                bucketName: sourceBucketName,
+                namespace,
+                objectKey,
+                headers: {
+                    'x-amz-checksum-algorithm': 'SHA256',
+                    'x-amz-metadata-directive': 'REPLACE',
+                },
+                url: `/${sourceBucketName}/${objectKey}`,
+                socket: {},
+            });
+            objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, err => {
+                dataPutSpy.restore();
+                assert.ifError(err);
+                assert(dataPutSpy.called,
+                    'data.put should be called because versioning forces a new version write');
+                done();
+            });
+        });
+    });
+});
+describe('objectCopy checksum recompute on external backends', () => {
+    const prevConfigBackendsData = data.config.backends.data;
+    const prevConfigLocationConstraint = data.config.locationConstraints['us-east-1'].type;
+    const prevConfigLocationConstraint2 = data.config.locationConstraints['us-east-2'].type;
+
+    before(() => {
+        data.config.backends.data = 'multiple';
+        data.config.locationConstraints['us-east-1'].type = 'aws_s3';
+        data.config.locationConstraints['us-east-2'].type = 'aws_s3';
+    });
+
+    after(() => {
+        data.config.backends.data = prevConfigBackendsData;
+        data.config.locationConstraints['us-east-1'].type = prevConfigLocationConstraint;
+        data.config.locationConstraints['us-east-2'].type = prevConfigLocationConstraint2;
+    });
+
+    beforeEach(done => {
+        cleanup();
+        async.series([
+            next => bucketPut(authInfo, putDestBucketRequest, log, next),
+            next => bucketPut(authInfo, putSourceBucketRequest, log, next),
+            next => objectPut(authInfo, versioningTestUtils.createPutObjectRequest(
+                sourceBucketName, objectKey, objData[0]), undefined, log, next),
+        ], done);
+    });
+
+    afterEach(() => cleanup());
+
+    it('should recompute the checksum on a cross-key copy on an external backend', done => {
+        // A recompute streams the source through CloudServer (GET + PUT) and
+        // writes a FULL_OBJECT checksum on the destination.
+        const copyObjectSpy = sinon.spy(data, 'copyObject');
+        Promise.resolve(algorithms.sha256.digest(objData[0])).then(expectedDigest => {
+            const req = _createObjectCopyRequest(destBucketName, {
+                'x-amz-checksum-algorithm': 'SHA256',
+            });
+            objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, (err, xml) => {
+                copyObjectSpy.restore();
+                assert.ifError(err);
+                assert(!copyObjectSpy.called,
+                    'data.copyObject should NOT be called (recompute streams instead)');
+                assert(xml.includes(`<ChecksumSHA256>${expectedDigest}</ChecksumSHA256>`),
+                    'response XML should carry the recomputed checksum');
+                metadata.getObjectMD(destBucketName, objectKey, {}, log, (err, md) => {
+                    assert.ifError(err);
+                    assert.strictEqual(md.checksum.checksumType, 'FULL_OBJECT');
+                    assert.strictEqual(md.checksum.checksumAlgorithm, 'sha256');
+                    assert.strictEqual(md.checksum.checksumValue, expectedDigest);
+                    done();
+                });
+            });
+        }, done);
+    });
+
+    it('should recompute the checksum on a cross-location copy within the same external backend type', done => {
+        // AWS S3 us-east-1 -> us-east-2: the bytes stream through CloudServer and a FULL_OBJECT checksum is written.
+        const copyObjectSpy = sinon.spy(data, 'copyObject');
+        Promise.resolve(algorithms.sha256.digest(objData[0])).then(expectedDigest => {
+            const req = _createObjectCopyRequest(destBucketName, {
+                'x-amz-checksum-algorithm': 'SHA256',
+                'x-amz-metadata-directive': 'REPLACE',
+                'x-amz-meta-scal-location-constraint': 'us-east-2',
+            });
+            objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, (err, xml) => {
+                copyObjectSpy.restore();
+                assert.ifError(err);
+                assert(!copyObjectSpy.called,
+                    'data.copyObject should NOT be called (recompute streams instead)');
+                assert(xml.includes(`<ChecksumSHA256>${expectedDigest}</ChecksumSHA256>`),
+                    'response XML should carry the recomputed checksum');
+                done();
+            });
+        }, done);
+    });
+
+    it('should recompute the checksum in place on copy-to-self for an external backend', done => {
+        // Copy-to-self reuses the data location (no PUT) but GETs the bytes to
+        // recompute the checksum, written as FULL_OBJECT.
+        const copyObjectSpy = sinon.spy(data, 'copyObject');
+        const dataPutSpy = sinon.spy(data, 'put');
+        Promise.resolve(algorithms.sha256.digest(objData[0])).then(expectedDigest => {
+            const req = new DummyRequest({
+                bucketName: sourceBucketName,
+                namespace,
+                objectKey,
+                headers: {
+                    'x-amz-checksum-algorithm': 'SHA256',
+                    'x-amz-metadata-directive': 'REPLACE',
+                },
+                url: `/${sourceBucketName}/${objectKey}`,
+                socket: {},
+            });
+            objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, (err, xml) => {
+                copyObjectSpy.restore();
+                dataPutSpy.restore();
+                assert.ifError(err);
+                assert(!copyObjectSpy.called, 'data.copyObject should NOT be called (location reused)');
+                assert(!dataPutSpy.called, 'data.put should NOT be called (location reused)');
+                assert(xml.includes(`<ChecksumSHA256>${expectedDigest}</ChecksumSHA256>`),
+                    'response XML should carry the recomputed checksum');
+                metadata.getObjectMD(sourceBucketName, objectKey, {}, log, (err, md) => {
+                    assert.ifError(err);
+                    assert.strictEqual(md.checksum.checksumType, 'FULL_OBJECT');
+                    assert.strictEqual(md.checksum.checksumValue, expectedDigest);
+                    done();
+                });
+            });
+        }, done);
     });
 });
 

--- a/tests/unit/api/objectCopy.js
+++ b/tests/unit/api/objectCopy.js
@@ -640,3 +640,217 @@ describe('objectCopy with objectKeyByteLimit', () => {
             });
     });
 });
+
+describe('objectCopy data orphan cleanup on cross-backend copy-to-self', () => {
+    const prevConfigBackendsData = data.config.backends.data;
+    const prevConfigLocationConstraint1 = data.config.locationConstraints['us-east-1'].type;
+    const prevConfigLocationConstraint2 = data.config.locationConstraints['us-east-2'].type;
+
+    before(() => {
+        data.config.backends.data = 'multiple';
+        data.config.locationConstraints['us-east-1'].type = 'aws_s3';
+        data.config.locationConstraints['us-east-2'].type = 'aws_s3';
+    });
+
+    after(() => {
+        data.config.backends.data = prevConfigBackendsData;
+        data.config.locationConstraints['us-east-1'].type = prevConfigLocationConstraint1;
+        data.config.locationConstraints['us-east-2'].type = prevConfigLocationConstraint2;
+    });
+
+    beforeEach(done => {
+        cleanup();
+        async.series([
+            next => bucketPut(authInfo, putSourceBucketRequest, log, next),
+            next => objectPut(authInfo, versioningTestUtils.createPutObjectRequest(
+                sourceBucketName, objectKey, objData[0]), undefined, log, next),
+        ], done);
+    });
+
+    afterEach(() => cleanup());
+
+    it('should reclaim the old location on copy-to-self that lands at a different backend key', done => {
+        // Copy-to-self where the new metadata points to a different data key
+        // than the source did (cross-backend rewrite via x-amz-meta-scal-
+        // location-constraint). The old key is no longer referenced and must
+        // be batchDeleted — guards against a pre-existing orphan bug.
+        const batchDeleteSpy = sinon.spy(data, 'batchDelete');
+        const copyObjectStub = sinon.stub(data, 'copyObject').callsFake(
+            (req, srcLoc, sMP, dataLocator, ctx, backendInfo, srcBM, dstBM, sse, l, cb) =>
+                cb(null, [{ key: 'new-backend-key', dataStoreName: 'us-east-2', size: objData[0].length, start: 0 }]));
+        metadata.getObjectMD(sourceBucketName, objectKey, {}, log, (err, srcMd) => {
+            assert.ifError(err);
+            const oldKeys = srcMd.location.map(l => l.key);
+            const req = new DummyRequest({
+                bucketName: sourceBucketName,
+                namespace,
+                objectKey,
+                headers: {
+                    'x-amz-metadata-directive': 'REPLACE',
+                    'x-amz-meta-scal-location-constraint': 'us-east-2',
+                },
+                url: `/${sourceBucketName}/${objectKey}`,
+                socket: {},
+            });
+            objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, err => {
+                batchDeleteSpy.restore();
+                copyObjectStub.restore();
+                assert.ifError(err);
+                assert(batchDeleteSpy.calledOnce,
+                    'data.batchDelete should reclaim the old data location');
+                const reclaimed = batchDeleteSpy.firstCall.args[0];
+                const reclaimedKeys = reclaimed.map(l => l.key);
+                assert.deepStrictEqual(reclaimedKeys, oldKeys,
+                    'batchDelete should target the old source key, not the new backend key');
+                done();
+            });
+        });
+    });
+
+    it('should reclaim the old location when the new backend key collides with the old one', done => {
+        // bucketMatch-style external backends derive the backend key from the
+        // S3 object key, so a copy-to-self that changes dataStoreName lands at
+        // the same `key` in a different backend. Identity must include
+        // dataStoreName or the old slot is silently leaked.
+        const batchDeleteSpy = sinon.spy(data, 'batchDelete');
+        metadata.getObjectMD(sourceBucketName, objectKey, {}, log, (err, srcMd) => {
+            assert.ifError(err);
+            const oldLoc = srcMd.location[0];
+            const copyObjectStub = sinon.stub(data, 'copyObject').callsFake(
+                (req, srcLoc, sMP, dataLocator, ctx, backendInfo, srcBM, dstBM, sse, l, cb) =>
+                    cb(null, [{ key: oldLoc.key, dataStoreName: 'us-east-2',
+                        size: objData[0].length, start: 0 }]));
+            const req = new DummyRequest({
+                bucketName: sourceBucketName,
+                namespace,
+                objectKey,
+                headers: {
+                    'x-amz-metadata-directive': 'REPLACE',
+                    'x-amz-meta-scal-location-constraint': 'us-east-2',
+                },
+                url: `/${sourceBucketName}/${objectKey}`,
+                socket: {},
+            });
+            objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, err => {
+                batchDeleteSpy.restore();
+                copyObjectStub.restore();
+                assert.ifError(err);
+                assert(batchDeleteSpy.calledOnce,
+                    'data.batchDelete should reclaim the old slot even when the backend key matches');
+                const reclaimed = batchDeleteSpy.firstCall.args[0];
+                assert.strictEqual(reclaimed.length, 1);
+                assert.strictEqual(reclaimed[0].dataStoreName, oldLoc.dataStoreName,
+                    'batchDelete must target the old dataStoreName, not the new one');
+                assert.strictEqual(reclaimed[0].key, oldLoc.key);
+                done();
+            });
+        });
+    });
+});
+
+describe('objectCopy legacy string-location copy-to-self', () => {
+    beforeEach(done => {
+        cleanup();
+        async.series([
+            next => bucketPut(authInfo, putSourceBucketRequest, log, next),
+            next => objectPut(authInfo, versioningTestUtils.createPutObjectRequest(
+                sourceBucketName, objectKey, objData[0]), undefined, log, next),
+        ], done);
+    });
+
+    afterEach(() => cleanup());
+
+    it('should not delete the reused location on copy-to-self with a legacy string location', done => {
+        // Pre-md-model-version-2 objects store `location` as a bare string;
+        // versioningPreprocessing then surfaces dataToDelete as a string array
+        // while the reused new locator is { key }. The orphan filter must
+        // normalize both or it deletes the live data on copy-to-self.
+        const batchDeleteSpy = sinon.spy(data, 'batchDelete');
+        metadata.getObjectMD(sourceBucketName, objectKey, {}, log, (err, md) => {
+            assert.ifError(err);
+            const legacyKey = String(md.location[0].key);
+            // eslint-disable-next-line no-param-reassign
+            md.location = legacyKey;
+            // FULL_OBJECT checksum + no algo header keeps us on the propagate
+            // (metadata-only reuse) path, so no data.get on the string key.
+            // eslint-disable-next-line no-param-reassign
+            md.checksum = { checksumAlgorithm: 'crc32', checksumValue: 'AAAAAA==', checksumType: 'FULL_OBJECT' };
+            metadata.putObjectMD(sourceBucketName, objectKey, md, {}, log, err => {
+                assert.ifError(err);
+                const req = new DummyRequest({
+                    bucketName: sourceBucketName,
+                    namespace,
+                    objectKey,
+                    headers: { 'x-amz-metadata-directive': 'REPLACE' },
+                    url: `/${sourceBucketName}/${objectKey}`,
+                    socket: {},
+                });
+                objectCopy(authInfo, req, sourceBucketName, objectKey, undefined, log, err => {
+                    batchDeleteSpy.restore();
+                    assert.ifError(err);
+                    assert(batchDeleteSpy.notCalled,
+                        'the reused legacy string location must not be treated as an orphan');
+                    done();
+                });
+            });
+        });
+    });
+});
+
+describe('_orphanedDataLocations', () => {
+    const orphanedDataLocations = objectCopy._orphanedDataLocations;
+
+    it('should return null when there is nothing to delete', () => {
+        const newLocs = [{ dataStoreName: 'l1', key: 'a' }];
+        assert.strictEqual(orphanedDataLocations(undefined, newLocs), null);
+        assert.strictEqual(orphanedDataLocations(null, newLocs), null);
+        assert.strictEqual(orphanedDataLocations([], newLocs), null);
+    });
+
+    it('should return null when every prior location is still referenced', () => {
+        const locs = [
+            { dataStoreName: 'l1', key: 'a' },
+            { dataStoreName: 'l1', key: 'b' },
+        ];
+        assert.strictEqual(orphanedDataLocations(locs, locs), null);
+    });
+
+    it('should flag a prior location whose key is no longer referenced', () => {
+        const oldLocs = [{ dataStoreName: 'l1', key: 'a' }];
+        const newLocs = [{ dataStoreName: 'l1', key: 'b' }];
+        assert.deepStrictEqual(orphanedDataLocations(oldLocs, newLocs), oldLocs);
+    });
+
+    it('should treat the same key under a different dataStoreName as an orphan', () => {
+        const oldLocs = [{ dataStoreName: 'us-east-1', key: 'a' }];
+        const newLocs = [{ dataStoreName: 'us-east-2', key: 'a' }];
+        assert.deepStrictEqual(orphanedDataLocations(oldLocs, newLocs), oldLocs);
+    });
+
+    it('should return only the subset of prior locations that are orphaned', () => {
+        const reused = { dataStoreName: 'l1', key: 'keep' };
+        const orphan = { dataStoreName: 'l1', key: 'gone' };
+        assert.deepStrictEqual(
+            orphanedDataLocations([reused, orphan], [reused]), [orphan]);
+    });
+
+    it('should not flag a key referenced by any of several new locations', () => {
+        const oldLocs = [{ dataStoreName: 'l1', key: 'a' }];
+        const newLocs = [
+            { dataStoreName: 'l1', key: 'x' },
+            { dataStoreName: 'l1', key: 'a' },
+        ];
+        assert.strictEqual(orphanedDataLocations(oldLocs, newLocs), null);
+    });
+
+    it('should normalize a reused legacy string location (not an orphan)', () => {
+        // pre-md-model-version-2 string location reused as { key } by goGetData
+        assert.strictEqual(
+            orphanedDataLocations(['legacyKey'], [{ key: 'legacyKey' }]), null);
+    });
+
+    it('should flag a legacy string location that is no longer referenced', () => {
+        assert.deepStrictEqual(
+            orphanedDataLocations(['oldKey'], [{ key: 'newKey' }]), ['oldKey']);
+    });
+});

--- a/tests/unit/auth/ChecksumWritable.js
+++ b/tests/unit/auth/ChecksumWritable.js
@@ -1,0 +1,96 @@
+const assert = require('assert');
+const { errors } = require('arsenal');
+const { Readable } = require('stream');
+
+const { algorithms } = require('../../../lib/api/apiUtils/integrity/validateChecksums');
+const ChecksumWritable = require('../../../lib/auth/streamingV4/ChecksumWritable');
+const { DummyRequestLogger } = require('../helpers');
+
+const log = new DummyRequestLogger();
+const testData = Buffer.from('hello world');
+const algos = Object.keys(algorithms);
+
+// Helper: write chunks into the sink and resolve on finish (digest is ready by then)
+function drainWritable(sink, chunks) {
+    return new Promise((resolve, reject) => {
+        sink.on('finish', resolve);
+        sink.on('error', reject);
+        for (const chunk of chunks) {
+            sink.write(chunk);
+        }
+        sink.end();
+    });
+}
+
+describe('ChecksumWritable', () => {
+    let expectedDigests;
+
+    before(async () => {
+        expectedDigests = {};
+        for (const algo of algos) {
+            expectedDigests[algo] = await Promise.resolve(algorithms[algo].digest(testData));
+        }
+    });
+
+    for (const algo of algos) {
+        it(`should compute digest correctly after finish [${algo}]`, async () => {
+            const sink = new ChecksumWritable(algo, log);
+            await drainWritable(sink, [testData]);
+            assert.strictEqual(sink.digest, expectedDigests[algo]);
+        });
+
+        it(`should leave digest undefined until finish [${algo}]`, () => {
+            const sink = new ChecksumWritable(algo, log);
+            assert.strictEqual(sink.digest, undefined);
+            sink.write(testData);
+            assert.strictEqual(sink.digest, undefined);
+        });
+
+        it(`should handle multi-chunk input: digest matches single-chunk equivalent [${algo}]`, async () => {
+            const half = Math.floor(testData.length / 2);
+            const sink = new ChecksumWritable(algo, log);
+            await drainWritable(sink, [testData.subarray(0, half), testData.subarray(half)]);
+            assert.strictEqual(sink.digest, expectedDigests[algo]);
+        });
+
+        it(`should handle Buffer and string chunks equally [${algo}]`, async () => {
+            const sinkBuf = new ChecksumWritable(algo, log);
+            const sinkStr = new ChecksumWritable(algo, log);
+            await drainWritable(sinkBuf, [testData]);
+            await drainWritable(sinkStr, [testData.toString()]);
+            assert.strictEqual(sinkBuf.digest, sinkStr.digest);
+        });
+
+        it(`should compute the digest when piped from a Readable [${algo}]`, done => {
+            const sink = new ChecksumWritable(algo, log);
+            sink.once('error', done);
+            sink.once('finish', () => {
+                assert.strictEqual(sink.digest, expectedDigests[algo]);
+                done();
+            });
+            Readable.from([testData]).pipe(sink);
+        });
+    }
+
+    it('should hash an empty body to the zero-length digest', async () => {
+        const algo = 'crc32';
+        const expected = await Promise.resolve(algorithms[algo].digest(Buffer.alloc(0)));
+        const sink = new ChecksumWritable(algo, log);
+        await drainWritable(sink, []);
+        assert.strictEqual(sink.digest, expected);
+    });
+
+    it('should emit error via stream error event if digestFromHash fails', done => {
+        const sink = new ChecksumWritable('crc32', log);
+        // Replace digestFromHash to return a rejected Promise
+        sink.algo = Object.assign({}, sink.algo, {
+            digestFromHash: () => Promise.reject(new Error('simulated digest failure')),
+        });
+        sink.on('error', err => {
+            assert.deepStrictEqual(err, errors.InternalError);
+            done();
+        });
+        sink.write(testData);
+        sink.end();
+    });
+});


### PR DESCRIPTION
- Forward a src object checksum to the dest object
- Recompute the checksum when required (x-amz-checksum-algorithm header set, src object MPU with COMPOSITE checksum, ...). If needed this will trigger a GET operation to download and calculate the object checksum
- Compute a CRC64NMVE for the dest object if the src object has no checksum (counts as a recompute so the same conditions as above apply)

```
  ┌─────┬─────────────────────┬────────────────────────────────────┬──────────────────────────────────────────────────────────────────┐
  │  #  │   Source checksum   │ x-amz-checksum-algorithm requested │                            Recompute?                            │
  ├─────┼─────────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
  │ 1   │ none                │ none                               │ Yes (Compute default CRC64NVME)                                  │
  ├─────┼─────────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
  │ 2   │ FULL_OBJECT, algo X │ none                               │ No — propagate as-is                                             │
  ├─────┼─────────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
  │ 3   │ FULL_OBJECT, algo X │ X (same algo)                      │ No — propagate as-is                                             │
  ├─────┼─────────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
  │ 4   │ FULL_OBJECT, algo X │ Y (different algo)                 │ Yes                                                              │
  ├─────┼─────────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
  │ 5   │ COMPOSITE, algo X   │ none                               │ Yes (can't propagate a MPU format digest to a single-object dest)│
  ├─────┼─────────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
  │ 6   │ COMPOSITE, algo X   │ X (same algo)                      │ Yes                                                              │
  ├─────┼─────────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
  │ 7   │ COMPOSITE, algo X   │ Y (different algo)                 │ Yes                                                              │
  ├─────┼─────────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
  │ 8   │ none                │ any algo                           │ Yes (source has no digest, must compute)                         │
  ├─────┼─────────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
  │ 9   │ any                 │ source is 0-byte                   │ Yes (special-cased — empty-bytes digest, no streaming)           │
  └─────┴─────────────────────┴────────────────────────────────────┴──────────────────────────────────────────────────────────────────┘
```

| Backend / scenario | Copy method | Old Copy method (pre-PR) |
|---|---|---|
| **file / mem / sproxyd (scality)** | `GET` + `PUT` + `DELETE` | `GET` + `PUT` + `DELETE` (same) |
| **aws_s3 / azure / gcp — propagate** (FULL_OBJECT src, algorithm absent or matching) | Native server-side copy (`CopyObject` / `beginCopyFromURL` / `copyObject`) — no GET | Native server-side copy (same) |
| **aws_s3 / azure / gcp — recompute** | `GET` + `PUT` + `DELETE` — streamed through CloudServer | Native server-side copy — no GET |
| **external, cross-type or external ↔ local** (e.g. aws → azure, aws → file) | `GET` + `PUT` + `DELETE` | `GET` + `PUT` + `DELETE` (same) |
| **external, any + SSE** | `GET` + `PUT` + `DELETE` | `GET` + `PUT` + `DELETE` (same) |
| **copy-to-self — propagate** (same location, no SSE, unversioned) | metadata-only — reuse location (no data) | metadata-only — reuse location (same) |
| **copy-to-self — recompute** (any backend) | `GET` only — reuse location (no PUT, no DELETE) | metadata-only — reuse location, no GET |
| **0-byte source** (same location / local) | metadata-only — no data | metadata-only — no data (same) |
| **0-byte source → different external backend** | `PUT` (`data.put(null)`) | `PUT` (`data.put(null)`) (same) |