### PR TITLE
CLDSRV-937: Drop --ignore-optional from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN npm install -g \
     typescript@4.9.5
 COPY package.json yarn.lock /usr/src/app/
 
-RUN yarn install --production --ignore-optional --frozen-lockfile --ignore-engines --network-concurrency 1
+RUN yarn install --production --frozen-lockfile --ignore-engines --network-concurrency 1
 
 ################################################################################
 FROM node:${NODE_VERSION} AS production


### PR DESCRIPTION
## Summary

Drop the `--ignore-optional` flag from `Dockerfile:30`. There's no documented intent behind it, it's not used by any other Scality service, and removing it has no observable downside on the current dep tree.

```diff
-RUN yarn install --production --ignore-optional --frozen-lockfile --ignore-engines --network-concurrency 1
+RUN yarn install --production --frozen-lockfile --ignore-engines --network-concurrency 1
```

## Archeology — why is the flag here?

Added 2019-08-01 in commit `81bce441b`:

> improvement/S3C-2365 migrate package manager to yarn

That's the whole commit message. The flag was **new behaviour** in the npm→yarn migration — the prior `npm install --production` did not skip optionals, so this wasn't a port of an existing constraint. The Dockerfile has been touched many times since (line moves, dep re-orderings, multi-stage build), but the flag itself has never been revisited or referenced anywhere.

## Other Scality services don't use this flag

Backbeat, for example:

```
RUN yarn install --ignore-engines --frozen-lockfile --production --network-concurrency 1
```

No `--ignore-optional`. Cloudserver was the outlier — there's no project-wide convention behind it.

## Doesn't break anything

Full list of `optionalDependencies` reachable from the current dep tree:

| Package | Source | Effect when installed |
|---|---|---|
| `ioctl` | arsenal | Native module. Used by `setDirSyncFlag` on the Linux **file** metadata backend only (production Zenko uses bucketd / MongoDB, never the file backend). Already wrapped in `try/catch` with a warning fallback. Builds cleanly — the builder stage already installs `build-essential`, `python3`, `node-gyp`, `libffi-dev`, `zlib1g-dev`. |
| `fsevents` | chokidar | macOS-only file watcher. Modern yarn auto-skips it on Linux via its `"os": ["darwin"]` field. No-op. |
| `uglify-js`, `commander`, `source-map`, `encoding`, `@pkgjs/parseargs` | handlebars / z-schema / escodegen / minipass-fetch / jackspeak | Low-impact dev-ish transitives, no runtime regression risk. |
| `@opentelemetry/{sdk-node, sdk-trace-base, resources, exporter-trace-otlp-http}` | arsenal | Being promoted to regular `dependencies` in ARSN-601, so will be installed regardless of this flag once that lands. |

`yarn.lock` already contains full `resolved` URLs and `integrity` hashes for everything — with `--frozen-lockfile`, yarn just fetches the existing locked tarballs. No `package.json` or `yarn.lock` change in this PR.

Related: ARSN-601

Issue: CLDSRV-937