### PR TITLE
CLDSRV-884: Bump version to 9.4.0-preview.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zenko/cloudserver",
-    "version": "9.4.0",
+    "version": "9.4.0-preview.1",
     "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
     "main": "index.js",
     "engines": {


### PR DESCRIPTION
## Summary
- Bump cloudserver version to `9.4.0-preview.1` so the merged CLDSRV-884 OTEL changes can be picked up by [Zenko #2378](https://github.com/scality/Zenko/pull/2378) for integration testing.

Issue: CLDSRV-884