### PR TITLE
CLDSRV-918: raise SDK request timeout in functional test client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zenko/cloudserver",
-    "version": "9.3.10",
+    "version": "9.3.11",
     "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
     "main": "index.js",
     "engines": {

--- a/tests/functional/aws-node-sdk/test/support/config.js
+++ b/tests/functional/aws-node-sdk/test/support/config.js
@@ -22,15 +22,23 @@ const DEFAULT_GLOBAL_OPTIONS = {
     httpOptions,
 };
 
+// Heavy server-side operations (multi-megabyte UploadPartCopy, 1000-key
+// batch deletes) send no response bytes until they complete, so they can
+// exceed a short request timeout under CI load. 30s gives ample headroom
+// while staying under mocha's 40s global timeout, so a genuine hang still
+// surfaces as the SDK's informative TimeoutError rather than a bare mocha
+// timeout.
+const REQUEST_TIMEOUT = 30000;
+
 const DEFAULT_MEM_OPTIONS = {
     endpoint: `${transport}://127.0.0.1:8000`,
     port: 8000,
     forcePathStyle: true,
-    region: 'us-east-1', 
+    region: 'us-east-1',
     maxAttempts: 3,
     requestHandler: new NodeHttpHandler({
         connectionTimeout: 5000,
-        requestTimeout: 5000,
+        requestTimeout: REQUEST_TIMEOUT,
         httpAgent: new (ssl ? https : http).Agent({
             maxSockets: 200,
             keepAlive: true,
@@ -44,7 +52,7 @@ const DEFAULT_AWS_OPTIONS = {
     maxAttempts: 3,
     requestHandler: new NodeHttpHandler({
         connectionTimeout: 5000,
-        socketTimeout: 5000,
+        requestTimeout: REQUEST_TIMEOUT,
         httpAgent: new https.Agent({
             maxSockets: 200,
             keepAlive: true,
@@ -64,9 +72,7 @@ function _getMemCredentials(profile) {
 function _getMemConfig(profile, config) {
     const credentials = _getMemCredentials(profile);
 
-    const memConfig = Object.assign({}
-        , DEFAULT_GLOBAL_OPTIONS, DEFAULT_MEM_OPTIONS
-        , { credentials }, config);
+    const memConfig = Object.assign({}, DEFAULT_GLOBAL_OPTIONS, DEFAULT_MEM_OPTIONS, { credentials }, config);
 
     if (process.env.IP) {
         memConfig.endpoint = `${transport}://${process.env.IP}:8000`;
@@ -78,9 +84,7 @@ function _getMemConfig(profile, config) {
 function _getAwsConfig(profile, config) {
     const credentials = getAwsCredentials(profile);
 
-    const awsConfig = Object.assign({}
-        , DEFAULT_GLOBAL_OPTIONS, DEFAULT_AWS_OPTIONS
-        , { credentials }, config);
+    const awsConfig = Object.assign({}, DEFAULT_GLOBAL_OPTIONS, DEFAULT_AWS_OPTIONS, { credentials }, config);
 
     return awsConfig;
 }


### PR DESCRIPTION
The AWS SDK v3 migration introduced a 5-second request timeout in the functional test client where SDK v2 previously ran with its 120-second default. Test operations that get no response bytes until the server finishes working - a 50MB server-side part copy, 1000-key batch deletes - regularly exceed 5 seconds of socket silence under CI load, producing `Connection timed out after 5000 ms` failures on more than a dozen unrelated branches over the past 60 days, including one merge-queue hit.

Raising the timeout to 30 seconds restores the pre-migration behavior within mocha's 40-second global cap: a genuine hang still fails the test, surfacing as the SDK's informative `TimeoutError` instead of a generic mocha timeout.

**Why this also bumps arsenal (ARSN-594, scality/Arsenal#2640):**

Raising the timeout uncovered a latent server-crash bug. In `@smithy/node-http-handler`, a `requestTimeout` below 6s is registered through `request.setTimeout()`, which Node cleans up when the request completes. At 6s and above, registration is deferred by 3s; for any request lasting longer than 3s the timer then attaches directly to the socket (`socket.setTimeout()`) and is never removed when the request finishes. With a keep-alive agent, the pooled socket keeps that stale timer and its handler later destroys the connection out from under whichever request is using it - so the 30s config turns every >3s test request into a delayed, random mid-stream disconnect.

A client vanishing mid-stream then hit a latent bug in arsenal's `retrieveData`: its `once()` guard around the iteration callback was created per data-layer callback invocation rather than per iteration, so a double callback during the teardown race ran the iteration callback twice, raising `Callback was already called` as an uncaughtException and killing the server. This crashed the `file-ft-tests` suites deterministically (3 out of 3 runs, 200+ cascading ECONNREFUSED failures each). The arsenal fix makes the guard iteration-scoped; a client disconnect can no longer take the server down.

**Reference for the previous 120s behavior:**
- The SDK v2 default: `aws-sdk@2.1692.0` ships `httpOptions: { timeout: 120000 }` ([`lib/config.js#L626-L628`](https://github.com/aws/aws-sdk-js/blob/v2.1692.0/lib/config.js#L626-L628)), documented as "Sets the socket to timeout after timeout milliseconds of inactivity on the socket. Defaults to two minutes (120000)" ([AWS.Config docs](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#httpOptions-property)).
- The pre-migration test config never overrode it: before the SDK v3 migration, [`tests/functional/aws-node-sdk/test/support/config.js` at `ea4659029`](https://github.com/scality/cloudserver/blob/ea46590291db2d2cd4af42a61c52aa68f32a25ad/tests/functional/aws-node-sdk/test/support/config.js) configured no timeout at all, so every functional test ran with the 120s default.