### PR TITLE
👷 CLDSRV-926: skip async/await diff check when PR has skip-async-migration label

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -109,11 +109,10 @@ jobs:
         run: yamllint -c yamllint.yml $(git ls-files "*.yml")
       - name: Check async/await compliance in diff
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           BRANCH_NAME: ${{ github.ref_name }}
         run: |
-          if gh pr list --head "$BRANCH_NAME" --state open --json labels \
-               --jq '.[].labels[].name' 2>/dev/null | grep -qx 'skip-async-migration'; then
+          if gh pr list --head "$BRANCH_NAME" --state open --label "skip-async-migration" 2>/dev/null | grep -q .; then
             echo "Skipping async/await check: 'skip-async-migration' label found"
           else
             yarn run check-diff-async

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -73,6 +73,7 @@ env:
 permissions:
   contents: read
   packages: write
+  pull-requests: read
 
 jobs:
   lint:
@@ -107,7 +108,15 @@ jobs:
       - name: Lint Yaml
         run: yamllint -c yamllint.yml $(git ls-files "*.yml")
       - name: Check async/await compliance in diff
-        run: yarn run check-diff-async
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh pr list --head "${{ github.ref_name }}" --state open --json labels \
+               --jq '.[].labels[].name' 2>/dev/null | grep -qx 'skip-async-migration'; then
+            echo "Skipping async/await check: 'skip-async-migration' label found"
+          else
+            yarn run check-diff-async
+          fi
 
   async-migration-report:
     runs-on: ubuntu-24.04

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -110,8 +110,9 @@ jobs:
       - name: Check async/await compliance in diff
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: ${{ github.ref_name }}
         run: |
-          if gh pr list --head "${{ github.ref_name }}" --state open --json labels \
+          if gh pr list --head "$BRANCH_NAME" --state open --json labels \
                --jq '.[].labels[].name' 2>/dev/null | grep -qx 'skip-async-migration'; then
             echo "Skipping async/await check: 'skip-async-migration' label found"
           else


### PR DESCRIPTION
## Summary

- Adds `pull-requests: read` permission to the `tests.yaml` workflow
- The "Check async/await compliance in diff" step now checks whether the current branch's open PR carries the `skip-async-migration` label before running `check-diff-async`
- If the label is present the step exits cleanly; otherwise the check runs as before

## Behaviour

| Scenario | Result |
|---|---|
| PR has `skip-async-migration` label | Step skips, exits 0 |
| PR does not have the label | `check-diff-async` runs normally |
| No open PR (direct push / `workflow_dispatch`) | `check-diff-async` runs normally |

## Pre-requisite

The `skip-async-migration` label must be created in the repository settings before use.

Closes CLDSRV-926