### PR TITLE
Support Days=0 lifecycle expiration: bump arsenal and add functional tests

### DIFF
--- a/lib/api/bucketPutLifecycle.js
+++ b/lib/api/bucketPutLifecycle.js
@@ -1,4 +1,4 @@
-const { waterfall } = require('async');
+const { promisify } = require('util');
 const uuid = require('uuid').v4;
 const LifecycleConfiguration = require('arsenal').models.LifecycleConfiguration;
 
@@ -15,11 +15,16 @@ const monitoring = require('../utilities/monitoringHandler');
  * @param {AuthInfo} authInfo - Instance of AuthInfo class with requester's info
  * @param {object} request - http request object
  * @param {object} log - Werelogs logger
- * @param {function} callback - callback to server
- * @return {undefined}
+ * @param {function} [callback] - callback to server
+ * @return {Promise} - resolves with the CORS response headers
  */
+async function bucketPutLifecycle(authInfo, request, log, callback) {
+    if (callback) {
+        return bucketPutLifecycle(authInfo, request, log)
+            .then(corsHeaders => callback(null, corsHeaders))
+            .catch(err => callback(err, err.additionalResHeaders));
+    }
 
-function bucketPutLifecycle(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'bucketPutLifecycle' });
 
     const { bucketName } = request;
@@ -29,51 +34,33 @@ function bucketPutLifecycle(authInfo, request, log, callback) {
         requestType: request.apiMethods || 'bucketPutLifecycle',
         request,
     };
-    return waterfall(
-        [
-            next => parseXML(request.post, log, next),
-            (parsedXml, next) => {
-                const lcConfigClass = new LifecycleConfiguration(parsedXml, log, config);
-                // if there was an error getting lifecycle configuration,
-                // returned configObj will contain 'error' key
-                process.nextTick(() => {
-                    const configObj = lcConfigClass.getLifecycleConfiguration();
-                    if (configObj.error) {
-                        return next(configObj.error);
-                    }
-                    return next(null, configObj);
-                });
-            },
-            (lcConfig, next) =>
-                standardMetadataValidateBucket(metadataValParams, request.actionImplicitDenies, log, (err, bucket) => {
-                    if (err) {
-                        return next(err, bucket);
-                    }
-                    return next(null, bucket, lcConfig);
-                }),
-            (bucket, lcConfig, next) => {
-                if (!bucket.getUid()) {
-                    bucket.setUid(uuid());
-                }
-                bucket.setLifecycleConfiguration(lcConfig);
-                metadata.updateBucket(bucket.getName(), bucket, log, err => next(err, bucket));
-            },
-        ],
-        (err, bucket) => {
-            const corsHeaders = collectCorsHeaders(request.headers.origin, request.method, bucket);
-            if (err) {
-                log.trace('error processing request', { error: err, method: 'bucketPutLifecycle' });
-                monitoring.promMetrics('PUT', bucketName, err.code, 'putBucketLifecycle');
-                return callback(err, corsHeaders);
-            }
-            pushMetric('putBucketLifecycle', log, {
-                authInfo,
-                bucket: bucketName,
-            });
-            monitoring.promMetrics('PUT', bucketName, '200', 'putBucketLifecycle');
-            return callback(null, corsHeaders);
-        },
-    );
+
+    let bucket;
+    try {
+        const parsedXml = await promisify(parseXML)(request.post, log);
+        const lcConfig = new LifecycleConfiguration(parsedXml, log, config).getLifecycleConfiguration();
+        if (lcConfig.error) {
+            throw lcConfig.error;
+        }
+        bucket = await promisify(standardMetadataValidateBucket)(metadataValParams, request.actionImplicitDenies, log);
+        if (!bucket.getUid()) {
+            bucket.setUid(uuid());
+        }
+        bucket.setLifecycleConfiguration(lcConfig);
+        await promisify(metadata.updateBucket).call(metadata, bucket.getName(), bucket, log);
+    } catch (err) {
+        log.trace('error processing request', { error: err, method: 'bucketPutLifecycle' });
+        monitoring.promMetrics('PUT', bucketName, err.code, 'putBucketLifecycle');
+        err.additionalResHeaders ||= collectCorsHeaders(request.headers.origin, request.method, bucket);
+        throw err;
+    }
+
+    pushMetric('putBucketLifecycle', log, {
+        authInfo,
+        bucket: bucketName,
+    });
+    monitoring.promMetrics('PUT', bucketName, '200', 'putBucketLifecycle');
+    return collectCorsHeaders(request.headers.origin, request.method, bucket);
 }
 
 module.exports = bucketPutLifecycle;

--- a/lib/api/bucketPutLifecycle.js
+++ b/lib/api/bucketPutLifecycle.js
@@ -1,7 +1,6 @@
 const { waterfall } = require('async');
 const uuid = require('uuid').v4;
-const LifecycleConfiguration =
-    require('arsenal').models.LifecycleConfiguration;
+const LifecycleConfiguration = require('arsenal').models.LifecycleConfiguration;
 
 const config = require('../Config').config;
 const parseXML = require('../utilities/parseXML');
@@ -30,53 +29,51 @@ function bucketPutLifecycle(authInfo, request, log, callback) {
         requestType: request.apiMethods || 'bucketPutLifecycle',
         request,
     };
-    return waterfall([
-        next => parseXML(request.post, log, next),
-        (parsedXml, next) => {
-            const lcConfigClass =
-                new LifecycleConfiguration(parsedXml, config);
-            // if there was an error getting lifecycle configuration,
-            // returned configObj will contain 'error' key
-            process.nextTick(() => {
-                const configObj = lcConfigClass.getLifecycleConfiguration();
-                if (configObj.error) {
-                    return next(configObj.error);
+    return waterfall(
+        [
+            next => parseXML(request.post, log, next),
+            (parsedXml, next) => {
+                const lcConfigClass = new LifecycleConfiguration(parsedXml, config);
+                // if there was an error getting lifecycle configuration,
+                // returned configObj will contain 'error' key
+                process.nextTick(() => {
+                    const configObj = lcConfigClass.getLifecycleConfiguration();
+                    if (configObj.error) {
+                        return next(configObj.error);
+                    }
+                    return next(null, configObj);
+                });
+            },
+            (lcConfig, next) =>
+                standardMetadataValidateBucket(metadataValParams, request.actionImplicitDenies, log, (err, bucket) => {
+                    if (err) {
+                        return next(err, bucket);
+                    }
+                    return next(null, bucket, lcConfig);
+                }),
+            (bucket, lcConfig, next) => {
+                if (!bucket.getUid()) {
+                    bucket.setUid(uuid());
                 }
-                return next(null, configObj);
-            });
-        },
-        (lcConfig, next) => standardMetadataValidateBucket(metadataValParams, request.actionImplicitDenies, log,
-            (err, bucket) => {
-                if (err) {
-                    return next(err, bucket);
-                }
-                return next(null, bucket, lcConfig);
-            }),
-        (bucket, lcConfig, next) => {
-            if (!bucket.getUid()) {
-                bucket.setUid(uuid());
+                bucket.setLifecycleConfiguration(lcConfig);
+                metadata.updateBucket(bucket.getName(), bucket, log, err => next(err, bucket));
+            },
+        ],
+        (err, bucket) => {
+            const corsHeaders = collectCorsHeaders(request.headers.origin, request.method, bucket);
+            if (err) {
+                log.trace('error processing request', { error: err, method: 'bucketPutLifecycle' });
+                monitoring.promMetrics('PUT', bucketName, err.code, 'putBucketLifecycle');
+                return callback(err, corsHeaders);
             }
-            bucket.setLifecycleConfiguration(lcConfig);
-            metadata.updateBucket(bucket.getName(), bucket, log, err =>
-                next(err, bucket));
+            pushMetric('putBucketLifecycle', log, {
+                authInfo,
+                bucket: bucketName,
+            });
+            monitoring.promMetrics('PUT', bucketName, '200', 'putBucketLifecycle');
+            return callback(null, corsHeaders);
         },
-    ], (err, bucket) => {
-        const corsHeaders = collectCorsHeaders(request.headers.origin,
-            request.method, bucket);
-        if (err) {
-            log.trace('error processing request', { error: err,
-                method: 'bucketPutLifecycle' });
-            monitoring.promMetrics(
-                'PUT', bucketName, err.code, 'putBucketLifecycle');
-            return callback(err, corsHeaders);
-        }
-        pushMetric('putBucketLifecycle', log, {
-            authInfo,
-            bucket: bucketName,
-        });
-        monitoring.promMetrics('PUT', bucketName, '200', 'putBucketLifecycle');
-        return callback(null, corsHeaders);
-    });
+    );
 }
 
 module.exports = bucketPutLifecycle;

--- a/lib/api/bucketPutLifecycle.js
+++ b/lib/api/bucketPutLifecycle.js
@@ -33,7 +33,7 @@ function bucketPutLifecycle(authInfo, request, log, callback) {
         [
             next => parseXML(request.post, log, next),
             (parsedXml, next) => {
-                const lcConfigClass = new LifecycleConfiguration(parsedXml, config);
+                const lcConfigClass = new LifecycleConfiguration(parsedXml, log, config);
                 // if there was an error getting lifecycle configuration,
                 // returned configObj will contain 'error' key
                 process.nextTick(() => {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@opentelemetry/instrumentation-ioredis": "~0.64.0",
         "@opentelemetry/instrumentation-mongodb": "~0.69.0",
         "@smithy/node-http-handler": "^3.0.0",
-        "arsenal": "git+https://github.com/scality/arsenal#8.5.4",
+        "arsenal": "git+https://github.com/scality/arsenal#8.5.6",
         "async": "2.6.4",
         "bucketclient": "scality/bucketclient#8.2.7",
         "bufferutil": "^4.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zenko/cloudserver",
-    "version": "9.4.0-preview.3",
+    "version": "9.4.0-preview.4",
     "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
     "main": "index.js",
     "engines": {

--- a/tests/functional/aws-node-sdk/test/bucket/putBucketLifecycle.js
+++ b/tests/functional/aws-node-sdk/test/bucket/putBucketLifecycle.js
@@ -1,9 +1,11 @@
 const assert = require('assert');
 const { errors } = require('arsenal');
-const { S3Client,
+const {
+    S3Client,
     CreateBucketCommand,
     DeleteBucketCommand,
-    PutBucketLifecycleConfigurationCommand } = require('@aws-sdk/client-s3');
+    PutBucketLifecycleConfigurationCommand,
+} = require('@aws-sdk/client-s3');
 
 const getConfig = require('../support/config');
 const BucketUtility = require('../../lib/utility/bucket-util');
@@ -26,11 +28,17 @@ function assertError(err, expectedErr) {
     if (expectedErr === null) {
         assert.strictEqual(err, null, `expected no error but got '${err}'`);
     } else {
-        assert.strictEqual(err.name, expectedErr, 'incorrect error response ' +
-            `code: should be '${expectedErr}' but got '${err.name}'`);
-        assert.strictEqual(err.$metadata.httpStatusCode, errors[expectedErr].code,
+        assert.strictEqual(
+            err.name,
+            expectedErr,
+            'incorrect error response ' + `code: should be '${expectedErr}' but got '${err.name}'`,
+        );
+        assert.strictEqual(
+            err.$metadata.httpStatusCode,
+            errors[expectedErr].code,
             'incorrect error status code: should be  ' +
-            `${errors[expectedErr].code}, but got '${err.$metadata.httpStatusCode}'`);
+                `${errors[expectedErr].code}, but got '${err.$metadata.httpStatusCode}'`,
+        );
     }
 }
 
@@ -89,40 +97,42 @@ describe('aws-sdk test put bucket lifecycle', () => {
             const params = getLifecycleParams();
             await s3.send(new PutBucketLifecycleConfigurationCommand(params));
         });
-        
-        it('should not allow lifecycle configuration with duplicated rule id ' +
-        'and with Origin header set', async () => {
-            const origin = 'http://www.allowedwebsite.com';
-            const lifecycleConfig = {
-                Rules: [expirationRule, expirationRule],
-            };
-            const params = {
-                Bucket: bucket,
-                LifecycleConfiguration: lifecycleConfig,
-            };
 
-            const clientConfig = getConfig('default', { signatureVersion: 'v4' });
-            const clientWithOrigin = new S3Client({
-                ...clientConfig,
-                requestHandler: {
-                    handle: async request => {
-                        if (!request.headers) {
+        it(
+            'should not allow lifecycle configuration with duplicated rule id ' + 'and with Origin header set',
+            async () => {
+                const origin = 'http://www.allowedwebsite.com';
+                const lifecycleConfig = {
+                    Rules: [expirationRule, expirationRule],
+                };
+                const params = {
+                    Bucket: bucket,
+                    LifecycleConfiguration: lifecycleConfig,
+                };
+
+                const clientConfig = getConfig('default', { signatureVersion: 'v4' });
+                const clientWithOrigin = new S3Client({
+                    ...clientConfig,
+                    requestHandler: {
+                        handle: async request => {
+                            if (!request.headers) {
+                                // eslint-disable-next-line no-param-reassign
+                                request.headers = {};
+                            }
                             // eslint-disable-next-line no-param-reassign
-                            request.headers = {};
-                        }
-                        // eslint-disable-next-line no-param-reassign
-                        request.headers.origin = origin;
-                        return clientConfig.requestHandler.handle(request);
-                    }
+                            request.headers.origin = origin;
+                            return clientConfig.requestHandler.handle(request);
+                        },
+                    },
+                });
+                try {
+                    await clientWithOrigin.send(new PutBucketLifecycleConfigurationCommand(params));
+                    throw new Error('Expected InvalidRequest error');
+                } catch (err) {
+                    assertError(err, 'InvalidRequest');
                 }
-            });
-            try {
-                await clientWithOrigin.send(new PutBucketLifecycleConfigurationCommand(params));
-                throw new Error('Expected InvalidRequest error');
-            } catch (err) {
-                assertError(err, 'InvalidRequest');
-            }
-        });
+            },
+        );
 
         it('should not allow lifecycle config with no Status', async () => {
             const params = getLifecycleParams({ key: 'Status', value: '' });
@@ -155,8 +165,7 @@ describe('aws-sdk test put bucket lifecycle', () => {
         });
 
         it('should not allow lifecycle config with ID longer than 255 char', async () => {
-            const params =
-                getLifecycleParams({ key: 'ID', value: 'a'.repeat(256) });
+            const params = getLifecycleParams({ key: 'ID', value: 'a'.repeat(256) });
             try {
                 await s3.send(new PutBucketLifecycleConfigurationCommand(params));
                 throw new Error('Expected InvalidArgument error');
@@ -166,20 +175,17 @@ describe('aws-sdk test put bucket lifecycle', () => {
         });
 
         it('should allow lifecycle config with Prefix length < 1024', async () => {
-            const params =
-                getLifecycleParams({ key: 'Prefix', value: 'a'.repeat(1023) });
+            const params = getLifecycleParams({ key: 'Prefix', value: 'a'.repeat(1023) });
             await s3.send(new PutBucketLifecycleConfigurationCommand(params));
         });
 
         it('should allow lifecycle config with Prefix length === 1024', async () => {
-            const params =
-                getLifecycleParams({ key: 'Prefix', value: 'a'.repeat(1024) });
+            const params = getLifecycleParams({ key: 'Prefix', value: 'a'.repeat(1024) });
             await s3.send(new PutBucketLifecycleConfigurationCommand(params));
         });
 
         it('should not allow lifecycle config with Prefix length > 1024', async () => {
-            const params =
-                getLifecycleParams({ key: 'Prefix', value: 'a'.repeat(1025) });
+            const params = getLifecycleParams({ key: 'Prefix', value: 'a'.repeat(1025) });
             try {
                 await s3.send(new PutBucketLifecycleConfigurationCommand(params));
                 throw new Error('Expected InvalidRequest error');
@@ -202,8 +208,7 @@ describe('aws-sdk test put bucket lifecycle', () => {
             }
         });
 
-        it('should not allow lifecycle config with Filter.And.Prefix length ' +
-        '> 1024', async () => {
+        it('should not allow lifecycle config with Filter.And.Prefix length ' + '> 1024', async () => {
             const params = getLifecycleParams({
                 key: 'Filter',
                 value: {
@@ -287,8 +292,7 @@ describe('aws-sdk test put bucket lifecycle', () => {
         });
 
         it('should not allow lifecycle config with Prefix and Filter', async () => {
-            const params = getLifecycleParams(
-                { key: 'Filter', value: { Prefix: 'foo' } });
+            const params = getLifecycleParams({ key: 'Filter', value: { Prefix: 'foo' } });
             try {
                 await s3.send(new PutBucketLifecycleConfigurationCommand(params));
                 throw new Error('Expected MalformedXML error');
@@ -310,7 +314,6 @@ describe('aws-sdk test put bucket lifecycle', () => {
             await s3.send(new PutBucketLifecycleConfigurationCommand(params));
         });
 
-
         describe('with Rule.Filter not Rule.Prefix', () => {
             before(done => {
                 expirationRule.Prefix = null;
@@ -323,8 +326,7 @@ describe('aws-sdk test put bucket lifecycle', () => {
             });
 
             it('should not allow config with And & Prefix', async () => {
-                const params = getLifecycleParams(
-                    { key: 'Filter', value: { Prefix: 'foo', And: {} } });
+                const params = getLifecycleParams({ key: 'Filter', value: { Prefix: 'foo', And: {} } });
                 try {
                     await s3.send(new PutBucketLifecycleConfigurationCommand(params));
                     throw new Error('Expected MalformedXML error');
@@ -360,8 +362,7 @@ describe('aws-sdk test put bucket lifecycle', () => {
             });
 
             it('should allow config with only Prefix', async () => {
-                const params = getLifecycleParams(
-                    { key: 'Filter', value: { Prefix: 'foo' } });
+                const params = getLifecycleParams({ key: 'Filter', value: { Prefix: 'foo' } });
                 await s3.send(new PutBucketLifecycleConfigurationCommand(params));
             });
 
@@ -374,8 +375,7 @@ describe('aws-sdk test put bucket lifecycle', () => {
             });
 
             it('should not allow config with And.Prefix & no And.Tags', async () => {
-                const params = getLifecycleParams(
-                    { key: 'Filter', value: { And: { Prefix: 'foo' } } });
+                const params = getLifecycleParams({ key: 'Filter', value: { And: { Prefix: 'foo' } } });
                 try {
                     await s3.send(new PutBucketLifecycleConfigurationCommand(params));
                     throw new Error('Expected MalformedXML error');
@@ -400,9 +400,14 @@ describe('aws-sdk test put bucket lifecycle', () => {
             it('should allow config with And.Tags & no And.Prefix', async () => {
                 const params = getLifecycleParams({
                     key: 'Filter',
-                    value: { And: { Tags:
-                        [{ Key: 'foo', Value: 'bar' },
-                         { Key: 'foo2', Value: 'bar2' }] } },
+                    value: {
+                        And: {
+                            Tags: [
+                                { Key: 'foo', Value: 'bar' },
+                                { Key: 'foo2', Value: 'bar2' },
+                            ],
+                        },
+                    },
                 });
                 await s3.send(new PutBucketLifecycleConfigurationCommand(params));
             });
@@ -410,9 +415,15 @@ describe('aws-sdk test put bucket lifecycle', () => {
             it('should allow config with And.Tags & And.Prefix', async () => {
                 const params = getLifecycleParams({
                     key: 'Filter',
-                    value: { And: { Prefix: 'foo', Tags:
-                        [{ Key: 'foo', Value: 'bar' },
-                         { Key: 'foo2', Value: 'bar2' }] } },
+                    value: {
+                        And: {
+                            Prefix: 'foo',
+                            Tags: [
+                                { Key: 'foo', Value: 'bar' },
+                                { Key: 'foo2', Value: 'bar2' },
+                            ],
+                        },
+                    },
                 });
                 await s3.send(new PutBucketLifecycleConfigurationCommand(params));
             });
@@ -423,12 +434,14 @@ describe('aws-sdk test put bucket lifecycle', () => {
                 return {
                     Bucket: bucket,
                     LifecycleConfiguration: {
-                        Rules: [{
-                            ID: 'test',
-                            Status: 'Enabled',
-                            Prefix: '',
-                            noncurrentVersionTransition,
-                        }],
+                        Rules: [
+                            {
+                                ID: 'test',
+                                Status: 'Enabled',
+                                Prefix: '',
+                                noncurrentVersionTransition,
+                            },
+                        ],
                     },
                 };
             }
@@ -464,9 +477,10 @@ describe('aws-sdk test put bucket lifecycle', () => {
                     throw new Error('Expected InvalidArgument error');
                 } catch (err) {
                     assert.strictEqual(err.name, 'InvalidArgument');
-                    assert.strictEqual(err.message,
-                    "'NoncurrentDays' in NoncurrentVersionExpiration " +
-                    'action must be nonnegative');
+                    assert.strictEqual(
+                        err.message,
+                        "'NoncurrentDays' in NoncurrentVersionExpiration " + 'action must be nonnegative',
+                    );
                 }
             });
 
@@ -487,21 +501,25 @@ describe('aws-sdk test put bucket lifecycle', () => {
                 return {
                     Bucket: bucket,
                     LifecycleConfiguration: {
-                        Rules: [{
-                            ID: 'test',
-                            Status: 'Enabled',
-                            Prefix: '',
-                            NoncurrentVersionTransitions: noncurrentVersionTransitions,
-                        }],
+                        Rules: [
+                            {
+                                ID: 'test',
+                                Status: 'Enabled',
+                                Prefix: '',
+                                NoncurrentVersionTransitions: noncurrentVersionTransitions,
+                            },
+                        ],
                     },
                 };
             }
 
             it('should allow config', async () => {
-                const noncurrentVersionTransitions = [{
-                    NoncurrentDays: 1,
-                    StorageClass: 'us-east-2',
-                }];
+                const noncurrentVersionTransitions = [
+                    {
+                        NoncurrentDays: 1,
+                        StorageClass: 'us-east-2',
+                    },
+                ];
                 const params = getParams(noncurrentVersionTransitions);
                 try {
                     await s3.send(new PutBucketLifecycleConfigurationCommand(params));
@@ -514,13 +532,16 @@ describe('aws-sdk test put bucket lifecycle', () => {
             });
 
             it.skip('should not allow duplicate StorageClass', async () => {
-                const noncurrentVersionTransitions = [{
-                    NoncurrentDays: 1,
-                    StorageClass: 'us-east-2',
-                }, {
-                    NoncurrentDays: 2,
-                    StorageClass: 'us-east-2',
-                }];
+                const noncurrentVersionTransitions = [
+                    {
+                        NoncurrentDays: 1,
+                        StorageClass: 'us-east-2',
+                    },
+                    {
+                        NoncurrentDays: 2,
+                        StorageClass: 'us-east-2',
+                    },
+                ];
                 const params = getParams(noncurrentVersionTransitions);
                 try {
                     await s3.send(new PutBucketLifecycleConfigurationCommand(params));
@@ -532,88 +553,111 @@ describe('aws-sdk test put bucket lifecycle', () => {
                         return;
                     }
                     assert.strictEqual(err.name, 'InvalidRequest');
-                    assert.strictEqual(err.message,
+                    assert.strictEqual(
+                        err.message,
                         "'StorageClass' must be different for " +
-                        "'NoncurrentVersionTransition' actions in same " +
-                        "'Rule' with prefix ''");
+                            "'NoncurrentVersionTransition' actions in same " +
+                            "'Rule' with prefix ''",
+                    );
                 }
             });
 
             it('should not allow unknown StorageClass', async () => {
-                const noncurrentVersionTransitions = [{
-                    NoncurrentDays: 1,
-                    StorageClass: 'unknown',
-                }];
+                const noncurrentVersionTransitions = [
+                    {
+                        NoncurrentDays: 1,
+                        StorageClass: 'unknown',
+                    },
+                ];
                 const params = getParams(noncurrentVersionTransitions);
                 try {
                     await s3.send(new PutBucketLifecycleConfigurationCommand(params));
                     throw new Error('Expected MalformedXML error');
                 } catch (err) {
-                    assert(err.name === 'MalformedXML' || err.name === 'NotImplemented',
-                        `Expected MalformedXML or NotImplemented, got ${err.name}`);
+                    assert(
+                        err.name === 'MalformedXML' || err.name === 'NotImplemented',
+                        `Expected MalformedXML or NotImplemented, got ${err.name}`,
+                    );
                 }
             });
 
             it(`should not allow NoncurrentDays value exceeding ${MAX_DAYS}`, async () => {
-                const noncurrentVersionTransitions = [{
-                    NoncurrentDays: MAX_DAYS + 1,
-                    StorageClass: 'us-east-2',
-                }];
+                const noncurrentVersionTransitions = [
+                    {
+                        NoncurrentDays: MAX_DAYS + 1,
+                        StorageClass: 'us-east-2',
+                    },
+                ];
                 const params = getParams(noncurrentVersionTransitions);
                 try {
                     await s3.send(new PutBucketLifecycleConfigurationCommand(params));
                     throw new Error('Expected MalformedXML error');
                 } catch (err) {
-                    assert(err.name === 'MalformedXML' || err.name === 'NotImplemented',
-                        `Expected MalformedXML or NotImplemented, got ${err.name}`);
+                    assert(
+                        err.name === 'MalformedXML' || err.name === 'NotImplemented',
+                        `Expected MalformedXML or NotImplemented, got ${err.name}`,
+                    );
                 }
             });
 
             it('should not allow negative NoncurrentDays', async () => {
-                const noncurrentVersionTransitions = [{
-                    NoncurrentDays: -1,
-                    StorageClass: 'us-east-2',
-                }];
+                const noncurrentVersionTransitions = [
+                    {
+                        NoncurrentDays: -1,
+                        StorageClass: 'us-east-2',
+                    },
+                ];
                 const params = getParams(noncurrentVersionTransitions);
                 try {
                     await s3.send(new PutBucketLifecycleConfigurationCommand(params));
                     throw new Error('Expected error');
                 } catch (err) {
-                    assert(err.name === 'InvalidArgument' || err.name === 'NotImplemented',
-                        `Expected InvalidArgument or NotImplemented, got ${err.name}`);
+                    assert(
+                        err.name === 'InvalidArgument' || err.name === 'NotImplemented',
+                        `Expected InvalidArgument or NotImplemented, got ${err.name}`,
+                    );
                     if (err.name === 'InvalidArgument') {
-                        assert.strictEqual(err.message,
-                        "'NoncurrentDays' in NoncurrentVersionTransition " +
-                        'action must be nonnegative');
+                        assert.strictEqual(
+                            err.message,
+                            "'NoncurrentDays' in NoncurrentVersionTransition " + 'action must be nonnegative',
+                        );
                     }
                 }
             });
 
             it('should not allow config missing NoncurrentDays', async () => {
-                const noncurrentVersionTransitions = [{
-                    StorageClass: 'us-east-2',
-                }];
+                const noncurrentVersionTransitions = [
+                    {
+                        StorageClass: 'us-east-2',
+                    },
+                ];
                 const params = getParams(noncurrentVersionTransitions);
                 try {
                     await s3.send(new PutBucketLifecycleConfigurationCommand(params));
                     throw new Error('Expected error');
                 } catch (err) {
-                    assert(err.name === 'MalformedXML' || err.name === 'NotImplemented',
-                        `Expected MalformedXML or NotImplemented, got ${err.name}`);
+                    assert(
+                        err.name === 'MalformedXML' || err.name === 'NotImplemented',
+                        `Expected MalformedXML or NotImplemented, got ${err.name}`,
+                    );
                 }
             });
 
             it('should not allow config missing StorageClass', async () => {
-                const noncurrentVersionTransitions = [{
-                    NoncurrentDays: 1,
-                }];
+                const noncurrentVersionTransitions = [
+                    {
+                        NoncurrentDays: 1,
+                    },
+                ];
                 const params = getParams(noncurrentVersionTransitions);
                 try {
                     await s3.send(new PutBucketLifecycleConfigurationCommand(params));
                     throw new Error('Expected error');
                 } catch (err) {
-                    assert(err.name === 'MalformedXML' || err.name === 'NotImplemented',
-                        `Expected MalformedXML or NotImplemented, got ${err.name}`);
+                    assert(
+                        err.name === 'MalformedXML' || err.name === 'NotImplemented',
+                        `Expected MalformedXML or NotImplemented, got ${err.name}`,
+                    );
                 }
             });
         });
@@ -626,15 +670,19 @@ describe('aws-sdk test put bucket lifecycle', () => {
                 const params = {
                     Bucket: bucket,
                     LifecycleConfiguration: {
-                        Rules: [{
-                            ID: 'test',
-                            Status: 'Enabled',
-                            Prefix: '',
-                            Transitions: [{
-                                Days: 2,
-                                StorageClass: 'us-east-2',
-                            }],
-                        }],
+                        Rules: [
+                            {
+                                ID: 'test',
+                                Status: 'Enabled',
+                                Prefix: '',
+                                Transitions: [
+                                    {
+                                        Days: 2,
+                                        StorageClass: 'us-east-2',
+                                    },
+                                ],
+                            },
+                        ],
                     },
                 };
                 try {
@@ -652,60 +700,72 @@ describe('aws-sdk test put bucket lifecycle', () => {
                 return {
                     Bucket: bucket,
                     LifecycleConfiguration: {
-                        Rules: [{
-                            ID: 'test',
-                            Status: 'Enabled',
-                            Prefix: '',
-                            Transitions: transitions,
-                        }],
+                        Rules: [
+                            {
+                                ID: 'test',
+                                Status: 'Enabled',
+                                Prefix: '',
+                                Transitions: transitions,
+                            },
+                        ],
                     },
                 };
             }
 
             it('should allow config', async () => {
-                const transitions = [{
-                    Days: 1,
-                    StorageClass: 'us-east-2',
-                }];
+                const transitions = [
+                    {
+                        Days: 1,
+                        StorageClass: 'us-east-2',
+                    },
+                ];
                 const params = getParams(transitions);
                 await s3.send(new PutBucketLifecycleConfigurationCommand(params));
             });
 
             it('should not allow duplicate StorageClass', async () => {
-                const transitions = [{
-                    Days: 1,
-                    StorageClass: 'us-east-2',
-                }, {
-                    Days: 2,
-                    StorageClass: 'us-east-2',
-                }];
+                const transitions = [
+                    {
+                        Days: 1,
+                        StorageClass: 'us-east-2',
+                    },
+                    {
+                        Days: 2,
+                        StorageClass: 'us-east-2',
+                    },
+                ];
                 const params = getParams(transitions);
                 try {
                     await s3.send(new PutBucketLifecycleConfigurationCommand(params));
                     throw new Error('Expected InvalidRequest error');
                 } catch (err) {
                     assert.strictEqual(err.name, 'InvalidRequest');
-                    assert.strictEqual(err.message,
-                        "'StorageClass' must be different for 'Transition' " +
-                        "actions in same 'Rule' with prefix ''");
+                    assert.strictEqual(
+                        err.message,
+                        "'StorageClass' must be different for 'Transition' " + "actions in same 'Rule' with prefix ''",
+                    );
                 }
             });
 
             it('should allow Date', async () => {
-                const transitions = [{
-                    Date: new Date('2016-01-01T00:00:00.000Z'),
-                    StorageClass: 'us-east-2',
-                }];
+                const transitions = [
+                    {
+                        Date: new Date('2016-01-01T00:00:00.000Z'),
+                        StorageClass: 'us-east-2',
+                    },
+                ];
                 const params = getParams(transitions);
                 await s3.send(new PutBucketLifecycleConfigurationCommand(params));
             });
 
             it('should not allow speficying both Days and Date value', async () => {
-                const transitions = [{
-                    Date: new Date('2016-01-01T00:00:00.000Z'),
-                    Days: 1,
-                    StorageClass: 'us-east-2',
-                }];
+                const transitions = [
+                    {
+                        Date: new Date('2016-01-01T00:00:00.000Z'),
+                        Days: 1,
+                        StorageClass: 'us-east-2',
+                    },
+                ];
                 const params = getParams(transitions);
                 try {
                     await s3.send(new PutBucketLifecycleConfigurationCommand(params));
@@ -716,87 +776,104 @@ describe('aws-sdk test put bucket lifecycle', () => {
             });
 
             // TODO: Upgrade to aws-sdk >= 2.60.0 for correct Date field support
-            it.skip('should not allow speficying both Days and Date value ' +
-            'across transitions', done => {
-                const transitions = [{
-                    Date: '2016-01-01T00:00:00.000Z',
-                    StorageClass: 'us-east-2',
-                }, {
-                    Days: 1,
-                    StorageClass: 'zenko',
-                }];
+            it.skip('should not allow speficying both Days and Date value ' + 'across transitions', done => {
+                const transitions = [
+                    {
+                        Date: '2016-01-01T00:00:00.000Z',
+                        StorageClass: 'us-east-2',
+                    },
+                    {
+                        Days: 1,
+                        StorageClass: 'zenko',
+                    },
+                ];
                 const params = getParams(transitions);
                 s3.putBucketLifecycleConfiguration(params, err => {
                     assert.strictEqual(err.code, 'InvalidRequest');
-                    assert.strictEqual(err.message,
-                        "Found mixed 'Date' and 'Days' based Transition " +
-                        "actions in lifecycle rule for prefix ''");
+                    assert.strictEqual(
+                        err.message,
+                        "Found mixed 'Date' and 'Days' based Transition " + "actions in lifecycle rule for prefix ''",
+                    );
                     done();
                 });
             });
 
-            it('should not allow speficying both Days and Date value ' +
-            'across transitions and expiration', async () => {
-                const transitions = [{
-                    Days: 1,
-                    StorageClass: 'us-east-2',
-                }];
-                const params = getParams(transitions);
-                params.LifecycleConfiguration.Rules[0].Expiration = { 
-                    Date: new Date('2016-01-01T00:00:00.000Z') // Use proper Date object
-                };
-                try {
-                    await s3.send(new PutBucketLifecycleConfigurationCommand(params));
-                    throw new Error('Expected InvalidRequest error');
-                } catch (err) {
-                    assert.strictEqual(err.name, 'InvalidRequest');
-                    assert.strictEqual(err.message,
-                        "Found mixed 'Date' and 'Days' based Expiration and " +
-                        "Transition actions in lifecycle rule for prefix ''");
-                }
-            });
+            it(
+                'should not allow speficying both Days and Date value ' + 'across transitions and expiration',
+                async () => {
+                    const transitions = [
+                        {
+                            Days: 1,
+                            StorageClass: 'us-east-2',
+                        },
+                    ];
+                    const params = getParams(transitions);
+                    params.LifecycleConfiguration.Rules[0].Expiration = {
+                        Date: new Date('2016-01-01T00:00:00.000Z'), // Use proper Date object
+                    };
+                    try {
+                        await s3.send(new PutBucketLifecycleConfigurationCommand(params));
+                        throw new Error('Expected InvalidRequest error');
+                    } catch (err) {
+                        assert.strictEqual(err.name, 'InvalidRequest');
+                        assert.strictEqual(
+                            err.message,
+                            "Found mixed 'Date' and 'Days' based Expiration and " +
+                                "Transition actions in lifecycle rule for prefix ''",
+                        );
+                    }
+                },
+            );
         });
 
         // NoncurrentVersionTransitions not implemented
-        describe.skip('with NoncurrentVersionTransitions and Transitions',
-        () => {
+        describe.skip('with NoncurrentVersionTransitions and Transitions', () => {
             it('should allow config', async () => {
                 const params = {
                     Bucket: bucket,
                     LifecycleConfiguration: {
-                        Rules: [{
-                            ID: 'test',
-                            Status: 'Enabled',
-                            Prefix: '',
-                            NoncurrentVersionTransitions: [{
-                                NoncurrentDays: 1,
-                                StorageClass: 'us-east-2',
-                            }],
-                            Transitions: [{
-                                Days: 1,
-                                StorageClass: 'us-east-2',
-                            }],
-                        }],
+                        Rules: [
+                            {
+                                ID: 'test',
+                                Status: 'Enabled',
+                                Prefix: '',
+                                NoncurrentVersionTransitions: [
+                                    {
+                                        NoncurrentDays: 1,
+                                        StorageClass: 'us-east-2',
+                                    },
+                                ],
+                                Transitions: [
+                                    {
+                                        Days: 1,
+                                        StorageClass: 'us-east-2',
+                                    },
+                                ],
+                            },
+                        ],
                     },
                 };
                 await s3.send(new PutBucketLifecycleConfigurationCommand(params));
             });
         });
 
-        it.skip('should not allow config when specifying ' +
-        'NoncurrentVersionTransitions', async () => {
+        it.skip('should not allow config when specifying ' + 'NoncurrentVersionTransitions', async () => {
             const params = {
                 Bucket: bucket,
                 LifecycleConfiguration: {
-                    Rules: [{
-                        ID: 'test',
-                        Status: 'Enabled',
-                        Prefix: '',
-                        NoncurrentVersionTransitions: [{
-                            NoncurrentDays: 1,
-                            StorageClass: 'us-east-2',
-                        }],
-                    }],
+                    Rules: [
+                        {
+                            ID: 'test',
+                            Status: 'Enabled',
+                            Prefix: '',
+                            NoncurrentVersionTransitions: [
+                                {
+                                    NoncurrentDays: 1,
+                                    StorageClass: 'us-east-2',
+                                },
+                            ],
+                        },
+                    ],
                 },
             };
             try {

--- a/tests/functional/aws-node-sdk/test/bucket/putBucketLifecycle.js
+++ b/tests/functional/aws-node-sdk/test/bucket/putBucketLifecycle.js
@@ -5,6 +5,7 @@ const {
     CreateBucketCommand,
     DeleteBucketCommand,
     PutBucketLifecycleConfigurationCommand,
+    GetBucketLifecycleConfigurationCommand,
 } = require('@aws-sdk/client-s3');
 
 const getConfig = require('../support/config');
@@ -96,6 +97,75 @@ describe('aws-sdk test put bucket lifecycle', () => {
         it('should put lifecycle configuration on bucket', async () => {
             const params = getLifecycleParams();
             await s3.send(new PutBucketLifecycleConfigurationCommand(params));
+        });
+
+        it('should allow Expiration Days=0 (explicit bucket-emptying intent) ' + 'and round-trip it', async () => {
+            const params = getLifecycleParams({ key: 'Expiration', value: { Days: 0 } });
+            await s3.send(new PutBucketLifecycleConfigurationCommand(params));
+            const got = await s3.send(new GetBucketLifecycleConfigurationCommand({ Bucket: bucket }));
+            assert.strictEqual(got.Rules[0].Expiration.Days, 0);
+        });
+
+        it('should not allow negative Expiration Days', async () => {
+            const params = getLifecycleParams({ key: 'Expiration', value: { Days: -1 } });
+            try {
+                await s3.send(new PutBucketLifecycleConfigurationCommand(params));
+                throw new Error('Expected InvalidArgument error');
+            } catch (err) {
+                assert.strictEqual(err.name, 'InvalidArgument');
+                assert.strictEqual(err.message, "'Days' for Expiration action must be a positive integer");
+            }
+        });
+
+        it(`should not allow Expiration Days exceeding ${MAX_DAYS}`, async () => {
+            const params = getLifecycleParams({
+                key: 'Expiration',
+                value: { Days: MAX_DAYS + 1 },
+            });
+            try {
+                await s3.send(new PutBucketLifecycleConfigurationCommand(params));
+                throw new Error('Expected MalformedXML error');
+            } catch (err) {
+                assert.strictEqual(err.name, 'MalformedXML');
+            }
+        });
+
+        it('should allow NoncurrentVersionExpiration NoncurrentDays=0', async () => {
+            const params = {
+                Bucket: bucket,
+                LifecycleConfiguration: {
+                    Rules: [
+                        {
+                            ID: 'test-id',
+                            Status: 'Enabled',
+                            Prefix: '',
+                            NoncurrentVersionExpiration: { NoncurrentDays: 0 },
+                        },
+                    ],
+                },
+            };
+            await s3.send(new PutBucketLifecycleConfigurationCommand(params));
+            const got = await s3.send(new GetBucketLifecycleConfigurationCommand({ Bucket: bucket }));
+            assert.strictEqual(got.Rules[0].NoncurrentVersionExpiration.NoncurrentDays, 0);
+        });
+
+        it('should allow AbortIncompleteMultipartUpload DaysAfterInitiation=0', async () => {
+            const params = {
+                Bucket: bucket,
+                LifecycleConfiguration: {
+                    Rules: [
+                        {
+                            ID: 'test-id',
+                            Status: 'Enabled',
+                            Prefix: '',
+                            AbortIncompleteMultipartUpload: { DaysAfterInitiation: 0 },
+                        },
+                    ],
+                },
+            };
+            await s3.send(new PutBucketLifecycleConfigurationCommand(params));
+            const got = await s3.send(new GetBucketLifecycleConfigurationCommand({ Bucket: bucket }));
+            assert.strictEqual(got.Rules[0].AbortIncompleteMultipartUpload.DaysAfterInitiation, 0);
         });
 
         it(
@@ -479,7 +549,7 @@ describe('aws-sdk test put bucket lifecycle', () => {
                     assert.strictEqual(err.name, 'InvalidArgument');
                     assert.strictEqual(
                         err.message,
-                        "'NoncurrentDays' in NoncurrentVersionExpiration " + 'action must be nonnegative',
+                        "'NoncurrentDays' for NoncurrentVersionExpiration action must be a positive integer",
                     );
                 }
             });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6595,9 +6595,9 @@ arraybuffer.prototype.slice@^1.0.4:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#8.5.4":
-  version "8.5.4"
-  resolved "git+https://github.com/scality/arsenal#53702574e7b97a5626f9ede53fcad18995bae80b"
+"arsenal@git+https://github.com/scality/arsenal#8.5.6":
+  version "8.5.6"
+  resolved "git+https://github.com/scality/arsenal#0db557930c7d13204167188a7503e6e00d154df5"
   dependencies:
     "@aws-sdk/client-kms" "^3.975.0"
     "@aws-sdk/client-s3" "^3.975.0"


### PR DESCRIPTION
## What

CloudServer side of `Days = 0` lifecycle support — bumps arsenal to the released **8.5.6** and wires it up:

1. **Apply prettier** to the touched `putBucketLifecycle` handler + test.
2. **Pass the werelogs logger** to `LifecycleConfiguration` so arsenal can emit the 0-day audit log.
3. **Functional tests** (`tests/functional/aws-node-sdk/test/bucket/putBucketLifecycle.js`):
   - `Expiration` `Days: 0`, `NoncurrentVersionExpiration` `NoncurrentDays: 0`, and `AbortIncompleteMultipartUpload` `DaysAfterInitiation: 0` accepted and round-trip via GetBucketLifecycle
   - negative day values rejected with the exact AWS wording (`'<field>' for <action> action must be a positive integer`), `> MAX_DAYS` rejected (`MalformedXML`)
4. **Bump arsenal to `8.5.6`** — the released tag carrying the Days=0 validation, the AWS-matching error wording, and the multi-backend sproxyd `head()` crash fix (ARSN-607).
5. **Migrate `bucketPutLifecycle` to async/await** — clears the CodeQL "callback-style function" alert, using the dual callback+async trampoline (per the async-migration TAD).

## Why

`Days = 0` is an explicit *"empty this bucket"* lifecycle signal. It was rejected everywhere until now, so it's unambiguous (unlike `Days = 1`, used by legitimate short-retention buckets) and lets backbeat (BB-779) skip building costly lifecycle indexes for buckets being drained. CloudServer delegates lifecycle validation to arsenal, so the substantive change is the dependency bump; the rest wires the logger, adds coverage, and migrates the handler.

## Related

- ARSN-597 (arsenal) — Days=0 validation + AWS error wording; merged, released in **8.5.6** (scality/Arsenal#2648)
- ARSN-607 (arsenal) — multi-backend sproxyd `head()` crash fix, also in 8.5.6
- BB-779 / backbeat#2748 — skip-index heuristic that consumes Days=0

Issue: CLDSRV-928
