### PR TITLE
CLDSRV-916: fix stale github.com/scality/S3 URL references

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,6 @@
 [![Docker Pulls][badgedocker]](https://hub.docker.com/r/zenko/cloudserver)
 [![Docker Pulls][badgetwitter]](https://twitter.com/zenko)
 
-## Build Status
-
-![Public Build Status][badgepub]
-![Private Build Status][badgepriv]
-
 ## Overview
 
 CloudServer (formerly S3 Server) is an open-source Amazon S3-compatible
@@ -169,5 +164,3 @@ This starts a Zenko CloudServer using Vault for user management.
 
 [badgetwitter]: https://img.shields.io/twitter/follow/zenko.svg?style=social&label=Follow
 [badgedocker]: https://img.shields.io/docker/pulls/scality/s3server.svg
-[badgepub]: https://circleci.com/gh/scality/S3.svg?style=svg
-[badgepriv]: http://ci.ironmann.io/gh/scality/S3.svg?style=svg&circle-token=1f105b7518b53853b5b7cf72302a3f75d8c598ae

--- a/docs/MD_SEARCH.rst
+++ b/docs/MD_SEARCH.rst
@@ -103,14 +103,14 @@ Performing Metadata Searches with Zenko
 You can perform metadata searches by:
 
 + Using the :code:`search_bucket` tool in the
-  `Scality/S3 <https://github.com/scality/S3>`_ GitHub repository.
+  `Scality/cloudserver <https://github.com/scality/cloudserver>`_ GitHub repository.
 + Creating a signed HTTP request to Zenko in your preferred programming
   language.
 
 Using the S3 Tool
 +++++++++++++++++
 
-After cloning the `Scality/S3 <https://github.com/scality/S3>`_ GitHub repository
+After cloning the `Scality/cloudserver <https://github.com/scality/cloudserver>`_ GitHub repository
 and installing the necessary dependencies, run the following command in the S3
 project’s root directory to access the search tool:
 


### PR DESCRIPTION
Update stale `github.com/scality/S3` URL references to `github.com/scality/cloudserver`.