### PR TITLE
CLDSRV-935: fix claude review

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -4,28 +4,28 @@ run-name: "Code Review for #${{ github.event.pull_request.number || inputs.pr_nu
 # yamllint enable rule:line-length
 
 on:
-    pull_request:
-        types: [opened, synchronize, labeled, unlabeled]
-    pull_request_target:
-        types: [opened, synchronize]
-    workflow_dispatch:
-        inputs:
-            pr_number:
-                description: Pull Request number to review
-                required: true
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled]
+  pull_request_target:
+    types: [opened, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull Request number to review
+        required: true
 
 jobs:
-    review:
-        if: github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'
-        uses: scality/workflows/.github/workflows/claude-code-review.yml@v2
-        with:
-            allowed-tools: >-
-                ${{ github.event_name == 'workflow_dispatch' && '"Bash(gh api repos/*/contents)"' || '' }}
-        secrets: inherit
+  review:
+    if: github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'
+    uses: scality/workflows/.github/workflows/claude-code-review.yml@v2
+    with:
+      allowed-tools: >-
+        ${{ github.event_name == 'workflow_dispatch' && '"Bash(gh api repos/*/contents)"' || '' }}
+    secrets: inherit
 
-    review-dependency-bump:
-        if: github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]'
-        uses: scality/workflows/.github/workflows/claude-code-dependency-review.yml@v2
-        with:
-            ACTIONS_APP_ID: ${{ vars.ACTIONS_APP_ID }}
-        secrets: inherit
+  review-dependency-bump:
+    if: github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]'
+    uses: scality/workflows/.github/workflows/claude-code-dependency-review.yml@v2
+    with:
+      ACTIONS_APP_ID: ${{ vars.ACTIONS_APP_ID }}
+    secrets: inherit


### PR DESCRIPTION
## Problem

Claude code reviews silently stop on PRs targeting `development/9.4`. The Anthropic
review action requires `.github/workflows/review.yml` to be **byte-identical to the
default branch** (`development/9.3`). 9.4's copy had drifted to 2-space indentation
(vs 9.3's 4-space) from a hand-resolved merge conflict when #6194 waterfalled in, so
validation failed and the job went green **without posting a review**.

## Fix

Standardize `review.yml` on Prettier's native **2-space** indentation and land it at
the root of the 9.x line (`development/9.2`) so it waterfalls up to 9.3 and 9.4 —
making 9.2 / 9.3 / 9.4 converge on a single, identical file.

Going to 2-space (rather than dragging 9.4 back to 4-space) means the file matches
Prettier's default style and the six other workflow files, so **no `.prettierignore`
carve-out** is needed to keep the drift from recurring.

## Notes

- Targets `development/9.2` so the change waterfalls up the whole 9.x line; the default
  branch (9.3) becomes 2-space via the waterfall, which is exactly what the review
  action validates against.
- The resulting `review.yml` is byte-identical to 9.4's current copy, so the waterfall
  converges with no conflict.
- `review.yml` is the only branch with the file in {9.2, 9.3, 9.4}; 9.0/9.1 don't have it.
