### PR TITLE
CLDSRV-922: do not reference null version from master in null-key mode

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -7,8 +7,7 @@ const joi = require('@hapi/joi');
 const backbeatProxy = httpProxy.createProxyServer({
     ignorePath: true,
 });
-const { auth, errors, errorInstances, s3middleware, s3routes, models, storage } =
-    require('arsenal');
+const { auth, errors, errorInstances, s3middleware, s3routes, models, storage } = require('arsenal');
 
 const { responseJSONBody } = s3routes.routesUtils;
 const { getSubPartIds } = s3middleware.azureHelper.mpuUtils;
@@ -17,18 +16,13 @@ const { parseLC, MultipleBackendGateway } = storage.data;
 const vault = require('../auth/vault');
 const dataWrapper = require('../data/wrapper');
 const metadata = require('../metadata/wrapper');
-const locationConstraintCheck = require(
-    '../api/apiUtils/object/locationConstraintCheck');
-const locationStorageCheck =
-    require('../api/apiUtils/object/locationStorageCheck');
+const locationConstraintCheck = require('../api/apiUtils/object/locationConstraintCheck');
+const locationStorageCheck = require('../api/apiUtils/object/locationStorageCheck');
 const { dataStore } = require('../api/apiUtils/object/storeObject');
-const prepareRequestContexts = require(
-'../api/apiUtils/authorization/prepareRequestContexts');
+const prepareRequestContexts = require('../api/apiUtils/authorization/prepareRequestContexts');
 const { decodeVersionId } = require('../api/apiUtils/object/versioning');
-const locationKeysHaveChanged
-      = require('../api/apiUtils/object/locationKeysHaveChanged');
-const { standardMetadataValidateBucketAndObj,
-    metadataGetObject } = require('../metadata/metadataUtils');
+const locationKeysHaveChanged = require('../api/apiUtils/object/locationKeysHaveChanged');
+const { standardMetadataValidateBucketAndObj, metadataGetObject } = require('../metadata/metadataUtils');
 const { config } = require('../Config');
 const constants = require('../../constants');
 const { BackendInfo } = models;
@@ -40,9 +34,8 @@ const { listLifecycleOrphanDeleteMarkers } = require('../api/backbeat/listLifecy
 const { objectDeleteInternal } = require('../api/objectDelete');
 const quotaUtils = require('../api/apiUtils/quotas/quotaUtils');
 const { handleAuthorizationResults } = require('../api/api');
-const { versioningPreprocessing }
-    = require('../api/apiUtils/object/versioning');
-const {promisify} = require('util');
+const { versioningPreprocessing } = require('../api/apiUtils/object/versioning');
+const { promisify } = require('util');
 
 const versioningPreprocessingPromised = promisify(versioningPreprocessing);
 metadata.getObjectMDPromised = promisify(metadata.getObjectMD);
@@ -69,8 +62,7 @@ config.on('location-constraints-update', () => {
     locationConstraints = config.locationConstraints;
     if (implName === 'multipleBackends') {
         const clients = parseLC(config, vault);
-        dataClient = new MultipleBackendGateway(
-            clients, metadata, locationStorageCheck);
+        dataClient = new MultipleBackendGateway(clients, metadata, locationStorageCheck);
     }
 });
 
@@ -93,12 +85,7 @@ function _normalizeBackbeatRequest(req) {
 }
 
 function _isObjectRequest(req) {
-    return [
-        'data',
-        'metadata',
-        'multiplebackenddata',
-        'multiplebackendmetadata',
-    ].includes(req.resourceType);
+    return ['data', 'metadata', 'multiplebackenddata', 'multiplebackendmetadata'].includes(req.resourceType);
 }
 
 function _respondWithHeaders(response, payload, extraHeaders, log, callback) {
@@ -108,12 +95,15 @@ function _respondWithHeaders(response, payload, extraHeaders, log, callback) {
     } else if (typeof payload === 'object') {
         body = JSON.stringify(payload);
     }
-    const httpHeaders = Object.assign({
-        'x-amz-id-2': log.getSerializedUids(),
-        'x-amz-request-id': log.getSerializedUids(),
-        'content-type': 'application/json',
-        'content-length': Buffer.byteLength(body),
-    }, extraHeaders);
+    const httpHeaders = Object.assign(
+        {
+            'x-amz-id-2': log.getSerializedUids(),
+            'x-amz-request-id': log.getSerializedUids(),
+            'content-type': 'application/json',
+            'content-length': Buffer.byteLength(body),
+        },
+        extraHeaders,
+    );
     if (response.serverAccessLog) {
         // eslint-disable-next-line no-param-reassign
         response.serverAccessLog.bytesSent = Buffer.byteLength(body);
@@ -140,8 +130,9 @@ function _getRequestPayload(req, cb) {
     req.on('data', chunk => {
         payload.push(chunk);
         payloadLen += chunk.length;
-    }).on('error', cb)
-    .on('end', () => cb(null, Buffer.concat(payload, payloadLen).toString()));
+    })
+        .on('error', cb)
+        .on('end', () => cb(null, Buffer.concat(payload, payloadLen).toString()));
 }
 
 function _checkMultipleBackendRequest(request, log) {
@@ -154,31 +145,29 @@ function _checkMultipleBackendRequest(request, log) {
         log.error(errMessage);
         return errorInstances.BadRequest.customizeDescription(errMessage);
     }
-    if (operation === 'putpart' &&
-        headers['x-scal-part-number'] === undefined) {
+    if (operation === 'putpart' && headers['x-scal-part-number'] === undefined) {
         errMessage = 'bad request: missing part-number header';
         log.error(errMessage);
         return errorInstances.BadRequest.customizeDescription(errMessage);
     }
-    const isMPUOperation =
-        ['putpart', 'completempu', 'abortmpu'].includes(operation);
+    const isMPUOperation = ['putpart', 'completempu', 'abortmpu'].includes(operation);
     if (isMPUOperation && headers['x-scal-upload-id'] === undefined) {
         errMessage = 'bad request: missing upload-id header';
         log.error(errMessage);
         return errorInstances.BadRequest.customizeDescription(errMessage);
     }
-    if (operation === 'putobject' &&
-        headers['x-scal-canonical-id'] === undefined) {
+    if (operation === 'putobject' && headers['x-scal-canonical-id'] === undefined) {
         errMessage = 'bad request: missing x-scal-canonical-id header';
         log.error(errMessage);
         return errorInstances.BadRequest.customizeDescription(errMessage);
     }
     // Ensure the external backend has versioning before asserting version ID.
-    if (!constants.versioningNotImplBackends[storageType] &&
-        (operation === 'puttagging' || operation === 'deletetagging')) {
+    if (
+        !constants.versioningNotImplBackends[storageType] &&
+        (operation === 'puttagging' || operation === 'deletetagging')
+    ) {
         if (headers['x-scal-data-store-version-id'] === undefined) {
-            errMessage =
-                'bad request: missing x-scal-data-store-version-id header';
+            errMessage = 'bad request: missing x-scal-data-store-version-id header';
             log.error(errMessage);
             return errorInstances.BadRequest.customizeDescription(errMessage);
         }
@@ -188,14 +177,12 @@ function _checkMultipleBackendRequest(request, log) {
             return errorInstances.BadRequest.customizeDescription(errMessage);
         }
         if (headers['x-scal-replication-endpoint-site'] === undefined) {
-            errMessage = 'bad request: missing ' +
-                'x-scal-replication-endpoint-site';
+            errMessage = 'bad request: missing ' + 'x-scal-replication-endpoint-site';
             log.error(errMessage);
             return errorInstances.BadRequest.customizeDescription(errMessage);
         }
     }
-    if (operation === 'putobject' &&
-        headers['content-md5'] === undefined) {
+    if (operation === 'putobject' && headers['content-md5'] === undefined) {
         errMessage = 'bad request: missing content-md5 header';
         log.error(errMessage);
         return errorInstances.BadRequest.customizeDescription(errMessage);
@@ -207,8 +194,7 @@ function _checkMultipleBackendRequest(request, log) {
     }
     const location = locationConstraints[headers['x-scal-storage-class']];
     const storageTypeList = storageType.split(',');
-    const isValidLocation = location &&
-          storageTypeList.includes(location.type);
+    const isValidLocation = location && storageTypeList.includes(location.type);
     if (!isValidLocation) {
         errMessage = 'invalid request: invalid location constraint in request';
         log.debug(errMessage, {
@@ -250,13 +236,11 @@ function generateMpuAggregateInfo(parts) {
     // MultipleBackendTask does not, so check if size is defined in
     // the first part.
     if (parts[0] && parts[0].Size) {
-        aggregateSize = parts.reduce(
-            (agg, part) => agg + Number.parseInt(part.Size[0], 10), 0);
+        aggregateSize = parts.reduce((agg, part) => agg + Number.parseInt(part.Size[0], 10), 0);
     }
     return {
         aggregateSize,
-        aggregateETag: s3middleware.processMpuParts.createAggregateETag(
-            parts.map(part => part.ETag[0])),
+        aggregateETag: s3middleware.processMpuParts.createAggregateETag(parts.map(part => part.ETag[0])),
     };
 }
 
@@ -281,15 +265,17 @@ function constructPutResponse(params) {
     // create the location as they are usually stored in the
     // "locations" attribute, with size/start info.
 
-    const location = [{
-        dataStoreName: params.dataStoreName,
-        dataStoreType: params.dataStoreType,
-        key: params.key,
-        start: 0,
-        size: params.size,
-        dataStoreETag: params.dataStoreETag,
-        dataStoreVersionId: params.dataStoreVersionId,
-    }];
+    const location = [
+        {
+            dataStoreName: params.dataStoreName,
+            dataStoreType: params.dataStoreType,
+            key: params.key,
+            start: 0,
+            size: params.size,
+            dataStoreETag: params.dataStoreETag,
+            dataStoreVersionId: params.dataStoreVersionId,
+        },
+    ];
     return {
         // TODO: Remove '' when versioning implemented for Azure.
         versionId: params.dataStoreVersionId || '',
@@ -297,8 +283,7 @@ function constructPutResponse(params) {
     };
 }
 
-function handleTaggingOperation(request, response, type, dataStoreVersionId,
-    log, callback) {
+function handleTaggingOperation(request, response, type, dataStoreVersionId, log, callback) {
     const storageLocation = request.headers['x-scal-storage-class'];
     const objectMD = {
         dataStoreName: storageLocation,
@@ -313,8 +298,7 @@ function handleTaggingOperation(request, response, type, dataStoreVersionId,
             return callback(errors.MalformedPOSTRequest);
         }
     }
-    return dataClient.objectTagging(type, request.objectKey,
-    request.bucketName, objectMD, log, err => {
+    return dataClient.objectTagging(type, request.objectKey, request.bucketName, objectMD, log, err => {
         if (err) {
             log.error(`error during object tagging: ${type}`, {
                 error: err,
@@ -432,8 +416,7 @@ function putData(request, response, bucketInfo, objMd, log, callback) {
         objectKey: request.objectKey,
     };
     const payloadLen = parseInt(request.headers['content-length'], 10);
-    const backendInfoObj = locationConstraintCheck(
-        request, null, bucketInfo, log);
+    const backendInfoObj = locationConstraintCheck(request, null, bucketInfo, log);
     if (backendInfoObj.err) {
         log.error('error getting backendInfo', {
             error: backendInfoObj.err,
@@ -452,8 +435,14 @@ function putData(request, response, bucketInfo, objMd, log, callback) {
             return callback(errors.InternalError);
         }
         return dataStore(
-            context, cipherBundle, request, payloadLen, {},
-            backendInfo, log, (err, retrievalInfo, md5) => {
+            context,
+            cipherBundle,
+            request,
+            payloadLen,
+            {},
+            backendInfo,
+            log,
+            (err, retrievalInfo, md5) => {
                 if (err) {
                     log.error('error putting data', {
                         error: err,
@@ -465,20 +454,29 @@ function putData(request, response, bucketInfo, objMd, log, callback) {
                     return callback(errors.BadDigest);
                 }
                 const { key, dataStoreName } = retrievalInfo;
-                const dataRetrievalInfo = [{
-                    key,
-                    dataStoreName,
-                }];
+                const dataRetrievalInfo = [
+                    {
+                        key,
+                        dataStoreName,
+                    },
+                ];
                 if (cipherBundle) {
                     dataRetrievalInfo[0].cryptoScheme = cipherBundle.cryptoScheme;
                     dataRetrievalInfo[0].cipheredDataKey = cipherBundle.cipheredDataKey;
-                    return _respondWithHeaders(response, dataRetrievalInfo, {
-                        'x-amz-server-side-encryption': cipherBundle.algorithm,
-                        'x-amz-server-side-encryption-aws-kms-key-id': cipherBundle.masterKeyId,
-                    }, log, callback);
+                    return _respondWithHeaders(
+                        response,
+                        dataRetrievalInfo,
+                        {
+                            'x-amz-server-side-encryption': cipherBundle.algorithm,
+                            'x-amz-server-side-encryption-aws-kms-key-id': cipherBundle.masterKeyId,
+                        },
+                        log,
+                        callback,
+                    );
                 }
                 return _respond(response, dataRetrievalInfo, log, callback);
-            });
+            },
+        );
     });
 }
 
@@ -493,7 +491,7 @@ function putData(request, response, bucketInfo, objMd, log, callback) {
  */
 
 /**
- * 
+ *
  * @param {string} accountId - account ID
  * @param {Log} log - logger instance
  * @param {CanonicalIdCallback} cb - callback function
@@ -539,10 +537,12 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
         // Destination-side delete-marker replication.
         // We need the REPLICA status to distinguish from
         // source-side replication status updates that also carry isDeleteMarker=true.
-        if (omVal.isDeleteMarker
-            && omVal.replicationInfo
-            && omVal.replicationInfo.status === 'REPLICA'
-            && request.serverAccessLog) {
+        if (
+            omVal.isDeleteMarker &&
+            omVal.replicationInfo &&
+            omVal.replicationInfo.status === 'REPLICA' &&
+            request.serverAccessLog
+        ) {
             // eslint-disable-next-line no-param-reassign
             request.serverAccessLog.replication = true;
             // eslint-disable-next-line no-param-reassign
@@ -554,11 +554,12 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
         // is replicated as a PUT of an empty tag set with the same
         // URI shape.
         // The REPLICA status excludes source-side replication-status updates.
-        if (omVal.replicationInfo
-            && omVal.replicationInfo.status === 'REPLICA'
-            && (omVal.originOp === 's3:ObjectTagging:Put'
-                || omVal.originOp === 's3:ObjectTagging:Delete')
-            && request.serverAccessLog) {
+        if (
+            omVal.replicationInfo &&
+            omVal.replicationInfo.status === 'REPLICA' &&
+            (omVal.originOp === 's3:ObjectTagging:Put' || omVal.originOp === 's3:ObjectTagging:Delete') &&
+            request.serverAccessLog
+        ) {
             // eslint-disable-next-line no-param-reassign
             request.serverAccessLog.replication = true;
             // eslint-disable-next-line no-param-reassign
@@ -570,10 +571,12 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
         // PUT /<bucket>/<key>?acl&versionId=<srcVersionId> and
         // populates the aclRequired field.
         // The REPLICA status excludes source-side replication-status updates.
-        if (omVal.replicationInfo
-            && omVal.replicationInfo.status === 'REPLICA'
-            && omVal.originOp === 's3:ObjectAcl:Put'
-            && request.serverAccessLog) {
+        if (
+            omVal.replicationInfo &&
+            omVal.replicationInfo.status === 'REPLICA' &&
+            omVal.originOp === 's3:ObjectAcl:Put' &&
+            request.serverAccessLog
+        ) {
             // eslint-disable-next-line no-param-reassign
             request.serverAccessLog.replication = true;
             // eslint-disable-next-line no-param-reassign
@@ -701,75 +704,83 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
             options.isNull = isNull;
         }
 
-        return async.series([
-            // Zenko's CRR delegates replacing the account
-            // information to the destination's Cloudserver, as
-            // Vault admin APIs are not exposed externally.
-            next => {
-                // Internal users of this API (other features in Zenko) will
-                // not provide the accountId in the request, as they only update
-                // the metadata of existing objects, so there is no need to
-                // replace the account information.
-                if (!request.query?.accountId) {
-                    return next();
-                }
-
-                return getCanonicalIdsByAccountId(request.query.accountId, log, (err, res) => {
-                    if (err) {
-                        return next(err);
+        return async.series(
+            [
+                // Zenko's CRR delegates replacing the account
+                // information to the destination's Cloudserver, as
+                // Vault admin APIs are not exposed externally.
+                next => {
+                    // Internal users of this API (other features in Zenko) will
+                    // not provide the accountId in the request, as they only update
+                    // the metadata of existing objects, so there is no need to
+                    // replace the account information.
+                    if (!request.query?.accountId) {
+                        return next();
                     }
-                    omVal['owner-display-name'] = res.name;
-                    omVal['owner-id'] = res.canonicalId;
-                    return next();
-                });
-            },
-            async () => {
-                // If we create a new version of an object (so objMd is null),
-                // we should make sure that the masterVersion is versioned.
-                // If an object already exists, we just want to update the metadata
-                // of the existing object and not create a new one
-                if (versioning && !objMd) {
-                    let masterMD;
 
-                    try {
-                        masterMD = await metadata.getObjectMDPromised(bucketName, objectKey, {}, log);
-                    } catch (err) {
-                        if (err.is?.NoSuchKey) {
-                            log.debug('no master found for versioned object', {
-                                method: 'putMetadata',
-                                bucketName,
-                                objectKey,
-                            });
-                        } else {
-                            throw err;
+                    return getCanonicalIdsByAccountId(request.query.accountId, log, (err, res) => {
+                        if (err) {
+                            return next(err);
+                        }
+                        omVal['owner-display-name'] = res.name;
+                        omVal['owner-id'] = res.canonicalId;
+                        return next();
+                    });
+                },
+                async () => {
+                    // If we create a new version of an object (so objMd is null),
+                    // we should make sure that the masterVersion is versioned.
+                    // If an object already exists, we just want to update the metadata
+                    // of the existing object and not create a new one
+                    if (versioning && !objMd) {
+                        let masterMD;
+
+                        try {
+                            masterMD = await metadata.getObjectMDPromised(bucketName, objectKey, {}, log);
+                        } catch (err) {
+                            if (err.is?.NoSuchKey) {
+                                log.debug('no master found for versioned object', {
+                                    method: 'putMetadata',
+                                    bucketName,
+                                    objectKey,
+                                });
+                            } else {
+                                throw err;
+                            }
+                        }
+
+                        if (!masterMD) {
+                            return;
+                        }
+
+                        const versioningPreprocessingResult = await versioningPreprocessingPromised(
+                            bucketName,
+                            bucketInfo,
+                            objectKey,
+                            masterMD,
+                            log,
+                        );
+
+                        if (versioningPreprocessingResult) {
+                            options.deleteNullKey = versioningPreprocessingResult.deleteNullKey;
+
+                            // The master references a null version only via extraMD,
+                            // which is set solely in nullVersionCompatMode. In null-key
+                            // mode there is no extraMD and the master must NOT carry
+                            // nullVersionId (mirrors the normal createAndStoreObject path).
+                            if (versioningPreprocessingResult.extraMD) {
+                                Object.assign(omVal, versioningPreprocessingResult.extraMD);
+                            }
                         }
                     }
-
-                    if (!masterMD) {
-                        return;
-                    }
-
-                    const versioningPreprocessingResult =
-                        await versioningPreprocessingPromised(bucketName, bucketInfo, objectKey, masterMD, log);
-
-                    if (versioningPreprocessingResult) {
-                        options.deleteNullKey = versioningPreprocessingResult.deleteNullKey;
-
-                        // The master references a null version only via extraMD,
-                        // which is set solely in nullVersionCompatMode. In null-key
-                        // mode there is no extraMD and the master must NOT carry
-                        // nullVersionId (mirrors the normal createAndStoreObject path).
-                        if (versioningPreprocessingResult.extraMD) {
-                            Object.assign(omVal, versioningPreprocessingResult.extraMD);
-                        }
-                    }
-                }
-            },
-            next => {
-                log.trace('putting object version', {
-                    objectKey: request.objectKey, omVal, options });
-                return metadata.putObjectMD(bucketName, objectKey, omVal, options, log,
-                    (err, md) => {
+                },
+                next => {
+                    log.trace('putting object version', {
+                        objectKey: request.objectKey,
+                        omVal,
+                        options,
+                    });
+                    return metadata.putObjectMD(bucketName, objectKey, omVal, options, log, (err, md) => {
                         if (err) {
                             // Handle duplicate key error during repair operation
                             // This can happen due to race conditions when multiple operations
@@ -777,11 +788,12 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
                             // is idempotent, if the master version already exists, we can
                             // treat this as success.
                             const errorMessage = err.message || err.toString() || '';
-                            const isRepairDuplicateKeyError = options.repairMaster &&
+                            const isRepairDuplicateKeyError =
+                                options.repairMaster &&
                                 (errorMessage.includes('E11000') ||
-                                 errorMessage.includes('duplicate key') ||
-                                 errorMessage.includes('repair'));
-                            
+                                    errorMessage.includes('duplicate key') ||
+                                    errorMessage.includes('repair'));
+
                             if (isRepairDuplicateKeyError) {
                                 log.warn('duplicate key error during repair - treating as success', {
                                     error: err,
@@ -792,20 +804,19 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
                                 });
                                 // Treat as success - the repair already completed
                                 // Get the current metadata to return
-                                return metadata.getObjectMD(bucketName, objectKey, {}, log,
-                                    (getErr, currentMD) => {
-                                        if (getErr) {
-                                            log.warn('could not retrieve metadata after repair duplicate key error', {
-                                                error: getErr,
-                                                method: 'putMetadata',
-                                            });
-                                            // Still treat as success since repair likely completed
-                                            return next(null, md || {});
-                                        }
-                                        return next(null, currentMD || md || {});
-                                    });
+                                return metadata.getObjectMD(bucketName, objectKey, {}, log, (getErr, currentMD) => {
+                                    if (getErr) {
+                                        log.warn('could not retrieve metadata after repair duplicate key error', {
+                                            error: getErr,
+                                            method: 'putMetadata',
+                                        });
+                                        // Still treat as success since repair likely completed
+                                        return next(null, md || {});
+                                    }
+                                    return next(null, currentMD || md || {});
+                                });
                             }
-    
+
                             log.error('error putting object metadata', {
                                 error: err,
                                 method: 'putMetadata',
@@ -813,47 +824,54 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
                             return next(err);
                         }
                         pushReplicationMetric(objMd, omVal, bucketName, objectKey, log);
-                        if (objMd &&
+                        if (
+                            objMd &&
                             headers['x-scal-replication-content'] !== 'METADATA' &&
                             versionId &&
                             // The new data location is set to null when archiving to a Cold site.
                             // In that case "removing old data location key" is handled by the lifecycle
                             // transition processor. Check the content-length as a null location can
                             // also be from an empty object.
-                            (omVal['content-length'] === 0 ||
-                             (omVal.location && Array.isArray(omVal.location))) &&
-                            locationKeysHaveChanged(objMd.location, omVal.location)) {
+                            (omVal['content-length'] === 0 || (omVal.location && Array.isArray(omVal.location))) &&
+                            locationKeysHaveChanged(objMd.location, omVal.location)
+                        ) {
                             log.info('removing old data locations', {
                                 method: 'putMetadata',
                                 bucketName,
                                 objectKey,
                             });
-                            async.eachLimit(objMd.location, 5,
-                            (loc, nextEach) => dataWrapper.data.delete(loc, log, err => {
-                                if (err) {
-                                    log.warn('error removing old data location key', {
+                            async.eachLimit(
+                                objMd.location,
+                                5,
+                                (loc, nextEach) =>
+                                    dataWrapper.data.delete(loc, log, err => {
+                                        if (err) {
+                                            log.warn('error removing old data location key', {
+                                                bucketName,
+                                                objectKey,
+                                                locationKey: loc,
+                                                error: err.message,
+                                            });
+                                        }
+                                        // do not forward the error to let other
+                                        // locations be deleted
+                                        nextEach();
+                                    }),
+                                () => {
+                                    log.debug('done removing old data locations', {
+                                        method: 'putMetadata',
                                         bucketName,
                                         objectKey,
-                                        locationKey: loc,
-                                        error: err.message,
                                     });
-                                }
-                                // do not forward the error to let other
-                                // locations be deleted
-                                nextEach();
-                            }),
-                            () => {
-                                log.debug('done removing old data locations', {
-                                    method: 'putMetadata',
-                                    bucketName,
-                                    objectKey,
-                                });
-                            });
+                                },
+                            );
                         }
                         return _respond(response, md, log, next);
                     });
-            }
-        ], callback);
+                },
+            ],
+            callback,
+        );
     });
 }
 
@@ -907,29 +925,27 @@ function putObject(request, response, log, callback) {
     }
     const payloadLen = parseInt(request.headers['content-length'], 10);
     const backendInfo = new BackendInfo(config, storageLocation);
-    return dataStore(context, CIPHER, request, payloadLen, {}, backendInfo, log,
-        (err, retrievalInfo, md5) => {
-            if (err) {
-                log.error('error putting data', {
-                    error: err,
-                    method: 'putObject',
-                });
-                return callback(err);
-            }
-            if (contentMD5 !== md5) {
-                return callback(errors.BadDigest);
-            }
-            const responsePayload = constructPutResponse({
-                dataStoreName: retrievalInfo.dataStoreName,
-                dataStoreType: retrievalInfo.dataStoreType,
-                key: retrievalInfo.key,
-                size: payloadLen,
-                dataStoreETag: retrievalInfo.dataStoreETag ?
-                    `1:${retrievalInfo.dataStoreETag}` : `1:${md5}`,
-                dataStoreVersionId: retrievalInfo.dataStoreVersionId,
+    return dataStore(context, CIPHER, request, payloadLen, {}, backendInfo, log, (err, retrievalInfo, md5) => {
+        if (err) {
+            log.error('error putting data', {
+                error: err,
+                method: 'putObject',
             });
-            return _respond(response, responsePayload, log, callback);
+            return callback(err);
+        }
+        if (contentMD5 !== md5) {
+            return callback(errors.BadDigest);
+        }
+        const responsePayload = constructPutResponse({
+            dataStoreName: retrievalInfo.dataStoreName,
+            dataStoreType: retrievalInfo.dataStoreType,
+            key: retrievalInfo.key,
+            size: payloadLen,
+            dataStoreETag: retrievalInfo.dataStoreETag ? `1:${retrievalInfo.dataStoreETag}` : `1:${md5}`,
+            dataStoreVersionId: retrievalInfo.dataStoreVersionId,
         });
+        return _respond(response, responsePayload, log, callback);
+    });
 }
 
 function deleteObjectFromExpiration(request, response, userInfo, log, callback) {
@@ -955,8 +971,7 @@ function deleteObject(request, response, log, callback) {
         return callback(err);
     }
     const storageLocation = request.headers['x-scal-storage-class'];
-    const objectGetInfo = dataClient.toObjectGetInfo(
-        request.objectKey, request.bucketName, storageLocation);
+    const objectGetInfo = dataClient.toObjectGetInfo(request.objectKey, request.bucketName, storageLocation);
     if (!objectGetInfo) {
         log.error('error deleting object in multiple backend', {
             error: 'cannot create objectGetInfo',
@@ -1020,9 +1035,18 @@ function initiateMultipartUpload(request, response, log, callback) {
             return callback(errors.MalformedPOSTRequest);
         }
     }
-    return dataClient.createMPU(request.objectKey, metaHeaders,
-        request.bucketName, undefined, storageLocation, contentType,
-        cacheControl, contentDisposition, contentEncoding, tagging, log,
+    return dataClient.createMPU(
+        request.objectKey,
+        metaHeaders,
+        request.bucketName,
+        undefined,
+        storageLocation,
+        contentType,
+        cacheControl,
+        contentDisposition,
+        contentEncoding,
+        tagging,
+        log,
         (err, data) => {
             if (err) {
                 log.error('error initiating multipart upload', {
@@ -1035,7 +1059,8 @@ function initiateMultipartUpload(request, response, log, callback) {
                 uploadId: data.UploadId,
             };
             return _respond(response, dataRetrievalInfo, log, callback);
-        });
+        },
+    );
 }
 
 function abortMultipartUpload(request, response, log, callback) {
@@ -1045,17 +1070,16 @@ function abortMultipartUpload(request, response, log, callback) {
     }
     const storageLocation = request.headers['x-scal-storage-class'];
     const uploadId = request.headers['x-scal-upload-id'];
-    return dataClient.abortMPU(request.objectKey, uploadId,
-        storageLocation, request.bucketName, log, err => {
-            if (err) {
-                log.error('error aborting MPU', {
-                    error: err,
-                    method: 'abortMultipartUpload',
-                });
-                return callback(err);
-            }
-            return _respond(response, {}, log, callback);
-        });
+    return dataClient.abortMPU(request.objectKey, uploadId, storageLocation, request.bucketName, log, err => {
+        if (err) {
+            log.error('error aborting MPU', {
+                error: err,
+                method: 'abortMultipartUpload',
+            });
+            return callback(err);
+        }
+        return _respond(response, {}, log, callback);
+    });
 }
 
 function putPart(request, response, log, callback) {
@@ -1067,9 +1091,18 @@ function putPart(request, response, log, callback) {
     const partNumber = request.headers['x-scal-part-number'];
     const uploadId = request.headers['x-scal-upload-id'];
     const payloadLen = parseInt(request.headers['content-length'], 10);
-    return dataClient.uploadPart(undefined, {}, request, payloadLen,
-        storageLocation, request.objectKey, uploadId, partNumber,
-        request.bucketName, log, (err, data) => {
+    return dataClient.uploadPart(
+        undefined,
+        {},
+        request,
+        payloadLen,
+        storageLocation,
+        request.objectKey,
+        uploadId,
+        partNumber,
+        request.bucketName,
+        log,
+        (err, data) => {
             if (err) {
                 log.error('error putting MPU part', {
                     error: err,
@@ -1083,7 +1116,8 @@ function putPart(request, response, log, callback) {
                 numberSubParts: data.numberSubParts,
             };
             return _respond(response, dataRetrievalInfo, log, callback);
-        });
+        },
+    );
 }
 
 function completeMultipartUpload(request, response, log, callback) {
@@ -1114,8 +1148,7 @@ function completeMultipartUpload(request, response, log, callback) {
             // FIXME: add error type MalformedJSON
             return callback(errors.MalformedPOSTRequest);
         }
-        const partList = getPartList(
-            parts, request.objectKey, uploadId, storageLocation);
+        const partList = getPartList(parts, request.objectKey, uploadId, storageLocation);
         // Azure client will set user metadata at this point.
         const metaHeaders = { 'x-amz-meta-scal-replication-status': 'REPLICA' };
         if (sourceVersionId) {
@@ -1148,9 +1181,17 @@ function completeMultipartUpload(request, response, log, callback) {
             contentDisposition: contentDisposition || undefined,
             contentEncoding: contentEncoding || undefined,
         };
-        return dataClient.completeMPU(request.objectKey, uploadId,
-            storageLocation, partList, undefined, request.bucketName,
-            metaHeaders, contentSettings, tagging, log,
+        return dataClient.completeMPU(
+            request.objectKey,
+            uploadId,
+            storageLocation,
+            partList,
+            undefined,
+            request.bucketName,
+            metaHeaders,
+            contentSettings,
+            tagging,
+            log,
             (err, retrievalInfo) => {
                 if (err) {
                     log.error('error completing MPU', {
@@ -1162,16 +1203,14 @@ function completeMultipartUpload(request, response, log, callback) {
                 // The logic here is an aggregate of code coming from
                 // lib/api/completeMultipartUpload.js.
 
-                const { key, dataStoreType, dataStoreVersionId } =
-                      retrievalInfo;
+                const { key, dataStoreType, dataStoreVersionId } = retrievalInfo;
                 let size;
                 let dataStoreETag;
                 if (skipMpuPartProcessing(retrievalInfo)) {
                     size = retrievalInfo.contentLength;
                     dataStoreETag = retrievalInfo.eTag;
                 } else {
-                    const { aggregateSize, aggregateETag } =
-                          generateMpuAggregateInfo(parts);
+                    const { aggregateSize, aggregateETag } = generateMpuAggregateInfo(parts);
                     size = aggregateSize;
                     dataStoreETag = aggregateETag;
                 }
@@ -1184,7 +1223,8 @@ function completeMultipartUpload(request, response, log, callback) {
                     dataStoreVersionId,
                 });
                 return _respond(response, responsePayload, log, callback);
-            });
+            },
+        );
     });
     return undefined;
 }
@@ -1202,23 +1242,19 @@ function putObjectTagging(request, response, log, callback) {
     // Kafka entry will not have the dataStoreVersionId available so we
     // retrieve it from metadata here.
     if (dataStoreVersionId === '') {
-        return metadataGetObject(sourceBucket, request.objectKey,
-            sourceVersionId, null, log, (err, objMD) => {
-                if (err) {
-                    return callback(err);
-                }
-                if (!objMD) {
-                    return callback(errors.NoSuchKey);
-                }
-                const backend = objMD.replicationInfo.backends.find(o =>
-                    o.site === site);
-                dataStoreVersionId = backend.dataStoreVersionId;
-                return handleTaggingOperation(request, response, 'Put',
-                    dataStoreVersionId, log, callback);
-            });
+        return metadataGetObject(sourceBucket, request.objectKey, sourceVersionId, null, log, (err, objMD) => {
+            if (err) {
+                return callback(err);
+            }
+            if (!objMD) {
+                return callback(errors.NoSuchKey);
+            }
+            const backend = objMD.replicationInfo.backends.find(o => o.site === site);
+            dataStoreVersionId = backend.dataStoreVersionId;
+            return handleTaggingOperation(request, response, 'Put', dataStoreVersionId, log, callback);
+        });
     }
-    return handleTaggingOperation(request, response, 'Put', dataStoreVersionId,
-        log, callback);
+    return handleTaggingOperation(request, response, 'Put', dataStoreVersionId, log, callback);
 }
 
 function deleteObjectTagging(request, response, log, callback) {
@@ -1234,29 +1270,24 @@ function deleteObjectTagging(request, response, log, callback) {
     // Kafka entry will not have the dataStoreVersionId available so we
     // retrieve it from metadata here.
     if (dataStoreVersionId === '') {
-        return metadataGetObject(sourceBucket, request.objectKey,
-            sourceVersionId, null, log, (err, objMD) => {
-                if (err) {
-                    return callback(err);
-                }
-                if (!objMD) {
-                    return callback(errors.NoSuchKey);
-                }
-                const backend = objMD.replicationInfo.backends.find(o =>
-                    o.site === site);
-                dataStoreVersionId = backend.dataStoreVersionId;
-                return handleTaggingOperation(request, response, 'Delete',
-                    dataStoreVersionId, log, callback);
-            });
+        return metadataGetObject(sourceBucket, request.objectKey, sourceVersionId, null, log, (err, objMD) => {
+            if (err) {
+                return callback(err);
+            }
+            if (!objMD) {
+                return callback(errors.NoSuchKey);
+            }
+            const backend = objMD.replicationInfo.backends.find(o => o.site === site);
+            dataStoreVersionId = backend.dataStoreVersionId;
+            return handleTaggingOperation(request, response, 'Delete', dataStoreVersionId, log, callback);
+        });
     }
-    return handleTaggingOperation(request, response, 'Delete',
-        dataStoreVersionId, log, callback);
+    return handleTaggingOperation(request, response, 'Delete', dataStoreVersionId, log, callback);
 }
 
 function _createAzureConditionalDeleteObjectGetInfo(request) {
     const { objectKey, bucketName, headers } = request;
-    const objectGetInfo = dataClient.toObjectGetInfo(
-        objectKey, bucketName, headers['x-scal-storage-class']);
+    const objectGetInfo = dataClient.toObjectGetInfo(objectKey, bucketName, headers['x-scal-storage-class']);
     return Object.assign({}, objectGetInfo, {
         options: {
             accessConditions: {
@@ -1345,10 +1376,7 @@ function _shouldConditionallyDelete(request, locations) {
         return false;
     }
     const storageClass = request.headers['x-scal-storage-class'];
-    const type =
-        storageClass &&
-        locationConstraints[storageClass] &&
-        locationConstraints[storageClass].type;
+    const type = storageClass && locationConstraints[storageClass] && locationConstraints[storageClass].type;
     const isExternalBackend = type && constants.externalBackends[type];
     const isNotVersioned = !locations[0].dataStoreVersionId;
     return isExternalBackend && isNotVersioned;
@@ -1371,67 +1399,84 @@ function batchDelete(request, response, userInfo, log, callback) {
         }
         const locations = parsedPayload.Locations;
         if (_shouldConditionallyDelete(request, locations)) {
-            return _performConditionalDelete(
-                request, response, locations, log, callback);
+            return _performConditionalDelete(request, response, locations, log, callback);
         }
         log.trace('batch delete locations', { locations });
-        return async.eachLimit(locations, 5, (loc, next) => {
-            const _loc = Object.assign({}, loc);
-            if (_loc.dataStoreVersionId !== undefined) {
-                // required by cloud backends
-                _loc.deleteVersion = true;
-            }
-            dataWrapper.data.delete(_loc, log, err => {
-                if (err?.is?.ObjNotFound) {
-                    log.info('batch delete: data location do not exist', {
-                        method: 'batchDelete',
-                        location: loc,
-                    });
-                    return next();
+        return async.eachLimit(
+            locations,
+            5,
+            (loc, next) => {
+                const _loc = Object.assign({}, loc);
+                if (_loc.dataStoreVersionId !== undefined) {
+                    // required by cloud backends
+                    _loc.deleteVersion = true;
                 }
-                return next(err);
-            });
-        }, err => {
-            if (err) {
-                log.error('batch delete failed', {
-                    method: 'batchDelete',
-                    locations,
-                    error: err,
+                dataWrapper.data.delete(_loc, log, err => {
+                    if (err?.is?.ObjNotFound) {
+                        log.info('batch delete: data location do not exist', {
+                            method: 'batchDelete',
+                            location: loc,
+                        });
+                        return next();
+                    }
+                    return next(err);
                 });
-                return callback(err);
-            }
-            log.debug('batch delete successful', { locations });
-
-            // Update inflight metrics for the data which has just been freed
-            const bucket = request.bucketName;
-            const contentLength = locations.reduce((length, loc) => length + loc.size, 0);
-
-            // TODO: `bucket` should probably always be passed, to be confirmed in CLDSRV-643
-            // For now be leniant and skip inflight updates if it is not specified, to avoid any
-            // impact esp. on CRR
-            if (!bucket || !config.isQuotaEnabled() || contentLength == 0) {
-                return _respond(response, null, log, callback);
-            }
-
-            return async.waterfall([
-                // eslint-disable-next-line no-unused-vars
-                next => metadata.getBucket(bucket, log, (err, bucketMD, raftSessionId) => next(err, bucketMD)),
-                (bucketMD, next) => quotaUtils.validateQuotas(request, bucketMD, request.accountQuotas,
-                    ['objectDelete'], 'objectDelete', -contentLength, false, log, next),
-            ], err => {
+            },
+            err => {
                 if (err) {
-                    // Ignore error, as the data has been deleted already: only inflight count
-                    // has not been updated, and will be eventually consistent anyway
-                    log.warn('batch delete failed to update inflights', {
+                    log.error('batch delete failed', {
                         method: 'batchDelete',
                         locations,
                         error: err,
                     });
+                    return callback(err);
+                }
+                log.debug('batch delete successful', { locations });
+
+                // Update inflight metrics for the data which has just been freed
+                const bucket = request.bucketName;
+                const contentLength = locations.reduce((length, loc) => length + loc.size, 0);
+
+                // TODO: `bucket` should probably always be passed, to be confirmed in CLDSRV-643
+                // For now be leniant and skip inflight updates if it is not specified, to avoid any
+                // impact esp. on CRR
+                if (!bucket || !config.isQuotaEnabled() || contentLength == 0) {
+                    return _respond(response, null, log, callback);
                 }
 
-                return _respond(response, null, log, callback);
-            });
-        });
+                return async.waterfall(
+                    [
+                        // eslint-disable-next-line no-unused-vars
+                        next => metadata.getBucket(bucket, log, (err, bucketMD, raftSessionId) => next(err, bucketMD)),
+                        (bucketMD, next) =>
+                            quotaUtils.validateQuotas(
+                                request,
+                                bucketMD,
+                                request.accountQuotas,
+                                ['objectDelete'],
+                                'objectDelete',
+                                -contentLength,
+                                false,
+                                log,
+                                next,
+                            ),
+                    ],
+                    err => {
+                        if (err) {
+                            // Ignore error, as the data has been deleted already: only inflight count
+                            // has not been updated, and will be eventually consistent anyway
+                            log.warn('batch delete failed to update inflights', {
+                                method: 'batchDelete',
+                                locations,
+                                error: err,
+                            });
+                        }
+
+                        return _respond(response, null, log, callback);
+                    },
+                );
+            },
+        );
     });
 }
 
@@ -1465,59 +1510,45 @@ function listLifecycle(request, response, userInfo, log, cb) {
 }
 
 function putBucketIndexes(indexes, request, response, userInfo, log, callback) {
-    metadata.putBucketIndexes(
-        request.bucketName,
-        indexes,
-        log,
-        err => {
-            if (err) {
-                log.error('error putting indexes', {
-                    error: err,
-                    method: 'putBucketindexes',
-                });
-                return callback(err);
-            }
+    metadata.putBucketIndexes(request.bucketName, indexes, log, err => {
+        if (err) {
+            log.error('error putting indexes', {
+                error: err,
+                method: 'putBucketindexes',
+            });
+            return callback(err);
+        }
 
-            return _respond(response, {}, log, callback);
-        },
-    );
+        return _respond(response, {}, log, callback);
+    });
 }
 
 function getBucketIndexes(request, response, userInfo, log, callback) {
-    metadata.getBucketIndexes(
-        request.bucketName,
-        log,
-        (err, indexObj) => {
-            if (err) {
-                log.error('error getting indexes', {
-                    error: err,
-                    method: 'getBucketindexes',
-                });
-                return callback(err);
-            }
+    metadata.getBucketIndexes(request.bucketName, log, (err, indexObj) => {
+        if (err) {
+            log.error('error getting indexes', {
+                error: err,
+                method: 'getBucketindexes',
+            });
+            return callback(err);
+        }
 
-            return _respond(response, { Indexes: indexObj }, log, callback);
-        },
-    );
+        return _respond(response, { Indexes: indexObj }, log, callback);
+    });
 }
 
 function deleteBucketIndexes(indexes, request, response, userInfo, log, callback) {
-    metadata.deleteBucketIndexes(
-        request.bucketName,
-        indexes,
-        log,
-        err => {
-            if (err) {
-                log.error('error deleting indexes', {
-                    error: err,
-                    method: 'deleteBucketindexes',
-                });
-                return callback(err);
-            }
+    metadata.deleteBucketIndexes(request.bucketName, indexes, log, err => {
+        if (err) {
+            log.error('error deleting indexes', {
+                error: err,
+                method: 'deleteBucketindexes',
+            });
+            return callback(err);
+        }
 
-            return _respond(response, {}, log, callback);
-        },
-    );
+        return _respond(response, {}, log, callback);
+    });
 }
 
 const backbeatRoutes = {
@@ -1559,12 +1590,16 @@ const backbeatRoutes = {
 
 const indexEntrySchema = joi.object({
     name: joi.string().required(),
-    keys: joi.array().items(joi.object({
-        key: joi.string(),
-        order: joi.number().valid(1, -1),
-    })).required(),
+    keys: joi
+        .array()
+        .items(
+            joi.object({
+                key: joi.string(),
+                order: joi.number().valid(1, -1),
+            }),
+        )
+        .required(),
 });
-
 
 const indexingSchema = joi.array().items(indexEntrySchema).min(1);
 
@@ -1609,40 +1644,45 @@ function routeBackbeatAPIProxy(request, response, requestContexts, log) {
     const { host, port } = config.backbeat;
     const target = `http://${host}:${port}${path}`;
 
-    auth.server.doAuth(request, log, (err, userInfo, authorizationResults, streamingV4Params, infos) => {
-        if (err) {
-            log.debug('authentication error', {
-                error: err,
-                method: request.method,
-                bucketName: request.bucketName,
-                objectKey: request.objectKey,
-            });
-            return responseJSONBody(err, null, response, log);
-        }
-        // We don't use the authorization results for now  
-        // as the UI uses the external Cloudserver instance
-        // as a proxy to access the Backbeat API service.
+    auth.server.doAuth(
+        request,
+        log,
+        (err, userInfo, authorizationResults, streamingV4Params, infos) => {
+            if (err) {
+                log.debug('authentication error', {
+                    error: err,
+                    method: request.method,
+                    bucketName: request.bucketName,
+                    objectKey: request.objectKey,
+                });
+                return responseJSONBody(err, null, response, log);
+            }
+            // We don't use the authorization results for now
+            // as the UI uses the external Cloudserver instance
+            // as a proxy to access the Backbeat API service.
 
-        // eslint-disable-next-line no-param-reassign
-        request.accountQuotas = infos?.accountQuota;
-        // FIXME for now, any authenticated user can access API
-        // routes. We should introduce admin accounts or accounts
-        // with admin privileges, and restrict access to those
-        // only.
-        if (userInfo.getCanonicalID() === constants.publicId) {
-            log.debug('unauthenticated access to API routes', {
-                method: request.method,
-                bucketName: request.bucketName,
-                objectKey: request.objectKey,
+            // eslint-disable-next-line no-param-reassign
+            request.accountQuotas = infos?.accountQuota;
+            // FIXME for now, any authenticated user can access API
+            // routes. We should introduce admin accounts or accounts
+            // with admin privileges, and restrict access to those
+            // only.
+            if (userInfo.getCanonicalID() === constants.publicId) {
+                log.debug('unauthenticated access to API routes', {
+                    method: request.method,
+                    bucketName: request.bucketName,
+                    objectKey: request.objectKey,
+                });
+                return responseJSONBody(errors.AccessDenied, null, response, log);
+            }
+            return backbeatProxy.web(request, response, { target }, err => {
+                log.error('error proxying request to api server', { error: err.message });
+                return responseJSONBody(errors.ServiceUnavailable, null, response, log);
             });
-            return responseJSONBody(errors.AccessDenied, null, response, log);
-        }
-        return backbeatProxy.web(request, response, { target }, err => {
-            log.error('error proxying request to api server',
-                { error: err.message });
-            return responseJSONBody(errors.ServiceUnavailable, null, response, log);
-        });
-    }, 's3', requestContexts);
+        },
+        's3',
+        requestContexts,
+    );
 }
 
 function routeNonObjectRequest(request, response, userInfo, log, callback) {
@@ -1731,20 +1771,16 @@ function routeBackbeat(clientIP, request, response, log) {
         return routeBackbeatAPIProxy(request, response, requestContexts, log);
     }
 
-    const useMultipleBackend =
-        request.resourceType && request.resourceType.startsWith('multiplebackend');
+    const useMultipleBackend = request.resourceType && request.resourceType.startsWith('multiplebackend');
     const invalidRequest =
-          (!request.resourceType ||
-           (_isObjectRequest(request) &&
-            (!request.bucketName || !request.objectKey)) ||
-           (!request.query.operation &&
-             request.resourceType === 'multiplebackenddata'));
+        !request.resourceType ||
+        (_isObjectRequest(request) && (!request.bucketName || !request.objectKey)) ||
+        (!request.query.operation && request.resourceType === 'multiplebackenddata');
     const invalidRoute =
-          (backbeatRoutes[request.method] === undefined ||
-           backbeatRoutes[request.method][request.resourceType] === undefined ||
-           (backbeatRoutes[request.method][request.resourceType]
-            [request.query.operation] === undefined &&
-            request.resourceType === 'multiplebackenddata'));
+        backbeatRoutes[request.method] === undefined ||
+        backbeatRoutes[request.method][request.resourceType] === undefined ||
+        (backbeatRoutes[request.method][request.resourceType][request.query.operation] === undefined &&
+            request.resourceType === 'multiplebackenddata');
     if (invalidRequest || invalidRoute) {
         log.debug(invalidRequest ? 'invalid request' : 'no such route');
         return responseJSONBody(errors.MethodNotAllowed, null, response, log);
@@ -1762,81 +1798,104 @@ function routeBackbeat(clientIP, request, response, log) {
         request.serverAccessLog.analyticsAction = route?.name ?? 'BACKBEAT_INVALID';
     }
 
-    return async.waterfall([
-        next => auth.server.doAuth(
-            request, log, (err, userInfo, authorizationResults, streamingV4Params, infos) => {
-                if (err) {
-                    log.debug('authentication error', {
-                        error: err,
-                        bucketName: request.bucketName,
-                        objectKey: request.objectKey,
+    return async.waterfall(
+        [
+            next =>
+                auth.server.doAuth(
+                    request,
+                    log,
+                    (err, userInfo, authorizationResults, streamingV4Params, infos) => {
+                        if (err) {
+                            log.debug('authentication error', {
+                                error: err,
+                                bucketName: request.bucketName,
+                                objectKey: request.objectKey,
+                            });
+                        }
+                        if (request.serverAccessLog && userInfo) {
+                            // eslint-disable-next-line no-param-reassign
+                            request.serverAccessLog.authInfo = userInfo;
+                            // eslint-disable-next-line no-param-reassign
+                            request.serverAccessLog.analyticsAccountName = userInfo.getAccountDisplayName();
+                            // eslint-disable-next-line no-param-reassign
+                            request.serverAccessLog.analyticsUserName = userInfo.getIAMdisplayName();
+                        }
+                        // eslint-disable-next-line no-param-reassign
+                        request.accountQuotas = infos?.accountQuota;
+                        return next(err, userInfo, authorizationResults);
+                    },
+                    's3',
+                    requestContexts,
+                ),
+            (userInfo, authorizationResults, next) =>
+                handleAuthorizationResults(request, authorizationResults, apiMethods[0], undefined, log, err =>
+                    next(err, userInfo),
+                ),
+            (userInfo, next) => {
+                if (request.serverAccessLog) {
+                    // eslint-disable-next-line no-param-reassign
+                    request.serverAccessLog.startTurnAroundTime = process.hrtime.bigint();
+                }
+                // TODO: understand why non-object requests (batchdelete) were not authenticated
+                if (!isObjectRequest) {
+                    return routeNonObjectRequest(request, response, userInfo, log, next);
+                }
+                const decodedVidResult = decodeVersionId(request.query);
+                if (decodedVidResult instanceof Error) {
+                    log.trace('invalid versionId query', {
+                        versionId: request.query.versionId,
+                        error: decodedVidResult,
                     });
+                    return next(errors.InvalidArgument);
                 }
-                if (request.serverAccessLog && userInfo) {
-                    // eslint-disable-next-line no-param-reassign
-                    request.serverAccessLog.authInfo = userInfo;
-                    // eslint-disable-next-line no-param-reassign
-                    request.serverAccessLog.analyticsAccountName = userInfo.getAccountDisplayName();
-                    // eslint-disable-next-line no-param-reassign
-                    request.serverAccessLog.analyticsUserName = userInfo.getIAMdisplayName();
-                }
-                // eslint-disable-next-line no-param-reassign
-                request.accountQuotas = infos?.accountQuota;
-                return next(err, userInfo, authorizationResults);
-            }, 's3', requestContexts),
-        (userInfo, authorizationResults, next) => handleAuthorizationResults(
-                request, authorizationResults, apiMethods[0], undefined, log, err => next(err, userInfo)),
-        (userInfo, next) => {
-            if (request.serverAccessLog) {
-                // eslint-disable-next-line no-param-reassign
-                request.serverAccessLog.startTurnAroundTime = process.hrtime.bigint();
-            }
-            // TODO: understand why non-object requests (batchdelete) were not authenticated
-            if (!isObjectRequest) {
-                return routeNonObjectRequest(request, response, userInfo, log, next);
-            }
-            const decodedVidResult = decodeVersionId(request.query);
-            if (decodedVidResult instanceof Error) {
-                log.trace('invalid versionId query', {
-                    versionId: request.query.versionId,
-                    error: decodedVidResult,
-                });
-                return next(errors.InvalidArgument);
-            }
-            const versionId = decodedVidResult;
-            if (useMultipleBackend) {
-                if (request.resourceType === 'multiplebackendmetadata') {
-                    return backbeatRoutes[request.method][request.resourceType](
-                        request, response, log, next);
-                }
-                return backbeatRoutes[request.method][request.resourceType]
-                    [request.query.operation](request, response, log, next);
-            }
-            const mdValParams = {
-                bucketName: request.bucketName,
-                objectKey: request.objectKey,
-                authInfo: userInfo,
-                versionId,
-                requestType: request.apiMethods || 'ReplicateObject',
-                request,
-            };
-            return standardMetadataValidateBucketAndObj(mdValParams, request.actionImplicitDenies, log,
-                (err, bucketInfo, objMd) => {
-                    if (err) {
-                        return next(err);
+                const versionId = decodedVidResult;
+                if (useMultipleBackend) {
+                    if (request.resourceType === 'multiplebackendmetadata') {
+                        return backbeatRoutes[request.method][request.resourceType](request, response, log, next);
                     }
-                    const versioningConfig = bucketInfo.getVersioningConfiguration();
-                    // The following makes sure that only replication destination-related operations
-                    // target buckets with versioning enabled.
-                    const isVersioningRequired = request.headers['x-scal-versioning-required'] === 'true';
-                    if (isVersioningRequired && (!versioningConfig || versioningConfig.Status !== 'Enabled')) {
-                        log.debug('bucket versioning is not enabled');
-                        return next(errors.InvalidBucketState);
-                    }
-                    return backbeatRoutes[request.method][request.resourceType](
-                        request, response, bucketInfo, objMd, log, next);
-                });
-        }],
+                    return backbeatRoutes[request.method][request.resourceType][request.query.operation](
+                        request,
+                        response,
+                        log,
+                        next,
+                    );
+                }
+                const mdValParams = {
+                    bucketName: request.bucketName,
+                    objectKey: request.objectKey,
+                    authInfo: userInfo,
+                    versionId,
+                    requestType: request.apiMethods || 'ReplicateObject',
+                    request,
+                };
+                return standardMetadataValidateBucketAndObj(
+                    mdValParams,
+                    request.actionImplicitDenies,
+                    log,
+                    (err, bucketInfo, objMd) => {
+                        if (err) {
+                            return next(err);
+                        }
+                        const versioningConfig = bucketInfo.getVersioningConfiguration();
+                        // The following makes sure that only replication destination-related operations
+                        // target buckets with versioning enabled.
+                        const isVersioningRequired = request.headers['x-scal-versioning-required'] === 'true';
+                        if (isVersioningRequired && (!versioningConfig || versioningConfig.Status !== 'Enabled')) {
+                            log.debug('bucket versioning is not enabled');
+                            return next(errors.InvalidBucketState);
+                        }
+                        return backbeatRoutes[request.method][request.resourceType](
+                            request,
+                            response,
+                            bucketInfo,
+                            objMd,
+                            log,
+                            next,
+                        );
+                    },
+                );
+            },
+        ],
         err => {
             async.forEachLimit(
                 // Finalizer hooks are used in a quota context and ensure consistent
@@ -1863,9 +1922,9 @@ function routeBackbeat(clientIP, request, response, log) {
                     return responseJSONBody(null, null, response, log);
                 },
             );
-    });
+        },
+    );
 }
-
 
 module.exports = {
     backbeatRoutes,

--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -752,12 +752,15 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
                     const versioningPreprocessingResult =
                         await versioningPreprocessingPromised(bucketName, bucketInfo, objectKey, masterMD, log);
 
-                    if (versioningPreprocessingResult?.nullVersionId) {
-                        omVal.nullVersionId = versioningPreprocessingResult.nullVersionId;
+                    if (versioningPreprocessingResult) {
                         options.deleteNullKey = versioningPreprocessingResult.deleteNullKey;
 
+                        // The master references a null version only via extraMD,
+                        // which is set solely in nullVersionCompatMode. In null-key
+                        // mode there is no extraMD and the master must NOT carry
+                        // nullVersionId (mirrors the normal createAndStoreObject path).
                         if (versioningPreprocessingResult.extraMD) {
-                            Object.assign(omVal, options.extraMD);
+                            Object.assign(omVal, versioningPreprocessingResult.extraMD);
                         }
                     }
                 }

--- a/tests/multipleBackend/routes/routeBackbeatForReplication.js
+++ b/tests/multipleBackend/routes/routeBackbeatForReplication.js
@@ -59,6 +59,8 @@ const dst = {
 
 const testData = 'testkey data';
 
+const isNullVersionCompatMode = process.env.ENABLE_NULL_VERSION_COMPAT_MODE === 'true';
+
 // Generate unique bucket name function
 function generateUniqueBucketName(prefix) {
     return `${prefix}-${uuidv4().substring(0, 8)}`;
@@ -1174,6 +1176,115 @@ describe(`backbeat routes for replication (${name})`, () => {
 
             assert.strictEqual(nonCurrentVersion.VersionId, 'null');
             assert.strictEqual(nonCurrentVersion.IsLatest, false);
+
+            return done();
+        });
+    });
+
+    // CLDSRV-922: when replicating a version on top of a pre-existing null
+    // version, the new master must reference the null version via nullVersionId
+    // only in null-version compatibility mode. In null-key mode the null version
+    // is stored under the null key, and a master carrying nullVersionId leads the
+    // metadata backend to orphan the null key on a later version-specific delete
+    // (causing BucketNotEmpty).
+    it('should set nullVersionId on the master when replicating a version ' +
+        'over a null version only in compat mode', done => {
+        let objMD;
+        let versionId;
+
+        async.series({
+            putObjectDestinationInitial: next => dstS3.send(new PutObjectCommand({
+                Bucket: bucketDestination,
+                Key: keyName,
+                Body: Buffer.from(testData),
+            })).then(data => next(null, data)).catch(err => next(err)),
+
+            enableVersioningDestination: next => dstS3.send(new PutBucketVersioningCommand({
+                Bucket: bucketDestination,
+                VersioningConfiguration: { Status: 'Enabled' }
+            })).then(data => next(null, data)).catch(err => next(err)),
+
+            enableVersioningSource: next => srcS3.send(new PutBucketVersioningCommand({
+                Bucket: bucketSource,
+                VersioningConfiguration: { Status: 'Enabled' }
+            })).then(data => next(null, data)).catch(err => next(err)),
+
+            putObjectSource: next => srcS3.send(new PutObjectCommand({
+                Bucket: bucketSource,
+                Key: keyName,
+                Body: Buffer.from(testData)
+            })).then(data => {
+                versionId = data.VersionId;
+                return next(null, data);
+            }).catch(err => next(err)),
+
+            getMetadata: next => makeBackbeatRequest({
+                method: 'GET',
+                resourceType: 'metadata',
+                bucket: bucketSource,
+                objectKey: keyName,
+                queryObj: {
+                    versionId,
+                },
+                authCredentials: sourceAuthCredentials,
+            }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+
+                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
+                return next();
+            }),
+            replicateMetadata: next => makeBackbeatRequest({
+                method: 'PUT',
+                resourceType: 'metadata',
+                bucket: bucketDestination,
+                objectKey: keyName,
+                queryObj: {
+                    versionId,
+                },
+                authCredentials: destinationAuthCredentials,
+                requestBody: objMD,
+            }, next),
+            // GET with no versionId returns the master metadata.
+            getMasterMetadata: next => makeBackbeatRequest({
+                method: 'GET',
+                resourceType: 'metadata',
+                bucket: bucketDestination,
+                objectKey: keyName,
+                authCredentials: destinationAuthCredentials,
+            }, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                return next(null, data);
+            }),
+            // The user-visible symptom of the bug is a null key orphaned on
+            // delete, leaving the bucket non-empty: emptying it here exercises
+            // the version-specific delete of the null version.
+            emptyDestination: next => dstBucketUtil.empty(bucketDestination)
+                .then(() => next()).catch(err => next(err)),
+            listAfterEmpty: next => dstS3.send(new ListObjectVersionsCommand({
+                Bucket: bucketDestination,
+            })).then(data => next(null, data)).catch(err => next(err)),
+        }, (err, results) => {
+            if (err) {
+                return done(err);
+            }
+
+            const masterMD = objectMDFromRequestBody(results.getMasterMetadata);
+            if (isNullVersionCompatMode) {
+                // compat mode references the null version from the master
+                assert.notStrictEqual(masterMD.getNullVersionId(), undefined);
+            } else {
+                // null-key mode: the master must not reference the null version
+                assert.strictEqual(masterMD.getNullVersionId(), undefined);
+            }
+
+            // no orphaned null key must survive: the bucket is fully empty
+            const listAfterEmpty = results.listAfterEmpty;
+            assert.strictEqual((listAfterEmpty.Versions || []).length, 0);
+            assert.strictEqual((listAfterEmpty.DeleteMarkers || []).length, 0);
 
             return done();
         });

--- a/tests/multipleBackend/routes/routeBackbeatForReplication.js
+++ b/tests/multipleBackend/routes/routeBackbeatForReplication.js
@@ -32,10 +32,8 @@ const destinationAuthCredentials = {
 };
 
 // Note: for S3C tests, those conf files needs to be modified beforehand
-const dstAccountInfo = require('../../../conf/authdata.json')
-    .accounts.find(acc => acc.name === 'Replication');
-const srcAccountInfo = require('../../../conf/authdata.json')
-    .accounts.find(acc => acc.name === 'Bart');
+const dstAccountInfo = require('../../../conf/authdata.json').accounts.find(acc => acc.name === 'Replication');
+const srcAccountInfo = require('../../../conf/authdata.json').accounts.find(acc => acc.name === 'Bart');
 
 const srcBucketUtil = new BucketUtility('default', { signatureVersion: 'v4' });
 const srcS3 = srcBucketUtil.s3;
@@ -76,9 +74,7 @@ function objectMDWithUpdatedAccountInfo(data, dstAccountInfo = null) {
     const objMD = objectMDFromRequestBody(data);
 
     if (dstAccountInfo) {
-        objMD
-            .setOwnerDisplayName(dstAccountInfo.name)
-            .setOwnerId(dstAccountInfo.canonicalID);
+        objMD.setOwnerDisplayName(dstAccountInfo.name).setOwnerId(dstAccountInfo.canonicalID);
     }
 
     return objMD.getSerialized();
@@ -91,1996 +87,3016 @@ const scenarios = [
 ];
 
 scenarios.forEach(({ name, src, dst }) => {
-describe(`backbeat routes for replication (${name})`, () => {
-    const { s3: srcS3, bucketUtil: srcBucketUtil, credentials: sourceAuthCredentials } = src;
-    const { s3: dstS3, bucketUtil: dstBucketUtil, credentials: destinationAuthCredentials } = dst;
-    const { accountInfo: dstAccountInfo } = dst;
+    describe(`backbeat routes for replication (${name})`, () => {
+        const { s3: srcS3, bucketUtil: srcBucketUtil, credentials: sourceAuthCredentials } = src;
+        const { s3: dstS3, bucketUtil: dstBucketUtil, credentials: destinationAuthCredentials } = dst;
+        const { accountInfo: dstAccountInfo } = dst;
 
-    let bucketSource;
-    let bucketDestination;
-    const keyName = 'key0';
-    const storageClass = 'foo';
+        let bucketSource;
+        let bucketDestination;
+        const keyName = 'key0';
+        const storageClass = 'foo';
 
-    beforeEach(async () => {
-        bucketSource = generateUniqueBucketName('backbeatbucket-replication-source');
-        bucketDestination = generateUniqueBucketName('backbeatbucket-replication-destination');
-        await srcBucketUtil.emptyIfExists(bucketSource);
-        await srcS3.send(new CreateBucketCommand({ Bucket: bucketSource }));
-        await dstBucketUtil.emptyIfExists(bucketDestination);
-        await dstS3.send(new CreateBucketCommand({ Bucket: bucketDestination }));
-    });
-
-    afterEach(async () => {
-        await srcBucketUtil.empty(bucketSource);
-        await srcS3.send(new DeleteBucketCommand({ Bucket: bucketSource }));
-        await dstBucketUtil.empty(bucketDestination);
-        await dstS3.send(new DeleteBucketCommand({ Bucket: bucketDestination }));
-    });
-
-    it('should successfully replicate a version', done => {
-        let objMD;
-        let versionId;
-
-        async.series({
-            enableVersioningSource: next => srcS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketSource,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(() => next()).catch(next),
-
-            putObject: next => srcS3.send(new PutObjectCommand({
-                Bucket: bucketSource,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data=> {
-                versionId = data.VersionId;
-                return next(null, data);
-            }).catch(err => next(err)),
-
-            enableVersioningDestination: next => dstS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketDestination,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            getMetadata: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: {
-                    versionId,
-                },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
-                return next();
-            }),
-            replicateMetadata: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: {
-                    versionId,
-                },
-                authCredentials: destinationAuthCredentials,
-                requestBody: objMD,
-            }, next),
-            headObject: next => dstS3.send(new HeadObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                VersionId: versionId
-            })).then(data => next(null, data)).catch(err => next(err)),
-            listObjectVersions: next => dstS3.send(new ListObjectVersionsCommand({
-                Bucket: bucketDestination
-            })).then(data => next(null, data)).catch(err => next(err)),
-        }, (err, results) => {
-            if (err) {
-                return done(err);
-            }
-
-            const headObjectRes = results.headObject;
-            assert.strictEqual(headObjectRes.VersionId, versionId);
-
-            const listObjectVersionsRes = results.listObjectVersions;
-            const { Versions } = listObjectVersionsRes;
-            assert.strictEqual(Versions.length, 1);
-            assert.strictEqual(Versions[0].IsLatest, true);
-            assert.strictEqual(Versions[0].VersionId, versionId);
-
-            return done();
+        beforeEach(async () => {
+            bucketSource = generateUniqueBucketName('backbeatbucket-replication-source');
+            bucketDestination = generateUniqueBucketName('backbeatbucket-replication-destination');
+            await srcBucketUtil.emptyIfExists(bucketSource);
+            await srcS3.send(new CreateBucketCommand({ Bucket: bucketSource }));
+            await dstBucketUtil.emptyIfExists(bucketDestination);
+            await dstS3.send(new CreateBucketCommand({ Bucket: bucketDestination }));
         });
-    });
 
-    it('should successfully replicate a version and update it', done => {
-        let objMD;
-        let versionId;
+        afterEach(async () => {
+            await srcBucketUtil.empty(bucketSource);
+            await srcS3.send(new DeleteBucketCommand({ Bucket: bucketSource }));
+            await dstBucketUtil.empty(bucketDestination);
+            await dstS3.send(new DeleteBucketCommand({ Bucket: bucketDestination }));
+        });
 
-        async.series({
-            enableVersioningSource: next => srcS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketSource,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
+        it('should successfully replicate a version', done => {
+            let objMD;
+            let versionId;
 
-            putObject: next => srcS3.send(new PutObjectCommand({
-                Bucket: bucketSource,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => {
-                versionId = data.VersionId;
-                next(null, data);
-            }).catch(err => next(err)),
+            async.series(
+                {
+                    enableVersioningSource: next =>
+                        srcS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketSource,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(() => next())
+                            .catch(next),
 
-            enableVersioningDestination: next => dstS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketDestination,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
+                    putObject: next =>
+                        srcS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketSource,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => {
+                                versionId = data.VersionId;
+                                return next(null, data);
+                            })
+                            .catch(err => next(err)),
 
-            getMetadata: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: {
-                    versionId,
+                    enableVersioningDestination: next =>
+                        dstS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketDestination,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+
+                    getMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId,
+                                },
+                                authCredentials: sourceAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
+                                return next();
+                            },
+                        ),
+                    replicateMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId,
+                                },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: objMD,
+                            },
+                            next,
+                        ),
+                    headObject: next =>
+                        dstS3
+                            .send(
+                                new HeadObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    VersionId: versionId,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    listObjectVersions: next =>
+                        dstS3
+                            .send(
+                                new ListObjectVersionsCommand({
+                                    Bucket: bucketDestination,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
                 },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
-                return next();
-            }),
-            replicateMetadata: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: {
-                    versionId,
+                (err, results) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    const headObjectRes = results.headObject;
+                    assert.strictEqual(headObjectRes.VersionId, versionId);
+
+                    const listObjectVersionsRes = results.listObjectVersions;
+                    const { Versions } = listObjectVersionsRes;
+                    assert.strictEqual(Versions.length, 1);
+                    assert.strictEqual(Versions[0].IsLatest, true);
+                    assert.strictEqual(Versions[0].VersionId, versionId);
+
+                    return done();
                 },
-                authCredentials: destinationAuthCredentials,
-                requestBody: objMD,
-            }, next),
-            updateMetadata: next => {
-                const { result, error } = ObjectMD.createFromBlob(objMD);
-                if (error) {
-                    return next(error);
-                }
-                result.setTags({ foo: 'bar' });
-                return makeBackbeatRequest({
-                    method: 'PUT',
-                    resourceType: 'metadata',
-                    bucket: bucketDestination,
-                    objectKey: keyName,
-                    queryObj: {
-                        versionId,
+            );
+        });
+
+        it('should successfully replicate a version and update it', done => {
+            let objMD;
+            let versionId;
+
+            async.series(
+                {
+                    enableVersioningSource: next =>
+                        srcS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketSource,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+
+                    putObject: next =>
+                        srcS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketSource,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => {
+                                versionId = data.VersionId;
+                                next(null, data);
+                            })
+                            .catch(err => next(err)),
+
+                    enableVersioningDestination: next =>
+                        dstS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketDestination,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+
+                    getMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId,
+                                },
+                                authCredentials: sourceAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
+                                return next();
+                            },
+                        ),
+                    replicateMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId,
+                                },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: objMD,
+                            },
+                            next,
+                        ),
+                    updateMetadata: next => {
+                        const { result, error } = ObjectMD.createFromBlob(objMD);
+                        if (error) {
+                            return next(error);
+                        }
+                        result.setTags({ foo: 'bar' });
+                        return makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId,
+                                },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: result.getSerialized(),
+                            },
+                            next,
+                        );
                     },
-                    authCredentials: destinationAuthCredentials,
-                    requestBody: result.getSerialized(),
-                }, next);
-            },
-            getObjectTagging: next => dstS3.send(new GetObjectTaggingCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                VersionId: versionId
-            })).then(data => next(null, data)).catch(err => next(err)),
-            listObjectVersions: next => dstS3.send(new ListObjectVersionsCommand({
-                Bucket: bucketDestination
-            })).then(data => next(null, data)).catch(err => next(err)),
-        }, (err, results) => {
-            if (err) {
-                return done(err);
-            }
+                    getObjectTagging: next =>
+                        dstS3
+                            .send(
+                                new GetObjectTaggingCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    VersionId: versionId,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    listObjectVersions: next =>
+                        dstS3
+                            .send(
+                                new ListObjectVersionsCommand({
+                                    Bucket: bucketDestination,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                },
+                (err, results) => {
+                    if (err) {
+                        return done(err);
+                    }
 
-            const getObjectTaggingRes = results.getObjectTagging;
-            assert.strictEqual(getObjectTaggingRes.VersionId, versionId);
-            assert.deepStrictEqual(getObjectTaggingRes.TagSet, [{ Key: 'foo', Value: 'bar' }]);
+                    const getObjectTaggingRes = results.getObjectTagging;
+                    assert.strictEqual(getObjectTaggingRes.VersionId, versionId);
+                    assert.deepStrictEqual(getObjectTaggingRes.TagSet, [{ Key: 'foo', Value: 'bar' }]);
 
-            const listObjectVersionsRes = results.listObjectVersions;
-            const { Versions } = listObjectVersionsRes;
-            assert.strictEqual(Versions.length, 1);
-            assert.strictEqual(Versions[0].IsLatest, true);
-            assert.strictEqual(Versions[0].VersionId, versionId);
+                    const listObjectVersionsRes = results.listObjectVersions;
+                    const { Versions } = listObjectVersionsRes;
+                    assert.strictEqual(Versions.length, 1);
+                    assert.strictEqual(Versions[0].IsLatest, true);
+                    assert.strictEqual(Versions[0].VersionId, versionId);
 
-            return done();
+                    return done();
+                },
+            );
         });
-    });
 
-    it('should successfully replicate a version and update account info', done => {
-        let objMD;
-        let versionId;
+        it('should successfully replicate a version and update account info', done => {
+            let objMD;
+            let versionId;
 
-        async.series({
-            enableVersioningSource: next => srcS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketSource,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
+            async.series(
+                {
+                    enableVersioningSource: next =>
+                        srcS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketSource,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-            putObject: next => srcS3.send(new PutObjectCommand({
-                Bucket: bucketSource,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => {
-                versionId = data.VersionId;
-                next(null, data);
-            }).catch(err => next(err)),
+                    putObject: next =>
+                        srcS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketSource,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => {
+                                versionId = data.VersionId;
+                                next(null, data);
+                            })
+                            .catch(err => next(err)),
 
-            enableVersioningDestination: next => dstS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketDestination,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
+                    enableVersioningDestination: next =>
+                        dstS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketDestination,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-            getMetadata: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: {
-                    versionId,
+                    getMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId,
+                                },
+                                authCredentials: sourceAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                // AccountInfo not provided here as the replicateMetadata request should do it
+                                objMD = objectMDWithUpdatedAccountInfo(data, null);
+                                return next();
+                            },
+                        ),
+                    replicateMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId,
+                                    // Specifying the account id in the query string
+                                    // should make it update the account info in the
+                                    // metadata to the destination account info
+                                    accountId: dstAccountInfo.shortid,
+                                },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: objMD,
+                            },
+                            next,
+                        ),
+                    getDestinationMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId,
+                                },
+                                authCredentials: destinationAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                return next(null, objectMDFromRequestBody(data));
+                            },
+                        ),
                 },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                // AccountInfo not provided here as the replicateMetadata request should do it
-                objMD = objectMDWithUpdatedAccountInfo(data, null);
-                return next();
-            }),
-            replicateMetadata: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: {
-                    versionId,
-                    // Specifying the account id in the query string
-                    // should make it update the account info in the
-                    // metadata to the destination account info
-                    accountId: dstAccountInfo.shortid,
-                },
-                authCredentials: destinationAuthCredentials,
-                requestBody: objMD,
-            }, next),
-            getDestinationMetadata: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: {
-                    versionId,
-                },
-                authCredentials: destinationAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                return next(null, objectMDFromRequestBody(data));
-            }),
-        }, (err, results) => {
-            if (err) {
-                return done(err);
-            }
+                (err, results) => {
+                    if (err) {
+                        return done(err);
+                    }
 
-            const dstObjMD = results.getDestinationMetadata;
-            assert.strictEqual(dstObjMD.getOwnerDisplayName(), dstAccountInfo.name);
-            assert.strictEqual(dstObjMD.getOwnerId(), dstAccountInfo.canonicalID);
+                    const dstObjMD = results.getDestinationMetadata;
+                    assert.strictEqual(dstObjMD.getOwnerDisplayName(), dstAccountInfo.name);
+                    assert.strictEqual(dstObjMD.getOwnerId(), dstAccountInfo.canonicalID);
 
-            return done();
+                    return done();
+                },
+            );
         });
-    });
 
-    it('should fail to replicate a version if the provided account is invalid', done => {
-        let objMD;
-        let versionId;
+        it('should fail to replicate a version if the provided account is invalid', done => {
+            let objMD;
+            let versionId;
 
-        async.series({
-            enableVersioningSource: next => srcS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketSource,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
+            async.series(
+                {
+                    enableVersioningSource: next =>
+                        srcS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketSource,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-            putObject: next => srcS3.send(new PutObjectCommand({
-                Bucket: bucketSource,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => {
-                versionId = data.VersionId;
-                return next(null, data);
-            }).catch(err => next(err)),
+                    putObject: next =>
+                        srcS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketSource,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => {
+                                versionId = data.VersionId;
+                                return next(null, data);
+                            })
+                            .catch(err => next(err)),
 
-            enableVersioningDestination: next => dstS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketDestination,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
+                    enableVersioningDestination: next =>
+                        dstS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketDestination,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-            getMetadata: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: {
-                    versionId,
+                    getMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId,
+                                },
+                                authCredentials: sourceAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                // AccountInfo not provided here as the replicateMetadata request should do it
+                                objMD = objectMDWithUpdatedAccountInfo(data, null);
+                                return next();
+                            },
+                        ),
+                    replicateMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId,
+                                    // Vault v1 differentiate InvalidAccountId from NoSuchEntity
+                                    accountId: '888888888888',
+                                },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: objMD,
+                            },
+                            next,
+                        ),
                 },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                // AccountInfo not provided here as the replicateMetadata request should do it
-                objMD = objectMDWithUpdatedAccountInfo(data, null);
-                return next();
-            }),
-            replicateMetadata: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: {
-                    versionId,
-                    accountId: '888888888888', // Vault v1 differentiate InvalidAccountId from NoSuchEntity
+                err => {
+                    assert.strictEqual(err.code, process.env.S3_END_TO_END ? 'NoSuchEntity' : 'AccountNotFound');
+                    return done();
                 },
-                authCredentials: destinationAuthCredentials,
-                requestBody: objMD,
-            }, next),
-        }, err => {
-            assert.strictEqual(err.code, process.env.S3_END_TO_END ? 'NoSuchEntity' : 'AccountNotFound');
-            return done();
+            );
         });
-    });
 
-    it('should successfully replicate multiple versions and keep original order', done => {
-        let objMDCurrent, objMDNonCurrent;
-        let versionIdCurrent, versionIdNonCurrent;
+        it('should successfully replicate multiple versions and keep original order', done => {
+            let objMDCurrent, objMDNonCurrent;
+            let versionIdCurrent, versionIdNonCurrent;
 
-        async.series({
-            enableVersioningSource: next => srcS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketSource,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
+            async.series(
+                {
+                    enableVersioningSource: next =>
+                        srcS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketSource,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-            putObjectNonCurrent: next => srcS3.send(new PutObjectCommand({
-                Bucket: bucketSource,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => {
-                versionIdNonCurrent = data.VersionId;
-                return next(null, data);
-            }).catch(err => next(err)),
+                    putObjectNonCurrent: next =>
+                        srcS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketSource,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => {
+                                versionIdNonCurrent = data.VersionId;
+                                return next(null, data);
+                            })
+                            .catch(err => next(err)),
 
-            putObjectCurrent: next => srcS3.send(new PutObjectCommand({
-                Bucket: bucketSource,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => {
-                versionIdCurrent = data.VersionId;
-                return next(null, data);
-            }).catch(err => next(err)),
+                    putObjectCurrent: next =>
+                        srcS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketSource,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => {
+                                versionIdCurrent = data.VersionId;
+                                return next(null, data);
+                            })
+                            .catch(err => next(err)),
 
-            enableVersioningDestination: next => dstS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketDestination,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
+                    enableVersioningDestination: next =>
+                        dstS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketDestination,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-            getMetadataNonCurrent: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: versionIdNonCurrent,
+                    getMetadataNonCurrent: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: versionIdNonCurrent,
+                                },
+                                authCredentials: sourceAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                objMDNonCurrent = objectMDWithUpdatedAccountInfo(
+                                    data,
+                                    src === dst ? null : dstAccountInfo,
+                                );
+                                return next();
+                            },
+                        ),
+                    getMetadataCurrent: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: versionIdCurrent,
+                                },
+                                authCredentials: sourceAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                objMDCurrent = objectMDWithUpdatedAccountInfo(
+                                    data,
+                                    src === dst ? null : dstAccountInfo,
+                                );
+                                return next();
+                            },
+                        ),
+                    // replicating the objects in the reverse order
+                    replicateMetadataCurrent: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: versionIdCurrent,
+                                },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: objMDCurrent,
+                            },
+                            next,
+                        ),
+                    replicateMetadataNonCurrent: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: versionIdNonCurrent,
+                                },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: objMDNonCurrent,
+                            },
+                            next,
+                        ),
+                    listObjectVersions: next =>
+                        dstS3
+                            .send(
+                                new ListObjectVersionsCommand({
+                                    Bucket: bucketDestination,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
                 },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                objMDNonCurrent = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
-                return next();
-            }),
-            getMetadataCurrent: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: versionIdCurrent,
+                (err, results) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    const listObjectVersionsRes = results.listObjectVersions;
+                    const { Versions } = listObjectVersionsRes;
+                    assert.strictEqual(Versions.length, 2);
+
+                    const [currentVersion, nonCurrentVersion] = Versions;
+
+                    assert.strictEqual(currentVersion.IsLatest, true);
+                    assert.strictEqual(currentVersion.VersionId, versionIdCurrent);
+
+                    assert.strictEqual(nonCurrentVersion.IsLatest, false);
+                    assert.strictEqual(nonCurrentVersion.VersionId, versionIdNonCurrent);
+
+                    return done();
                 },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                objMDCurrent = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
-                return next();
-            }),
-            // replicating the objects in the reverse order
-            replicateMetadataCurrent: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: versionIdCurrent,
-                },
-                authCredentials: destinationAuthCredentials,
-                requestBody: objMDCurrent,
-            }, next),
-            replicateMetadataNonCurrent: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: versionIdNonCurrent,
-                },
-                authCredentials: destinationAuthCredentials,
-                requestBody: objMDNonCurrent,
-            }, next),
-            listObjectVersions: next => dstS3.send(new ListObjectVersionsCommand({
-                Bucket: bucketDestination
-            })).then(data => next(null, data)).catch(err => next(err)),
-        }, (err, results) => {
-            if (err) {
-                return done(err);
-            }
-
-            const listObjectVersionsRes = results.listObjectVersions;
-            const { Versions } = listObjectVersionsRes;
-            assert.strictEqual(Versions.length, 2);
-
-            const [currentVersion, nonCurrentVersion] = Versions;
-
-            assert.strictEqual(currentVersion.IsLatest, true);
-            assert.strictEqual(currentVersion.VersionId, versionIdCurrent);
-
-            assert.strictEqual(nonCurrentVersion.IsLatest, false);
-            assert.strictEqual(nonCurrentVersion.VersionId, versionIdNonCurrent);
-
-            return done();
+            );
         });
-    });
 
-    it('should successfully replicate a delete marker', done => {
-        let objMDVersion, objMDDeleteMarker;
-        let versionIdVersion, versionIdDeleteMarker;
+        it('should successfully replicate a delete marker', done => {
+            let objMDVersion, objMDDeleteMarker;
+            let versionIdVersion, versionIdDeleteMarker;
 
-        async.series({
-            enableVersioningSource: next => srcS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketSource,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
+            async.series(
+                {
+                    enableVersioningSource: next =>
+                        srcS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketSource,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-            putObject: next => srcS3.send(new PutObjectCommand({
-                Bucket: bucketSource,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => {
-                versionIdVersion = data.VersionId;
-                return next(null, data);
-            }).catch(err => next(err)),
+                    putObject: next =>
+                        srcS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketSource,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => {
+                                versionIdVersion = data.VersionId;
+                                return next(null, data);
+                            })
+                            .catch(err => next(err)),
 
-            deleteObject: next => srcS3.send(new DeleteObjectCommand({
-                Bucket: bucketSource,
-                Key: keyName
-            })).then(data => {
-                versionIdDeleteMarker = data.VersionId;
-                return next(null, data);
-            }).catch(err => next(err)),
+                    deleteObject: next =>
+                        srcS3
+                            .send(
+                                new DeleteObjectCommand({
+                                    Bucket: bucketSource,
+                                    Key: keyName,
+                                }),
+                            )
+                            .then(data => {
+                                versionIdDeleteMarker = data.VersionId;
+                                return next(null, data);
+                            })
+                            .catch(err => next(err)),
 
-            enableVersioningDestination: next => dstS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketDestination,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
+                    enableVersioningDestination: next =>
+                        dstS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketDestination,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-            getMetadataVersion: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: versionIdVersion,
+                    getMetadataVersion: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: versionIdVersion,
+                                },
+                                authCredentials: sourceAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                objMDVersion = objectMDWithUpdatedAccountInfo(
+                                    data,
+                                    src === dst ? null : dstAccountInfo,
+                                );
+                                return next();
+                            },
+                        ),
+                    replicateMetadataVersion: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: versionIdVersion,
+                                },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: objMDVersion,
+                            },
+                            next,
+                        ),
+                    getMetadataDeleteMarker: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: versionIdDeleteMarker,
+                                },
+                                authCredentials: sourceAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                objMDDeleteMarker = objectMDWithUpdatedAccountInfo(
+                                    data,
+                                    src === dst ? null : dstAccountInfo,
+                                );
+                                return next();
+                            },
+                        ),
+                    replicateMetadataDeleteMarker: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: versionIdDeleteMarker,
+                                },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: objMDDeleteMarker,
+                            },
+                            next,
+                        ),
+                    listObjectVersions: next =>
+                        dstS3
+                            .send(
+                                new ListObjectVersionsCommand({
+                                    Bucket: bucketDestination,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
                 },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                objMDVersion = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
-                return next();
-            }),
-            replicateMetadataVersion: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: versionIdVersion,
+                (err, results) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    const listObjectVersionsRes = results.listObjectVersions;
+                    const { Versions, DeleteMarkers } = listObjectVersionsRes;
+
+                    assert.strictEqual(Versions.length, 1);
+                    assert.strictEqual(DeleteMarkers.length, 1);
+
+                    assert.strictEqual(Versions[0].IsLatest, false);
+                    assert.strictEqual(Versions[0].VersionId, versionIdVersion);
+
+                    assert.strictEqual(DeleteMarkers[0].IsLatest, true);
+                    assert.strictEqual(DeleteMarkers[0].VersionId, versionIdDeleteMarker);
+
+                    return done();
                 },
-                authCredentials: destinationAuthCredentials,
-                requestBody: objMDVersion,
-            }, next),
-            getMetadataDeleteMarker: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: versionIdDeleteMarker,
-                },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                objMDDeleteMarker = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
-                return next();
-            }),
-            replicateMetadataDeleteMarker: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: versionIdDeleteMarker,
-                },
-                authCredentials: destinationAuthCredentials,
-                requestBody: objMDDeleteMarker,
-            }, next),
-            listObjectVersions: next => dstS3.send(new ListObjectVersionsCommand({
-                Bucket: bucketDestination
-            })).then(data => next(null, data)).catch(err => next(err)),
-        }, (err, results) => {
-            if (err) {
-                return done(err);
-            }
-
-            const listObjectVersionsRes = results.listObjectVersions;
-            const { Versions, DeleteMarkers } = listObjectVersionsRes;
-
-            assert.strictEqual(Versions.length, 1);
-            assert.strictEqual(DeleteMarkers.length, 1);
-
-            assert.strictEqual(Versions[0].IsLatest, false);
-            assert.strictEqual(Versions[0].VersionId, versionIdVersion);
-
-            assert.strictEqual(DeleteMarkers[0].IsLatest, true);
-            assert.strictEqual(DeleteMarkers[0].VersionId, versionIdDeleteMarker);
-
-            return done();
+            );
         });
-    });
 
-    it('should successfully replicate a null version', done => {
-        let objMD;
+        it('should successfully replicate a null version', done => {
+            let objMD;
 
-        async.series({
-            putObject: next => srcS3.send(new PutObjectCommand({
-                Bucket: bucketSource,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => next(null, data)).catch(err => next(err)),
-            enableVersioningSource: next => srcS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketSource,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
-            enableVersioningDestination: next => dstS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketDestination,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
-            getMetadata: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: 'null',
+            async.series(
+                {
+                    putObject: next =>
+                        srcS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketSource,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    enableVersioningSource: next =>
+                        srcS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketSource,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    enableVersioningDestination: next =>
+                        dstS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketDestination,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    getMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: 'null',
+                                },
+                                authCredentials: sourceAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
+                                return next();
+                            },
+                        ),
+                    replicateMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: 'null',
+                                },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: objMD,
+                            },
+                            next,
+                        ),
+                    headObject: next =>
+                        dstS3
+                            .send(
+                                new HeadObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    VersionId: 'null',
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    listObjectVersions: next =>
+                        dstS3
+                            .send(
+                                new ListObjectVersionsCommand({
+                                    Bucket: bucketDestination,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
                 },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
-                return next();
-            }),
-            replicateMetadata: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: 'null',
+                (err, results) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    const headObjectRes = results.headObject;
+                    assert.strictEqual(headObjectRes.VersionId, 'null');
+
+                    const listObjectVersionsRes = results.listObjectVersions;
+                    const { Versions } = listObjectVersionsRes;
+
+                    assert.strictEqual(Versions.length, 1);
+
+                    const [currentVersion] = Versions;
+                    assert.strictEqual(currentVersion.IsLatest, true);
+                    assert.strictEqual(currentVersion.VersionId, 'null');
+
+                    return done();
                 },
-                authCredentials: destinationAuthCredentials,
-                requestBody: objMD,
-            }, next),
-            headObject: next => dstS3.send(new HeadObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                VersionId: 'null'
-            })).then(data => next(null, data)).catch(err => next(err)),
-            listObjectVersions: next => dstS3.send(new ListObjectVersionsCommand({
-                Bucket: bucketDestination
-            })).then(data => next(null, data)).catch(err => next(err)),
-        }, (err, results) => {
-            if (err) {
-                return done(err);
-            }
-
-            const headObjectRes = results.headObject;
-            assert.strictEqual(headObjectRes.VersionId, 'null');
-
-            const listObjectVersionsRes = results.listObjectVersions;
-            const { Versions } = listObjectVersionsRes;
-
-            assert.strictEqual(Versions.length, 1);
-
-            const [currentVersion] = Versions;
-            assert.strictEqual(currentVersion.IsLatest, true);
-            assert.strictEqual(currentVersion.VersionId, 'null');
-
-            return done();
+            );
         });
-    });
 
-    it('should successfully replicate a suspended null version', done => {
-        let objMD;
+        it('should successfully replicate a suspended null version', done => {
+            let objMD;
 
-        async.series({
-            suspendVersioningSource: next => srcS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketSource,
-                VersioningConfiguration: { Status: 'Suspended' }
-            })).then(data => next(null, data)).catch(err => next(err)),
+            async.series(
+                {
+                    suspendVersioningSource: next =>
+                        srcS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketSource,
+                                    VersioningConfiguration: { Status: 'Suspended' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-            putObject: next => srcS3.send(new PutObjectCommand({
-                Bucket: bucketSource,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => next(null, data)).catch(err => next(err)),
+                    putObject: next =>
+                        srcS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketSource,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-            enableVersioningSource: next => srcS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketSource,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
+                    enableVersioningSource: next =>
+                        srcS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketSource,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-            enableVersioningDestination: next => dstS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketDestination,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
+                    enableVersioningDestination: next =>
+                        dstS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketDestination,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-            getMetadata: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: 'null',
+                    getMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: 'null',
+                                },
+                                authCredentials: sourceAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
+                                return next();
+                            },
+                        ),
+                    replicateMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: 'null',
+                                },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: objMD,
+                            },
+                            next,
+                        ),
+                    headObject: next =>
+                        dstS3
+                            .send(
+                                new HeadObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    VersionId: 'null',
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    listObjectVersions: next =>
+                        dstS3
+                            .send(
+                                new ListObjectVersionsCommand({
+                                    Bucket: bucketDestination,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
                 },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
-                return next();
-            }),
-            replicateMetadata: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: 'null',
+                (err, results) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    const headObjectRes = results.headObject;
+                    assert.strictEqual(headObjectRes.VersionId, 'null');
+
+                    const listObjectVersionsRes = results.listObjectVersions;
+                    const { Versions } = listObjectVersionsRes;
+
+                    assert.strictEqual(Versions.length, 1);
+
+                    const [currentVersion] = Versions;
+                    assert.strictEqual(currentVersion.IsLatest, true);
+                    assert.strictEqual(currentVersion.VersionId, 'null');
+
+                    return done();
                 },
-                authCredentials: destinationAuthCredentials,
-                requestBody: objMD,
-            }, next),
-            headObject: next => dstS3.send(new HeadObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                VersionId: 'null'
-            })).then(data => next(null, data)).catch(err => next(err)),
-            listObjectVersions: next => dstS3.send(new ListObjectVersionsCommand({
-                Bucket: bucketDestination
-            })).then(data => next(null, data)).catch(err => next(err)),
-        }, (err, results) => {
-            if (err) {
-                return done(err);
-            }
-
-            const headObjectRes = results.headObject;
-            assert.strictEqual(headObjectRes.VersionId, 'null');
-
-            const listObjectVersionsRes = results.listObjectVersions;
-            const { Versions } = listObjectVersionsRes;
-
-            assert.strictEqual(Versions.length, 1);
-
-            const [currentVersion] = Versions;
-            assert.strictEqual(currentVersion.IsLatest, true);
-            assert.strictEqual(currentVersion.VersionId, 'null');
-
-            return done();
+            );
         });
-    });
 
-    it('should successfully replicate a null version and update it', done => {
-        let objMD;
+        it('should successfully replicate a null version and update it', done => {
+            let objMD;
 
-        async.series({
-            putObject: next => srcS3.send(new PutObjectCommand({
-                Bucket: bucketSource,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => next(null, data)).catch(err => next(err)),
+            async.series(
+                {
+                    putObject: next =>
+                        srcS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketSource,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-            enableVersioningSource: next => srcS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketSource,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
+                    enableVersioningSource: next =>
+                        srcS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketSource,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-            enableVersioningDestination: next => dstS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketDestination,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
+                    enableVersioningDestination: next =>
+                        dstS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketDestination,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-            getMetadata: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: 'null',
-                },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
-                return next();
-            }),
-            replicateMetadata: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: 'null',
-                },
-                authCredentials: destinationAuthCredentials,
-                requestBody: objMD,
-            }, next),
-            updateMetadata: next => {
-                const { result, error } = ObjectMD.createFromBlob(objMD);
-                if (error) {
-                    return next(error);
-                }
-                result.setAmzStorageClass(storageClass);
-                return makeBackbeatRequest({
-                    method: 'PUT',
-                    resourceType: 'metadata',
-                    bucket: bucketDestination,
-                    objectKey: keyName,
-                    queryObj: {
-                        versionId: 'null',
+                    getMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: 'null',
+                                },
+                                authCredentials: sourceAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
+                                return next();
+                            },
+                        ),
+                    replicateMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: 'null',
+                                },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: objMD,
+                            },
+                            next,
+                        ),
+                    updateMetadata: next => {
+                        const { result, error } = ObjectMD.createFromBlob(objMD);
+                        if (error) {
+                            return next(error);
+                        }
+                        result.setAmzStorageClass(storageClass);
+                        return makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: 'null',
+                                },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: result.getSerialized(),
+                            },
+                            next,
+                        );
                     },
-                    authCredentials: destinationAuthCredentials,
-                    requestBody: result.getSerialized(),
-                }, next);
+                    headObject: next =>
+                        dstS3
+                            .send(
+                                new HeadObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    VersionId: 'null',
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    listObjectVersions: next =>
+                        dstS3
+                            .send(
+                                new ListObjectVersionsCommand({
+                                    Bucket: bucketDestination,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                },
+                (err, results) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    const headObjectRes = results.headObject;
+                    assert.strictEqual(headObjectRes.VersionId, 'null');
+                    assert.strictEqual(headObjectRes.StorageClass, storageClass);
+
+                    const listObjectVersionsRes = results.listObjectVersions;
+                    const { Versions } = listObjectVersionsRes;
+
+                    assert.strictEqual(Versions.length, 1);
+
+                    const [currentVersion] = Versions;
+                    assert.strictEqual(currentVersion.IsLatest, true);
+                    assert.strictEqual(currentVersion.VersionId, 'null');
+                    assert.strictEqual(currentVersion.StorageClass, storageClass);
+
+                    return done();
+                },
+            );
+        });
+
+        it('should successfully put object after replicating a null version', done => {
+            let objMD;
+            let expectedVersionId;
+
+            async.series(
+                {
+                    putObjectSource: next =>
+                        srcS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketSource,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+
+                    enableVersioningSource: next =>
+                        srcS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketSource,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+
+                    enableVersioningDestination: next =>
+                        dstS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketDestination,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+
+                    getMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: 'null',
+                                },
+                                authCredentials: sourceAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
+                                return next();
+                            },
+                        ),
+                    replicateMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: 'null',
+                                },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: objMD,
+                            },
+                            next,
+                        ),
+                    putObjectDestination: next =>
+                        dstS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => {
+                                expectedVersionId = data.VersionId;
+                                return next(null, data);
+                            })
+                            .catch(err => next(err)),
+                    headObject: next =>
+                        dstS3
+                            .send(
+                                new HeadObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    VersionId: 'null',
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    listObjectVersions: next =>
+                        dstS3
+                            .send(
+                                new ListObjectVersionsCommand({
+                                    Bucket: bucketDestination,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                },
+                (err, results) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    const headObjectRes = results.headObject;
+                    assert.strictEqual(headObjectRes.VersionId, 'null');
+
+                    const listObjectVersionsRes = results.listObjectVersions;
+                    const { Versions } = listObjectVersionsRes;
+
+                    assert.strictEqual(Versions.length, 2);
+
+                    const [currentVersion, nonCurrentVersion] = Versions;
+                    assert.strictEqual(currentVersion.VersionId, expectedVersionId);
+                    assert.strictEqual(nonCurrentVersion.VersionId, 'null');
+
+                    return done();
+                },
+            );
+        });
+
+        it('should replicate/put metadata to a destination that has a version', done => {
+            let objMD;
+            let firstVersionId;
+            let secondVersionId;
+
+            async.series(
+                {
+                    enableVersioningDestination: next =>
+                        dstS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketDestination,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+
+                    putObjectDestination: next =>
+                        dstS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => {
+                                firstVersionId = data.VersionId;
+                                return next(null, data);
+                            })
+                            .catch(err => next(err)),
+
+                    enableVersioningSource: next =>
+                        srcS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketSource,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+
+                    putObjectSource: next =>
+                        srcS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketSource,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => {
+                                secondVersionId = data.VersionId;
+                                return next(null, data);
+                            })
+                            .catch(err => next(err)),
+
+                    getMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: secondVersionId,
+                                },
+                                authCredentials: sourceAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
+                                return next();
+                            },
+                        ),
+                    replicateMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: secondVersionId,
+                                },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: objMD,
+                            },
+                            next,
+                        ),
+                    headObjectFirstVersion: next =>
+                        dstS3
+                            .send(
+                                new HeadObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    VersionId: firstVersionId,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    headObjectSecondVersion: next =>
+                        dstS3
+                            .send(
+                                new HeadObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    VersionId: secondVersionId,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    listObjectVersions: next =>
+                        dstS3
+                            .send(
+                                new ListObjectVersionsCommand({
+                                    Bucket: bucketDestination,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                },
+                (err, results) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    const firstHeadObjectRes = results.headObjectFirstVersion;
+                    assert.strictEqual(firstHeadObjectRes.VersionId, firstVersionId);
+
+                    const secondHeadObjectRes = results.headObjectSecondVersion;
+                    assert.strictEqual(secondHeadObjectRes.VersionId, secondVersionId);
+
+                    const listObjectVersionsRes = results.listObjectVersions;
+                    const { Versions } = listObjectVersionsRes;
+
+                    assert.strictEqual(Versions.length, 2);
+                    const [currentVersion, nonCurrentVersion] = Versions;
+
+                    assert.strictEqual(currentVersion.VersionId, secondVersionId);
+                    assert.strictEqual(currentVersion.IsLatest, true);
+
+                    assert.strictEqual(nonCurrentVersion.VersionId, firstVersionId);
+                    assert.strictEqual(nonCurrentVersion.IsLatest, false);
+
+                    return done();
+                },
+            );
+        });
+
+        it('should replicate/put metadata to a destination that has a null version', done => {
+            let objMD;
+            let versionId;
+
+            async.series(
+                {
+                    putObjectDestinationInitial: next =>
+                        dstS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+
+                    enableVersioningDestination: next =>
+                        dstS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketDestination,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+
+                    enableVersioningSource: next =>
+                        srcS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketSource,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+
+                    putObjectSource: next =>
+                        srcS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketSource,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => {
+                                versionId = data.VersionId;
+                                return next(null, data);
+                            })
+                            .catch(err => next(err)),
+
+                    getMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId,
+                                },
+                                authCredentials: sourceAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+
+                                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
+                                return next();
+                            },
+                        ),
+                    replicateMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId,
+                                },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: objMD,
+                            },
+                            next,
+                        ),
+                    headObjectNullVersion: next =>
+                        dstS3
+                            .send(
+                                new HeadObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    VersionId: 'null',
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    listObjectVersions: next =>
+                        dstS3
+                            .send(
+                                new ListObjectVersionsCommand({
+                                    Bucket: bucketDestination,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                },
+                (err, results) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    const headObjectRes = results.headObjectNullVersion;
+                    assert.strictEqual(headObjectRes.VersionId, 'null');
+
+                    const listObjectVersionsRes = results.listObjectVersions;
+                    const { Versions } = listObjectVersionsRes;
+
+                    assert.strictEqual(Versions.length, 2);
+                    const [currentVersion, nonCurrentVersion] = Versions;
+
+                    assert.strictEqual(currentVersion.VersionId, versionId);
+                    assert.strictEqual(currentVersion.IsLatest, true);
+
+                    assert.strictEqual(nonCurrentVersion.VersionId, 'null');
+                    assert.strictEqual(nonCurrentVersion.IsLatest, false);
+
+                    return done();
+                },
+            );
+        });
+
+        // CLDSRV-922: when replicating a version on top of a pre-existing null
+        // version, the new master must reference the null version via nullVersionId
+        // only in null-version compatibility mode. In null-key mode the null version
+        // is stored under the null key, and a master carrying nullVersionId leads the
+        // metadata backend to orphan the null key on a later version-specific delete
+        // (causing BucketNotEmpty).
+        it(
+            'should set nullVersionId on the master when replicating a version ' +
+                'over a null version only in compat mode',
+            done => {
+                let objMD;
+                let versionId;
+
+                async.series(
+                    {
+                        putObjectDestinationInitial: next =>
+                            dstS3
+                                .send(
+                                    new PutObjectCommand({
+                                        Bucket: bucketDestination,
+                                        Key: keyName,
+                                        Body: Buffer.from(testData),
+                                    }),
+                                )
+                                .then(data => next(null, data))
+                                .catch(err => next(err)),
+
+                        enableVersioningDestination: next =>
+                            dstS3
+                                .send(
+                                    new PutBucketVersioningCommand({
+                                        Bucket: bucketDestination,
+                                        VersioningConfiguration: { Status: 'Enabled' },
+                                    }),
+                                )
+                                .then(data => next(null, data))
+                                .catch(err => next(err)),
+
+                        enableVersioningSource: next =>
+                            srcS3
+                                .send(
+                                    new PutBucketVersioningCommand({
+                                        Bucket: bucketSource,
+                                        VersioningConfiguration: { Status: 'Enabled' },
+                                    }),
+                                )
+                                .then(data => next(null, data))
+                                .catch(err => next(err)),
+
+                        putObjectSource: next =>
+                            srcS3
+                                .send(
+                                    new PutObjectCommand({
+                                        Bucket: bucketSource,
+                                        Key: keyName,
+                                        Body: Buffer.from(testData),
+                                    }),
+                                )
+                                .then(data => {
+                                    versionId = data.VersionId;
+                                    return next(null, data);
+                                })
+                                .catch(err => next(err)),
+
+                        getMetadata: next =>
+                            makeBackbeatRequest(
+                                {
+                                    method: 'GET',
+                                    resourceType: 'metadata',
+                                    bucket: bucketSource,
+                                    objectKey: keyName,
+                                    queryObj: {
+                                        versionId,
+                                    },
+                                    authCredentials: sourceAuthCredentials,
+                                },
+                                (err, data) => {
+                                    if (err) {
+                                        return next(err);
+                                    }
+
+                                    objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
+                                    return next();
+                                },
+                            ),
+                        replicateMetadata: next =>
+                            makeBackbeatRequest(
+                                {
+                                    method: 'PUT',
+                                    resourceType: 'metadata',
+                                    bucket: bucketDestination,
+                                    objectKey: keyName,
+                                    queryObj: {
+                                        versionId,
+                                    },
+                                    authCredentials: destinationAuthCredentials,
+                                    requestBody: objMD,
+                                },
+                                next,
+                            ),
+                        // GET with no versionId returns the master metadata.
+                        getMasterMetadata: next =>
+                            makeBackbeatRequest(
+                                {
+                                    method: 'GET',
+                                    resourceType: 'metadata',
+                                    bucket: bucketDestination,
+                                    objectKey: keyName,
+                                    authCredentials: destinationAuthCredentials,
+                                },
+                                (err, data) => {
+                                    if (err) {
+                                        return next(err);
+                                    }
+                                    return next(null, data);
+                                },
+                            ),
+                        // The user-visible symptom of the bug is a null key orphaned on
+                        // delete, leaving the bucket non-empty: emptying it here exercises
+                        // the version-specific delete of the null version.
+                        emptyDestination: next =>
+                            dstBucketUtil
+                                .empty(bucketDestination)
+                                .then(() => next())
+                                .catch(err => next(err)),
+                        listAfterEmpty: next =>
+                            dstS3
+                                .send(
+                                    new ListObjectVersionsCommand({
+                                        Bucket: bucketDestination,
+                                    }),
+                                )
+                                .then(data => next(null, data))
+                                .catch(err => next(err)),
+                    },
+                    (err, results) => {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        const masterMD = objectMDFromRequestBody(results.getMasterMetadata);
+                        if (isNullVersionCompatMode) {
+                            // compat mode references the null version from the master
+                            assert.notStrictEqual(masterMD.getNullVersionId(), undefined);
+                        } else {
+                            // null-key mode: the master must not reference the null version
+                            assert.strictEqual(masterMD.getNullVersionId(), undefined);
+                        }
+
+                        // no orphaned null key must survive: the bucket is fully empty
+                        const listAfterEmpty = results.listAfterEmpty;
+                        assert.strictEqual((listAfterEmpty.Versions || []).length, 0);
+                        assert.strictEqual((listAfterEmpty.DeleteMarkers || []).length, 0);
+
+                        return done();
+                    },
+                );
             },
-            headObject: next => dstS3.send(new HeadObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                VersionId: 'null'
-            })).then(data => next(null, data)).catch(err => next(err)),
-            listObjectVersions: next => dstS3.send(new ListObjectVersionsCommand({
-                Bucket: bucketDestination
-            })).then(data => next(null, data)).catch(err => next(err)),
-        }, (err, results) => {
-            if (err) {
-                return done(err);
-            }
+        );
 
-            const headObjectRes = results.headObject;
-            assert.strictEqual(headObjectRes.VersionId, 'null');
-            assert.strictEqual(headObjectRes.StorageClass, storageClass);
+        it('should replicate/put metadata to a destination that has a suspended null version', done => {
+            let objMD;
+            let versionId;
 
-            const listObjectVersionsRes = results.listObjectVersions;
-            const { Versions } = listObjectVersionsRes;
+            async.series(
+                {
+                    suspendVersioningDestination: next =>
+                        dstS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketDestination,
+                                    VersioningConfiguration: { Status: 'Suspended' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-            assert.strictEqual(Versions.length, 1);
+                    putObjectDestinationInitial: next =>
+                        dstS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-            const [currentVersion] = Versions;
-            assert.strictEqual(currentVersion.IsLatest, true);
-            assert.strictEqual(currentVersion.VersionId, 'null');
-            assert.strictEqual(currentVersion.StorageClass, storageClass);
+                    enableVersioningDestination: next =>
+                        dstS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketDestination,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-            return done();
+                    enableVersioningSource: next =>
+                        srcS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketSource,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+
+                    putObjectSource: next =>
+                        srcS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketSource,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => {
+                                versionId = data.VersionId;
+                                return next(null, data);
+                            })
+                            .catch(err => next(err)),
+
+                    getMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId,
+                                },
+                                authCredentials: sourceAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
+                                return next();
+                            },
+                        ),
+
+                    replicateMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId,
+                                },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: objMD,
+                            },
+                            next,
+                        ),
+
+                    headObjectNullVersion: next =>
+                        dstS3
+                            .send(
+                                new HeadObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    VersionId: 'null',
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+
+                    listObjectVersions: next =>
+                        dstS3
+                            .send(
+                                new ListObjectVersionsCommand({
+                                    Bucket: bucketDestination,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                },
+                (err, results) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    const headObjectRes = results.headObjectNullVersion;
+                    assert.strictEqual(headObjectRes.VersionId, 'null');
+
+                    const listObjectVersionsRes = results.listObjectVersions;
+                    const { Versions } = listObjectVersionsRes;
+
+                    assert.strictEqual(Versions.length, 2);
+                    const [currentVersion, nonCurrentVersion] = Versions;
+
+                    assert.strictEqual(currentVersion.VersionId, versionId);
+                    assert.strictEqual(currentVersion.IsLatest, true);
+
+                    assert.strictEqual(nonCurrentVersion.VersionId, 'null');
+                    assert.strictEqual(nonCurrentVersion.IsLatest, false);
+
+                    return done();
+                },
+            );
         });
-    });
 
-    it('should successfully put object after replicating a null version', done => {
-        let objMD;
-        let expectedVersionId;
+        it('should replicate/put metadata to a destination that has a previously updated null version', done => {
+            let objMD;
+            let objMDNull;
+            let versionId;
 
-        async.series({
-            putObjectSource: next => srcS3.send(new PutObjectCommand({
-                Bucket: bucketSource,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            enableVersioningSource: next => srcS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketSource,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            enableVersioningDestination: next => dstS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketDestination,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            getMetadata: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: 'null',
+            async.series(
+                {
+                    putObjectDestinationInitial: next =>
+                        dstS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    enableVersioningDestination: next =>
+                        dstS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketDestination,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    getMetadataNullVersion: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: 'null',
+                                },
+                                authCredentials: destinationAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                objMDNull = JSON.parse(data.body).Body;
+                                return next();
+                            },
+                        ),
+                    updateMetadataNullVersion: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: 'null',
+                                },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: objMDNull,
+                            },
+                            next,
+                        ),
+                    enableVersioningSource: next =>
+                        srcS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketSource,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    putObjectSource: next =>
+                        srcS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketSource,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => {
+                                versionId = data.VersionId;
+                                return next(null, data);
+                            })
+                            .catch(err => next(err)),
+                    getMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId,
+                                },
+                                authCredentials: sourceAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
+                                return next();
+                            },
+                        ),
+                    replicateMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId,
+                                },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: objMD,
+                            },
+                            next,
+                        ),
+                    headObjectNullVersion: next =>
+                        dstS3
+                            .send(
+                                new HeadObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    VersionId: 'null',
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    listObjectVersions: next =>
+                        dstS3
+                            .send(
+                                new ListObjectVersionsCommand({
+                                    Bucket: bucketDestination,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
                 },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
-                return next();
-            }),
-            replicateMetadata: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: 'null',
+                (err, results) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    const headObjectRes = results.headObjectNullVersion;
+                    assert.strictEqual(headObjectRes.VersionId, 'null');
+
+                    const listObjectVersionsRes = results.listObjectVersions;
+                    const { Versions } = listObjectVersionsRes;
+
+                    assert.strictEqual(Versions.length, 2);
+                    const [currentVersion, nonCurrentVersion] = Versions;
+
+                    assert.strictEqual(currentVersion.VersionId, versionId);
+                    assert.strictEqual(currentVersion.IsLatest, true);
+
+                    assert.strictEqual(nonCurrentVersion.VersionId, 'null');
+                    assert.strictEqual(nonCurrentVersion.IsLatest, false);
+
+                    return done();
                 },
-                authCredentials: destinationAuthCredentials,
-                requestBody: objMD,
-            }, next),
-            putObjectDestination: next => dstS3.send(new PutObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => {
-                expectedVersionId = data.VersionId;
-                return next(null, data);
-            }).catch(err => next(err)),
-            headObject: next => dstS3.send(new HeadObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                VersionId: 'null'
-            })).then(data => next(null, data)).catch(err => next(err)),
-            listObjectVersions: next => dstS3.send(new ListObjectVersionsCommand({
-                Bucket: bucketDestination
-            })).then(data => next(null, data)).catch(err => next(err)),
-        }, (err, results) => {
-            if (err) {
-                return done(err);
-            }
-
-            const headObjectRes = results.headObject;
-            assert.strictEqual(headObjectRes.VersionId, 'null');
-
-            const listObjectVersionsRes = results.listObjectVersions;
-            const { Versions } = listObjectVersionsRes;
-
-            assert.strictEqual(Versions.length, 2);
-
-            const [currentVersion, nonCurrentVersion] = Versions;
-            assert.strictEqual(currentVersion.VersionId, expectedVersionId);
-            assert.strictEqual(nonCurrentVersion.VersionId, 'null');
-
-            return done();
+            );
         });
-    });
 
-    it('should replicate/put metadata to a destination that has a version', done => {
-        let objMD;
-        let firstVersionId;
-        let secondVersionId;
+        it(
+            'should replicate/put metadata to a destination that has a suspended null version' +
+                ' with internal version',
+            done => {
+                const tagSet = [
+                    {
+                        Key: 'key1',
+                        Value: 'value1',
+                    },
+                ];
+                let objMD;
+                let versionId;
 
-        async.series({
-            enableVersioningDestination: next => dstS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketDestination,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
+                async.series(
+                    {
+                        suspendVersioningDestination: next =>
+                            dstS3
+                                .send(
+                                    new PutBucketVersioningCommand({
+                                        Bucket: bucketDestination,
+                                        VersioningConfiguration: { Status: 'Suspended' },
+                                    }),
+                                )
+                                .then(data => next(null, data))
+                                .catch(err => next(err)),
 
-            putObjectDestination: next => dstS3.send(new PutObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => {
-                firstVersionId = data.VersionId;
-                return next(null, data);
-            }).catch(err => next(err)),
+                        putObjectDestinationInitial: next =>
+                            dstS3
+                                .send(
+                                    new PutObjectCommand({
+                                        Bucket: bucketDestination,
+                                        Key: keyName,
+                                        Body: Buffer.from(testData),
+                                    }),
+                                )
+                                .then(data => next(null, data))
+                                .catch(err => next(err)),
 
-            enableVersioningSource: next => srcS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketSource,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
+                        putObjectTagging: next =>
+                            dstS3
+                                .send(
+                                    new PutObjectTaggingCommand({
+                                        Bucket: bucketDestination,
+                                        Key: keyName,
+                                        Tagging: { TagSet: tagSet },
+                                    }),
+                                )
+                                .then(data => next(null, data))
+                                .catch(err => next(err)),
 
-            putObjectSource: next => srcS3.send(new PutObjectCommand({
-                Bucket: bucketSource,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => {
-                secondVersionId = data.VersionId;
-                return next(null, data);
-            }).catch(err => next(err)),
+                        enableVersioningDestination: next =>
+                            dstS3
+                                .send(
+                                    new PutBucketVersioningCommand({
+                                        Bucket: bucketDestination,
+                                        VersioningConfiguration: { Status: 'Enabled' },
+                                    }),
+                                )
+                                .then(data => next(null, data))
+                                .catch(err => next(err)),
 
-            getMetadata: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: secondVersionId,
-                },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
-                return next();
-            }),
-            replicateMetadata: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: secondVersionId,
-                },
-                authCredentials: destinationAuthCredentials,
-                requestBody: objMD,
-            }, next),
-            headObjectFirstVersion: next => dstS3.send(new HeadObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                VersionId: firstVersionId
-            })).then(data => next(null, data)).catch(err => next(err)),
-            headObjectSecondVersion: next => dstS3.send(new HeadObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                VersionId: secondVersionId
-            })).then(data => next(null, data)).catch(err => next(err)),
-            listObjectVersions: next => dstS3.send(new ListObjectVersionsCommand({
-                Bucket: bucketDestination
-            })).then(data => next(null, data)).catch(err => next(err)),
-        }, (err, results) => {
-            if (err) {
-                return done(err);
-            }
+                        enableVersioningSource: next =>
+                            srcS3
+                                .send(
+                                    new PutBucketVersioningCommand({
+                                        Bucket: bucketSource,
+                                        VersioningConfiguration: { Status: 'Enabled' },
+                                    }),
+                                )
+                                .then(data => next(null, data))
+                                .catch(err => next(err)),
 
-            const firstHeadObjectRes = results.headObjectFirstVersion;
-            assert.strictEqual(firstHeadObjectRes.VersionId, firstVersionId);
+                        putObjectSource: next =>
+                            srcS3
+                                .send(
+                                    new PutObjectCommand({
+                                        Bucket: bucketSource,
+                                        Key: keyName,
+                                        Body: Buffer.from(testData),
+                                    }),
+                                )
+                                .then(data => {
+                                    versionId = data.VersionId;
+                                    next(null, data);
+                                })
+                                .catch(err => next(err)),
+                        getMetadata: next =>
+                            makeBackbeatRequest(
+                                {
+                                    method: 'GET',
+                                    resourceType: 'metadata',
+                                    bucket: bucketSource,
+                                    objectKey: keyName,
+                                    queryObj: {
+                                        versionId,
+                                    },
+                                    authCredentials: sourceAuthCredentials,
+                                },
+                                (err, data) => {
+                                    if (err) {
+                                        return next(err);
+                                    }
+                                    objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
+                                    return next();
+                                },
+                            ),
+                        replicateMetadata: next =>
+                            makeBackbeatRequest(
+                                {
+                                    method: 'PUT',
+                                    resourceType: 'metadata',
+                                    bucket: bucketDestination,
+                                    objectKey: keyName,
+                                    queryObj: {
+                                        versionId,
+                                    },
+                                    authCredentials: destinationAuthCredentials,
+                                    requestBody: objMD,
+                                },
+                                next,
+                            ),
+                        headObjectNullVersion: next =>
+                            dstS3
+                                .send(
+                                    new HeadObjectCommand({
+                                        Bucket: bucketDestination,
+                                        Key: keyName,
+                                        VersionId: 'null',
+                                    }),
+                                )
+                                .then(data => next(null, data))
+                                .catch(err => next(err)),
+                        getObjectTaggingNullVersion: next =>
+                            dstS3
+                                .send(
+                                    new GetObjectTaggingCommand({
+                                        Bucket: bucketDestination,
+                                        Key: keyName,
+                                        VersionId: 'null',
+                                    }),
+                                )
+                                .then(data => next(null, data))
+                                .catch(err => next(err)),
+                        listObjectVersions: next =>
+                            dstS3
+                                .send(
+                                    new ListObjectVersionsCommand({
+                                        Bucket: bucketDestination,
+                                    }),
+                                )
+                                .then(data => next(null, data))
+                                .catch(err => next(err)),
+                    },
+                    (err, results) => {
+                        if (err) {
+                            return done(err);
+                        }
 
-            const secondHeadObjectRes = results.headObjectSecondVersion;
-            assert.strictEqual(secondHeadObjectRes.VersionId, secondVersionId);
+                        const headObjectRes = results.headObjectNullVersion;
+                        assert.strictEqual(headObjectRes.VersionId, 'null');
 
-            const listObjectVersionsRes = results.listObjectVersions;
-            const { Versions } = listObjectVersionsRes;
+                        const getObjectTaggingRes = results.getObjectTaggingNullVersion;
+                        assert.deepStrictEqual(getObjectTaggingRes.TagSet, tagSet);
 
-            assert.strictEqual(Versions.length, 2);
-            const [currentVersion, nonCurrentVersion] = Versions;
+                        const listObjectVersionsRes = results.listObjectVersions;
+                        const { Versions } = listObjectVersionsRes;
 
-            assert.strictEqual(currentVersion.VersionId, secondVersionId);
-            assert.strictEqual(currentVersion.IsLatest, true);
+                        assert.strictEqual(Versions.length, 2);
+                        const [currentVersion, nonCurrentVersion] = Versions;
 
-            assert.strictEqual(nonCurrentVersion.VersionId, firstVersionId);
-            assert.strictEqual(nonCurrentVersion.IsLatest, false);
+                        assert.strictEqual(currentVersion.VersionId, versionId);
+                        assert.strictEqual(currentVersion.IsLatest, true);
 
-            return done();
-        });
-    });
+                        assert.strictEqual(nonCurrentVersion.VersionId, 'null');
+                        assert.strictEqual(nonCurrentVersion.IsLatest, false);
 
-    it('should replicate/put metadata to a destination that has a null version', done => {
-        let objMD;
-        let versionId;
-
-        async.series({
-            putObjectDestinationInitial: next => dstS3.send(new PutObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            enableVersioningDestination: next => dstS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketDestination,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            enableVersioningSource: next => srcS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketSource,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            putObjectSource: next => srcS3.send(new PutObjectCommand({
-                Bucket: bucketSource,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => {
-                versionId = data.VersionId;
-                return next(null, data);
-            }).catch(err => next(err)),
-
-            getMetadata: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: {
-                    versionId,
-                },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-
-                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
-                return next();
-            }),
-            replicateMetadata: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: {
-                    versionId,
-                },
-                authCredentials: destinationAuthCredentials,
-                requestBody: objMD,
-            }, next),
-            headObjectNullVersion: next => dstS3.send(new HeadObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                VersionId: 'null'
-            })).then(data => next(null, data)).catch(err => next(err)),
-            listObjectVersions: next => dstS3.send(new ListObjectVersionsCommand({
-                Bucket: bucketDestination
-            })).then(data => next(null, data)).catch(err => next(err)),
-        }, (err, results) => {
-            if (err) {
-                return done(err);
-            }
-
-            const headObjectRes = results.headObjectNullVersion;
-            assert.strictEqual(headObjectRes.VersionId, 'null');
-
-            const listObjectVersionsRes = results.listObjectVersions;
-            const { Versions } = listObjectVersionsRes;
-
-            assert.strictEqual(Versions.length, 2);
-            const [currentVersion, nonCurrentVersion] = Versions;
-
-            assert.strictEqual(currentVersion.VersionId, versionId);
-            assert.strictEqual(currentVersion.IsLatest, true);
-
-            assert.strictEqual(nonCurrentVersion.VersionId, 'null');
-            assert.strictEqual(nonCurrentVersion.IsLatest, false);
-
-            return done();
-        });
-    });
-
-    // CLDSRV-922: when replicating a version on top of a pre-existing null
-    // version, the new master must reference the null version via nullVersionId
-    // only in null-version compatibility mode. In null-key mode the null version
-    // is stored under the null key, and a master carrying nullVersionId leads the
-    // metadata backend to orphan the null key on a later version-specific delete
-    // (causing BucketNotEmpty).
-    it('should set nullVersionId on the master when replicating a version ' +
-        'over a null version only in compat mode', done => {
-        let objMD;
-        let versionId;
-
-        async.series({
-            putObjectDestinationInitial: next => dstS3.send(new PutObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                Body: Buffer.from(testData),
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            enableVersioningDestination: next => dstS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketDestination,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            enableVersioningSource: next => srcS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketSource,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            putObjectSource: next => srcS3.send(new PutObjectCommand({
-                Bucket: bucketSource,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => {
-                versionId = data.VersionId;
-                return next(null, data);
-            }).catch(err => next(err)),
-
-            getMetadata: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: {
-                    versionId,
-                },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-
-                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
-                return next();
-            }),
-            replicateMetadata: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: {
-                    versionId,
-                },
-                authCredentials: destinationAuthCredentials,
-                requestBody: objMD,
-            }, next),
-            // GET with no versionId returns the master metadata.
-            getMasterMetadata: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                authCredentials: destinationAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                return next(null, data);
-            }),
-            // The user-visible symptom of the bug is a null key orphaned on
-            // delete, leaving the bucket non-empty: emptying it here exercises
-            // the version-specific delete of the null version.
-            emptyDestination: next => dstBucketUtil.empty(bucketDestination)
-                .then(() => next()).catch(err => next(err)),
-            listAfterEmpty: next => dstS3.send(new ListObjectVersionsCommand({
-                Bucket: bucketDestination,
-            })).then(data => next(null, data)).catch(err => next(err)),
-        }, (err, results) => {
-            if (err) {
-                return done(err);
-            }
-
-            const masterMD = objectMDFromRequestBody(results.getMasterMetadata);
-            if (isNullVersionCompatMode) {
-                // compat mode references the null version from the master
-                assert.notStrictEqual(masterMD.getNullVersionId(), undefined);
-            } else {
-                // null-key mode: the master must not reference the null version
-                assert.strictEqual(masterMD.getNullVersionId(), undefined);
-            }
-
-            // no orphaned null key must survive: the bucket is fully empty
-            const listAfterEmpty = results.listAfterEmpty;
-            assert.strictEqual((listAfterEmpty.Versions || []).length, 0);
-            assert.strictEqual((listAfterEmpty.DeleteMarkers || []).length, 0);
-
-            return done();
-        });
-    });
-
-    it('should replicate/put metadata to a destination that has a suspended null version', done => {
-    let objMD;
-    let versionId;
-
-    async.series({
-        suspendVersioningDestination: next => dstS3.send(new PutBucketVersioningCommand({
-            Bucket: bucketDestination,
-            VersioningConfiguration: { Status: 'Suspended' }
-        })).then(data => next(null, data)).catch(err => next(err)),
-
-        putObjectDestinationInitial: next => dstS3.send(new PutObjectCommand({
-            Bucket: bucketDestination,
-            Key: keyName,
-            Body: Buffer.from(testData)
-        })).then(data => next(null, data)).catch(err => next(err)),
-
-        enableVersioningDestination: next => dstS3.send(new PutBucketVersioningCommand({
-            Bucket: bucketDestination,
-            VersioningConfiguration: { Status: 'Enabled' }
-        })).then(data => next(null, data)).catch(err => next(err)),
-
-        enableVersioningSource: next => srcS3.send(new PutBucketVersioningCommand({
-            Bucket: bucketSource,
-            VersioningConfiguration: { Status: 'Enabled' }
-        })).then(data => next(null, data)).catch(err => next(err)),
-
-        putObjectSource: next => srcS3.send(new PutObjectCommand({
-            Bucket: bucketSource,
-            Key: keyName,
-            Body: Buffer.from(testData)
-        })).then(data => {
-            versionId = data.VersionId;
-            return next(null, data);
-        }).catch(err => next(err)),
-
-        getMetadata: next => makeBackbeatRequest({
-            method: 'GET',
-            resourceType: 'metadata',
-            bucket: bucketSource,
-            objectKey: keyName,
-            queryObj: {
-                versionId,
+                        return done();
+                    },
+                );
             },
-            authCredentials: sourceAuthCredentials,
-        }, (err, data) => {
-            if (err) {
-                return next(err);
-            }
-            objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
-            return next();
-        }),
-        
-        replicateMetadata: next => makeBackbeatRequest({
-            method: 'PUT',
-            resourceType: 'metadata',
-            bucket: bucketDestination,
-            objectKey: keyName,
-            queryObj: {
-                versionId,
-            },
-            authCredentials: destinationAuthCredentials,
-            requestBody: objMD,
-        }, next),
-        
-        headObjectNullVersion: next => dstS3.send(new HeadObjectCommand({
-            Bucket: bucketDestination,
-            Key: keyName,
-            VersionId: 'null'
-        })).then(data => next(null, data)).catch(err => next(err)),
-        
-        listObjectVersions: next => dstS3.send(new ListObjectVersionsCommand({
-            Bucket: bucketDestination
-        })).then(data => next(null, data)).catch(err => next(err)),
-    }, (err, results) => {
-        if (err) {
-            return done(err);
-        }
+        );
 
-        const headObjectRes = results.headObjectNullVersion;
-        assert.strictEqual(headObjectRes.VersionId, 'null');
+        it('should mimic null version replication by crrExistingObjects, then replicate version', done => {
+            let objMDNull;
+            let objMDNullReplicated;
+            let objMDVersion;
+            let versionId;
 
-        const listObjectVersionsRes = results.listObjectVersions;
-        const { Versions } = listObjectVersionsRes;
+            async.series(
+                {
+                    createNullSoloMasterKey: next =>
+                        srcS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketSource,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-        assert.strictEqual(Versions.length, 2);
-        const [currentVersion, nonCurrentVersion] = Versions;
+                    enableVersioningSource: next =>
+                        srcS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketSource,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-        assert.strictEqual(currentVersion.VersionId, versionId);
-        assert.strictEqual(currentVersion.IsLatest, true);
-
-        assert.strictEqual(nonCurrentVersion.VersionId, 'null');
-        assert.strictEqual(nonCurrentVersion.IsLatest, false);
-
-        return done();
-    });
-    });
-
-    it('should replicate/put metadata to a destination that has a previously updated null version', done => {
-        let objMD;
-        let objMDNull;
-        let versionId;
-
-        async.series({
-            putObjectDestinationInitial: next => dstS3.send(new PutObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                Body: Buffer.from(testData),
-            })).then(data => next(null, data)).catch(err => next(err)),
-            enableVersioningDestination: next => dstS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketDestination,
-                VersioningConfiguration: { Status: 'Enabled' },
-            })).then(data => next(null, data)).catch(err => next(err)),
-            getMetadataNullVersion: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: 'null',
+                    simulateCrrExistingObjectsGetMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: 'null',
+                                },
+                                authCredentials: sourceAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                objMDNull = JSON.parse(data.body).Body;
+                                assert.strictEqual(JSON.parse(objMDNull).versionId, undefined);
+                                return next();
+                            },
+                        ),
+                    simulateCrrExistingObjectsPutMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: 'null',
+                                },
+                                authCredentials: sourceAuthCredentials,
+                                requestBody: objMDNull,
+                            },
+                            next,
+                        ),
+                    enableVersioningDestination: next =>
+                        dstS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketDestination,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    replicateNullVersion: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: 'null',
+                                },
+                                authCredentials: sourceAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                objMDNullReplicated = objectMDWithUpdatedAccountInfo(
+                                    data,
+                                    src === dst ? null : dstAccountInfo,
+                                );
+                                return next();
+                            },
+                        ),
+                    putReplicatedNullVersion: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId: 'null',
+                                },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: objMDNullReplicated,
+                            },
+                            next,
+                        ),
+                    putNewVersionSource: next =>
+                        srcS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketSource,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => {
+                                versionId = data.VersionId;
+                                return next(null, data);
+                            })
+                            .catch(err => next(err)),
+                    simulateMetadataReplicationVersion: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId,
+                                },
+                                authCredentials: sourceAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                objMDVersion = objectMDWithUpdatedAccountInfo(
+                                    data,
+                                    src === dst ? null : dstAccountInfo,
+                                );
+                                return next();
+                            },
+                        ),
+                    listObjectVersionsBeforeReplicate: next =>
+                        dstS3
+                            .send(
+                                new ListObjectVersionsCommand({
+                                    Bucket: bucketDestination,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    putReplicatedVersion: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: {
+                                    versionId,
+                                },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: objMDVersion,
+                            },
+                            next,
+                        ),
+                    checkReplicatedNullVersion: next =>
+                        dstS3
+                            .send(
+                                new HeadObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    VersionId: 'null',
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    checkReplicatedVersion: next =>
+                        dstS3
+                            .send(
+                                new HeadObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    VersionId: versionId,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    listObjectVersionsAfterReplicate: next =>
+                        dstS3
+                            .send(
+                                new ListObjectVersionsCommand({
+                                    Bucket: bucketDestination,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
                 },
-                authCredentials: destinationAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                objMDNull = JSON.parse(data.body).Body;
-                return next();
-            }),
-            updateMetadataNullVersion: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: 'null',
+                (err, results) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    const headObjectNullVersionRes = results.checkReplicatedNullVersion;
+                    assert.strictEqual(headObjectNullVersionRes.VersionId, 'null');
+
+                    const headObjectVersionRes = results.checkReplicatedVersion;
+                    assert.strictEqual(headObjectVersionRes.VersionId, versionId);
+
+                    const listObjectVersionsRes = results.listObjectVersionsAfterReplicate;
+                    const { Versions } = listObjectVersionsRes;
+
+                    assert.strictEqual(Versions.length, 2);
+
+                    const [currentVersion, nonCurrentVersion] = Versions;
+
+                    assert.strictEqual(currentVersion.VersionId, versionId);
+                    assert.strictEqual(currentVersion.IsLatest, true);
+
+                    assert.strictEqual(nonCurrentVersion.VersionId, 'null');
+                    assert.strictEqual(nonCurrentVersion.IsLatest, false);
+
+                    return done();
                 },
-                authCredentials: destinationAuthCredentials,
-                requestBody: objMDNull,
-            }, next),
-            enableVersioningSource: next => srcS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketSource,
-                VersioningConfiguration: { Status: 'Enabled' },
-            })).then(data => next(null, data)).catch(err => next(err)),
-            putObjectSource: next => srcS3.send(new PutObjectCommand({
-                Bucket: bucketSource,
-                Key: keyName,
-                Body: Buffer.from(testData),
-            })).then(data => {
-                versionId = data.VersionId;
-                return next(null, data);
-            }).catch(err => next(err)),
-            getMetadata: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: {
-                    versionId,
+            );
+        });
+
+        // TODO: CLDSRV-739 unskip once flaky afterEach cleanup is fixed
+        const itSkipS3CV0 = process.env.S3_END_TO_END && process.env.DEFAULT_BUCKET_KEY_FORMAT === 'v0' ? it.skip : it;
+        itSkipS3CV0('should replicate/put NULL metadata to a destination that has a version', done => {
+            let objMD;
+            let versionId;
+
+            async.series(
+                {
+                    enableVersioningDestination: next =>
+                        dstS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketDestination,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+
+                    putObjectDestination: next =>
+                        dstS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => {
+                                versionId = data.VersionId;
+                                return next(null, data);
+                            })
+                            .catch(err => next(err)),
+
+                    putObjectSource: next =>
+                        srcS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketSource,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+
+                    enableVersioningSource: next =>
+                        srcS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketSource,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+
+                    getMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: { versionId: 'null' },
+                                authCredentials: sourceAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
+                                return next();
+                            },
+                        ),
+                    replicateMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: { versionId: 'null' },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: objMD,
+                            },
+                            next,
+                        ),
+                    headObjectByVersionId: next =>
+                        dstS3
+                            .send(
+                                new HeadObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    VersionId: versionId,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    headObjectByNullVersionId: next =>
+                        dstS3
+                            .send(
+                                new HeadObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    VersionId: 'null',
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    listObjectVersions: next =>
+                        dstS3
+                            .send(
+                                new ListObjectVersionsCommand({
+                                    Bucket: bucketDestination,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
                 },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
-                return next();
-            }),
-            replicateMetadata: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: {
-                    versionId,
+                (err, results) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    const firstHeadObjectRes = results.headObjectByVersionId;
+                    assert.strictEqual(firstHeadObjectRes.VersionId, versionId);
+
+                    const secondHeadObjectRes = results.headObjectByNullVersionId;
+                    assert.strictEqual(secondHeadObjectRes.VersionId, 'null');
+
+                    const listObjectVersionsRes = results.listObjectVersions;
+                    const { Versions } = listObjectVersionsRes;
+
+                    assert.strictEqual(Versions.length, 2);
+                    const [currentVersion, nonCurrentVersion] = Versions;
+
+                    assert.strictEqual(currentVersion.VersionId, 'null');
+                    assert.strictEqual(currentVersion.IsLatest, true);
+
+                    assert.strictEqual(nonCurrentVersion.VersionId, versionId);
+                    assert.strictEqual(nonCurrentVersion.IsLatest, false);
+
+                    return done();
                 },
-                authCredentials: destinationAuthCredentials,
-                requestBody: objMD,
-            }, next),
-            headObjectNullVersion: next => dstS3.send(new HeadObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                VersionId: 'null',
-            })).then(data => next(null, data)).catch(err => next(err)),
-            listObjectVersions: next => dstS3.send(new ListObjectVersionsCommand({
-                Bucket: bucketDestination,
-            })).then(data => next(null, data)).catch(err => next(err)),
-        }, (err, results) => {
-            if (err) {
-                return done(err);
-            }
+            );
+        });
 
-            const headObjectRes = results.headObjectNullVersion;
-            assert.strictEqual(headObjectRes.VersionId, 'null');
+        it('should replicate/put NULL metadata to a destination that has a null version', done => {
+            let objMD;
 
-            const listObjectVersionsRes = results.listObjectVersions;
-            const { Versions } = listObjectVersionsRes;
+            async.series(
+                {
+                    putObjectDestinationInitial: next =>
+                        dstS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-            assert.strictEqual(Versions.length, 2);
-            const [currentVersion, nonCurrentVersion] = Versions;
+                    enableVersioningDestination: next =>
+                        dstS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketDestination,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-            assert.strictEqual(currentVersion.VersionId, versionId);
-            assert.strictEqual(currentVersion.IsLatest, true);
+                    putObjectSource: next =>
+                        srcS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketSource,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-            assert.strictEqual(nonCurrentVersion.VersionId, 'null');
-            assert.strictEqual(nonCurrentVersion.IsLatest, false);
+                    enableVersioningSource: next =>
+                        srcS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketSource,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
 
-            return done();
+                    putObjectTaggingSource: next =>
+                        srcS3
+                            .send(
+                                new PutObjectTaggingCommand({
+                                    Bucket: bucketSource,
+                                    Key: keyName,
+                                    VersionId: 'null',
+                                    Tagging: { TagSet: [{ Key: 'key1', Value: 'value1' }] },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+
+                    getMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: { versionId: 'null' },
+                                authCredentials: sourceAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
+                                return next();
+                            },
+                        ),
+                    replicateMetadata: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: { versionId: 'null' },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: objMD,
+                            },
+                            next,
+                        ),
+                    headObjectNullVersion: next =>
+                        dstS3
+                            .send(
+                                new HeadObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    VersionId: 'null',
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    getObjectTaggingNullVersion: next =>
+                        dstS3
+                            .send(
+                                new GetObjectTaggingCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    VersionId: 'null',
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    listObjectVersions: next =>
+                        dstS3
+                            .send(
+                                new ListObjectVersionsCommand({
+                                    Bucket: bucketDestination,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                },
+                (err, results) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    const headObjectRes = results.headObjectNullVersion;
+                    assert.strictEqual(headObjectRes.VersionId, 'null');
+
+                    const getObjectTaggingRes = results.getObjectTaggingNullVersion;
+                    assert.deepStrictEqual(getObjectTaggingRes.TagSet, [{ Key: 'key1', Value: 'value1' }]);
+
+                    const listObjectVersionsRes = results.listObjectVersions;
+                    const { Versions } = listObjectVersionsRes;
+
+                    assert.strictEqual(Versions.length, 1);
+                    const [currentVersion] = Versions;
+
+                    assert.strictEqual(currentVersion.VersionId, 'null');
+                    assert.strictEqual(currentVersion.IsLatest, true);
+
+                    return done();
+                },
+            );
+        });
+
+        itSkipS3CV0('should replicate/put a lifecycled NULL metadata to a destination that has a version', done => {
+            let objMDUpdated;
+            let objMDReplicated;
+            let versionId;
+
+            async.series(
+                {
+                    enableVersioningDestination: next =>
+                        dstS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketDestination,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    putObjectDestination: next =>
+                        dstS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => {
+                                versionId = data.VersionId;
+                                return next(null, data);
+                            })
+                            .catch(err => next(err)),
+
+                    putObjectSource: next =>
+                        srcS3
+                            .send(
+                                new PutObjectCommand({
+                                    Bucket: bucketSource,
+                                    Key: keyName,
+                                    Body: Buffer.from(testData),
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+
+                    enableVersioningSource: next =>
+                        srcS3
+                            .send(
+                                new PutBucketVersioningCommand({
+                                    Bucket: bucketSource,
+                                    VersioningConfiguration: { Status: 'Enabled' },
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    // === LIFECYCLE SIMULATION PHASE ===
+                    // Lifecycle Simulation: GET current null version metadata
+                    getSourceNullVersionForLifecycle: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: { versionId: 'null' },
+                                authCredentials: sourceAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                objMDUpdated = JSON.parse(data.body).Body;
+                                return next(null, data);
+                            },
+                        ),
+                    // Lifecycle Simulation: Apply lifecycle changes to null version metadata
+                    // Lifecycle changes can consist of:
+                    // - storage class transitions (STANDARD -> IA -> GLACIER)
+                    // - data location changes (different storage backend)
+                    // Here metadata is unchanged for the simulation
+                    applyLifecycleToSourceNullVersion: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: { versionId: 'null' },
+                                authCredentials: sourceAuthCredentials,
+                                requestBody: objMDUpdated,
+                            },
+                            next,
+                        ),
+                    // === REPLICATION PHASE ===
+                    // Replication: GET lifecycled metadata from source for replication
+                    getSourceLifecycledNullVersionForReplication: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'GET',
+                                resourceType: 'metadata',
+                                bucket: bucketSource,
+                                objectKey: keyName,
+                                queryObj: { versionId: 'null' },
+                                authCredentials: sourceAuthCredentials,
+                            },
+                            (err, data) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                objMDReplicated = objectMDWithUpdatedAccountInfo(
+                                    data,
+                                    src === dst ? null : dstAccountInfo,
+                                );
+                                return next(null, data);
+                            },
+                        ),
+                    // Replication: PUT lifecycled null version to destination
+                    replicateLifecycledNullVersionToDestination: next =>
+                        makeBackbeatRequest(
+                            {
+                                method: 'PUT',
+                                resourceType: 'metadata',
+                                bucket: bucketDestination,
+                                objectKey: keyName,
+                                queryObj: { versionId: 'null' },
+                                authCredentials: destinationAuthCredentials,
+                                requestBody: objMDReplicated,
+                            },
+                            next,
+                        ),
+                    headObjectByVersionId: next =>
+                        dstS3
+                            .send(
+                                new HeadObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    VersionId: versionId,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    headObjectByNullVersion: next =>
+                        dstS3
+                            .send(
+                                new HeadObjectCommand({
+                                    Bucket: bucketDestination,
+                                    Key: keyName,
+                                    VersionId: 'null',
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                    listObjectVersionsDestination: next =>
+                        dstS3
+                            .send(
+                                new ListObjectVersionsCommand({
+                                    Bucket: bucketDestination,
+                                }),
+                            )
+                            .then(data => next(null, data))
+                            .catch(err => next(err)),
+                },
+                (err, results) => {
+                    if (err) {
+                        return done(err);
+                    }
+                    const firstHeadObjectRes = results.headObjectByVersionId;
+                    assert.strictEqual(firstHeadObjectRes.VersionId, versionId);
+
+                    const secondHeadObjectRes = results.headObjectByNullVersion;
+                    assert.strictEqual(secondHeadObjectRes.VersionId, 'null');
+
+                    const listObjectVersionsRes = results.listObjectVersionsDestination;
+                    const { Versions } = listObjectVersionsRes;
+
+                    assert.strictEqual(Versions.length, 2);
+                    const [currentVersion, nonCurrentVersion] = Versions;
+
+                    assert.strictEqual(currentVersion.VersionId, 'null');
+                    assert.strictEqual(currentVersion.IsLatest, true);
+
+                    assert.strictEqual(nonCurrentVersion.VersionId, versionId);
+                    assert.strictEqual(nonCurrentVersion.IsLatest, false);
+
+                    return done();
+                },
+            );
         });
     });
-
-    it(
-        'should replicate/put metadata to a destination that has a suspended null version with internal version',
-    done => {
-        const tagSet = [
-            {
-                Key: 'key1',
-                Value: 'value1',
-            },
-        ];
-        let objMD;
-        let versionId;
-
-        async.series({
-            suspendVersioningDestination: next => dstS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketDestination,
-                VersioningConfiguration: { Status: 'Suspended' }
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            putObjectDestinationInitial: next => dstS3.send(new PutObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            putObjectTagging: next => dstS3.send(new PutObjectTaggingCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                Tagging: { TagSet: tagSet }
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            enableVersioningDestination: next => dstS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketDestination,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            enableVersioningSource: next => srcS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketSource,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            putObjectSource: next => srcS3.send(new PutObjectCommand({
-                Bucket: bucketSource,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => {
-                versionId = data.VersionId;
-                next(null, data);
-            }).catch(err => next(err)),
-            getMetadata: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: {
-                    versionId,
-                },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
-                return next();
-            }),
-            replicateMetadata: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: {
-                    versionId,
-                },
-                authCredentials: destinationAuthCredentials,
-                requestBody: objMD,
-            }, next),
-            headObjectNullVersion: next => dstS3.send(new HeadObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                VersionId: 'null'
-            })).then(data => next(null, data)).catch(err => next(err)),
-            getObjectTaggingNullVersion: next => dstS3.send(new GetObjectTaggingCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                VersionId: 'null'
-            })).then(data => next(null, data)).catch(err => next(err)),
-            listObjectVersions: next => dstS3.send(new ListObjectVersionsCommand({
-                Bucket: bucketDestination
-            })).then(data => next(null, data)).catch(err => next(err)),
-        }, (err, results) => {
-            if (err) {
-                return done(err);
-            }
-
-            const headObjectRes = results.headObjectNullVersion;
-            assert.strictEqual(headObjectRes.VersionId, 'null');
-
-            const getObjectTaggingRes = results.getObjectTaggingNullVersion;
-            assert.deepStrictEqual(getObjectTaggingRes.TagSet, tagSet);
-
-            const listObjectVersionsRes = results.listObjectVersions;
-            const { Versions } = listObjectVersionsRes;
-
-            assert.strictEqual(Versions.length, 2);
-            const [currentVersion, nonCurrentVersion] = Versions;
-
-            assert.strictEqual(currentVersion.VersionId, versionId);
-            assert.strictEqual(currentVersion.IsLatest, true);
-
-            assert.strictEqual(nonCurrentVersion.VersionId, 'null');
-            assert.strictEqual(nonCurrentVersion.IsLatest, false);
-
-            return done();
-        });
-    });
-
-    it('should mimic null version replication by crrExistingObjects, then replicate version', done => {
-        let objMDNull;
-        let objMDNullReplicated;
-        let objMDVersion;
-        let versionId;
-
-        async.series({
-            createNullSoloMasterKey: next => srcS3.send(new PutObjectCommand({
-                Bucket: bucketSource,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            enableVersioningSource: next => srcS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketSource,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            simulateCrrExistingObjectsGetMetadata: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: 'null',
-                },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                objMDNull = JSON.parse(data.body).Body;
-                assert.strictEqual(JSON.parse(objMDNull).versionId, undefined);
-                return next();
-            }),
-            simulateCrrExistingObjectsPutMetadata: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: 'null',
-                },
-                authCredentials: sourceAuthCredentials,
-                requestBody: objMDNull,
-            }, next),
-            enableVersioningDestination: next => dstS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketDestination,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
-            replicateNullVersion: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: 'null',
-                },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                objMDNullReplicated = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
-                return next();
-            }),
-            putReplicatedNullVersion: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: {
-                    versionId: 'null',
-                },
-                authCredentials: destinationAuthCredentials,
-                requestBody: objMDNullReplicated,
-            }, next),
-            putNewVersionSource: next => srcS3.send(new PutObjectCommand({
-                Bucket: bucketSource,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => {
-                versionId = data.VersionId;
-                return next(null, data);
-            }).catch(err => next(err)),
-            simulateMetadataReplicationVersion: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: {
-                    versionId,
-                },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                objMDVersion = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
-                return next();
-            }),
-            listObjectVersionsBeforeReplicate: next => dstS3.send(new ListObjectVersionsCommand({
-                Bucket: bucketDestination
-            })).then(data => next(null, data)).catch(err => next(err)),
-            putReplicatedVersion: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: {
-                    versionId,
-                },
-                authCredentials: destinationAuthCredentials,
-                requestBody: objMDVersion,
-            }, next),
-            checkReplicatedNullVersion: next => dstS3.send(new HeadObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                VersionId: 'null'
-            })).then(data => next(null, data)).catch(err => next(err)),
-            checkReplicatedVersion: next => dstS3.send(new HeadObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                VersionId: versionId
-            })).then(data => next(null, data)).catch(err => next(err)),
-            listObjectVersionsAfterReplicate: next => dstS3.send(new ListObjectVersionsCommand({
-                Bucket: bucketDestination
-            })).then(data => next(null, data)).catch(err => next(err)),
-        }, (err, results) => {
-            if (err) {
-                return done(err);
-            }
-
-            const headObjectNullVersionRes = results.checkReplicatedNullVersion;
-            assert.strictEqual(headObjectNullVersionRes.VersionId, 'null');
-
-            const headObjectVersionRes = results.checkReplicatedVersion;
-            assert.strictEqual(headObjectVersionRes.VersionId, versionId);
-
-            const listObjectVersionsRes = results.listObjectVersionsAfterReplicate;
-            const { Versions } = listObjectVersionsRes;
-
-            assert.strictEqual(Versions.length, 2);
-
-            const [currentVersion, nonCurrentVersion] = Versions;
-
-            assert.strictEqual(currentVersion.VersionId, versionId);
-            assert.strictEqual(currentVersion.IsLatest, true);
-
-            assert.strictEqual(nonCurrentVersion.VersionId, 'null');
-            assert.strictEqual(nonCurrentVersion.IsLatest, false);
-
-            return done();
-        });
-    });
-
-    // TODO: CLDSRV-739 unskip once flaky afterEach cleanup is fixed
-    const itSkipS3CV0 = (process.env.S3_END_TO_END && process.env.DEFAULT_BUCKET_KEY_FORMAT === 'v0') ? it.skip : it;
-    itSkipS3CV0('should replicate/put NULL metadata to a destination that has a version', done => {
-        let objMD;
-        let versionId;
-
-        async.series({
-            enableVersioningDestination: next => dstS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketDestination,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            putObjectDestination: next => dstS3.send(new PutObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data =>{
-                versionId = data.VersionId;
-                return next(null, data);
-            }).catch(err => next(err)),
-
-            putObjectSource: next => srcS3.send(new PutObjectCommand({
-                Bucket: bucketSource,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            enableVersioningSource: next => srcS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketSource,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            getMetadata: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: { versionId: 'null' },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
-                return next();
-            }),
-            replicateMetadata: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: { versionId: 'null' },
-                authCredentials: destinationAuthCredentials,
-                requestBody: objMD,
-            }, next),
-            headObjectByVersionId: next => dstS3.send(new HeadObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                VersionId: versionId
-            })).then(data => next(null, data)).catch(err => next(err)),
-            headObjectByNullVersionId: next => dstS3.send(new HeadObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                VersionId: 'null'
-            })).then(data => next(null, data)).catch(err => next(err)),
-            listObjectVersions: next => dstS3.send(new ListObjectVersionsCommand({
-                Bucket: bucketDestination
-            })).then(data => next(null, data)).catch(err => next(err)),
-        }, (err, results) => {
-            if (err) {
-                return done(err);
-            }
-
-            const firstHeadObjectRes = results.headObjectByVersionId;
-            assert.strictEqual(firstHeadObjectRes.VersionId, versionId);
-
-            const secondHeadObjectRes = results.headObjectByNullVersionId;
-            assert.strictEqual(secondHeadObjectRes.VersionId, 'null');
-
-            const listObjectVersionsRes = results.listObjectVersions;
-            const { Versions } = listObjectVersionsRes;
-
-            assert.strictEqual(Versions.length, 2);
-            const [currentVersion, nonCurrentVersion] = Versions;
-
-            assert.strictEqual(currentVersion.VersionId, 'null');
-            assert.strictEqual(currentVersion.IsLatest, true);
-
-            assert.strictEqual(nonCurrentVersion.VersionId, versionId);
-            assert.strictEqual(nonCurrentVersion.IsLatest, false);
-
-            return done();
-        });
-    });
-
-    it('should replicate/put NULL metadata to a destination that has a null version', done => {
-        let objMD;
-
-        async.series({
-            putObjectDestinationInitial: next => dstS3.send(new PutObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            enableVersioningDestination: next => dstS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketDestination,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            putObjectSource: next => srcS3.send(new PutObjectCommand({
-                Bucket: bucketSource,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            enableVersioningSource: next => srcS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketSource,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            putObjectTaggingSource: next => srcS3.send(new PutObjectTaggingCommand({
-                Bucket: bucketSource,
-                Key: keyName,
-                VersionId: 'null',
-                Tagging: { TagSet: [{ Key: 'key1', Value: 'value1' }] }
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            getMetadata: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: { versionId: 'null' },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                objMD = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
-                return next();
-            }),
-            replicateMetadata: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: { versionId: 'null' },
-                authCredentials: destinationAuthCredentials,
-                requestBody: objMD,
-            }, next),
-            headObjectNullVersion: next => dstS3.send(new HeadObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                VersionId: 'null'
-            })).then(data => next(null, data)).catch(err => next(err)),
-            getObjectTaggingNullVersion: next => dstS3.send(new GetObjectTaggingCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                VersionId: 'null'
-            })).then(data => next(null, data)).catch(err => next(err)),
-            listObjectVersions: next => dstS3.send(new ListObjectVersionsCommand({
-                Bucket: bucketDestination
-            })).then(data => next(null, data)).catch(err => next(err)),
-        }, (err, results) => {
-            if (err) {
-                return done(err);
-            }
-
-            const headObjectRes = results.headObjectNullVersion;
-            assert.strictEqual(headObjectRes.VersionId, 'null');
-
-            const getObjectTaggingRes = results.getObjectTaggingNullVersion;
-            assert.deepStrictEqual(getObjectTaggingRes.TagSet, [{ Key: 'key1', Value: 'value1' }]);
-
-            const listObjectVersionsRes = results.listObjectVersions;
-            const { Versions } = listObjectVersionsRes;
-
-            assert.strictEqual(Versions.length, 1);
-            const [currentVersion] = Versions;
-
-            assert.strictEqual(currentVersion.VersionId, 'null');
-            assert.strictEqual(currentVersion.IsLatest, true);
-
-            return done();
-        });
-    });
-
-    itSkipS3CV0('should replicate/put a lifecycled NULL metadata to a destination that has a version', done => {
-        let objMDUpdated;
-        let objMDReplicated;
-        let versionId;
-
-        async.series({
-            enableVersioningDestination: next => dstS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketDestination,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
-            putObjectDestination: next => dstS3.send(new PutObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => {
-                versionId = data.VersionId;
-                return next(null, data);
-            }).catch(err => next(err)),
-
-            putObjectSource: next => srcS3.send(new PutObjectCommand({
-                Bucket: bucketSource,
-                Key: keyName,
-                Body: Buffer.from(testData)
-            })).then(data => next(null, data)).catch(err => next(err)),
-
-            enableVersioningSource: next => srcS3.send(new PutBucketVersioningCommand({
-                Bucket: bucketSource,
-                VersioningConfiguration: { Status: 'Enabled' }
-            })).then(data => next(null, data)).catch(err => next(err)),
-            // === LIFECYCLE SIMULATION PHASE ===
-            // Lifecycle Simulation: GET current null version metadata
-            getSourceNullVersionForLifecycle: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: { versionId: 'null' },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                objMDUpdated = JSON.parse(data.body).Body;
-                return next(null, data);
-            }),
-            // Lifecycle Simulation: Apply lifecycle changes to null version metadata
-            // Lifecycle changes can consist of:
-            // - storage class transitions (STANDARD -> IA -> GLACIER)
-            // - data location changes (different storage backend)
-            // Here metadata is unchanged for the simulation
-            applyLifecycleToSourceNullVersion: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: { versionId: 'null' },
-                authCredentials: sourceAuthCredentials,
-                requestBody: objMDUpdated,
-            }, next),
-            // === REPLICATION PHASE ===
-            // Replication: GET lifecycled metadata from source for replication
-            getSourceLifecycledNullVersionForReplication: next => makeBackbeatRequest({
-                method: 'GET',
-                resourceType: 'metadata',
-                bucket: bucketSource,
-                objectKey: keyName,
-                queryObj: { versionId: 'null' },
-                authCredentials: sourceAuthCredentials,
-            }, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                objMDReplicated = objectMDWithUpdatedAccountInfo(data, src === dst ? null : dstAccountInfo);
-                return next(null, data);
-            }),
-            // Replication: PUT lifecycled null version to destination
-            replicateLifecycledNullVersionToDestination: next => makeBackbeatRequest({
-                method: 'PUT',
-                resourceType: 'metadata',
-                bucket: bucketDestination,
-                objectKey: keyName,
-                queryObj: { versionId: 'null' },
-                authCredentials: destinationAuthCredentials,
-                requestBody: objMDReplicated,
-            }, next),
-            headObjectByVersionId: next => dstS3.send(new HeadObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                VersionId: versionId
-            })).then(data => next(null, data)).catch(err => next(err)),
-            headObjectByNullVersion: next => dstS3.send(new HeadObjectCommand({
-                Bucket: bucketDestination,
-                Key: keyName,
-                VersionId: 'null'
-            })).then(data => next(null, data)).catch(err => next(err)),
-            listObjectVersionsDestination: next => dstS3.send(new ListObjectVersionsCommand({
-                Bucket: bucketDestination
-            })).then(data => next(null, data)).catch(err => next(err)),
-        }, (err, results) => {
-            if (err) {
-                return done(err);
-            }
-            const firstHeadObjectRes = results.headObjectByVersionId;
-            assert.strictEqual(firstHeadObjectRes.VersionId, versionId);
-
-            const secondHeadObjectRes = results.headObjectByNullVersion;
-            assert.strictEqual(secondHeadObjectRes.VersionId, 'null');
-
-            const listObjectVersionsRes = results.listObjectVersionsDestination;
-            const { Versions } = listObjectVersionsRes;
-
-            assert.strictEqual(Versions.length, 2);
-            const [currentVersion, nonCurrentVersion] = Versions;
-
-            assert.strictEqual(currentVersion.VersionId, 'null');
-            assert.strictEqual(currentVersion.IsLatest, true);
-
-            assert.strictEqual(nonCurrentVersion.VersionId, versionId);
-            assert.strictEqual(nonCurrentVersion.IsLatest, false);
-
-            return done();
-        });
-    });
-});
 });

--- a/tests/unit/routes/routeBackbeat.js
+++ b/tests/unit/routes/routeBackbeat.js
@@ -610,9 +610,9 @@ describe('routeBackbeat', () => {
                 metadataPutObjectMDStub.secondCall, // Create the new object
                 'bucket0',
                 'key0',
-                sinon.match({
-                    nullVersionId: '99999999999999999999RG001  ',
-                }),
+                // CLDSRV-922: in null-key mode the master must not reference the
+                // null version via nullVersionId (only compat mode does).
+                sinon.match(omVal => omVal.nullVersionId === undefined, 'omVal without nullVersionId'),
                 sinon.match({ versioning: true, isNull: false }),
                 log,
             );

--- a/tests/unit/routes/routeBackbeat.js
+++ b/tests/unit/routes/routeBackbeat.js
@@ -24,19 +24,22 @@ const bucketPutPolicy = require('../../../lib/api/bucketPutPolicy');
 const log = new DummyRequestLogger();
 
 function prepareDummyRequest(headers = {}, body = '') {
-    const request = new DummyRequest({
-        hostname: 'localhost',
-        method: 'PUT',
-        url: '/_/backbeat/metadata/bucket0/key0',
-        port: 80,
-        headers,
-        socket: {
-            remoteAddress: '0.0.0.0',
-            destroy: () => {},
-            on: () => {},
-            removeListener: () => {},
+    const request = new DummyRequest(
+        {
+            hostname: 'localhost',
+            method: 'PUT',
+            url: '/_/backbeat/metadata/bucket0/key0',
+            port: 80,
+            headers,
+            socket: {
+                remoteAddress: '0.0.0.0',
+                destroy: () => {},
+                on: () => {},
+                removeListener: () => {},
+            },
         },
-    }, body || '{"replicationInfo":"{}"}');
+        body || '{"replicationInfo":"{}"}',
+    );
     return request;
 }
 
@@ -52,7 +55,9 @@ describe('routeBackbeat', () => {
         sandbox = sinon.createSandbox();
 
         // create a Promise that resolves when response.end is called
-        endPromise = new Promise(resolve => { resolveEnd = resolve; });
+        endPromise = new Promise(resolve => {
+            resolveEnd = resolve;
+        });
 
         mockResponse = {
             statusCode: null,
@@ -114,7 +119,7 @@ describe('routeBackbeat', () => {
 
             routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
 
-            void await endPromise;
+            void (await endPromise);
 
             assert.strictEqual(mockResponse.statusCode, 409);
             assert.strictEqual(mockResponse.body.code, 'InvalidBucketState');
@@ -134,7 +139,7 @@ describe('routeBackbeat', () => {
 
         routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
 
-        void await endPromise;
+        void (await endPromise);
 
         assert.strictEqual(mockResponse.statusCode, 200);
         assert.deepStrictEqual(mockResponse.body, { Body: '{}' });
@@ -161,14 +166,15 @@ describe('routeBackbeat', () => {
             const objMd = {};
             callback(null, bucketInfo, objMd);
         });
-        storeObject.dataStore.callsFake((objectContext, cipherBundle, stream, size,
-            streamingV4Params, backendInfo, log, callback) => {
-            callback(null, {}, md5);
-        });
+        storeObject.dataStore.callsFake(
+            (objectContext, cipherBundle, stream, size, streamingV4Params, backendInfo, log, callback) => {
+                callback(null, {}, md5);
+            },
+        );
 
         routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
 
-        void await endPromise;
+        void (await endPromise);
 
         assert.strictEqual(mockResponse.statusCode, 200);
         assert.deepStrictEqual(mockResponse.body, [{}]);
@@ -182,15 +188,18 @@ describe('routeBackbeat', () => {
         let dataDeleteSpy;
 
         function preparePutMetadataRequest(body = {}) {
-            const req = prepareDummyRequest({
-                'x-scal-versioning-required': 'true',
-            }, JSON.stringify({
-                replicationInfo: {},
-                ...body,
-            }));
+            const req = prepareDummyRequest(
+                {
+                    'x-scal-versioning-required': 'true',
+                },
+                JSON.stringify({
+                    replicationInfo: {},
+                    ...body,
+                }),
+            );
             req.method = 'PUT';
             req.url = '/_/backbeat/metadata/bucket0/key0';
-            req.destroy = () => { };
+            req.destroy = () => {};
             return req;
         }
 
@@ -210,7 +219,7 @@ describe('routeBackbeat', () => {
             });
 
             routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-            void await endPromise;
+            void (await endPromise);
             assert.strictEqual(mockResponse.statusCode, 200);
             assert.deepStrictEqual(mockResponse.body, {});
         });
@@ -221,7 +230,7 @@ describe('routeBackbeat', () => {
             });
 
             routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-            void await endPromise;
+            void (await endPromise);
 
             assert.strictEqual(mockResponse.statusCode, 200);
             assert.deepStrictEqual(mockResponse.body, {});
@@ -230,18 +239,20 @@ describe('routeBackbeat', () => {
         it('should put metadata after updating account info', async () => {
             mockRequest.url = '/_/backbeat/metadata/bucket0/key0?accountId=123456789012';
             const putObjectMDStub = sandbox.stub(metadata, 'putObjectMD');
-            putObjectMDStub.onCall(0).callsFake(
-                (_bucketName, _objectKey, _omVal, _options, _logParam, cb) => cb(null, {})
-            );
+            putObjectMDStub
+                .onCall(0)
+                .callsFake((_bucketName, _objectKey, _omVal, _options, _logParam, cb) => cb(null, {}));
             putObjectMDStub.onCall(1).callsFake((_bucketName, _objectKey, omVal, _options, _logParam, cb) => {
                 assert.strictEqual(omVal['owner-display-name'], 'Bart');
-                assert.strictEqual(omVal['owner-id'],
-                    '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be');
+                assert.strictEqual(
+                    omVal['owner-id'],
+                    '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be',
+                );
                 cb(null, {});
             });
 
             routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-            void await endPromise;
+            void (await endPromise);
 
             assert.strictEqual(mockResponse.statusCode, 200);
             assert.deepStrictEqual(mockResponse.body, {});
@@ -251,14 +262,15 @@ describe('routeBackbeat', () => {
             mockRequest.url = '/_/backbeat/metadata/bucket0/key0?accountId=invalid';
 
             routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-            void await endPromise;
+            void (await endPromise);
 
             assert.strictEqual(mockResponse.statusCode, 404);
             assert.deepStrictEqual(mockResponse.body.code, 'AccountNotFound');
         });
 
         it('should repair master when putting metadata of a new version', async () => {
-            mockRequest.url = '/_/backbeat/metadata/bucket0/key0' +
+            mockRequest.url =
+                '/_/backbeat/metadata/bucket0/key0' +
                 '?accountId=123456789012&versionId=aIXVkw5Tw2Pd00000000001I4j3QKsvf';
 
             const putObjectMDStub = sandbox.stub(metadata, 'putObjectMD');
@@ -276,14 +288,15 @@ describe('routeBackbeat', () => {
             });
 
             routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-            void await endPromise;
+            void (await endPromise);
 
             assert.strictEqual(mockResponse.statusCode, 200);
             assert.deepStrictEqual(mockResponse.body, {});
         });
 
         it('should not repair master when updating metadata of an existing version', async () => {
-            mockRequest.url = '/_/backbeat/metadata/bucket0/key0' +
+            mockRequest.url =
+                '/_/backbeat/metadata/bucket0/key0' +
                 '?accountId=123456789012&versionId=aIXVkw5Tw2Pd00000000001I4j3QKsvf';
 
             sandbox.stub(metadata, 'putObjectMD').callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
@@ -292,7 +305,7 @@ describe('routeBackbeat', () => {
             });
 
             routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-            void await endPromise;
+            void (await endPromise);
             assert.strictEqual(mockResponse.statusCode, 200);
             assert.deepStrictEqual(mockResponse.body, {});
         });
@@ -304,7 +317,7 @@ describe('routeBackbeat', () => {
             });
 
             routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-            void await endPromise;
+            void (await endPromise);
 
             assert.strictEqual(mockResponse.statusCode, 500);
         });
@@ -313,26 +326,28 @@ describe('routeBackbeat', () => {
             mockRequest.url = '/_/backbeat/metadata/bucket0';
 
             routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-            void await endPromise;
+            void (await endPromise);
             assert.strictEqual(mockResponse.statusCode, 405);
         });
 
         it('should delete data when replacing with empty object', async () => {
             const existingMd = {
-                location: [{
-                    key: 'key0',
-                    dataStoreName: 'location1',
-                    size: 100,
-                }],
+                location: [
+                    {
+                        key: 'key0',
+                        dataStoreName: 'location1',
+                        size: 100,
+                    },
+                ],
             };
             metadataUtils.standardMetadataValidateBucketAndObj.callsFake((params, denies, log, callback) => {
                 callback(null, bucketInfo, existingMd);
             });
 
             const putObjectMDStub = sandbox.stub(metadata, 'putObjectMD');
-            putObjectMDStub.onCall(0).callsFake(
-                (_bucketName, _objectKey, _omVal, _options, _logParam, cb) => cb(null, {})
-            );
+            putObjectMDStub
+                .onCall(0)
+                .callsFake((_bucketName, _objectKey, _omVal, _options, _logParam, cb) => cb(null, {}));
             putObjectMDStub.onCall(1).callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
                 assert.deepStrictEqual(omVal.location, undefined);
                 cb(null, {});
@@ -344,7 +359,7 @@ describe('routeBackbeat', () => {
             mockRequest.url += '?versionId=aIXVkw5Tw2Pd00000000001I4j3QKsvf';
 
             routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-            void await endPromise;
+            void (await endPromise);
 
             assert.strictEqual(mockResponse.statusCode, 200);
             assert.deepStrictEqual(mockResponse.body, {});
@@ -353,11 +368,13 @@ describe('routeBackbeat', () => {
         });
 
         it('should preserve existing locations when x-scal-replication-content is METADATA', async () => {
-            const existingLocations = [{
-                key: 'key0',
-                dataStoreName: 'location1',
-                size: 100,
-            }];
+            const existingLocations = [
+                {
+                    key: 'key0',
+                    dataStoreName: 'location1',
+                    size: 100,
+                },
+            ];
             metadataUtils.standardMetadataValidateBucketAndObj.callsFake((params, denies, log, callback) => {
                 callback(null, bucketInfo, {
                     location: existingLocations,
@@ -383,7 +400,7 @@ describe('routeBackbeat', () => {
             mockRequest.url += '?versionId=aIXVkw5Tw2Pd00000000001I4j3QKsvf';
 
             routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-            void await endPromise;
+            void (await endPromise);
 
             assert.strictEqual(mockResponse.statusCode, 200);
             assert.deepStrictEqual(mockResponse.body, {});
@@ -392,20 +409,22 @@ describe('routeBackbeat', () => {
 
         it('should delete data when no more locations', async () => {
             const existingMd = {
-                location: [{
-                    key: 'key0',
-                    dataStoreName: 'location1',
-                    size: 100,
-                }],
+                location: [
+                    {
+                        key: 'key0',
+                        dataStoreName: 'location1',
+                        size: 100,
+                    },
+                ],
             };
             metadataUtils.standardMetadataValidateBucketAndObj.callsFake((params, denies, log, callback) => {
                 callback(null, bucketInfo, existingMd);
             });
 
             const putObjectMDStub = sandbox.stub(metadata, 'putObjectMD');
-            putObjectMDStub.onCall(0).callsFake(
-                (_bucketName, _objectKey, _omVal, _options, _logParam, cb) => cb(null, {})
-            );
+            putObjectMDStub
+                .onCall(0)
+                .callsFake((_bucketName, _objectKey, _omVal, _options, _logParam, cb) => cb(null, {}));
             putObjectMDStub.onCall(1).callsFake((_bucketName, _objectKey, omVal, _options, _logParam, cb) => {
                 // Verify that the location array is empty, indicating data deletion
                 assert.deepStrictEqual(omVal.location, []);
@@ -416,7 +435,7 @@ describe('routeBackbeat', () => {
             mockRequest.url += '?versionId=aIXVkw5Tw2Pd00000000001I4j3QKsvf';
 
             routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-            void await endPromise;
+            void (await endPromise);
 
             assert.strictEqual(mockResponse.statusCode, 200);
             assert.deepStrictEqual(mockResponse.body, {});
@@ -426,11 +445,13 @@ describe('routeBackbeat', () => {
 
         it('should delete data when locations change', async () => {
             const existingMd = {
-                location: [{
-                    key: 'key0',
-                    dataStoreName: 'location1',
-                    size: 100,
-                }],
+                location: [
+                    {
+                        key: 'key0',
+                        dataStoreName: 'location1',
+                        size: 100,
+                    },
+                ],
                 'content-length': 100,
             };
             metadataUtils.standardMetadataValidateBucketAndObj.callsFake((params, denies, log, callback) => {
@@ -439,20 +460,22 @@ describe('routeBackbeat', () => {
 
             // New metadata has different locations
             const reqBody = {
-                location: [{
-                    key: 'key1',
-                    dataStoreName: 'location1',
-                    size: 100,
-                }],
+                location: [
+                    {
+                        key: 'key1',
+                        dataStoreName: 'location1',
+                        size: 100,
+                    },
+                ],
                 'content-length': 100,
             };
             mockRequest = preparePutMetadataRequest(reqBody);
             mockRequest.url += '?versionId=aIXVkw5Tw2Pd00000000001I4j3QKsvf';
 
             const putObjectMDStub = sandbox.stub(metadata, 'putObjectMD');
-            putObjectMDStub.onCall(0).callsFake(
-                (_bucketName, _objectKey, _omVal, _options, _logParam, cb) => cb(null, {})
-            );
+            putObjectMDStub
+                .onCall(0)
+                .callsFake((_bucketName, _objectKey, _omVal, _options, _logParam, cb) => cb(null, {}));
             putObjectMDStub.onCall(1).callsFake((_bucketName, __objectKey, omVal, _options, _logParam, cb) => {
                 // Verify that the location array contains the new location
                 assert.deepStrictEqual(omVal.location, reqBody.location);
@@ -460,7 +483,7 @@ describe('routeBackbeat', () => {
             });
 
             routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-            void await endPromise;
+            void (await endPromise);
 
             assert.strictEqual(mockResponse.statusCode, 200);
             assert.deepStrictEqual(mockResponse.body, {});
@@ -470,15 +493,18 @@ describe('routeBackbeat', () => {
 
         it('should not delete data when some keys are still used', async () => {
             const existingMd = {
-                location: [{
-                    key: 'key0',
-                    dataStoreName: 'location1',
-                    size: 100,
-                }, {
-                    key: 'key1',
-                    dataStoreName: 'location1',
-                    size: 100,
-                }],
+                location: [
+                    {
+                        key: 'key0',
+                        dataStoreName: 'location1',
+                        size: 100,
+                    },
+                    {
+                        key: 'key1',
+                        dataStoreName: 'location1',
+                        size: 100,
+                    },
+                ],
                 'content-length': 100,
             };
             metadataUtils.standardMetadataValidateBucketAndObj.callsFake((params, denies, log, callback) => {
@@ -487,24 +513,27 @@ describe('routeBackbeat', () => {
 
             // New metadata has different locations
             const reqBody = {
-                location: [{
-                    key: 'key1',
-                    dataStoreName: 'location1',
-                    size: 100,
-                }, {
-                    key: 'key2',
-                    dataStoreName: 'location1',
-                    size: 100,
-                }],
+                location: [
+                    {
+                        key: 'key1',
+                        dataStoreName: 'location1',
+                        size: 100,
+                    },
+                    {
+                        key: 'key2',
+                        dataStoreName: 'location1',
+                        size: 100,
+                    },
+                ],
                 'content-length': 100,
             };
             mockRequest = preparePutMetadataRequest(reqBody);
             mockRequest.url += '?versionId=aIXVkw5Tw2Pd00000000001I4j3QKsvf';
 
             const putObjectMDStub = sandbox.stub(metadata, 'putObjectMD');
-            putObjectMDStub.onCall(0).callsFake(
-                (_bucketName, _objectKey, _omVal, _options, _logParam, cb) => cb(null, {})
-            );
+            putObjectMDStub
+                .onCall(0)
+                .callsFake((_bucketName, _objectKey, _omVal, _options, _logParam, cb) => cb(null, {}));
             putObjectMDStub.onCall(1).callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
                 // Verify that the location array contains the new location
                 assert.deepStrictEqual(omVal.location, reqBody.location);
@@ -512,7 +541,7 @@ describe('routeBackbeat', () => {
             });
 
             routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-            void await endPromise;
+            void (await endPromise);
 
             assert.strictEqual(mockResponse.statusCode, 200);
             assert.deepStrictEqual(mockResponse.body, {});
@@ -521,11 +550,13 @@ describe('routeBackbeat', () => {
 
         it('should not delete data when object is archived', async () => {
             const existingMd = {
-                location: [{
-                    key: 'key0',
-                    dataStoreName: 'location1',
-                    size: 100,
-                }],
+                location: [
+                    {
+                        key: 'key0',
+                        dataStoreName: 'location1',
+                        size: 100,
+                    },
+                ],
                 'content-length': 100,
             };
             metadataUtils.standardMetadataValidateBucketAndObj.callsFake((params, denies, log, callback) => {
@@ -533,17 +564,20 @@ describe('routeBackbeat', () => {
             });
 
             // New metadata has empty location array but keeps content-length (cold storage case)
-            mockRequest = prepareDummyRequest(mockRequest.headers, JSON.stringify({
-                location: undefined,
-                'content-length': 100,
-                replicationInfo: {},
-            }));
+            mockRequest = prepareDummyRequest(
+                mockRequest.headers,
+                JSON.stringify({
+                    location: undefined,
+                    'content-length': 100,
+                    replicationInfo: {},
+                }),
+            );
             mockRequest.url += '?versionId=aIXVkw5Tw2Pd00000000001I4j3QKsvf';
 
             const putObjectMDStub = sandbox.stub(metadata, 'putObjectMD');
-            putObjectMDStub.onCall(0).callsFake(
-                (_bucketName, _objectKey, _omVal, _options, _logParam, cb) => cb(null, {})
-            );
+            putObjectMDStub
+                .onCall(0)
+                .callsFake((_bucketName, _objectKey, _omVal, _options, _logParam, cb) => cb(null, {}));
             putObjectMDStub.onCall(1).callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
                 // Verify that the location array is empty
                 assert.deepStrictEqual(omVal.location, undefined);
@@ -553,73 +587,79 @@ describe('routeBackbeat', () => {
             });
 
             routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-            void await endPromise;
+            void (await endPromise);
 
             assert.strictEqual(mockResponse.statusCode, 200);
             assert.deepStrictEqual(mockResponse.body, {});
             assert.strictEqual(dataDeleteSpy.called, false);
         });
 
-        it('should transform a non-versioned object to a versioned' +
-          ' one and create a new object if the bucket is versioned', async () => {
-            const bucketInfo = {
-                getVersioningConfiguration: () => ({ Status: 'Enabled' }),
-                isVersioningEnabled: () => true,
-            };
-            const notFoundObject = undefined;
-            const nonVersionedObject = {
-                'content-length': 100,
-            };
+        it(
+            'should transform a non-versioned object to a versioned' +
+                ' one and create a new object if the bucket is versioned',
+            async () => {
+                const bucketInfo = {
+                    getVersioningConfiguration: () => ({ Status: 'Enabled' }),
+                    isVersioningEnabled: () => true,
+                };
+                const notFoundObject = undefined;
+                const nonVersionedObject = {
+                    'content-length': 100,
+                };
 
-            const metadataGetObjectMDPromisedStub = sandbox.stub(metadata, 'getObjectMDPromised');
-            metadataGetObjectMDPromisedStub.callsFake(() => Promise.resolve({
-                    data: nonVersionedObject,
-                }));
-            const metadataPutObjectMDStub = sandbox.stub(metadata, 'putObjectMD')
-                .callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
-                    cb(null, {});
+                const metadataGetObjectMDPromisedStub = sandbox.stub(metadata, 'getObjectMDPromised');
+                metadataGetObjectMDPromisedStub.callsFake(() =>
+                    Promise.resolve({
+                        data: nonVersionedObject,
+                    }),
+                );
+                const metadataPutObjectMDStub = sandbox
+                    .stub(metadata, 'putObjectMD')
+                    .callsFake((bucketName, objectKey, omVal, options, logParam, cb) => {
+                        cb(null, {});
+                    });
+
+                mockRequest = prepareDummyRequest();
+                mockRequest.method = 'PUT';
+                mockRequest.url = '/_/backbeat/metadata/bucket0/key0';
+
+                metadataUtils.standardMetadataValidateBucketAndObj.callsFake((params, denies, log, callback) => {
+                    callback(null, bucketInfo, notFoundObject);
                 });
 
-            mockRequest = prepareDummyRequest();
-            mockRequest.method = 'PUT';
-            mockRequest.url = '/_/backbeat/metadata/bucket0/key0';
+                routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+                await endPromise;
 
-            metadataUtils.standardMetadataValidateBucketAndObj.callsFake((params, denies, log, callback) => {
-                callback(null, bucketInfo, notFoundObject);
-            });
+                sinon.assert.calledOnce(metadataGetObjectMDPromisedStub);
+                sinon.assert.calledTwice(metadataPutObjectMDStub);
+                sinon.assert.calledWith(
+                    metadataPutObjectMDStub.firstCall, // Transform the non versioned object to a versioned one
+                    'bucket0',
+                    'key0',
+                    sinon.match({
+                        data: nonVersionedObject,
+                        versionId: '99999999999999999999RG001  ',
+                        isNull: true,
+                        isNull2: true,
+                    }),
+                    sinon.match({ versionId: 'null' }),
+                    log,
+                );
+                sinon.assert.calledWith(
+                    metadataPutObjectMDStub.secondCall, // Create the new object
+                    'bucket0',
+                    'key0',
+                    // CLDSRV-922: in null-key mode the master must not reference the
+                    // null version via nullVersionId (only compat mode does).
+                    sinon.match(omVal => omVal.nullVersionId === undefined, 'omVal without nullVersionId'),
+                    sinon.match({ versioning: true, isNull: false }),
+                    log,
+                );
 
-            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-            await endPromise;
-
-            sinon.assert.calledOnce(metadataGetObjectMDPromisedStub);
-            sinon.assert.calledTwice(metadataPutObjectMDStub);
-            sinon.assert.calledWith(
-                metadataPutObjectMDStub.firstCall, // Transform the non versioned object to a versioned one
-                'bucket0',
-                'key0',
-                sinon.match({
-                    data: nonVersionedObject,
-                    versionId: '99999999999999999999RG001  ',
-                    isNull: true,
-                    isNull2: true
-                }),
-                sinon.match({ versionId: 'null' }),
-                log,
-            );
-            sinon.assert.calledWith(
-                metadataPutObjectMDStub.secondCall, // Create the new object
-                'bucket0',
-                'key0',
-                // CLDSRV-922: in null-key mode the master must not reference the
-                // null version via nullVersionId (only compat mode does).
-                sinon.match(omVal => omVal.nullVersionId === undefined, 'omVal without nullVersionId'),
-                sinon.match({ versioning: true, isNull: false }),
-                log,
-            );
-
-            assert.strictEqual(mockResponse.statusCode, 200);
-            assert.deepStrictEqual(mockResponse.body, {});
-        });
+                assert.strictEqual(mockResponse.statusCode, 200);
+                assert.deepStrictEqual(mockResponse.body, {});
+            },
+        );
     });
 
     describe('batchDelete', () => {
@@ -627,18 +667,23 @@ describe('routeBackbeat', () => {
         let validateQuotasSpy;
 
         const prepareBatchDeleteRequest = (locations = undefined) => {
-            const mockRequest = prepareDummyRequest({
-                'x-scal-versioning-required': 'true'
-            }, JSON.stringify({
-                Locations: locations || [{
-                    key: 'key0',
-                    bucket: 'bucket0',
-                    size: 100,
-                }],
-            }));
+            const mockRequest = prepareDummyRequest(
+                {
+                    'x-scal-versioning-required': 'true',
+                },
+                JSON.stringify({
+                    Locations: locations || [
+                        {
+                            key: 'key0',
+                            bucket: 'bucket0',
+                            size: 100,
+                        },
+                    ],
+                }),
+            );
             mockRequest.method = 'POST';
             mockRequest.url = '/_/backbeat/batchdelete/bucket0/key0';
-            mockRequest.destroy = () => { };
+            mockRequest.destroy = () => {};
             return mockRequest;
         };
 
@@ -661,7 +706,7 @@ describe('routeBackbeat', () => {
             doAuthStub.callThrough();
 
             routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-            void await endPromise;
+            void (await endPromise);
             assert.strictEqual(mockResponse.statusCode, 403);
         });
 
@@ -677,7 +722,8 @@ describe('routeBackbeat', () => {
             await endPromise;
 
             sinon.assert.calledOnce(validateQuotasSpy);
-            sinon.assert.calledWith(validateQuotasSpy,
+            sinon.assert.calledWith(
+                validateQuotasSpy,
                 mockRequest,
                 bucketMD,
                 mockRequest.accountQuotas,
@@ -698,7 +744,7 @@ describe('routeBackbeat', () => {
             mockRequest.url = '/_/backbeat/batchdelete';
 
             routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-            void await endPromise;
+            void (await endPromise);
 
             assert(!validateQuotasSpy.called);
 
@@ -710,7 +756,7 @@ describe('routeBackbeat', () => {
             sandbox.stub(config, 'isQuotaEnabled').returns(false);
 
             routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-            void await endPromise;
+            void (await endPromise);
 
             assert(!validateQuotasSpy.called);
 
@@ -720,14 +766,16 @@ describe('routeBackbeat', () => {
 
         it('should skip quota updates when content length is 0', async () => {
             sandbox.stub(config, 'isQuotaEnabled').returns(true);
-            mockRequest = prepareBatchDeleteRequest([{
-                key: 'key0',
-                bucket: 'bucket0',
-                size: 0,
-            }]);
+            mockRequest = prepareBatchDeleteRequest([
+                {
+                    key: 'key0',
+                    bucket: 'bucket0',
+                    size: 0,
+                },
+            ]);
 
             routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-            void await endPromise;
+            void (await endPromise);
 
             assert(!validateQuotasSpy.called);
 
@@ -743,99 +791,109 @@ describe('routeBackbeat', () => {
             };
 
             routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-        void await endPromise;
-        assert.strictEqual(mockResponse.statusCode, 200);
-        assert.deepStrictEqual(mockResponse.body, {});
-    });
+            void (await endPromise);
+            assert.strictEqual(mockResponse.statusCode, 200);
+            assert.deepStrictEqual(mockResponse.body, {});
+        });
 
-    it('should not batchDelete with conditions if "if-unmodified-since" header unset', async () => {
-        mockRequest.headers = {
-            'x-scal-versioning-required': 'true',
-            'x-scal-storage-class': 'azurebackend',
-        };
+        it('should not batchDelete with conditions if "if-unmodified-since" header unset', async () => {
+            mockRequest.headers = {
+                'x-scal-versioning-required': 'true',
+                'x-scal-storage-class': 'azurebackend',
+            };
 
-        routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-        void await endPromise;
+            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+            void (await endPromise);
 
-        assert.strictEqual(mockResponse.statusCode, 200);
-    });
+            assert.strictEqual(mockResponse.statusCode, 200);
+        });
 
-    it('should batchDelete with conditions and non-azure location', async () => {
-        const putRequest = prepareDummyRequest({
-            'x-scal-versioning-required': 'true',
-        }, JSON.stringify({
-            Locations: [
+        it('should batchDelete with conditions and non-azure location', async () => {
+            const putRequest = prepareDummyRequest(
                 {
-                    key: 'key0',
-                    bucket: 'bucket0',
-                    lastModified: '2020-01-01T00:00:00.000Z',
+                    'x-scal-versioning-required': 'true',
                 },
-            ],
-        }));
-        await promisify(dataWrapper.client.put)(putRequest, 91, 1, 'reqUids');
+                JSON.stringify({
+                    Locations: [
+                        {
+                            key: 'key0',
+                            bucket: 'bucket0',
+                            lastModified: '2020-01-01T00:00:00.000Z',
+                        },
+                    ],
+                }),
+            );
+            await promisify(dataWrapper.client.put)(putRequest, 91, 1, 'reqUids');
 
-        mockRequest = prepareBatchDeleteRequest([{
-            key: '1',
-            bucket: 'bucket0',
-        }]);
-        mockRequest.headers = {
-            'if-unmodified-since': '2000-01-01T00:00:00.000Z',
-            'x-scal-versioning-required': 'true',
-            'x-scal-storage-class': 'gcpbackend',
-            'x-scal-tags': JSON.stringify({ key: 'value' }),
-        };
+            mockRequest = prepareBatchDeleteRequest([
+                {
+                    key: '1',
+                    bucket: 'bucket0',
+                },
+            ]);
+            mockRequest.headers = {
+                'if-unmodified-since': '2000-01-01T00:00:00.000Z',
+                'x-scal-versioning-required': 'true',
+                'x-scal-storage-class': 'gcpbackend',
+                'x-scal-tags': JSON.stringify({ key: 'value' }),
+            };
 
-        routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-        void await endPromise;
+            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+            void (await endPromise);
 
-        assert.strictEqual(mockResponse.statusCode, 200);
-        assert.deepStrictEqual(mockResponse.body, null);
-    });
+            assert.strictEqual(mockResponse.statusCode, 200);
+            assert.deepStrictEqual(mockResponse.body, null);
+        });
 
-    it('should handle raftSessionId parameter from metadata.getBucket', async () => {
-        sandbox.stub(config, 'isQuotaEnabled').returns(true);
-        const testRaftSessionId = 12345;
-        const bucketMD = {
-            getName: () => 'bucket0',
-            getQuota: () => 0n,
-        };
+        it('should handle raftSessionId parameter from metadata.getBucket', async () => {
+            sandbox.stub(config, 'isQuotaEnabled').returns(true);
+            const testRaftSessionId = 12345;
+            const bucketMD = {
+                getName: () => 'bucket0',
+                getQuota: () => 0n,
+            };
 
-        const getBucketStub = sandbox.stub(metadata, 'getBucket')
-            .callsFake((bucket, log, cb) => cb(null, bucketMD, testRaftSessionId));
+            const getBucketStub = sandbox
+                .stub(metadata, 'getBucket')
+                .callsFake((bucket, log, cb) => cb(null, bucketMD, testRaftSessionId));
 
-        routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
-        void await endPromise;
+            routeBackbeat('127.0.0.1', mockRequest, mockResponse, log);
+            void (await endPromise);
 
-        sinon.assert.calledOnce(getBucketStub);
+            sinon.assert.calledOnce(getBucketStub);
 
-        sinon.assert.calledOnce(validateQuotasSpy);
-        sinon.assert.calledWith(validateQuotasSpy,
-            mockRequest,
-            bucketMD,
-            mockRequest.accountQuotas,
-            ['objectDelete'],
-            'objectDelete',
-            -100,
-            false,
-            log,
-            sinon.match.any,
-        );
+            sinon.assert.calledOnce(validateQuotasSpy);
+            sinon.assert.calledWith(
+                validateQuotasSpy,
+                mockRequest,
+                bucketMD,
+                mockRequest.accountQuotas,
+                ['objectDelete'],
+                'objectDelete',
+                -100,
+                false,
+                log,
+                sinon.match.any,
+            );
 
-        assert.strictEqual(mockResponse.statusCode, 200);
-        assert.deepStrictEqual(mockResponse.body, null);
-    });
+            assert.strictEqual(mockResponse.statusCode, 200);
+            assert.deepStrictEqual(mockResponse.body, null);
+        });
     });
 
     describe('routeBackbeatAPIProxy', () => {
         let mockBackbeat;
 
-        const request = new DummyRequest({
-            method: 'POST',
-            url: '/_/backbeat/api/ingestion/pause',
-            socket: {
-                remoteAddress: '127.0.0.1',
+        const request = new DummyRequest(
+            {
+                method: 'POST',
+                url: '/_/backbeat/api/ingestion/pause',
+                socket: {
+                    remoteAddress: '127.0.0.1',
+                },
             },
-        }, Buffer.from(''));
+            Buffer.from(''),
+        );
 
         beforeEach(() => {
             mockBackbeat = http.createServer((req, res) => {
@@ -851,12 +909,20 @@ describe('routeBackbeat', () => {
         });
 
         it('should correctly proxy the request to the backbeat API', async () => {
-            sinon.stub(auth.server, 'doAuth').yields(null, new AuthInfo({
-                canonicalID: 'abcdef/lifecycle',
-                accountDisplayName: 'Lifecycle Service Account',
-            }), undefined, undefined, undefined);
+            sinon.stub(auth.server, 'doAuth').yields(
+                null,
+                new AuthInfo({
+                    canonicalID: 'abcdef/lifecycle',
+                    accountDisplayName: 'Lifecycle Service Account',
+                }),
+                undefined,
+                undefined,
+                undefined,
+            );
 
-            endPromise = new Promise(resolve => { resolveEnd = resolve; });
+            endPromise = new Promise(resolve => {
+                resolveEnd = resolve;
+            });
             const response = {
                 on: sinon.stub(),
                 once: sinon.stub(),
@@ -864,12 +930,12 @@ describe('routeBackbeat', () => {
                 setHeader: sinon.stub(),
                 end: sinon.stub().callsFake(() => {
                     resolveEnd();
-                })
+                }),
             };
 
             routeBackbeat('127.0.0.1', request, response, log);
 
-            void await endPromise;
+            void (await endPromise);
 
             const proxyReq = response.emit.getCall(0).args[1].req;
             assert.strictEqual(proxyReq.method, 'POST');
@@ -892,30 +958,35 @@ describe('routeBackbeat authorization', () => {
         bucketName,
         namespace,
         headers: {
-            'host': `${bucketName}.s3.amazonaws.com`,
+            host: `${bucketName}.s3.amazonaws.com`,
         },
         url: `/${bucketName}`,
         actionImplicitDenies: false,
     };
 
-    const testObject = new DummyRequest({
-        bucketName,
-        namespace,
-        objectKey: objectName,
-        headers: {
-            'x-amz-meta-test': 'some metadata',
-            'content-length': '12',
+    const testObject = new DummyRequest(
+        {
+            bucketName,
+            namespace,
+            objectKey: objectName,
+            headers: {
+                'x-amz-meta-test': 'some metadata',
+                'content-length': '12',
+            },
+            parsedContentLength: 12,
+            url: `/${bucketName}/${objectName}`,
         },
-        parsedContentLength: 12,
-        url: `/${bucketName}/${objectName}`,
-    }, Buffer.from('I am a body', 'utf8'));
+        Buffer.from('I am a body', 'utf8'),
+    );
 
     let request;
     let response;
 
     beforeEach(() => {
         // create a Promise that resolves when response.end is called
-        endPromise = new Promise(resolve => { resolveEnd = resolve; });
+        endPromise = new Promise(resolve => {
+            resolveEnd = resolve;
+        });
 
         request = new DummyRequest(
             {
@@ -923,7 +994,7 @@ describe('routeBackbeat authorization', () => {
                 headers: { 'content-length': '123' },
                 url: '/_/backbeat/multiplebackendmetadata/bucketName/objectKey?operation=putobject',
             },
-            'body'
+            'body',
         );
         response = {
             setHeader: sinon.stub(),
@@ -931,7 +1002,7 @@ describe('routeBackbeat authorization', () => {
             end: sinon.stub().callsFake((body, encoding, callback) => {
                 resolveEnd();
                 callback();
-            })
+            }),
         };
     });
 
@@ -1099,7 +1170,7 @@ describe('routeBackbeat authorization', () => {
             operation: 'delete',
             versionId: false,
             expect: errors.NotImplemented,
-        }
+        },
     ].forEach(testCase => {
         describe(`${testCase.method} ${testCase.resourceType}`, () => {
             let versionIdParsed = null;
@@ -1115,53 +1186,65 @@ describe('routeBackbeat authorization', () => {
                     hasQuery = true;
                 }
 
-                const enableVersioningRequest =
-                    versioningTestUtils.createBucketPutVersioningReq(bucketName, 'Enabled');
+                const enableVersioningRequest = versioningTestUtils.createBucketPutVersioningReq(bucketName, 'Enabled');
 
-                return async.series([
-                    next => bucketPut(authInfo, testBucket, log, next),
-                    next => bucketPutVersioning(authInfo, enableVersioningRequest, log, next),
-                    next => objectPut(authInfo, testObject, undefined, log, (err, res) => {
-                        if (!err && res) {
-                            versionIdParsed = res['x-amz-version-id'];
-                            if (testCase.versionId) {
-                                request.url += `${(hasQuery ? '&' : '?')}&versionId=${versionIdParsed}`;
-                            }
-                        }
-                        next(err);
-                    }),
-                ], done);
+                return async.series(
+                    [
+                        next => bucketPut(authInfo, testBucket, log, next),
+                        next => bucketPutVersioning(authInfo, enableVersioningRequest, log, next),
+                        next =>
+                            objectPut(authInfo, testObject, undefined, log, (err, res) => {
+                                if (!err && res) {
+                                    versionIdParsed = res['x-amz-version-id'];
+                                    if (testCase.versionId) {
+                                        request.url += `${hasQuery ? '&' : '?'}&versionId=${versionIdParsed}`;
+                                    }
+                                }
+                                next(err);
+                            }),
+                    ],
+                    done,
+                );
             });
 
             afterEach(done => {
-                async.series([
-                    next => {
-                        const deleteRequest = {
-                            bucketName,
-                            objectKey: objectName,
-                            headers: {},
-                            query: versionIdParsed ? { versionId: versionIdParsed } : {},
-                        };
-                        objectDelete(authInfo, deleteRequest, log, next);
-                    },
-                    next => {
-                        bucketDelete(authInfo, testBucket, log, next);
-                    }
-                ], done);
+                async.series(
+                    [
+                        next => {
+                            const deleteRequest = {
+                                bucketName,
+                                objectKey: objectName,
+                                headers: {},
+                                query: versionIdParsed ? { versionId: versionIdParsed } : {},
+                            };
+                            objectDelete(authInfo, deleteRequest, log, next);
+                        },
+                        next => {
+                            bucketDelete(authInfo, testBucket, log, next);
+                        },
+                    ],
+                    done,
+                );
             });
 
             it('should call method successfully', async () => {
                 // Mock auth server to ignore auth in this test
-                sinon.stub(auth.server, 'doAuth').yields(null, new AuthInfo({
-                    canonicalID: 'abcdef/lifecycle',
-                    accountDisplayName: 'Lifecycle Service Account',
-                }), undefined, undefined, {
-                    accountQuota: 1000,
-                });
+                sinon.stub(auth.server, 'doAuth').yields(
+                    null,
+                    new AuthInfo({
+                        canonicalID: 'abcdef/lifecycle',
+                        accountDisplayName: 'Lifecycle Service Account',
+                    }),
+                    undefined,
+                    undefined,
+                    {
+                        accountQuota: 1000,
+                    },
+                );
 
                 routeBackbeat('127.0.0.1', request, response, log);
 
-                void await endPromise;
+                void (await endPromise);
 
                 if (testCase.expect) {
                     const errCode = response.writeHead.getCall(0).args[0];
@@ -1174,18 +1257,26 @@ describe('routeBackbeat authorization', () => {
             });
 
             it('should return access denied user is not authorized', async () => {
-                sinon.stub(auth.server, 'doAuth').yields(null, new AuthInfo({
-                    canonicalID: '123456789',
-                    accountDisplayName: 'user1',
-                }), [{
-                    isAllowed: false,
-                    implicitDeny: true,
-                    action: 'objectReplicate',
-                }], undefined, undefined);
+                sinon.stub(auth.server, 'doAuth').yields(
+                    null,
+                    new AuthInfo({
+                        canonicalID: '123456789',
+                        accountDisplayName: 'user1',
+                    }),
+                    [
+                        {
+                            isAllowed: false,
+                            implicitDeny: true,
+                            action: 'objectReplicate',
+                        },
+                    ],
+                    undefined,
+                    undefined,
+                );
 
                 routeBackbeat('127.0.0.1', request, response, log);
 
-                void await endPromise;
+                void (await endPromise);
 
                 const err = JSON.parse(response.end.getCall(0).args[0]);
                 assert.strictEqual(err.code, 'AccessDenied');
@@ -1198,20 +1289,22 @@ describe('routeBackbeat authorization', () => {
                 }
                 it(`should ${bypass ? '' : 'not '}bypass bucket policy evaluation`, async () => {
                     const policyRequest = {
-                    bucketName,
-                    headers: {
-                        host: `${bucketName}.s3.amazonaws.com`,
-                    },
-                    post: JSON.stringify({
-                        Version: '2012-10-17',
-                        Statement: [{
-                            Effect: 'Deny',
-                            Principal: '*',
-                            Action: '*',
-                            Resource: `arn:aws:s3:::${bucketName}/*`,
-                        }],
-                    }),
-                    actionImplicitDenies: false,
+                        bucketName,
+                        headers: {
+                            host: `${bucketName}.s3.amazonaws.com`,
+                        },
+                        post: JSON.stringify({
+                            Version: '2012-10-17',
+                            Statement: [
+                                {
+                                    Effect: 'Deny',
+                                    Principal: '*',
+                                    Action: '*',
+                                    Resource: `arn:aws:s3:::${bucketName}/*`,
+                                },
+                            ],
+                        }),
+                        actionImplicitDenies: false,
                     };
                     await bucketPutPolicyPromise(authInfo, policyRequest, log);
 
@@ -1222,17 +1315,25 @@ describe('routeBackbeat authorization', () => {
                         accountDisplayName: authInfo.getAccountDisplayName(),
                     });
 
-                    sinon.stub(auth.server, 'doAuth').yields(null, sessionAuthInfo, [{
-                        isAllowed: true,
-                        implicitDeny: false,
-                        action: 'objectReplicate',
-                    }], undefined, undefined);
+                    sinon.stub(auth.server, 'doAuth').yields(
+                        null,
+                        sessionAuthInfo,
+                        [
+                            {
+                                isAllowed: true,
+                                implicitDeny: false,
+                                action: 'objectReplicate',
+                            },
+                        ],
+                        undefined,
+                        undefined,
+                    );
 
                     request.bypassUserBucketPolicies = bypass;
 
                     routeBackbeat('127.0.0.1', request, response, log);
 
-                    void await endPromise;
+                    void (await endPromise);
 
                     if (bypass) {
                         const errCode = response.writeHead.getCall(0).args[0];


### PR DESCRIPTION
When replicating a version on top of a pre-existing null version, the destination master could end up referencing that null version in a way the storage layout no longer supports, which intermittently left a bucket non-empty after all its objects were deleted. This change makes replication follow the same null-version contract as the regular write path so the leftover key can no longer occur.

Added a deterministic test that asserts the master references the null version only in compatibility mode; it fails on the old behavior and passes on the new. The full backbeat-route functional suite was run against a bucketd-backed stack in both compatibility modes with no regressions.