### PR TITLE
CLDSRV-909: Reject CopyObject when source exceeds 5 GiB

### DIFF
--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -641,6 +641,17 @@ function objectCopy(authInfo, request, sourceBucket, sourceObject, sourceVersion
                             request.sourceServerAccessLog && (request.sourceServerAccessLog.error = err);
                             return next(err, destBucketMD);
                         }
+                        const sourceSize = parseInt(sourceObjMD['content-length'], 10);
+                        if (sourceSize > constants.maximumAllowedUploadSize) {
+                            log.debug('copy source object too large', { sourceSize });
+                            const err = errorInstances.InvalidRequest.customizeDescription(
+                                'The specified copy source is larger than the maximum ' +
+                                    `allowable size for a copy source: ${constants.maximumAllowedUploadSize}`,
+                            );
+                            // eslint-disable-next-line no-param-reassign
+                            request.sourceServerAccessLog && (request.sourceServerAccessLog.error = err);
+                            return next(err, destBucketMD);
+                        }
                         const headerValResult = validateHeaders(
                             request.headers,
                             sourceObjMD['last-modified'],

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -642,7 +642,7 @@ function objectCopy(authInfo, request, sourceBucket, sourceObject, sourceVersion
                             return next(err, destBucketMD);
                         }
                         const sourceSize = parseInt(sourceObjMD['content-length'], 10);
-                        if (sourceSize > constants.maximumAllowedUploadSize) {
+                        if (sourceSize > constants.maximumAllowedUploadSize && !config.bypassMaxPutObjectSize) {
                             log.debug('copy source object too large', { sourceSize });
                             const err = errorInstances.InvalidRequest.customizeDescription(
                                 'The specified copy source is larger than the maximum ' +

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -648,8 +648,10 @@ function objectCopy(authInfo, request, sourceBucket, sourceObject, sourceVersion
                                 'The specified copy source is larger than the maximum ' +
                                     `allowable size for a copy source: ${constants.maximumAllowedUploadSize}`,
                             );
-                            // eslint-disable-next-line no-param-reassign
-                            request.sourceServerAccessLog && (request.sourceServerAccessLog.error = err);
+                            if (request.sourceServerAccessLog) {
+                                // eslint-disable-next-line no-param-reassign
+                                request.sourceServerAccessLog.error = err;
+                            }
                             return next(err, destBucketMD);
                         }
                         const headerValResult = validateHeaders(

--- a/tests/unit/api/objectCopy.js
+++ b/tests/unit/api/objectCopy.js
@@ -1887,6 +1887,7 @@ describe('objectCopy source size limit', () => {
 
     after(() => {
         constants.maximumAllowedUploadSize = originalMaximumUploadSize;
+        config.bypassMaxPutObjectSize = false;
         cleanup();
     });
 
@@ -1911,5 +1912,16 @@ describe('objectCopy source size limit', () => {
             );
             done();
         });
+    });
+
+    it('should allow CopyObject when source size exceeds the limit but bypass flag is set', done => {
+        constants.maximumAllowedUploadSize = sourceSize - 1;
+        config.bypassMaxPutObjectSize = true;
+        const testObjectCopyRequest = _createObjectCopyRequest(destBucketName);
+        objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey,
+            undefined, log, err => {
+                assert.ifError(err);
+                done();
+            });
     });
 });

--- a/tests/unit/api/objectCopy.js
+++ b/tests/unit/api/objectCopy.js
@@ -16,7 +16,8 @@ const mpuUtils = require('../utils/mpuUtils');
 const metadata = require('../metadataswitch');
 const { data } = require('../../../lib/data/wrapper');
 const kms = require('../../../lib/kms/wrapper');
-const { objectLocationConstraintHeader } = require('../../../constants');
+const constants = require('../../../constants');
+const { objectLocationConstraintHeader } = constants;
 const { algorithms } = require('../../../lib/api/apiUtils/integrity/validateChecksums');
 const { fakeMetadataArchive } = require('../../functional/aws-node-sdk/test/utils/init');
 const { config } = require('../../../lib/Config');
@@ -1863,5 +1864,52 @@ describe('_orphanedDataLocations', () => {
 
     it('should flag a legacy string location that is no longer referenced', () => {
         assert.deepStrictEqual(orphanedDataLocations(['oldKey'], [{ key: 'newKey' }]), ['oldKey']);
+    });
+});
+
+describe('objectCopy source size limit', () => {
+    const testPutObjectRequest = versioningTestUtils.createPutObjectRequest(sourceBucketName, objectKey, objData[0]);
+    const sourceSize = objData[0].length;
+    let originalMaximumUploadSize;
+
+    before(done => {
+        cleanup();
+        originalMaximumUploadSize = constants.maximumAllowedUploadSize;
+        async.series(
+            [
+                callback => bucketPut(authInfo, putDestBucketRequest, log, callback),
+                callback => bucketPut(authInfo, putSourceBucketRequest, log, callback),
+                callback => objectPut(authInfo, testPutObjectRequest, undefined, log, callback),
+            ],
+            done,
+        );
+    });
+
+    after(() => {
+        constants.maximumAllowedUploadSize = originalMaximumUploadSize;
+        cleanup();
+    });
+
+    it('should allow CopyObject when source size equals the limit', done => {
+        constants.maximumAllowedUploadSize = sourceSize;
+        const testObjectCopyRequest = _createObjectCopyRequest(destBucketName);
+        objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey, undefined, log, err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+
+    it('should reject CopyObject when source size exceeds the limit', done => {
+        constants.maximumAllowedUploadSize = sourceSize - 1;
+        const testObjectCopyRequest = _createObjectCopyRequest(destBucketName);
+        objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey, undefined, log, err => {
+            assert(err);
+            assert.strictEqual(err.is.InvalidRequest, true);
+            assert.match(
+                err.description,
+                /The specified copy source is larger than the maximum allowable size for a copy source/,
+            );
+            done();
+        });
     });
 });

--- a/tests/unit/api/objectCopy.js
+++ b/tests/unit/api/objectCopy.js
@@ -1918,10 +1918,9 @@ describe('objectCopy source size limit', () => {
         constants.maximumAllowedUploadSize = sourceSize - 1;
         config.bypassMaxPutObjectSize = true;
         const testObjectCopyRequest = _createObjectCopyRequest(destBucketName);
-        objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey,
-            undefined, log, err => {
-                assert.ifError(err);
-                done();
-            });
+        objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey, undefined, log, err => {
+            assert.ifError(err);
+            done();
+        });
     });
 });


### PR DESCRIPTION
Align cloudserver's CopyObject with the AWS S3 contract by rejecting requests whose source object exceeds 5 GiB. AWS S3 returns HTTP 400 `InvalidRequest` ("The specified copy source is larger than the maximum allowable size for a copy source: 5368709120") and expects clients to use the multipart copy flow instead; cloudserver currently accepts these requests, leaving a gap with the published contract.

Targeting `development/9.4` because changing a previously-accepted response is a behavior break for clients that relied on cloudserver's permissive behavior, happy to retarget `development/9.3` if we prefer wider rollout.

Last commit contains a prettier fmt command and is kept separate from the actual code change for review. We should not focus on it as most of it is existing change.