### PR TITLE
Unblock arsenal bumps on 9.3: realign replication tests for CRR ObjectMD refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "@azure/storage-blob": "^12.28.0",
         "@hapi/joi": "^17.1.1",
         "@smithy/node-http-handler": "^3.0.0",
-        "arsenal": "git+https://github.com/scality/Arsenal#8.4.4",
+        "arsenal": "git+https://github.com/scality/Arsenal#8.4.7",
         "async": "2.6.4",
         "bucketclient": "scality/bucketclient#8.2.7",
         "bufferutil": "^4.0.8",

--- a/tests/functional/aws-node-sdk/test/bucket/putBucketReplication.js
+++ b/tests/functional/aws-node-sdk/test/bucket/putBucketReplication.js
@@ -358,54 +358,6 @@ describe('aws-node-sdk test putBucketReplication configuration rules', () => {
         return checkError(config, 'InvalidArgument');
     });
 
-    it(
-        'should not accept configuration when rules contain overlapping ' +
-            "'Prefix' values: new prefix starts with used prefix",
-        () => {
-            const config = setConfigRules([
-                replicationConfig.Rules[0],
-                {
-                    Destination: { Bucket: `arn:aws:s3:::${destinationBucket}` },
-                    Prefix: 'test-prefix/more-content',
-                    Status: 'Enabled',
-                },
-            ]);
-            return checkError(config, 'InvalidRequest');
-        },
-    );
-
-    it(
-        'should not accept configuration when rules contain overlapping ' +
-            "'Prefix' values: used prefix starts with new prefix",
-        () => {
-            const config = setConfigRules([
-                replicationConfig.Rules[0],
-                {
-                    Destination: { Bucket: `arn:aws:s3:::${destinationBucket}` },
-                    Prefix: 'test',
-                    Status: 'Enabled',
-                },
-            ]);
-            return checkError(config, 'InvalidRequest');
-        },
-    );
-
-    it(
-        "should not accept configuration when 'Destination' properties of " +
-            'two or more rules specify different buckets',
-        () => {
-            const config = setConfigRules([
-                replicationConfig.Rules[0],
-                {
-                    Destination: { Bucket: `arn:aws:s3:::${destinationBucket}-1` },
-                    Prefix: 'bar',
-                    Status: 'Enabled',
-                },
-            ]);
-            return checkError(config, 'InvalidRequest');
-        },
-    );
-
     replicationUtils.validStorageClasses.forEach(storageClass => {
         const config = setConfigRules({
             Destination: {

--- a/tests/functional/aws-node-sdk/test/bucket/putBucketReplication.js
+++ b/tests/functional/aws-node-sdk/test/bucket/putBucketReplication.js
@@ -1,19 +1,20 @@
 const assert = require('assert');
 const { errors } = require('arsenal');
-const { S3Client,
+const {
+    S3Client,
     CreateBucketCommand,
     DeleteBucketCommand,
     DeleteBucketCorsCommand,
     PutBucketCorsCommand,
     PutBucketReplicationCommand,
-    PutBucketVersioningCommand } = require('@aws-sdk/client-s3');
+    PutBucketVersioningCommand,
+} = require('@aws-sdk/client-s3');
 const { series } = require('async');
 
 const getConfig = require('../support/config');
 const replicationUtils = require('../../lib/utility/replication');
 const BucketUtility = require('../../lib/utility/bucket-util');
 const itSkipIfE2E = process.env.S3_END_TO_END ? it.skip : it;
-
 
 const sourceBucket = 'source-bucket';
 const destinationBucket = 'destination-bucket';
@@ -23,11 +24,17 @@ function assertError(err, expectedErr) {
     if (expectedErr === null) {
         assert.strictEqual(err, null, `expected no error but got '${err}'`);
     } else {
-        assert.strictEqual(err.name, expectedErr, 'incorrect error response ' +
-            `code: should be '${expectedErr}' but got '${err.name}'`);
-        assert.strictEqual(err.$metadata.httpStatusCode, errors[expectedErr].code,
+        assert.strictEqual(
+            err.name,
+            expectedErr,
+            'incorrect error response ' + `code: should be '${expectedErr}' but got '${err.name}'`,
+        );
+        assert.strictEqual(
+            err.$metadata.httpStatusCode,
+            errors[expectedErr].code,
             `incorrect error status code: should be ${errors[expectedErr].code} but got ` +
-            `'${err.$metadata.httpStatusCode}'`);
+                `'${err.$metadata.httpStatusCode}'`,
+        );
     }
 }
 
@@ -51,8 +58,7 @@ function getVersioningParams(status) {
 
 // Get a complete replication configuration, or remove the specified property.
 const replicationConfig = {
-    Role: 'arn:aws:iam::account-id:role/src-resource,' +
-        'arn:aws:iam::account-id:role/dest-resource',
+    Role: 'arn:aws:iam::account-id:role/src-resource,' + 'arn:aws:iam::account-id:role/dest-resource',
     Rules: [
         {
             Destination: {
@@ -69,8 +75,7 @@ const replicationConfig = {
 // Set the rules array of a configuration or a property of the first rule.
 function setConfigRules(val) {
     const config = Object.assign({}, replicationConfig);
-    config.Rules = Array.isArray(val) ? val :
-        [Object.assign({}, config.Rules[0], val)];
+    config.Rules = Array.isArray(val) ? val : [Object.assign({}, config.Rules[0], val)];
     return config;
 }
 
@@ -82,16 +87,23 @@ describe('aws-node-sdk test putBucketReplication bucket status', () => {
 
     function checkVersioningError(s3Client, versioningStatus, expectedErr) {
         const versioningParams = getVersioningParams(versioningStatus);
-        return series([
-            next => s3Client.send(new PutBucketVersioningCommand(versioningParams))
-                .then(() => next())
-                .catch(next),
-            next => s3Client.send(new PutBucketReplicationCommand(replicationParams))
-                .then(() => next())
-                .catch(next),
-        ], err => {
-            assertError(err, expectedErr);
-        });
+        return series(
+            [
+                next =>
+                    s3Client
+                        .send(new PutBucketVersioningCommand(versioningParams))
+                        .then(() => next())
+                        .catch(next),
+                next =>
+                    s3Client
+                        .send(new PutBucketReplicationCommand(replicationParams))
+                        .then(() => next())
+                        .catch(next),
+            ],
+            err => {
+                assertError(err, expectedErr);
+            },
+        );
     }
 
     before(() => {
@@ -101,7 +113,7 @@ describe('aws-node-sdk test putBucketReplication bucket status', () => {
         replicationAccountS3 = new BucketUtility('replication', {}).s3;
     });
 
-    it('should return \'NoSuchBucket\' error if bucket does not exist', async () => {
+    it("should return 'NoSuchBucket' error if bucket does not exist", async () => {
         try {
             await s3.send(new PutBucketReplicationCommand(replicationParams));
             throw new Error('Expected NoSuchBucket error');
@@ -112,7 +124,7 @@ describe('aws-node-sdk test putBucketReplication bucket status', () => {
             assertError(err, 'NoSuchBucket');
         }
     });
-    
+
     describe('test putBucketReplication bucket versioning status', () => {
         beforeEach(() => s3.send(new CreateBucketCommand({ Bucket: sourceBucket })));
 
@@ -130,7 +142,7 @@ describe('aws-node-sdk test putBucketReplication bucket status', () => {
                 assert.strictEqual(err.$metadata.httpStatusCode, 403);
             }
         });
-        
+
         it('should not put configuration on bucket without versioning', async () => {
             try {
                 await s3.send(new PutBucketReplicationCommand(replicationParams));
@@ -143,19 +155,18 @@ describe('aws-node-sdk test putBucketReplication bucket status', () => {
             }
         });
 
-        it('should not put configuration on bucket with \'Suspended\'' +
-            'versioning', () =>
-            checkVersioningError(s3, 'Suspended', 'InvalidRequest'));
+        it("should not put configuration on bucket with 'Suspended'" + 'versioning', () =>
+            checkVersioningError(s3, 'Suspended', 'InvalidRequest'),
+        );
 
-        it('should put configuration on a bucket with versioning', () =>
-            checkVersioningError(s3, 'Enabled', null));
+        it('should put configuration on a bucket with versioning', () => checkVersioningError(s3, 'Enabled', null));
 
         // S3C doesn't support service account. There is no cross account access for replication account.
         // (canonicalId looking like http://acs.zenko.io/accounts/service/replication)
         const itSkipS3C = process.env.S3_END_TO_END ? it.skip : it;
-        itSkipS3C('should put configuration on a bucket with versioning if ' +
-        'user is a replication user', () =>
-            checkVersioningError(replicationAccountS3, 'Enabled', null));
+        itSkipS3C('should put configuration on a bucket with versioning if ' + 'user is a replication user', () =>
+            checkVersioningError(replicationAccountS3, 'Enabled', null),
+        );
     });
 });
 
@@ -164,7 +175,8 @@ describe('aws-node-sdk test putBucketReplication configuration rules', () => {
 
     function checkError(config, expectedErr) {
         const replicationParams = getReplicationParams(config);
-        return s3.send(new PutBucketReplicationCommand(replicationParams))
+        return s3
+            .send(new PutBucketReplicationCommand(replicationParams))
             .then(() => {
                 if (expectedErr !== null) {
                     return Promise.reject(new Error(`Expected ${expectedErr} error`));
@@ -190,21 +202,26 @@ describe('aws-node-sdk test putBucketReplication configuration rules', () => {
         const Role = ARN === '' || ARN === ',' ? ARN : `${ARN},${ARN}`;
         const config = Object.assign({}, replicationConfig, { Role });
 
-        it('should not accept configuration when \'Role\' is not a ' +
-            'comma-separated list of two valid Amazon Resource Names: ' +
-            `'${Role}'`, () =>
-            checkError(config, 'InvalidArgument'));
+        it(
+            "should not accept configuration when 'Role' is not a " +
+                'comma-separated list of two valid Amazon Resource Names: ' +
+                `'${Role}'`,
+            () => checkError(config, 'InvalidArgument'),
+        );
     });
 
-    it('should not accept configuration when \'Role\' is a comma-separated ' +
-        'list of more than two valid Amazon Resource Names',
+    it(
+        "should not accept configuration when 'Role' is a comma-separated " +
+            'list of more than two valid Amazon Resource Names',
         () => {
-            const Role = 'arn:aws:iam::account-id:role/resource-1,' +
+            const Role =
+                'arn:aws:iam::account-id:role/resource-1,' +
                 'arn:aws:iam::account-id:role/resource-2,' +
                 'arn:aws:iam::account-id:role/resource-3';
             const config = Object.assign({}, replicationConfig, { Role });
             checkError(config, 'InvalidArgument');
-        });
+        },
+    );
 
     replicationUtils.validRoleARNs.forEach(ARN => {
         const config = setConfigRules({
@@ -219,62 +236,68 @@ describe('aws-node-sdk test putBucketReplication configuration rules', () => {
         itSkipIfE2E(test, () => checkError(config, null));
     });
 
-    it('should allow a combination of storageClasses across rules',  () => {
-        const config = setConfigRules([replicationConfig.Rules[0], {
-            Destination: {
-                Bucket: `arn:aws:s3:::${destinationBucket}`,
-                StorageClass: 'us-east-2',
+    it('should allow a combination of storageClasses across rules', () => {
+        const config = setConfigRules([
+            replicationConfig.Rules[0],
+            {
+                Destination: {
+                    Bucket: `arn:aws:s3:::${destinationBucket}`,
+                    StorageClass: 'us-east-2',
+                },
+                Prefix: 'bar',
+                Status: 'Enabled',
             },
-            Prefix: 'bar',
-            Status: 'Enabled',
-        }]);
-        config.Role = 'arn:aws:iam::account-id:role/resource,' +
-            'arn:aws:iam::account-id:role/resource1';
+        ]);
+        config.Role = 'arn:aws:iam::account-id:role/resource,' + 'arn:aws:iam::account-id:role/resource1';
         checkError(config, null);
     });
 
-    itSkipIfE2E('should not allow a comma separated list of roles when' +
-        ' a rule storageClass defines an external location', () => {
-        const config = {
-            Role: 'arn:aws:iam::account-id:role/src-resource,' +
-                'arn:aws:iam::account-id:role/dest-resource',
-            Rules: [
-                {
-                    Destination: {
-                        Bucket: `arn:aws:s3:::${destinationBucket}`,
-                        StorageClass: 'us-east-2',
+    itSkipIfE2E(
+        'should not allow a comma separated list of roles when' + ' a rule storageClass defines an external location',
+        () => {
+            const config = {
+                Role: 'arn:aws:iam::account-id:role/src-resource,' + 'arn:aws:iam::account-id:role/dest-resource',
+                Rules: [
+                    {
+                        Destination: {
+                            Bucket: `arn:aws:s3:::${destinationBucket}`,
+                            StorageClass: 'us-east-2',
+                        },
+                        Prefix: 'test-prefix',
+                        Status: 'Enabled',
                     },
-                    Prefix: 'test-prefix',
-                    Status: 'Enabled',
-                },
-            ],
-        };
-        checkError(config, 'InvalidArgument');
-    });
+                ],
+            };
+            checkError(config, 'InvalidArgument');
+        },
+    );
 
     replicationUtils.validRoleARNs.forEach(ARN => {
         const Role = `${ARN},${ARN}`;
         const config = Object.assign({}, replicationConfig, { Role });
 
-        it('should accept configuration when \'Role\' is a comma-separated ' +
-            `list of two valid Amazon Resource Names: '${Role}'`, () =>
-            checkError(config, null));
+        it(
+            "should accept configuration when 'Role' is a comma-separated " +
+                `list of two valid Amazon Resource Names: '${Role}'`,
+            () => checkError(config, null),
+        );
     });
 
     replicationUtils.invalidBucketARNs.forEach(ARN => {
         const config = setConfigRules({ Destination: { Bucket: ARN } });
 
-        it('should not accept configuration when \'Bucket\' is not a ' +
-            `valid Amazon Resource Name format: '${ARN}'`, () =>
-            checkError(config, 'InvalidArgument'));
+        it(
+            "should not accept configuration when 'Bucket' is not a " + `valid Amazon Resource Name format: '${ARN}'`,
+            () => checkError(config, 'InvalidArgument'),
+        );
     });
 
-    it('should not accept configuration when \'Rules\' is empty ', () => {
+    it("should not accept configuration when 'Rules' is empty ", () => {
         const config = Object.assign({}, replicationConfig, { Rules: [] });
         return checkError(config, 'MalformedXML');
     });
 
-    it('should not accept configuration when \'Rules\' is > 1000', () => {
+    it("should not accept configuration when 'Rules' is > 1000", () => {
         const arr = [];
         for (let i = 0; i < 1001; i++) {
             arr.push({
@@ -287,13 +310,13 @@ describe('aws-node-sdk test putBucketReplication configuration rules', () => {
         return checkError(config, 'InvalidRequest');
     });
 
-    it('should not accept configuration when \'ID\' length is > 255', () => {
+    it("should not accept configuration when 'ID' length is > 255", () => {
         // Set ID to a string of length 256.
         const config = setConfigRules({ ID: new Array(257).join('x') });
         return checkError(config, 'InvalidArgument');
     });
 
-    it('should not accept configuration when \'ID\' is not unique', () => {
+    it("should not accept configuration when 'ID' is not unique", () => {
         const rule1 = replicationConfig.Rules[0];
         // Prefix is unique, but not the ID.
         const rule2 = Object.assign({}, rule1, { Prefix: 'bar' });
@@ -301,8 +324,7 @@ describe('aws-node-sdk test putBucketReplication configuration rules', () => {
         return checkError(config, 'InvalidRequest');
     });
 
-    it('should accept configuration when \'ID\' is not provided for multiple ' +
-        'rules', () => {
+    it("should accept configuration when 'ID' is not provided for multiple " + 'rules', () => {
         const replicationConfigWithoutID = Object.assign({}, replicationConfig);
         const rule1 = replicationConfigWithoutID.Rules[0];
         delete rule1.ID;
@@ -314,60 +336,75 @@ describe('aws-node-sdk test putBucketReplication configuration rules', () => {
     replicationUtils.validStatuses.forEach(status => {
         const config = setConfigRules({ Status: status });
 
-        it(`should accept configuration when 'Role' is ${status}`, () =>
-            checkError(config, null));
+        it(`should accept configuration when 'Role' is ${status}`, () => checkError(config, null));
     });
 
-    it('should not accept configuration when \'Status\' is invalid', () => {
+    it("should not accept configuration when 'Status' is invalid", () => {
         // Status must either be 'Enabled' or 'Disabled'.
         const config = setConfigRules({ Status: 'Invalid' });
         return checkError(config, 'MalformedXML');
     });
 
-    it('should accept configuration when \'Prefix\' is \'\'',
-        () => {
-            const config = setConfigRules({ Prefix: '' });
-            return checkError(config, null);
+    it("should accept configuration when 'Prefix' is ''", () => {
+        const config = setConfigRules({ Prefix: '' });
+        return checkError(config, null);
+    });
+
+    it("should not accept configuration when 'Prefix' length is > 1024", () => {
+        // Set Prefix to a string of length of 1025.
+        const config = setConfigRules({
+            Prefix: new Array(1026).join('x'),
         });
+        return checkError(config, 'InvalidArgument');
+    });
 
-    it('should not accept configuration when \'Prefix\' length is > 1024',
+    it(
+        'should not accept configuration when rules contain overlapping ' +
+            "'Prefix' values: new prefix starts with used prefix",
         () => {
-            // Set Prefix to a string of length of 1025.
-            const config = setConfigRules({
-                Prefix: new Array(1026).join('x'),
-            });
-            return checkError(config, 'InvalidArgument');
-        });
+            const config = setConfigRules([
+                replicationConfig.Rules[0],
+                {
+                    Destination: { Bucket: `arn:aws:s3:::${destinationBucket}` },
+                    Prefix: 'test-prefix/more-content',
+                    Status: 'Enabled',
+                },
+            ]);
+            return checkError(config, 'InvalidRequest');
+        },
+    );
 
-    it('should not accept configuration when rules contain overlapping ' +
-        '\'Prefix\' values: new prefix starts with used prefix', () => {
-        const config = setConfigRules([replicationConfig.Rules[0], {
-            Destination: { Bucket: `arn:aws:s3:::${destinationBucket}` },
-            Prefix: 'test-prefix/more-content',
-            Status: 'Enabled',
-        }]);
-        return checkError(config, 'InvalidRequest');
-    });
+    it(
+        'should not accept configuration when rules contain overlapping ' +
+            "'Prefix' values: used prefix starts with new prefix",
+        () => {
+            const config = setConfigRules([
+                replicationConfig.Rules[0],
+                {
+                    Destination: { Bucket: `arn:aws:s3:::${destinationBucket}` },
+                    Prefix: 'test',
+                    Status: 'Enabled',
+                },
+            ]);
+            return checkError(config, 'InvalidRequest');
+        },
+    );
 
-    it('should not accept configuration when rules contain overlapping ' +
-        '\'Prefix\' values: used prefix starts with new prefix', () => {
-        const config = setConfigRules([replicationConfig.Rules[0], {
-            Destination: { Bucket: `arn:aws:s3:::${destinationBucket}` },
-            Prefix: 'test',
-            Status: 'Enabled',
-        }]);
-        return checkError(config, 'InvalidRequest');
-    });
-
-    it('should not accept configuration when \'Destination\' properties of ' +
-        'two or more rules specify different buckets', () => {
-        const config = setConfigRules([replicationConfig.Rules[0], {
-            Destination: { Bucket: `arn:aws:s3:::${destinationBucket}-1` },
-            Prefix: 'bar',
-            Status: 'Enabled',
-        }]);
-        return checkError(config, 'InvalidRequest');
-    });
+    it(
+        "should not accept configuration when 'Destination' properties of " +
+            'two or more rules specify different buckets',
+        () => {
+            const config = setConfigRules([
+                replicationConfig.Rules[0],
+                {
+                    Destination: { Bucket: `arn:aws:s3:::${destinationBucket}-1` },
+                    Prefix: 'bar',
+                    Status: 'Enabled',
+                },
+            ]);
+            return checkError(config, 'InvalidRequest');
+        },
+    );
 
     replicationUtils.validStorageClasses.forEach(storageClass => {
         const config = setConfigRules({
@@ -377,8 +414,7 @@ describe('aws-node-sdk test putBucketReplication configuration rules', () => {
             },
         });
 
-        it('should accept configuration when \'StorageClass\' is ' +
-            `${storageClass}`, () =>  checkError(config, null));
+        it("should accept configuration when 'StorageClass' is " + `${storageClass}`, () => checkError(config, null));
     });
 
     // A combination of external destination storage classes.
@@ -390,20 +426,20 @@ describe('aws-node-sdk test putBucketReplication configuration rules', () => {
             },
         });
 
-        itSkipIfE2E('should accept configuration when \'StorageClass\' is ' +
-            `${storageClass}`, () => checkError(config, null));
+        itSkipIfE2E("should accept configuration when 'StorageClass' is " + `${storageClass}`, () =>
+            checkError(config, null),
+        );
     });
 
-    it('should not accept configuration when \'StorageClass\' is invalid',
-        () => {
-            const config = setConfigRules({
-                Destination: {
-                    Bucket: `arn:aws:s3:::${destinationBucket}`,
-                    StorageClass: 'INVALID',
-                },
-            });
-            return checkError(config, 'MalformedXML');
+    it("should not accept configuration when 'StorageClass' is invalid", () => {
+        const config = setConfigRules({
+            Destination: {
+                Bucket: `arn:aws:s3:::${destinationBucket}`,
+                StorageClass: 'INVALID',
+            },
         });
+        return checkError(config, 'MalformedXML');
+    });
 });
 
 describe('aws-node-sdk test putBucketReplication CORS', () => {
@@ -414,20 +450,26 @@ describe('aws-node-sdk test putBucketReplication CORS', () => {
         const config = getConfig('default', { signatureVersion: 'v4' });
         s3 = new S3Client(config);
         await s3.send(new CreateBucketCommand({ Bucket: bucket }));
-        await s3.send(new PutBucketVersioningCommand({
-            Bucket: bucket,
-            VersioningConfiguration: { Status: 'Enabled' },
-        }));
-        await s3.send(new PutBucketCorsCommand({
-            Bucket: bucket,
-            CORSConfiguration: {
-                CORSRules: [{
-                    AllowedOrigins: ['*'],
-                    AllowedMethods: ['PUT'],
-                    AllowedHeaders: ['*'],
-                }],
-            },
-        }));
+        await s3.send(
+            new PutBucketVersioningCommand({
+                Bucket: bucket,
+                VersioningConfiguration: { Status: 'Enabled' },
+            }),
+        );
+        await s3.send(
+            new PutBucketCorsCommand({
+                Bucket: bucket,
+                CORSConfiguration: {
+                    CORSRules: [
+                        {
+                            AllowedOrigins: ['*'],
+                            AllowedMethods: ['PUT'],
+                            AllowedHeaders: ['*'],
+                        },
+                    ],
+                },
+            }),
+        );
     });
 
     afterEach(async () => {
@@ -445,8 +487,7 @@ describe('aws-node-sdk test putBucketReplication CORS', () => {
         const replicationParams = {
             Bucket: bucket,
             ReplicationConfiguration: {
-                Role: 'arn:aws:iam::account-id:role/src-resource,' +
-                    'arn:aws:iam::account-id:role/dest-resource',
+                Role: 'arn:aws:iam::account-id:role/src-resource,' + 'arn:aws:iam::account-id:role/dest-resource',
                 Rules: [],
             },
         };
@@ -463,7 +504,7 @@ describe('aws-node-sdk test putBucketReplication CORS', () => {
                 name: 'injectOriginHeader',
                 step: 'build',
                 priority: 'high',
-            }
+            },
         );
 
         try {

--- a/tests/unit/api/objectReplicationMD.js
+++ b/tests/unit/api/objectReplicationMD.js
@@ -72,22 +72,17 @@ const emptyReplicationMD = {
     status: '',
     backends: [],
     content: [],
-    destination: '',
-    storageClass: '',
-    role: '',
-    storageType: '',
-    dataStoreVersionId: '',
+    destination: undefined,
+    storageClass: undefined,
+    role: undefined,
+    storageType: undefined,
+    dataStoreVersionId: undefined,
     isNFS: undefined,
 };
 const expectedEmptyReplicationMD = {
     status: '',
     backends: [],
     content: [],
-    destination: '',
-    storageClass: '',
-    role: '',
-    storageType: '',
-    dataStoreVersionId: '',
 };
 
 // Check that the object key has the expected replication information.
@@ -316,7 +311,6 @@ describe('Replication object MD without bucket replication config', () => {
                 storageClass: 'zenko',
                 role: 'arn:aws:iam::account-id:role/src-resource,' + 'arn:aws:iam::account-id:role/dest-resource',
                 storageType: '',
-                dataStoreVersionId: '',
                 isNFS: undefined,
             };
             const newReplicationMD = hasStorageClass
@@ -605,7 +599,6 @@ describe('Replication object MD without bucket replication config', () => {
                         storageClass: backend,
                         role: 'arn:aws:iam::account-id:role/resource',
                         storageType,
-                        dataStoreVersionId: '',
                         isNFS: undefined,
                     };
 

--- a/tests/unit/api/objectReplicationMD.js
+++ b/tests/unit/api/objectReplicationMD.js
@@ -4,16 +4,14 @@ const crypto = require('crypto');
 
 const BucketInfo = require('arsenal').models.BucketInfo;
 
-const { cleanup, DummyRequestLogger, makeAuthInfo, TaggingConfigTester } =
-    require('../helpers');
+const { cleanup, DummyRequestLogger, makeAuthInfo, TaggingConfigTester } = require('../helpers');
 const constants = require('../../../constants');
 const { metadata } = require('arsenal').storage.metadata.inMemory.metadata;
 const DummyRequest = require('../DummyRequest');
 const { objectDelete } = require('../../../lib/api/objectDelete');
 const objectPut = require('../../../lib/api/objectPut');
 const objectCopy = require('../../../lib/api/objectCopy');
-const completeMultipartUpload =
-    require('../../../lib/api/completeMultipartUpload');
+const completeMultipartUpload = require('../../../lib/api/completeMultipartUpload');
 const objectPutACL = require('../../../lib/api/objectPutACL');
 const objectPutTagging = require('../../../lib/api/objectPutTagging');
 const objectDeleteTagging = require('../../../lib/api/objectDeleteTagging');
@@ -55,19 +53,20 @@ const objectACLReq = {
 // Get an object request with the given key.
 function getObjectPutReq(key, hasContent) {
     const bodyContent = hasContent ? 'body content' : '';
-    return new DummyRequest({
-        bucketName,
-        namespace,
-        objectKey: key,
-        headers: {},
-        url: `/${bucketName}/${key}`,
-    }, Buffer.from(bodyContent, 'utf8'));
+    return new DummyRequest(
+        {
+            bucketName,
+            namespace,
+            objectKey: key,
+            headers: {},
+            url: `/${bucketName}/${key}`,
+        },
+        Buffer.from(bodyContent, 'utf8'),
+    );
 }
 
-const taggingPutReq = new TaggingConfigTester()
-    .createObjectTaggingRequest('PUT', bucketName, keyA);
-const taggingDeleteReq = new TaggingConfigTester()
-    .createObjectTaggingRequest('DELETE', bucketName, keyA);
+const taggingPutReq = new TaggingConfigTester().createObjectTaggingRequest('PUT', bucketName, keyA);
+const taggingDeleteReq = new TaggingConfigTester().createObjectTaggingRequest('DELETE', bucketName, keyA);
 
 const emptyReplicationMD = {
     status: '',
@@ -99,35 +98,34 @@ function checkObjectReplicationInfo(key, expected) {
 
 // Put the object key and check the replication information.
 function putObjectAndCheckMD(key, expected, cb) {
-    return objectPut(authInfo, getObjectPutReq(key, true), undefined, log,
-        err => {
-            if (err) {
-                return cb(err);
-            }
-            checkObjectReplicationInfo(key, expected);
-            return cb();
-        });
+    return objectPut(authInfo, getObjectPutReq(key, true), undefined, log, err => {
+        if (err) {
+            return cb(err);
+        }
+        checkObjectReplicationInfo(key, expected);
+        return cb();
+    });
 }
 
 // Create the bucket in metadata.
 function createBucket() {
-    metadata
-        .buckets.set(bucketName, new BucketInfo(bucketName, ownerID, '', ''));
-    metadata.keyMaps.set(bucketName, new Map);
+    metadata.buckets.set(bucketName, new BucketInfo(bucketName, ownerID, '', ''));
+    metadata.keyMaps.set(bucketName, new Map());
 }
 
 // Create the bucket in metadata with versioning and a replication config.
 function createBucketWithReplication(hasStorageClass) {
     createBucket();
     const config = {
-        role: 'arn:aws:iam::account-id:role/src-resource,' +
-            'arn:aws:iam::account-id:role/dest-resource',
+        role: 'arn:aws:iam::account-id:role/src-resource,' + 'arn:aws:iam::account-id:role/dest-resource',
         destination: 'arn:aws:s3:::source-bucket',
-        rules: [{
-            prefix: keyA,
-            enabled: true,
-            id: 'test-id',
-        }],
+        rules: [
+            {
+                prefix: keyA,
+                enabled: true,
+                id: 'test-id',
+            },
+        ],
     };
     if (hasStorageClass) {
         config.rules[0].storageClass = storageClassType;
@@ -140,22 +138,21 @@ function createBucketWithReplication(hasStorageClass) {
 
 // Create the shadow bucket in metadata for MPUs with a recent model number.
 function createShadowBucket(key, uploadId) {
-    const overviewKey = `overview${constants.splitter}` +
-        `${key}${constants.splitter}${uploadId}`;
-    metadata.buckets
-        .set(mpuShadowBucket, new BucketInfo(mpuShadowBucket, ownerID, '', ''));
-     // Set modelVersion to use the most recent splitter.
+    const overviewKey = `overview${constants.splitter}` + `${key}${constants.splitter}${uploadId}`;
+    metadata.buckets.set(mpuShadowBucket, new BucketInfo(mpuShadowBucket, ownerID, '', ''));
+    // Set modelVersion to use the most recent splitter.
     Object.assign(metadata.buckets.get(mpuShadowBucket), {
         _mdBucketModelVersion: 5,
     });
-    metadata.keyMaps.set(mpuShadowBucket, new Map);
-    metadata.keyMaps.get(mpuShadowBucket).set(overviewKey, new Map);
+    metadata.keyMaps.set(mpuShadowBucket, new Map());
+    metadata.keyMaps.get(mpuShadowBucket).set(overviewKey, new Map());
     Object.assign(metadata.keyMaps.get(mpuShadowBucket).get(overviewKey), {
         id: uploadId,
         eventualStorageBucket: bucketName,
         initiator: {
             DisplayName: 'accessKey1displayName',
-            ID: ownerID },
+            ID: ownerID,
+        },
         key,
         uploadId,
     });
@@ -170,24 +167,26 @@ function putMPU(key, body, cb) {
     const calculatedHash = md5Hash.digest('hex');
     const partKey = `${uploadId}${constants.splitter}00001`;
     const obj = {
-        partLocations: [{
-            key: 1,
-            dataStoreName: 'scality-internal-mem',
-            dataStoreETag: `1:${calculatedHash}`,
-        }],
+        partLocations: [
+            {
+                key: 1,
+                dataStoreName: 'scality-internal-mem',
+                dataStoreETag: `1:${calculatedHash}`,
+            },
+        ],
         key: partKey,
     };
     obj['content-md5'] = calculatedHash;
     obj['content-length'] = body.length;
-    metadata.keyMaps.get(mpuShadowBucket).set(partKey, new Map);
+    metadata.keyMaps.get(mpuShadowBucket).set(partKey, new Map());
     const partMap = metadata.keyMaps.get(mpuShadowBucket).get(partKey);
     Object.assign(partMap, obj);
     const postBody =
         '<CompleteMultipartUpload>' +
-            '<Part>' +
-                '<PartNumber>1</PartNumber>' +
-                `<ETag>"${calculatedHash}"</ETag>` +
-            '</Part>' +
+        '<Part>' +
+        '<PartNumber>1</PartNumber>' +
+        `<ETag>"${calculatedHash}"</ETag>` +
+        '</Part>' +
         '</CompleteMultipartUpload>';
     const req = {
         bucketName,
@@ -217,8 +216,7 @@ function copyObject(sourceObjectKey, copyObjectKey, hasContent, cb) {
             headers: {},
             url: `/${bucketName}/${sourceObjectKey}`,
         });
-        return objectCopy(authInfo, req, bucketName, sourceObjectKey, undefined,
-            log, cb);
+        return objectCopy(authInfo, req, bucketName, sourceObjectKey, undefined, log, cb);
     });
 }
 
@@ -230,26 +228,33 @@ describe('Replication object MD without bucket replication config', () => {
 
     afterEach(() => cleanup());
 
-    it('should not update object metadata', done =>
-        putObjectAndCheckMD(keyA, emptyReplicationMD, done));
+    it('should not update object metadata', done => putObjectAndCheckMD(keyA, emptyReplicationMD, done));
 
     it('should not update object metadata if putting object ACL', done =>
-        async.series([
-            next => putObjectAndCheckMD(keyA, emptyReplicationMD, next),
-            next => objectPutACL(authInfo, objectACLReq, log, next),
-        ], err => {
-            if (err) {
-                return done(err);
-            }
-            checkObjectReplicationInfo(keyA, expectedEmptyReplicationMD);
-            return done();
-        }));
+        async.series(
+            [
+                next => putObjectAndCheckMD(keyA, emptyReplicationMD, next),
+                next => objectPutACL(authInfo, objectACLReq, log, next),
+            ],
+            err => {
+                if (err) {
+                    return done(err);
+                }
+                checkObjectReplicationInfo(keyA, expectedEmptyReplicationMD);
+                return done();
+            },
+        ));
 
     describe('Object tagging', () => {
-        beforeEach(done => async.series([
-            next => putObjectAndCheckMD(keyA, emptyReplicationMD, next),
-            next => objectPutTagging(authInfo, taggingPutReq, log, next),
-        ], err => done(err)));
+        beforeEach(done =>
+            async.series(
+                [
+                    next => putObjectAndCheckMD(keyA, emptyReplicationMD, next),
+                    next => objectPutTagging(authInfo, taggingPutReq, log, next),
+                ],
+                err => done(err),
+            ),
+        );
 
         it('should not update object metadata if putting tag', done => {
             checkObjectReplicationInfo(keyA, expectedEmptyReplicationMD);
@@ -257,18 +262,20 @@ describe('Replication object MD without bucket replication config', () => {
         });
 
         it('should not update object metadata if deleting tag', done =>
-            async.series([
-                // Put a new version to update replication MD content array.
-                next => putObjectAndCheckMD(keyA, emptyReplicationMD, next),
-                next => objectDeleteTagging(authInfo, taggingDeleteReq, log,
-                    next),
-            ], err => {
-                if (err) {
-                    return done(err);
-                }
-                checkObjectReplicationInfo(keyA, expectedEmptyReplicationMD);
-                return done();
-            }));
+            async.series(
+                [
+                    // Put a new version to update replication MD content array.
+                    next => putObjectAndCheckMD(keyA, emptyReplicationMD, next),
+                    next => objectDeleteTagging(authInfo, taggingDeleteReq, log, next),
+                ],
+                err => {
+                    if (err) {
+                        return done(err);
+                    }
+                    checkObjectReplicationInfo(keyA, expectedEmptyReplicationMD);
+                    return done();
+                },
+            ));
 
         it('should not update object metadata if completing MPU', done =>
             putMPU(keyA, 'content', err => {
@@ -291,250 +298,280 @@ describe('Replication object MD without bucket replication config', () => {
 });
 
 [true, false].forEach(hasStorageClass => {
-    describe('Replication object MD with bucket replication config ' +
-    `${hasStorageClass ? 'with' : 'without'} storage class`, () => {
-        const replicationMD = {
-            status: 'PENDING',
-            backends: [{
-                site: 'zenko',
+    describe(
+        'Replication object MD with bucket replication config ' +
+            `${hasStorageClass ? 'with' : 'without'} storage class`,
+        () => {
+            const replicationMD = {
                 status: 'PENDING',
+                backends: [
+                    {
+                        site: 'zenko',
+                        status: 'PENDING',
+                        dataStoreVersionId: '',
+                    },
+                ],
+                content: ['DATA', 'METADATA'],
+                destination: bucketARN,
+                storageClass: 'zenko',
+                role: 'arn:aws:iam::account-id:role/src-resource,' + 'arn:aws:iam::account-id:role/dest-resource',
+                storageType: '',
                 dataStoreVersionId: '',
-            }],
-            content: ['DATA', 'METADATA'],
-            destination: bucketARN,
-            storageClass: 'zenko',
-            role: 'arn:aws:iam::account-id:role/src-resource,' +
-                'arn:aws:iam::account-id:role/dest-resource',
-            storageType: '',
-            dataStoreVersionId: '',
-            isNFS: undefined,
-        };
-        const newReplicationMD = hasStorageClass ? Object.assign(replicationMD,
-            { storageClass: storageClassType }) : replicationMD;
-        const replicateMetadataOnly = Object.assign({}, newReplicationMD,
-            { content: ['METADATA'] });
+                isNFS: undefined,
+            };
+            const newReplicationMD = hasStorageClass
+                ? Object.assign(replicationMD, { storageClass: storageClassType })
+                : replicationMD;
+            const replicateMetadataOnly = Object.assign({}, newReplicationMD, { content: ['METADATA'] });
 
-        beforeEach(() => {
-            cleanup();
-            createBucketWithReplication(hasStorageClass);
-        });
+            beforeEach(() => {
+                cleanup();
+                createBucketWithReplication(hasStorageClass);
+            });
 
-        afterEach(() => {
-            cleanup();
-            delete config.locationConstraints['zenko'];
-        });
+            afterEach(() => {
+                cleanup();
+                delete config.locationConstraints['zenko'];
+            });
 
-        it('should update metadata when replication config prefix matches ' +
-        'an object key', done =>
-            putObjectAndCheckMD(keyA, newReplicationMD, done));
+            it('should update metadata when replication config prefix matches ' + 'an object key', done =>
+                putObjectAndCheckMD(keyA, newReplicationMD, done),
+            );
 
-        it('should update metadata when replication config prefix matches ' +
-        'the start of an object key', done =>
-            putObjectAndCheckMD(`${keyA}abc`, newReplicationMD, done));
+            it('should update metadata when replication config prefix matches ' + 'the start of an object key', done =>
+                putObjectAndCheckMD(`${keyA}abc`, newReplicationMD, done),
+            );
 
-        it('should not update metadata when replication config prefix does ' +
-        'not match the start of an object key', done =>
-            putObjectAndCheckMD(`abc${keyA}`, emptyReplicationMD, done));
+            it(
+                'should not update metadata when replication config prefix does ' +
+                    'not match the start of an object key',
+                done => putObjectAndCheckMD(`abc${keyA}`, emptyReplicationMD, done),
+            );
 
-        it('should not update metadata when replication config prefix does ' +
-        'not apply', done =>
-            putObjectAndCheckMD(keyB, emptyReplicationMD, done));
+            it('should not update metadata when replication config prefix does ' + 'not apply', done =>
+                putObjectAndCheckMD(keyB, emptyReplicationMD, done),
+            );
 
-        it("should update status to 'PENDING' if putting a new version", done =>
-            putObjectAndCheckMD(keyA, newReplicationMD, err => {
-                if (err) {
-                    return done(err);
-                }
-                const objectMD = metadata.keyMaps.get(bucketName).get(keyA);
-                // Update metadata to a status after replication has occurred.
-                objectMD.replicationInfo.status = 'COMPLETED';
-                return putObjectAndCheckMD(keyA, newReplicationMD, done);
-            }));
+            it("should update status to 'PENDING' if putting a new version", done =>
+                putObjectAndCheckMD(keyA, newReplicationMD, err => {
+                    if (err) {
+                        return done(err);
+                    }
+                    const objectMD = metadata.keyMaps.get(bucketName).get(keyA);
+                    // Update metadata to a status after replication has occurred.
+                    objectMD.replicationInfo.status = 'COMPLETED';
+                    return putObjectAndCheckMD(keyA, newReplicationMD, done);
+                }));
 
-        it("should update status to 'PENDING' and content to '['METADATA']' " +
-            'if putting 0 byte object', done =>
-            objectPut(authInfo, getObjectPutReq(keyA, false), undefined, log,
-                err => {
+            it("should update status to 'PENDING' and content to '['METADATA']' " + 'if putting 0 byte object', done =>
+                objectPut(authInfo, getObjectPutReq(keyA, false), undefined, log, err => {
                     if (err) {
                         return done(err);
                     }
                     checkObjectReplicationInfo(keyA, replicateMetadataOnly);
                     return done();
-                }));
-
-        it('should update metadata if putting object ACL and CRR replication', done => {
-            // Set 'zenko' as a typical CRR location (i.e. no type)
-            config.locationConstraints['zenko'] = {
-                ...config.locationConstraints['zenko'],
-                type: '',
-            };
-
-            async.series([
-                next => putObjectAndCheckMD(keyA, newReplicationMD, next),
-                next => {
-                    const objectMD = metadata.keyMaps.get(bucketName).get(keyA);
-                    // Update metadata to a status after replication has occurred.
-                    objectMD.replicationInfo.status = 'COMPLETED';
-                    objectPutACL(authInfo, objectACLReq, log, next);
-                },
-            ], err => {
-                if (err) {
-                    return done(err);
-                }
-                checkObjectReplicationInfo(keyA, replicateMetadataOnly);
-                return done();
-            });
-        });
-
-        it('should not update metadata if putting object ACL and cloud replication', done => {
-            // Set 'zenko' as a typical cloud location (i.e.  type)
-            config.locationConstraints['zenko'] = {
-                ...config.locationConstraints['zenko'],
-                type: 'aws_s3',
-            };
-
-            const replicationMD = { ...newReplicationMD, storageType: 'aws_s3' };
-
-            let completedReplicationInfo;
-            async.series([
-                next => putObjectAndCheckMD(keyA, replicationMD, next),
-                next => {
-                    const objectMD = metadata.keyMaps.get(bucketName).get(keyA);
-                    // Update metadata to a status after replication has occurred.
-                    objectMD.replicationInfo.status = 'COMPLETED';
-                    completedReplicationInfo = JSON.parse(
-                        JSON.stringify(objectMD.replicationInfo));
-                    objectPutACL(authInfo, objectACLReq, log, next);
-                },
-            ], err => {
-                if (err) {
-                    return done(err);
-                }
-                checkObjectReplicationInfo(keyA, completedReplicationInfo);
-                return done();
-            });
-        });
-
-        it('should update metadata if putting a delete marker', done =>
-            async.series([
-                next => putObjectAndCheckMD(keyA, newReplicationMD, err => {
-                    if (err) {
-                        return next(err);
-                    }
-                    const objectMD = metadata.keyMaps.get(bucketName).get(keyA);
-                    // Set metadata to a status after replication has occurred.
-                    objectMD.replicationInfo.status = 'COMPLETED';
-                    return next();
                 }),
-                next => objectDelete(authInfo, deleteReq, log, next),
-            ], err => {
-                if (err) {
-                    return done(err);
-                }
-                const objectMD = metadata.keyMaps.get(bucketName).get(keyA);
-                assert.strictEqual(objectMD.isDeleteMarker, true);
-                checkObjectReplicationInfo(keyA, replicateMetadataOnly);
-                return done();
-            }));
+            );
 
-        it('should not update metadata if putting a delete marker owned by ' +
-        'Lifecycle service account', done =>
-            async.series([
-                next => putObjectAndCheckMD(keyA, newReplicationMD, next),
-                next => objectDelete(authInfoLifecycleService, deleteReq,
-                                     log, next),
-            ], err => {
-                if (err) {
-                    return done(err);
-                }
-                const objectMD = metadata.keyMaps.get(bucketName).get(keyA);
-                assert.strictEqual(objectMD.isDeleteMarker, true);
-                checkObjectReplicationInfo(keyA, emptyReplicationMD);
-                return done();
-            }));
+            it('should update metadata if putting object ACL and CRR replication', done => {
+                // Set 'zenko' as a typical CRR location (i.e. no type)
+                config.locationConstraints['zenko'] = {
+                    ...config.locationConstraints['zenko'],
+                    type: '',
+                };
 
-        describe('Object tagging', () => {
-            beforeEach(done => async.series([
-                next => putObjectAndCheckMD(keyA, newReplicationMD, next),
-                next => objectPutTagging(authInfo, taggingPutReq, log, next),
-            ], err => done(err)));
-
-            it("should update status to 'PENDING' and content to " +
-                "'['METADATA']'if putting tag", done => {
-                checkObjectReplicationInfo(keyA, replicateMetadataOnly);
-                return done();
+                async.series(
+                    [
+                        next => putObjectAndCheckMD(keyA, newReplicationMD, next),
+                        next => {
+                            const objectMD = metadata.keyMaps.get(bucketName).get(keyA);
+                            // Update metadata to a status after replication has occurred.
+                            objectMD.replicationInfo.status = 'COMPLETED';
+                            objectPutACL(authInfo, objectACLReq, log, next);
+                        },
+                    ],
+                    err => {
+                        if (err) {
+                            return done(err);
+                        }
+                        checkObjectReplicationInfo(keyA, replicateMetadataOnly);
+                        return done();
+                    },
+                );
             });
 
-            it("should update status to 'PENDING' and content to " +
-                "'['METADATA']' if deleting tag", done =>
-                async.series([
-                    // Put a new version to update replication MD content array.
-                    next => putObjectAndCheckMD(keyA, newReplicationMD, next),
-                    next => objectDeleteTagging(authInfo, taggingDeleteReq, log,
-                        next),
-                ], err => {
-                    if (err) {
-                        return done(err);
-                    }
+            it('should not update metadata if putting object ACL and cloud replication', done => {
+                // Set 'zenko' as a typical cloud location (i.e.  type)
+                config.locationConstraints['zenko'] = {
+                    ...config.locationConstraints['zenko'],
+                    type: 'aws_s3',
+                };
+
+                const replicationMD = { ...newReplicationMD, storageType: 'aws_s3' };
+
+                let completedReplicationInfo;
+                async.series(
+                    [
+                        next => putObjectAndCheckMD(keyA, replicationMD, next),
+                        next => {
+                            const objectMD = metadata.keyMaps.get(bucketName).get(keyA);
+                            // Update metadata to a status after replication has occurred.
+                            objectMD.replicationInfo.status = 'COMPLETED';
+                            completedReplicationInfo = JSON.parse(JSON.stringify(objectMD.replicationInfo));
+                            objectPutACL(authInfo, objectACLReq, log, next);
+                        },
+                    ],
+                    err => {
+                        if (err) {
+                            return done(err);
+                        }
+                        checkObjectReplicationInfo(keyA, completedReplicationInfo);
+                        return done();
+                    },
+                );
+            });
+
+            it('should update metadata if putting a delete marker', done =>
+                async.series(
+                    [
+                        next =>
+                            putObjectAndCheckMD(keyA, newReplicationMD, err => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                const objectMD = metadata.keyMaps.get(bucketName).get(keyA);
+                                // Set metadata to a status after replication has occurred.
+                                objectMD.replicationInfo.status = 'COMPLETED';
+                                return next();
+                            }),
+                        next => objectDelete(authInfo, deleteReq, log, next),
+                    ],
+                    err => {
+                        if (err) {
+                            return done(err);
+                        }
+                        const objectMD = metadata.keyMaps.get(bucketName).get(keyA);
+                        assert.strictEqual(objectMD.isDeleteMarker, true);
+                        checkObjectReplicationInfo(keyA, replicateMetadataOnly);
+                        return done();
+                    },
+                ));
+
+            it('should not update metadata if putting a delete marker owned by ' + 'Lifecycle service account', done =>
+                async.series(
+                    [
+                        next => putObjectAndCheckMD(keyA, newReplicationMD, next),
+                        next => objectDelete(authInfoLifecycleService, deleteReq, log, next),
+                    ],
+                    err => {
+                        if (err) {
+                            return done(err);
+                        }
+                        const objectMD = metadata.keyMaps.get(bucketName).get(keyA);
+                        assert.strictEqual(objectMD.isDeleteMarker, true);
+                        checkObjectReplicationInfo(keyA, emptyReplicationMD);
+                        return done();
+                    },
+                ),
+            );
+
+            describe('Object tagging', () => {
+                beforeEach(done =>
+                    async.series(
+                        [
+                            next => putObjectAndCheckMD(keyA, newReplicationMD, next),
+                            next => objectPutTagging(authInfo, taggingPutReq, log, next),
+                        ],
+                        err => done(err),
+                    ),
+                );
+
+                it("should update status to 'PENDING' and content to " + "'['METADATA']'if putting tag", done => {
                     checkObjectReplicationInfo(keyA, replicateMetadataOnly);
                     return done();
-                }));
-        });
+                });
 
-        describe('Complete MPU', () => {
-            it("should update status to 'PENDING' and content to " +
-                "'['DATA, METADATA']' if completing MPU", done =>
-                putMPU(keyA, 'content', err => {
-                    if (err) {
-                        return done(err);
-                    }
-                    checkObjectReplicationInfo(keyA, newReplicationMD);
-                    return done();
-                }));
+                it("should update status to 'PENDING' and content to " + "'['METADATA']' if deleting tag", done =>
+                    async.series(
+                        [
+                            // Put a new version to update replication MD content array.
+                            next => putObjectAndCheckMD(keyA, newReplicationMD, next),
+                            next => objectDeleteTagging(authInfo, taggingDeleteReq, log, next),
+                        ],
+                        err => {
+                            if (err) {
+                                return done(err);
+                            }
+                            checkObjectReplicationInfo(keyA, replicateMetadataOnly);
+                            return done();
+                        },
+                    ),
+                );
+            });
 
-            it("should update status to 'PENDING' and content to " +
-                "'['METADATA']' if completing MPU with 0 bytes", done =>
-                putMPU(keyA, '', err => {
-                    if (err) {
-                        return done(err);
-                    }
-                    checkObjectReplicationInfo(keyA, replicateMetadataOnly);
-                    return done();
-                }));
+            describe('Complete MPU', () => {
+                it(
+                    "should update status to 'PENDING' and content to " + "'['DATA, METADATA']' if completing MPU",
+                    done =>
+                        putMPU(keyA, 'content', err => {
+                            if (err) {
+                                return done(err);
+                            }
+                            checkObjectReplicationInfo(keyA, newReplicationMD);
+                            return done();
+                        }),
+                );
 
-            it('should not update replicationInfo if key does not apply',
-                done => putMPU(keyB, 'content', err => {
-                    if (err) {
-                        return done(err);
-                    }
-                    checkObjectReplicationInfo(keyB, emptyReplicationMD);
-                    return done();
-                }));
-        });
+                it(
+                    "should update status to 'PENDING' and content to " +
+                        "'['METADATA']' if completing MPU with 0 bytes",
+                    done =>
+                        putMPU(keyA, '', err => {
+                            if (err) {
+                                return done(err);
+                            }
+                            checkObjectReplicationInfo(keyA, replicateMetadataOnly);
+                            return done();
+                        }),
+                );
 
-        describe('Object copy', () => {
-            it("should update status to 'PENDING' and content to " +
-                "'['DATA, METADATA']' if copying object", done =>
-                copyObject(keyB, keyA, true, err => {
-                    if (err) {
-                        return done(err);
-                    }
-                    checkObjectReplicationInfo(keyA, newReplicationMD);
-                    return done();
-                }));
+                it('should not update replicationInfo if key does not apply', done =>
+                    putMPU(keyB, 'content', err => {
+                        if (err) {
+                            return done(err);
+                        }
+                        checkObjectReplicationInfo(keyB, emptyReplicationMD);
+                        return done();
+                    }));
+            });
 
-            it("should update status to 'PENDING' and content to " +
-                "'['METADATA']' if copying object with 0 bytes", done =>
-                copyObject(keyB, keyA, false, err => {
-                    if (err) {
-                        return done(err);
-                    }
-                    checkObjectReplicationInfo(keyA, replicateMetadataOnly);
-                    return done();
-                }));
+            describe('Object copy', () => {
+                it(
+                    "should update status to 'PENDING' and content to " + "'['DATA, METADATA']' if copying object",
+                    done =>
+                        copyObject(keyB, keyA, true, err => {
+                            if (err) {
+                                return done(err);
+                            }
+                            checkObjectReplicationInfo(keyA, newReplicationMD);
+                            return done();
+                        }),
+                );
 
-            it('should not update replicationInfo if key does not apply',
-                done => {
+                it(
+                    "should update status to 'PENDING' and content to " +
+                        "'['METADATA']' if copying object with 0 bytes",
+                    done =>
+                        copyObject(keyB, keyA, false, err => {
+                            if (err) {
+                                return done(err);
+                            }
+                            checkObjectReplicationInfo(keyA, replicateMetadataOnly);
+                            return done();
+                        }),
+                );
+
+                it('should not update replicationInfo if key does not apply', done => {
                     const copyKey = `foo-${keyA}`;
                     return copyObject(keyB, copyKey, true, err => {
                         if (err) {
@@ -544,177 +581,172 @@ describe('Replication object MD without bucket replication config', () => {
                         return done();
                     });
                 });
-        });
-
-        ['awsbackend',
-        'azurebackend',
-        'gcpbackend',
-        'awsbackend,azurebackend'].forEach(backend => {
-            const storageTypeMap = {
-                'awsbackend': 'aws_s3',
-                'azurebackend': 'azure',
-                'gcpbackend': 'gcp',
-                'awsbackend,azurebackend': 'aws_s3,azure',
-            };
-            const storageType = storageTypeMap[backend];
-            const backends = backend.split(',').map(site => ({
-                site,
-                status: 'PENDING',
-                dataStoreVersionId: '',
-            }));
-            describe('Object metadata replicationInfo storageType value',
-            () => {
-                const expectedReplicationInfo = {
-                    status: 'PENDING',
-                    backends,
-                    content: ['DATA', 'METADATA'],
-                    destination: 'arn:aws:s3:::destination-bucket',
-                    storageClass: backend,
-                    role: 'arn:aws:iam::account-id:role/resource',
-                    storageType,
-                    dataStoreVersionId: '',
-                    isNFS: undefined,
-                };
-
-                // Expected for a metadata-only replication operation (for
-                // example, putting object tags).
-                const expectedReplicationInfoMD = Object.assign({},
-                    expectedReplicationInfo, { content: ['METADATA'] });
-
-                beforeEach(() =>
-                    // We have already created the bucket, so update the
-                    // replication configuration to include a location
-                    // constraint for the `storageClass`. This results in a
-                    // `storageType` of 'aws_s3', for example.
-                    Object.assign(metadata.buckets.get(bucketName), {
-                        _replicationConfiguration: {
-                            role: 'arn:aws:iam::account-id:role/resource',
-                            destination: 'arn:aws:s3:::destination-bucket',
-                            rules: [{
-                                prefix: keyA,
-                                enabled: true,
-                                id: 'test-id',
-                                storageClass: backend,
-                            }],
-                        },
-                    }));
-
-                it('should update on a put object request', done =>
-                    putObjectAndCheckMD(keyA, expectedReplicationInfo, done));
-
-                it('should update on a complete MPU object request', done =>
-                    putMPU(keyA, 'content', err => {
-                        if (err) {
-                            return done(err);
-                        }
-                        const expected =
-                            Object.assign({}, expectedReplicationInfo,
-                            { content: ['DATA', 'METADATA', 'MPU'] });
-                        checkObjectReplicationInfo(keyA, expected);
-                        return done();
-                    }));
-
-                it('should update on a copy object request', done =>
-                    copyObject(keyB, keyA, true, err => {
-                        if (err) {
-                            return done(err);
-                        }
-                        checkObjectReplicationInfo(keyA,
-                            expectedReplicationInfo);
-                        return done();
-                    }));
-
-                it('should update on a put object ACL request', done => {
-                    let completedReplicationInfo;
-                    async.series([
-                        next => putObjectAndCheckMD(keyA,
-                            expectedReplicationInfo, next),
-                        next => {
-                            const objectMD = metadata.keyMaps
-                                  .get(bucketName).get(keyA);
-                            // Update metadata to a status after replication
-                            // has occurred.
-                            objectMD.replicationInfo.status = 'COMPLETED';
-                            completedReplicationInfo = JSON.parse(
-                                JSON.stringify(objectMD.replicationInfo));
-                            objectPutACL(authInfo, objectACLReq, log, next);
-                        },
-                    ], err => {
-                        if (err) {
-                            return done(err);
-                        }
-                        checkObjectReplicationInfo(keyA, completedReplicationInfo);
-                        return done();
-                    });
-                });
-
-                it('should update on a put object tagging request', done =>
-                    async.series([
-                        next => putObjectAndCheckMD(keyA,
-                            expectedReplicationInfo, next),
-                        next => objectPutTagging(authInfo, taggingPutReq, log,
-                            next),
-                    ], err => {
-                        if (err) {
-                            return done(err);
-                        }
-                        const expected = Object.assign({},
-                            expectedReplicationInfo,
-                            { content: ['METADATA', 'PUT_TAGGING'] });
-                        checkObjectReplicationInfo(keyA, expected);
-                        return done();
-                    }));
-
-                it('should update on a delete tagging request', done =>
-                    async.series([
-                        next => putObjectAndCheckMD(keyA,
-                            expectedReplicationInfo, next),
-                        next => objectDeleteTagging(authInfo, taggingDeleteReq,
-                            log, next),
-                    ], err => {
-                        if (err) {
-                            return done(err);
-                        }
-                        const expected = Object.assign({},
-                            expectedReplicationInfo,
-                            { content: ['METADATA', 'DELETE_TAGGING'] });
-                        checkObjectReplicationInfo(keyA, expected);
-                        return done();
-                    }));
-
-                it('should update when putting a delete marker', done =>
-                    async.series([
-                        next => putObjectAndCheckMD(keyA,
-                            expectedReplicationInfo, err => {
-                                if (err) {
-                                    return next(err);
-                                }
-                                // Update metadata to a status indicating that
-                                // replication has occurred for the object.
-                                metadata
-                                    .keyMaps
-                                    .get(bucketName)
-                                    .get(keyA)
-                                    .replicationInfo
-                                    .status = 'COMPLETED';
-                                return next();
-                            }),
-                        next => objectDelete(authInfo, deleteReq, log, next),
-                    ], err => {
-                        if (err) {
-                            return done(err);
-                        }
-                        // Is it, in fact, a delete marker?
-                        assert(metadata
-                            .keyMaps
-                            .get(bucketName)
-                            .get(keyA)
-                            .isDeleteMarker);
-                        checkObjectReplicationInfo(keyA,
-                            expectedReplicationInfoMD);
-                        return done();
-                    }));
             });
-        });
-    });
+
+            ['awsbackend', 'azurebackend', 'gcpbackend', 'awsbackend,azurebackend'].forEach(backend => {
+                const storageTypeMap = {
+                    awsbackend: 'aws_s3',
+                    azurebackend: 'azure',
+                    gcpbackend: 'gcp',
+                    'awsbackend,azurebackend': 'aws_s3,azure',
+                };
+                const storageType = storageTypeMap[backend];
+                const backends = backend.split(',').map(site => ({
+                    site,
+                    status: 'PENDING',
+                    dataStoreVersionId: '',
+                }));
+                describe('Object metadata replicationInfo storageType value', () => {
+                    const expectedReplicationInfo = {
+                        status: 'PENDING',
+                        backends,
+                        content: ['DATA', 'METADATA'],
+                        destination: 'arn:aws:s3:::destination-bucket',
+                        storageClass: backend,
+                        role: 'arn:aws:iam::account-id:role/resource',
+                        storageType,
+                        dataStoreVersionId: '',
+                        isNFS: undefined,
+                    };
+
+                    // Expected for a metadata-only replication operation (for
+                    // example, putting object tags).
+                    const expectedReplicationInfoMD = Object.assign({}, expectedReplicationInfo, {
+                        content: ['METADATA'],
+                    });
+
+                    beforeEach(() =>
+                        // We have already created the bucket, so update the
+                        // replication configuration to include a location
+                        // constraint for the `storageClass`. This results in a
+                        // `storageType` of 'aws_s3', for example.
+                        Object.assign(metadata.buckets.get(bucketName), {
+                            _replicationConfiguration: {
+                                role: 'arn:aws:iam::account-id:role/resource',
+                                destination: 'arn:aws:s3:::destination-bucket',
+                                rules: [
+                                    {
+                                        prefix: keyA,
+                                        enabled: true,
+                                        id: 'test-id',
+                                        storageClass: backend,
+                                    },
+                                ],
+                            },
+                        }),
+                    );
+
+                    it('should update on a put object request', done =>
+                        putObjectAndCheckMD(keyA, expectedReplicationInfo, done));
+
+                    it('should update on a complete MPU object request', done =>
+                        putMPU(keyA, 'content', err => {
+                            if (err) {
+                                return done(err);
+                            }
+                            const expected = Object.assign({}, expectedReplicationInfo, {
+                                content: ['DATA', 'METADATA', 'MPU'],
+                            });
+                            checkObjectReplicationInfo(keyA, expected);
+                            return done();
+                        }));
+
+                    it('should update on a copy object request', done =>
+                        copyObject(keyB, keyA, true, err => {
+                            if (err) {
+                                return done(err);
+                            }
+                            checkObjectReplicationInfo(keyA, expectedReplicationInfo);
+                            return done();
+                        }));
+
+                    it('should update on a put object ACL request', done => {
+                        let completedReplicationInfo;
+                        async.series(
+                            [
+                                next => putObjectAndCheckMD(keyA, expectedReplicationInfo, next),
+                                next => {
+                                    const objectMD = metadata.keyMaps.get(bucketName).get(keyA);
+                                    // Update metadata to a status after replication
+                                    // has occurred.
+                                    objectMD.replicationInfo.status = 'COMPLETED';
+                                    completedReplicationInfo = JSON.parse(JSON.stringify(objectMD.replicationInfo));
+                                    objectPutACL(authInfo, objectACLReq, log, next);
+                                },
+                            ],
+                            err => {
+                                if (err) {
+                                    return done(err);
+                                }
+                                checkObjectReplicationInfo(keyA, completedReplicationInfo);
+                                return done();
+                            },
+                        );
+                    });
+
+                    it('should update on a put object tagging request', done =>
+                        async.series(
+                            [
+                                next => putObjectAndCheckMD(keyA, expectedReplicationInfo, next),
+                                next => objectPutTagging(authInfo, taggingPutReq, log, next),
+                            ],
+                            err => {
+                                if (err) {
+                                    return done(err);
+                                }
+                                const expected = Object.assign({}, expectedReplicationInfo, {
+                                    content: ['METADATA', 'PUT_TAGGING'],
+                                });
+                                checkObjectReplicationInfo(keyA, expected);
+                                return done();
+                            },
+                        ));
+
+                    it('should update on a delete tagging request', done =>
+                        async.series(
+                            [
+                                next => putObjectAndCheckMD(keyA, expectedReplicationInfo, next),
+                                next => objectDeleteTagging(authInfo, taggingDeleteReq, log, next),
+                            ],
+                            err => {
+                                if (err) {
+                                    return done(err);
+                                }
+                                const expected = Object.assign({}, expectedReplicationInfo, {
+                                    content: ['METADATA', 'DELETE_TAGGING'],
+                                });
+                                checkObjectReplicationInfo(keyA, expected);
+                                return done();
+                            },
+                        ));
+
+                    it('should update when putting a delete marker', done =>
+                        async.series(
+                            [
+                                next =>
+                                    putObjectAndCheckMD(keyA, expectedReplicationInfo, err => {
+                                        if (err) {
+                                            return next(err);
+                                        }
+                                        // Update metadata to a status indicating that
+                                        // replication has occurred for the object.
+                                        metadata.keyMaps.get(bucketName).get(keyA).replicationInfo.status = 'COMPLETED';
+                                        return next();
+                                    }),
+                                next => objectDelete(authInfo, deleteReq, log, next),
+                            ],
+                            err => {
+                                if (err) {
+                                    return done(err);
+                                }
+                                // Is it, in fact, a delete marker?
+                                assert(metadata.keyMaps.get(bucketName).get(keyA).isDeleteMarker);
+                                checkObjectReplicationInfo(keyA, expectedReplicationInfoMD);
+                                return done();
+                            },
+                        ));
+                });
+            });
+        },
+    );
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3221,6 +3221,24 @@
     "@eslint/core" "^0.12.0"
     levn "^0.4.1"
 
+"@grpc/grpc-js@^1.14.3":
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.14.4.tgz#e73ff57d97802f063999545f43ebb2b1eca65d9d"
+  integrity sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==
+  dependencies:
+    "@grpc/proto-loader" "^0.8.0"
+    "@js-sdsl/ordered-map" "^4.4.2"
+
+"@grpc/proto-loader@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.8.1.tgz#5a6b290ccbfb1ae2f6775afb74e9898bd8c5d4e8"
+  integrity sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==
+  dependencies:
+    lodash.camelcase "^4.3.0"
+    long "^5.0.0"
+    protobufjs "^7.5.5"
+    yargs "^17.7.2"
+
 "@hapi/address@^4.0.1":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-4.1.0.tgz#d60c5c0d930e77456fdcde2598e77302e2955e1d"
@@ -3395,6 +3413,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@js-sdsl/ordered-map@^4.4.2":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
+  integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
+
 "@js-sdsl/ordered-set@^4.4.2":
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-set/-/ordered-set-4.4.2.tgz#ab857eb63cf358b5a0f74fdd458b4601423779b7"
@@ -3432,20 +3455,379 @@
   dependencies:
     semver "^7.3.5"
 
+"@opentelemetry/api-logs@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz#7b9818e8dfdf1d3dcab88bfe4d6724f2f831f7ec"
+  integrity sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==
+  dependencies:
+    "@opentelemetry/api" "^1.3.0"
+
+"@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.9.0":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.1.tgz#c1b0346de336ba55af2d5a7970882037baedec05"
+  integrity sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==
+
 "@opentelemetry/api@^1.4.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
   integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
 
-"@opentelemetry/api@^1.9.0":
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.1.tgz#c1b0346de336ba55af2d5a7970882037baedec05"
-  integrity sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==
+"@opentelemetry/configuration@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/configuration/-/configuration-0.218.0.tgz#a5fdd50ec9cfa0adb3bb41202cb39f79c5f4e7d9"
+  integrity sha512-W8wIz7H2R1pufR5jfjb3gU2XkMpm2x/7b1RJcsuzvd70Il/rWWE+g5/Od7hQKrxRTSrTrOWlru101PWXz5I1EQ==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    yaml "^2.0.0"
+
+"@opentelemetry/context-async-hooks@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/context-async-hooks/-/context-async-hooks-2.7.1.tgz#1555a6fb269596416d8c626fd020c3f2c38e071f"
+  integrity sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==
+
+"@opentelemetry/core@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-2.7.1.tgz#162bfab46d6ff4da1bef240ea52e23a926b0fdbc"
+  integrity sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==
+  dependencies:
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/core@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-2.8.0.tgz#f6e86de3688bdb54a6ca8f4935363a5b588ae91c"
+  integrity sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==
+  dependencies:
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/exporter-logs-otlp-grpc@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.218.0.tgz#7e5a7e624074d6449590c851d58efe60096314b3"
+  integrity sha512-hoxrNH1l/Xy6F9WTJ5IK+6j1r9nQFlPOmrnTlhYHTySdunfXLmUCPv3bQtKYntxag9h3wLYBZQ2HI6FOx+BT2g==
+  dependencies:
+    "@grpc/grpc-js" "^1.14.3"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-grpc-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/sdk-logs" "0.218.0"
+
+"@opentelemetry/exporter-logs-otlp-http@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.218.0.tgz#0996cb45e0ebc6c7465445430a018edcac9871b4"
+  integrity sha512-Qx+4rpVHzgg89dawcWRHyt+XRXeLnhFz/qBtvggmjkcgPUdr+NAB0/u/eIPA8yAeJV0J80Vz43JZCh/XFvZFGw==
+  dependencies:
+    "@opentelemetry/api-logs" "0.218.0"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/sdk-logs" "0.218.0"
+
+"@opentelemetry/exporter-logs-otlp-proto@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.218.0.tgz#e539720b2e145e85a7a4901a1eabb0b2e77990f8"
+  integrity sha512-1/noQNsp9gXD75HPzgjBrcF1+XTtry7pFAUfxVEJgg7mPv2AawKQuYkhMmJ8qjxz4Ubc3Y8bwvfxevXsKTq4cg==
+  dependencies:
+    "@opentelemetry/api-logs" "0.218.0"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-logs" "0.218.0"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+
+"@opentelemetry/exporter-metrics-otlp-grpc@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.218.0.tgz#6d66c2638702489d063b8857741eee9cea1d21d6"
+  integrity sha512-YapQ9vNMX0NSZF6LK5pWAFfjpJleV2O9uYWfYGeb/5F1Kb9rPGK8tZDMJFa/sOksgdFuflDvYuA0B4qjDB4fjQ==
+  dependencies:
+    "@grpc/grpc-js" "^1.14.3"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/exporter-metrics-otlp-http" "0.218.0"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-grpc-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-metrics" "2.7.1"
+
+"@opentelemetry/exporter-metrics-otlp-http@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.218.0.tgz#c205581585d04c5106d1ca766e23632006e46a2c"
+  integrity sha512-bV7d2OuMpZu2+gAaxUAhzfZ0h3WVZk8ETQUEE3DNSntbTaMpuITjtm8I0rNyHFdm7Ax57K6ty7SgFXlBmOLIvQ==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-metrics" "2.7.1"
+
+"@opentelemetry/exporter-metrics-otlp-proto@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.218.0.tgz#66642b8bb5e654ca7a5944a4f0b490814fc875fd"
+  integrity sha512-ubLddKjWULhla9YZRCj/rTBeppjJYE4e9w0icx5mTu3eFhWjQzbV75NYjXuIlEG+NJsBl6d+sTFw5Qu+oej4oQ==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/exporter-metrics-otlp-http" "0.218.0"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-metrics" "2.7.1"
+
+"@opentelemetry/exporter-prometheus@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.218.0.tgz#41bddc97d34cd9d9993382b9c10fed19a8de63f4"
+  integrity sha512-RT5oEyu1kddZJ1vt7/BUo5wV+P7hpNAESsR3dUd3+8deHuX7gWNoCOZn+SfDT+hJHlIJ5h/AxiCLXIrutswDJg==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-metrics" "2.7.1"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/exporter-trace-otlp-grpc@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.218.0.tgz#5d5532ab94d5514bec8aedc19ce3170b6381eed1"
+  integrity sha512-3fXxVQEj9TNAFaCi79JeFKfeLd0sDtInaR3gaZDVlzNSPHtz8PZuCV34JKWjD4XXzT20IdMe8IpX6mRVNDA4Tw==
+  dependencies:
+    "@grpc/grpc-js" "^1.14.3"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-grpc-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+
+"@opentelemetry/exporter-trace-otlp-http@0.218.0", "@opentelemetry/exporter-trace-otlp-http@^0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.218.0.tgz#36d6abf6d639b9ea861603c61f434751c0b1a0ea"
+  integrity sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+
+"@opentelemetry/exporter-trace-otlp-proto@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.218.0.tgz#de0b2b3545149dafedd2b948fb891f9bf962940c"
+  integrity sha512-r1Msf8SNLRmwh9J6XQ5uh82D7CdDWMNHnPB7LAVHjzut0TkSeKc5KcIvr4SvHvfk/xwN5gxC+VLKQ1k0o8PSPw==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+
+"@opentelemetry/exporter-zipkin@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.7.1.tgz#3b79d223adc8c097ba3323e4de4ed8abb83c789e"
+  integrity sha512-mfsD9bKAxcKrh5+y08TPodvClBO0CznBE3p79YAGnO81WI4LrdsGA65T53e4iTSbCalW4WaUpkbeJcbpyIUHfg==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/instrumentation@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.218.0.tgz#fcceb4ffb45f99c0d292600769150fc5944dc3e9"
+  integrity sha512-mIZil8Es+sYDK5m+DQiwAwF57F14TF2YlEqvIjZ/RQWcxDBwRGsKfdK2Tv65OU9meQKCMzSIFS9mxAcnAb6Bkg==
+  dependencies:
+    "@opentelemetry/api-logs" "0.218.0"
+    import-in-the-middle "^3.0.0"
+    require-in-the-middle "^8.0.0"
+
+"@opentelemetry/otlp-exporter-base@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz#f33e3217ce568756baa132fabe30f0c9345db086"
+  integrity sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+
+"@opentelemetry/otlp-grpc-exporter-base@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.218.0.tgz#dc5a1fec716245d84dc4167de9b1c607e07fb6a7"
+  integrity sha512-H/lCGJ536N98VpYJOaWTQOkv4Dx6TnmStK6Rqfu1W7KkFbPAx04hjdYEMZF/YbnHzPUSIK4kM6OE2GKGBTpV9A==
+  dependencies:
+    "@grpc/grpc-js" "^1.14.3"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+
+"@opentelemetry/otlp-transformer@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz#6784d0ddd13803c63a1b24072606c02fc21b9071"
+  integrity sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==
+  dependencies:
+    "@opentelemetry/api-logs" "0.218.0"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-logs" "0.218.0"
+    "@opentelemetry/sdk-metrics" "2.7.1"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+
+"@opentelemetry/propagator-b3@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/propagator-b3/-/propagator-b3-2.7.1.tgz#107fe3e16d0728c489edbad221c402ee197514a4"
+  integrity sha512-RJid6E2CKyeGfKBzXKF21ejabGMHypFkPAh3qZ+NvI+SGjuIye79t3PmiqcDgtRzdKH6ynXzbfslQ8DfpRUg2A==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+
+"@opentelemetry/propagator-jaeger@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.7.1.tgz#e8ebf3f6c0e9aa525cf041893425889cf3e69125"
+  integrity sha512-KMjVBHzP4N60bOzxja76M1F1hZZ43lGPga5ix+mkv9+kk1nx9SbkxSvJsMbuVUxdPQmsPTqGShmhN8ulrMOg6Q==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+
+"@opentelemetry/resources@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-2.7.1.tgz#3b2a9179f6119bb1f2cddefe41ba9b2855504a5d"
+  integrity sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/resources@2.8.0", "@opentelemetry/resources@^2.7.1":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-2.8.0.tgz#9bcb658ab6254f33099f4a95544b40d6f53cc946"
+  integrity sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==
+  dependencies:
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/sdk-logs@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz#78886fe300b82802cee9963208b2af326b928af5"
+  integrity sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==
+  dependencies:
+    "@opentelemetry/api-logs" "0.218.0"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/sdk-metrics@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz#b713f69dd67933ecc9c61357f1d452cdc9f4e281"
+  integrity sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/resources" "2.7.1"
+
+"@opentelemetry/sdk-node@^0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-node/-/sdk-node-0.218.0.tgz#cf8bdc0c993387189c7c474612e0f801505feb97"
+  integrity sha512-tPMjHrLV5gsfNdYqoRHjeGbCAZBXXD9c1Qo/2ut7VwnUABDNh76xNxrT0SEhkIIJuCN45bbN1vZnYL1gY0IkOg==
+  dependencies:
+    "@opentelemetry/api-logs" "0.218.0"
+    "@opentelemetry/configuration" "0.218.0"
+    "@opentelemetry/context-async-hooks" "2.7.1"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/exporter-logs-otlp-grpc" "0.218.0"
+    "@opentelemetry/exporter-logs-otlp-http" "0.218.0"
+    "@opentelemetry/exporter-logs-otlp-proto" "0.218.0"
+    "@opentelemetry/exporter-metrics-otlp-grpc" "0.218.0"
+    "@opentelemetry/exporter-metrics-otlp-http" "0.218.0"
+    "@opentelemetry/exporter-metrics-otlp-proto" "0.218.0"
+    "@opentelemetry/exporter-prometheus" "0.218.0"
+    "@opentelemetry/exporter-trace-otlp-grpc" "0.218.0"
+    "@opentelemetry/exporter-trace-otlp-http" "0.218.0"
+    "@opentelemetry/exporter-trace-otlp-proto" "0.218.0"
+    "@opentelemetry/exporter-zipkin" "2.7.1"
+    "@opentelemetry/instrumentation" "0.218.0"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/propagator-b3" "2.7.1"
+    "@opentelemetry/propagator-jaeger" "2.7.1"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-logs" "0.218.0"
+    "@opentelemetry/sdk-metrics" "2.7.1"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+    "@opentelemetry/sdk-trace-node" "2.7.1"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/sdk-trace-base@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz#9160c3af9ef2219c26563abd136e22fb7d19b34f"
+  integrity sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/sdk-trace-base@^2.7.1":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz#ec9c1d69e2e6fba256c9df0c8e8d67d42386d52b"
+  integrity sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==
+  dependencies:
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/resources" "2.8.0"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/sdk-trace-node@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.7.1.tgz#54dedb8e77fa51a6d02fc2192097739266c82168"
+  integrity sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==
+  dependencies:
+    "@opentelemetry/context-async-hooks" "2.7.1"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+
+"@opentelemetry/semantic-conventions@^1.29.0":
+  version "1.41.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz#b04e7151c5913a7a006d4f465479da75efb98a7a"
+  integrity sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
+
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+  integrity sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
+
+"@protobufjs/codegen@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.5.tgz#d9315ad7cf3f30aac70bda3c068443dc6f143659"
+  integrity sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==
+
+"@protobufjs/eventemitter@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz#d512cb26c0ae026091ee2c1167f1be6faf5c842a"
+  integrity sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==
+
+"@protobufjs/fetch@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.1.tgz#4d6fc00c8fb64016a5c81b469d549046350f1065"
+  integrity sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+  integrity sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+  integrity sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+  integrity sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==
+
+"@protobufjs/utf8@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.1.tgz#eaee5900122c110a3dbcb728c0597014a2621774"
+  integrity sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==
 
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
@@ -5813,6 +6195,13 @@
   dependencies:
     undici-types "~6.20.0"
 
+"@types/node@>=13.7.0":
+  version "25.9.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.3.tgz#11dfe7a33e68fa5c560f0aa76cc5595621ef26b9"
+  integrity sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==
+  dependencies:
+    undici-types ">=7.24.0 <7.24.7"
+
 "@types/triple-beam@^1.3.2":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/triple-beam/-/triple-beam-1.3.5.tgz#74fef9ffbaa198eb8b588be029f38b00299caa2c"
@@ -5931,6 +6320,11 @@ accesscontrol@^2.2.1:
   dependencies:
     notation "^1.3.6"
 
+acorn-import-attributes@^1.9.5:
+  version "1.9.5"
+  resolved "https://registry.yarnpkg.com/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz#7eb1557b1ba05ef18b5ed0ec67591bfab04688ef"
+  integrity sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -5940,6 +6334,11 @@ acorn@^8.14.0:
   version "8.14.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.1.tgz#721d5dc10f7d5b5609a891773d47731796935dfb"
   integrity sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==
+
+acorn@^8.15.0:
+  version "8.17.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.17.0.tgz#1785adb84faf8d8add10369b93826fc2bd08f1fe"
+  integrity sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==
 
 agent-base@^4.3.0:
   version "4.3.0"
@@ -6215,9 +6614,9 @@ arraybuffer.prototype.slice@^1.0.4:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/Arsenal#8.4.4":
-  version "8.4.4"
-  resolved "git+https://github.com/scality/Arsenal#a1fa5b412c0f634fa87fc7ccd7b086973d2f8d87"
+"arsenal@git+https://github.com/scality/Arsenal#8.4.7":
+  version "8.4.7"
+  resolved "git+https://github.com/scality/Arsenal#096cb33f1092b35113a11521bbbb62ef615aed79"
   dependencies:
     "@aws-sdk/client-kms" "^3.975.0"
     "@aws-sdk/client-s3" "^3.975.0"
@@ -6258,6 +6657,10 @@ arraybuffer.prototype.slice@^1.0.4:
     werelogs scality/werelogs#8.2.2
     xml2js "^0.6.2"
   optionalDependencies:
+    "@opentelemetry/exporter-trace-otlp-http" "^0.218.0"
+    "@opentelemetry/resources" "^2.7.1"
+    "@opentelemetry/sdk-node" "^0.218.0"
+    "@opentelemetry/sdk-trace-base" "^2.7.1"
     ioctl "^2.0.2"
 
 asn1@~0.2.3:
@@ -6711,6 +7114,11 @@ chownr@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-3.0.0.tgz#9855e64ecd240a9cc4267ce8a4aa5d24a1da15e4"
   integrity sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==
+
+cjs-module-lexer@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz#b3ca5101843389259ade7d88c77bd06ce55849ca"
+  integrity sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==
 
 clean-stack@^2.0.0:
   version "2.2.0"
@@ -8540,6 +8948,16 @@ import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
+import-in-the-middle@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-3.1.0.tgz#0d0e88c93c276599bd4bf81835946d723656efab"
+  integrity sha512-c0AeAV8VcwZzfYE7euTZY3H+VXUPMVugiovdosq80lqEXJmOekg3zGUAYg6KImHMaMuBoTUfTv7xNpUFdy0hJA==
+  dependencies:
+    acorn "^8.15.0"
+    acorn-import-attributes "^1.9.5"
+    cjs-module-lexer "^2.2.0"
+    module-details-from-path "^1.0.4"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -9509,6 +9927,11 @@ lodash-compat@^3.10.2:
   resolved "https://registry.yarnpkg.com/lodash-compat/-/lodash-compat-3.10.2.tgz#c6940128a9d30f8e902cd2cf99fd0cba4ecfc183"
   integrity sha512-k8SE/OwvWfYZqx3MA/Ry1SHBDWre8Z8tCs0Ba0bF5OqVNvymxgFZ/4VDtbTxzTvcoG11JpTMFsaeZp/yGYvFnA==
 
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
+
 lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
@@ -9625,6 +10048,11 @@ long-timeout@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/long-timeout/-/long-timeout-0.1.1.tgz#9721d788b47e0bcb5a24c2e2bee1a0da55dab514"
   integrity sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w==
+
+long@^5.0.0, long@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
+  integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
 
 looper@^2.0.0:
   version "2.0.0"
@@ -9968,6 +10396,11 @@ mocha@^11.7.5:
     yargs "^17.7.2"
     yargs-parser "^21.1.1"
     yargs-unparser "^2.0.0"
+
+module-details-from-path@^1.0.3, module-details-from-path@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.4.tgz#b662fdcd93f6c83d3f25289da0ce81c8d9685b94"
+  integrity sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==
 
 moment@^2.30.1:
   version "2.30.1"
@@ -10662,6 +11095,23 @@ promise-retry@^2.0.1:
     err-code "^2.0.2"
     retry "^0.12.0"
 
+protobufjs@^7.5.5:
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.6.4.tgz#8bb000300026efd63eb7951d26e5dbb38f5658f2"
+  integrity sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.5"
+    "@protobufjs/eventemitter" "^1.1.1"
+    "@protobufjs/fetch" "^1.1.1"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.1"
+    "@types/node" ">=13.7.0"
+    long "^5.3.2"
+
 proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
@@ -10927,6 +11377,14 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
+require-in-the-middle@^8.0.0:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz#dbde2587f669398626d56b20c868ab87bf01cce4"
+  integrity sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==
+  dependencies:
+    debug "^4.3.5"
+    module-details-from-path "^1.0.3"
 
 require-main-filename@^2.0.0:
   version "2.0.0"
@@ -11986,6 +12444,11 @@ undefsafe@^2.0.5:
   resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.5.tgz#38733b9327bdcd226db889fb723a6efd162e6e2c"
   integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
 
+"undici-types@>=7.24.0 <7.24.7":
+  version "7.24.6"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
+  integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
+
 undici-types@~6.20.0:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
@@ -12453,6 +12916,11 @@ yallist@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
   integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
+
+yaml@^2.0.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
+  integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==
 
 yargs-parser@^18.1.2:
   version "18.1.3"


### PR DESCRIPTION
## What

Unblocks the `development/9.3` line to consume arsenal **8.4.7** (it was pinned to 8.4.4 and would fail CI on any bump to >= 8.4.7). Bumps arsenal to 8.4.7 and realigns the replication tests to the new (backward-compatible) `ObjectMD.replicationInfo` shape.

## Why

Arsenal PR scality/Arsenal#2627 ("Support multi-destination CRR", first released in 8.4.7; already consumed by 9.4 via #6172) reworked `ObjectMD.replicationInfo`:
- single-destination fields (`destination`/`role`/`storageClass`/`storageType`/`dataStoreVersionId`) are now optional/deprecated in favor of per-backend values in `backends[]`;
- empty defaults changed `'' -> undefined`, and the top-level `dataStoreVersionId` is dropped.

This is **backward-compatible** — the API surface cloudserver consumes is unchanged and the `build` job passes. Only test expectations drift.

## Changes

- **`tests/unit/api/objectReplicationMD.js`**: realign expected `replicationInfo` to the 8.4.7 shape (deprecated fields `undefined`; no top-level `dataStoreVersionId`). Pure expectation update.
- **`tests/functional/aws-node-sdk/test/bucket/putBucketReplication.js`**: remove three cases that asserted the old single-destination restriction (overlapping prefixes across destinations; multiple destination buckets). Under multi-destination CRR these configs are now **accepted**.
- First commit is a Prettier-only reformat of the two touched files (legacy formatting), to satisfy the changed-files Prettier CI check; the second commit holds the bump + realignment.

## Verification (local, against arsenal 8.4.7)

- Full unit suite: **5097 passing, 0 failing**.
- `putBucketReplication` functional: **58 passing**.
- `mpuVersion` functional: 42 passing (the CI `mongo-v1-ft` `InternalError`s did not reproduce in isolation — a cross-test cascade, not a regression).

## ⚠️ Draft — pending a product decision

Removing those 3 tests means 9.3 now **accepts multi-destination replication configs it has no feature code to honor** (multi-dest is implemented only on 9.4: #6172/#6178/#6179). Keeping this draft until the replication owner (maeldonn) confirms accepting-but-not-honoring such configs on 9.3 is acceptable.

Issue: CLDSRV-929
