### PR TITLE
CLDSRV-936 Lifecycle noncurrent expiration stalls when listing truncates on a bare master

### DIFF
--- a/lib/api/apiUtils/object/lifecycle.js
+++ b/lib/api/apiUtils/object/lifecycle.js
@@ -7,12 +7,11 @@ const { CURRENT_TYPE, NON_CURRENT_TYPE, ORPHAN_DM_TYPE } = lifecycleListing;
 function _makeTags(tags) {
     const res = [];
     Object.entries(tags).forEach(([key, value]) =>
-        res.push(
-            {
-                Key: key,
-                Value: value,
-            }
-        ));
+        res.push({
+            Key: key,
+            Value: value,
+        }),
+    );
     return res;
 }
 
@@ -51,8 +50,7 @@ function processCurrents(bucketName, listParams, isBucketVersioned, list) {
         // NOTE: The current versions listed to be lifecycle should include version id
         // if the bucket is versioned.
         if (isBucketVersioned) {
-            const versionId = (v.IsNull || v.VersionId === undefined) ?
-                'null' : versionIdUtils.encode(v.VersionId);
+            const versionId = v.IsNull || v.VersionId === undefined ? 'null' : versionIdUtils.encode(v.VersionId);
             content.VersionId = versionId;
         }
 
@@ -103,8 +101,7 @@ function processNonCurrents(bucketName, listParams, list) {
 
     list.Contents.forEach(item => {
         const v = item.value;
-        const versionId = (v.IsNull || v.VersionId === undefined) ?
-            'null' : versionIdUtils.encode(v.VersionId);
+        const versionId = v.IsNull || v.VersionId === undefined ? 'null' : versionIdUtils.encode(v.VersionId);
 
         const content = {
             Key: item.key,
@@ -144,8 +141,7 @@ function processOrphans(bucketName, listParams, list) {
 
     list.Contents.forEach(item => {
         const v = item.value;
-        const versionId = (v.IsNull || v.VersionId === undefined) ?
-            'null' : versionIdUtils.encode(v.VersionId);
+        const versionId = v.IsNull || v.VersionId === undefined ? 'null' : versionIdUtils.encode(v.VersionId);
         data.Contents.push({
             Key: item.key,
             LastModified: v.LastModified,
@@ -163,8 +159,10 @@ function processOrphans(bucketName, listParams, list) {
 }
 
 function getLocationConstraintErrorMessage(locationName) {
-    return 'value of the location you are attempting to set ' +
-        `- ${locationName} - is not listed in the locationConstraint config`;
+    return (
+        'value of the location you are attempting to set ' +
+        `- ${locationName} - is not listed in the locationConstraint config`
+    );
 }
 
 /**
@@ -183,8 +181,11 @@ function validateMaxScannedEntries(params, config, min) {
     if (params['max-scanned-lifecycle-listing-entries']) {
         const maxEntriesParams = Number.parseInt(params['max-scanned-lifecycle-listing-entries'], 10);
 
-        if (Number.isNaN(maxEntriesParams) || maxEntriesParams < min ||
-            maxEntriesParams > maxScannedLifecycleListingEntries) {
+        if (
+            Number.isNaN(maxEntriesParams) ||
+            maxEntriesParams < min ||
+            maxEntriesParams > maxScannedLifecycleListingEntries
+        ) {
             return { isValid: false };
         }
 

--- a/lib/api/apiUtils/object/lifecycle.js
+++ b/lib/api/apiUtils/object/lifecycle.js
@@ -1,4 +1,4 @@
-const { versioning } = require('arsenal');
+const { versioning, errorInstances } = require('arsenal');
 const versionIdUtils = versioning.VersionID;
 
 const { lifecycleListing } = require('../../../../constants');
@@ -68,6 +68,19 @@ function _encodeVersionId(vid) {
         versionId = versionIdUtils.encode(versionId);
     }
     return versionId;
+}
+
+// A 'null' or absent marker means "no marker". Any other value is decoded,
+// returning InvalidArgument if it is not a valid version id.
+function decodeVersionIdMarker(vid) {
+    if (!vid || vid === 'null') {
+        return undefined;
+    }
+    const decoded = versionIdUtils.decode(vid);
+    if (decoded instanceof Error) {
+        return errorInstances.InvalidArgument.customizeDescription('Invalid version id marker specified');
+    }
+    return decoded;
 }
 
 function processNonCurrents(bucketName, listParams, list) {
@@ -187,4 +200,5 @@ module.exports = {
     processOrphans,
     getLocationConstraintErrorMessage,
     validateMaxScannedEntries,
+    decodeVersionIdMarker,
 };

--- a/lib/api/backbeat/listLifecycleNonCurrents.js
+++ b/lib/api/backbeat/listLifecycleNonCurrents.js
@@ -4,12 +4,15 @@ const services = require('../../services');
 const { standardMetadataValidateBucket } = require('../../metadata/metadataUtils');
 const { pushMetric } = require('../../utapi/utilities');
 const monitoring = require('../../utilities/monitoringHandler');
-const { getLocationConstraintErrorMessage, processNonCurrents,
-    validateMaxScannedEntries, decodeVersionIdMarker } = require('../apiUtils/object/lifecycle');
+const {
+    getLocationConstraintErrorMessage,
+    processNonCurrents,
+    validateMaxScannedEntries,
+    decodeVersionIdMarker,
+} = require('../apiUtils/object/lifecycle');
 const { config } = require('../../Config');
 
-function handleResult(listParams, requestMaxKeys, authInfo,
-    bucketName, list, log, callback) {
+function handleResult(listParams, requestMaxKeys, authInfo, bucketName, list, log, callback) {
     // eslint-disable-next-line no-param-reassign
     listParams.maxKeys = requestMaxKeys;
     const res = processNonCurrents(bucketName, listParams, list);
@@ -35,11 +38,9 @@ function listLifecycleNonCurrents(authInfo, locationConstraints, request, log, c
     const bucketName = request.bucketName;
 
     log.debug('processing request', { method: 'listLifecycleNonCurrents' });
-    const requestMaxKeys = params['max-keys'] ?
-        Number.parseInt(params['max-keys'], 10) : 1000;
+    const requestMaxKeys = params['max-keys'] ? Number.parseInt(params['max-keys'], 10) : 1000;
     if (Number.isNaN(requestMaxKeys) || requestMaxKeys < 0) {
-        monitoring.promMetrics(
-            'GET', bucketName, 400, 'listLifecycleNonCurrents');
+        monitoring.promMetrics('GET', bucketName, 400, 'listLifecycleNonCurrents');
         return callback(errors.InvalidArgument);
     }
     const actualMaxKeys = Math.min(constants.listingHardLimit, requestMaxKeys);
@@ -47,8 +48,11 @@ function listLifecycleNonCurrents(authInfo, locationConstraints, request, log, c
     // 3 is required as a minimum because we must scan at least three entries to determine version eligibility.
     // Two entries representing the master key and the following one representing the non-current version.
     const minEntriesToBeScanned = 3;
-    const { isValid, maxScannedLifecycleListingEntries } =
-        validateMaxScannedEntries(params, config, minEntriesToBeScanned);
+    const { isValid, maxScannedLifecycleListingEntries } = validateMaxScannedEntries(
+        params,
+        config,
+        minEntriesToBeScanned,
+    );
     if (!isValid) {
         monitoring.promMetrics('GET', bucketName, 400, 'listLifecycleNonCurrents');
         return callback(errors.InvalidArgument);
@@ -90,8 +94,7 @@ function listLifecycleNonCurrents(authInfo, locationConstraints, request, log, c
     return standardMetadataValidateBucket(metadataValParams, request.actionImplicitDenies, log, (err, bucket) => {
         if (err) {
             log.debug('error processing request', { method: 'metadataValidateBucket', error: err });
-            monitoring.promMetrics(
-                'GET', bucketName, err.code, 'listLifecycleNonCurrents');
+            monitoring.promMetrics('GET', bucketName, err.code, 'listLifecycleNonCurrents');
             return callback(err, null);
         }
 
@@ -99,8 +102,7 @@ function listLifecycleNonCurrents(authInfo, locationConstraints, request, log, c
         const isBucketVersioned = vcfg && (vcfg.Status === 'Enabled' || vcfg.Status === 'Suspended');
         if (!isBucketVersioned) {
             log.debug('bucket is not versioned');
-            return callback(errorInstances.InvalidRequest.customizeDescription(
-                'bucket is not versioned'), null);
+            return callback(errorInstances.InvalidRequest.customizeDescription('bucket is not versioned'), null);
         }
 
         if (!requestMaxKeys) {
@@ -108,20 +110,16 @@ function listLifecycleNonCurrents(authInfo, locationConstraints, request, log, c
                 Contents: [],
                 IsTruncated: false,
             };
-            return handleResult(listParams, requestMaxKeys, authInfo,
-                bucketName, emptyList, log, callback);
+            return handleResult(listParams, requestMaxKeys, authInfo, bucketName, emptyList, log, callback);
         }
 
-        return services.getLifecycleListing(bucketName, listParams, log,
-        (err, list) => {
+        return services.getLifecycleListing(bucketName, listParams, log, (err, list) => {
             if (err) {
                 log.debug('error processing request', { method: 'services.getLifecycleListing', error: err });
-                monitoring.promMetrics(
-                    'GET', bucketName, err.code, 'listLifecycleNonCurrents');
+                monitoring.promMetrics('GET', bucketName, err.code, 'listLifecycleNonCurrents');
                 return callback(err, null);
             }
-            return handleResult(listParams, requestMaxKeys, authInfo,
-                bucketName, list, log, callback);
+            return handleResult(listParams, requestMaxKeys, authInfo, bucketName, list, log, callback);
         });
     });
 }

--- a/lib/api/backbeat/listLifecycleNonCurrents.js
+++ b/lib/api/backbeat/listLifecycleNonCurrents.js
@@ -1,12 +1,11 @@
-const { errors, errorInstances, versioning } = require('arsenal');
+const { errors, errorInstances } = require('arsenal');
 const constants = require('../../../constants');
 const services = require('../../services');
 const { standardMetadataValidateBucket } = require('../../metadata/metadataUtils');
 const { pushMetric } = require('../../utapi/utilities');
-const versionIdUtils = versioning.VersionID;
 const monitoring = require('../../utilities/monitoringHandler');
 const { getLocationConstraintErrorMessage, processNonCurrents,
-    validateMaxScannedEntries } = require('../apiUtils/object/lifecycle');
+    validateMaxScannedEntries, decodeVersionIdMarker } = require('../apiUtils/object/lifecycle');
 const { config } = require('../../Config');
 
 function handleResult(listParams, requestMaxKeys, authInfo,
@@ -80,8 +79,13 @@ function listLifecycleNonCurrents(authInfo, locationConstraints, request, log, c
         maxScannedLifecycleListingEntries,
     };
 
-    listParams.versionIdMarker = params['version-id-marker'] ?
-        versionIdUtils.decode(params['version-id-marker']) : undefined;
+    const versionIdMarker = decodeVersionIdMarker(params['version-id-marker']);
+    if (versionIdMarker instanceof Error) {
+        log.debug('invalid version id marker', { versionIdMarker: params['version-id-marker'] });
+        monitoring.promMetrics('GET', bucketName, 400, 'listLifecycleNonCurrents');
+        return callback(versionIdMarker);
+    }
+    listParams.versionIdMarker = versionIdMarker;
 
     return standardMetadataValidateBucket(metadataValParams, request.actionImplicitDenies, log, (err, bucket) => {
         if (err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zenko/cloudserver",
-    "version": "9.3.11",
+    "version": "9.3.12",
     "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
     "main": "index.js",
     "engines": {

--- a/tests/functional/backbeat/listLifecycleNonCurrents.js
+++ b/tests/functional/backbeat/listLifecycleNonCurrents.js
@@ -330,6 +330,26 @@ describe('listLifecycleNonCurrents', () => {
         });
     });
 
+    it('should return InvalidArgument error if version-id-marker is malformed', done => {
+        makeBackbeatRequest({
+            method: 'GET',
+            bucket: testBucket,
+            queryObj: {
+                'list-type': 'noncurrent',
+                'key-marker': 'key1',
+                'version-id-marker': 'notavalidversionid',
+            },
+            authCredentials: credentials,
+        }, err => {
+            // A non-null, undecodable marker must be rejected with a 400
+            // rather than reaching _encodeVersionId and crashing the worker.
+            assert(err);
+            assert.strictEqual(err.code, 'InvalidArgument');
+            assert.strictEqual(err.statusCode, 400);
+            return done();
+        });
+    });
+
     it('should return error if bucket not versioned', done => {
         makeBackbeatRequest({
             method: 'GET',
@@ -686,6 +706,45 @@ describe('listLifecycleNonCurrents', () => {
             checkContents(contents);
             assert.strictEqual(contents[0].Key, 'key2');
             assert.strictEqual(contents[0].VersionId, expectedKey2VersionIds[1]);
+            return done();
+        });
+    });
+
+    // Regression test: a scan-limit truncation that stops on a "bare master"
+    // (a pre-versioning object with no internal versionId) returns a
+    // version-id-marker equals to 'null'. On the following listing, 
+    // CloudServer should treat it as "no marker" instead of decoding it. 
+    // Decoding it was throwing and crashing the worker.
+    it('should treat a version-id-marker of "null" as no marker without crashing', done => {
+        makeBackbeatRequest({
+            method: 'GET',
+            bucket: testBucket,
+            queryObj: {
+                'list-type': 'noncurrent',
+                'before-date': date,
+                'key-marker': 'key1',
+                'version-id-marker': 'null',
+            },
+            authCredentials: credentials,
+        }, (err, response) => {
+            assert.ifError(err);
+            // Before the fix this request crashed the worker; assert it succeeds.
+            assert.strictEqual(response.statusCode, 200);
+            const data = JSON.parse(response.body);
+
+            assert.strictEqual(data.KeyMarker, 'key1');
+            // 'null' is echoed back unchanged and treated as no marker, so the
+            // listing resumes after key1 and returns key2's noncurrent versions.
+            assert.strictEqual(data.IsTruncated, false);
+            assert(!data.NextKeyMarker);
+
+            const contents = data.Contents;
+            checkContents(contents);
+            assert.strictEqual(contents.length, expectedKey2VersionIds.length);
+            contents.forEach((c, i) => {
+                assert.strictEqual(c.Key, 'key2');
+                assert.strictEqual(c.VersionId, expectedKey2VersionIds[i]);
+            });
             return done();
         });
     });

--- a/tests/functional/backbeat/listLifecycleNonCurrents.js
+++ b/tests/functional/backbeat/listLifecycleNonCurrents.js
@@ -1,9 +1,11 @@
 const assert = require('assert');
 const async = require('async');
-const { CreateBucketCommand,
+const {
+    CreateBucketCommand,
     DeleteBucketCommand,
     PutBucketVersioningCommand,
-    PutObjectCommand } = require('@aws-sdk/client-s3');
+    PutObjectCommand,
+} = require('@aws-sdk/client-s3');
 const BucketUtility = require('../aws-node-sdk/lib/utility/bucket-util');
 const { removeAllVersions } = require('../aws-node-sdk/lib/utility/versioning-util');
 const { makeBackbeatRequest } = require('./utils');
@@ -50,10 +52,12 @@ function checkContents(contents) {
         assert(d.VersionId);
         assert(d.staleDate);
         assert(!d.IsLatest);
-        assert.deepStrictEqual(d.TagSet, [{
-            Key: 'mykey',
-            Value: 'myvalue',
-        }]);
+        assert.deepStrictEqual(d.TagSet, [
+            {
+                Key: 'mykey',
+                Value: 'myvalue',
+            },
+        ]);
         assert.strictEqual(d.DataStoreName, location);
         assert.strictEqual(d.ListType, 'noncurrent');
         assert.strictEqual(d.Size, 3);
@@ -65,105 +69,147 @@ describe('listLifecycleNonCurrents', () => {
     let expectedKey1VersionIds = [];
     let expectedKey2VersionIds = [];
 
-    before(done => async.series([
-        next => {
-            getCredentials()
-                .then(creds => {
-                    credentials = creds;
-                    return getS3Hostname();
-                })
-                .then(() => next())
-                .catch(next);
-        },
-        next => {
-            s3.send(new CreateBucketCommand({ Bucket: testBucket }))
-                .then(() => next())
-                .catch(next);
-        },
-        next => {
-            s3.send(new CreateBucketCommand({ Bucket: emptyBucket }))
-                .then(() => next())
-                .catch(next);
-        },
-        next => {
-            s3.send(new CreateBucketCommand({ Bucket: nonVersionedBucket }))
-                .then(() => next())
-                .catch(next);
-        },
-        next => {
-            s3.send(new PutBucketVersioningCommand({
-                Bucket: testBucket,
-                VersioningConfiguration: { Status: 'Enabled' },
-            }))
-                .then(() => next())
-                .catch(next);
-        },
-        next => {
-            s3.send(new PutBucketVersioningCommand({
-                Bucket: emptyBucket,
-                VersioningConfiguration: { Status: 'Enabled' },
-            }))
-                .then(() => next())
-                .catch(next);
-        },
-        next => async.timesSeries(3, (n, cb) => {
-            s3.send(new PutObjectCommand({ 
-                Bucket: testBucket, 
-                Key: 'key1', 
-                Body: '123', 
-                Tagging: 'mykey=myvalue' 
-            }))
-                .then(data => cb(null, data))
-                .catch(cb);
-        }, (err, res) => {
-            // Only the two first ones are kept, since the stale date of the last one (3rd)
-            // Will be the last-modified of the next one (4th) that is created after the "date".
-            // The array is reverse since, for a specific key, we expect the listing to be ordered
-            // by last-modified date in descending order due to the way version id is generated.
-            expectedKey1VersionIds = res.map(r => r.VersionId).slice(0, 2).reverse();
-            return next(err);
-        }),
-        next => async.timesSeries(3, (n, cb) => {
-            s3.send(new PutObjectCommand({ 
-                Bucket: testBucket, 
-                Key: 'key2', 
-                Body: '123', 
-                Tagging: 'mykey=myvalue' 
-            }))
-                .then(data => cb(null, data))
-                .catch(cb);
-        }, (err, res) => {
-            // Only the two first ones are kept, since the stale date of the last one (3rd)
-            // Will be the last-modified of the next one (4th) that is created after the "date".
-            // The array is reverse since, for a specific key, we expect the listing to be ordered
-            // by last-modified date in descending order due to the way version id is generated.
-            expectedKey2VersionIds = res.map(r => r.VersionId).slice(0, 2).reverse();
-            return next(err);
-        }),
-        next => {
-            date = new Date(Date.now()).toISOString();
-            return async.times(5, (n, cb) => {
-                s3.send(new PutObjectCommand({ 
-                    Bucket: testBucket, 
-                    Key: 'key1', 
-                    Body: '123', 
-                    Tagging: 'mykey=myvalue' 
-                }))
-                    .then(() => cb())
-                    .catch(cb);
-            }, next);
-        },
-        next => async.times(5, (n, cb) => {
-            s3.send(new PutObjectCommand({ 
-                Bucket: testBucket, 
-                Key: 'key2', 
-                Body: '123', 
-                Tagging: 'mykey=myvalue' 
-            }))
-                .then(() => cb())
-                .catch(cb);
-        }, next),
-    ], done));
+    before(done =>
+        async.series(
+            [
+                next => {
+                    getCredentials()
+                        .then(creds => {
+                            credentials = creds;
+                            return getS3Hostname();
+                        })
+                        .then(() => next())
+                        .catch(next);
+                },
+                next => {
+                    s3.send(new CreateBucketCommand({ Bucket: testBucket }))
+                        .then(() => next())
+                        .catch(next);
+                },
+                next => {
+                    s3.send(new CreateBucketCommand({ Bucket: emptyBucket }))
+                        .then(() => next())
+                        .catch(next);
+                },
+                next => {
+                    s3.send(new CreateBucketCommand({ Bucket: nonVersionedBucket }))
+                        .then(() => next())
+                        .catch(next);
+                },
+                next => {
+                    s3.send(
+                        new PutBucketVersioningCommand({
+                            Bucket: testBucket,
+                            VersioningConfiguration: { Status: 'Enabled' },
+                        }),
+                    )
+                        .then(() => next())
+                        .catch(next);
+                },
+                next => {
+                    s3.send(
+                        new PutBucketVersioningCommand({
+                            Bucket: emptyBucket,
+                            VersioningConfiguration: { Status: 'Enabled' },
+                        }),
+                    )
+                        .then(() => next())
+                        .catch(next);
+                },
+                next =>
+                    async.timesSeries(
+                        3,
+                        (n, cb) => {
+                            s3.send(
+                                new PutObjectCommand({
+                                    Bucket: testBucket,
+                                    Key: 'key1',
+                                    Body: '123',
+                                    Tagging: 'mykey=myvalue',
+                                }),
+                            )
+                                .then(data => cb(null, data))
+                                .catch(cb);
+                        },
+                        (err, res) => {
+                            // Only the two first ones are kept, since the stale date of the last one (3rd)
+                            // Will be the last-modified of the next one (4th) that is created after the "date".
+                            // The array is reverse since, for a specific key, we expect the listing to be ordered
+                            // by last-modified date in descending order due to the way version id is generated.
+                            expectedKey1VersionIds = res
+                                .map(r => r.VersionId)
+                                .slice(0, 2)
+                                .reverse();
+                            return next(err);
+                        },
+                    ),
+                next =>
+                    async.timesSeries(
+                        3,
+                        (n, cb) => {
+                            s3.send(
+                                new PutObjectCommand({
+                                    Bucket: testBucket,
+                                    Key: 'key2',
+                                    Body: '123',
+                                    Tagging: 'mykey=myvalue',
+                                }),
+                            )
+                                .then(data => cb(null, data))
+                                .catch(cb);
+                        },
+                        (err, res) => {
+                            // Only the two first ones are kept, since the stale date of the last one (3rd)
+                            // Will be the last-modified of the next one (4th) that is created after the "date".
+                            // The array is reverse since, for a specific key, we expect the listing to be ordered
+                            // by last-modified date in descending order due to the way version id is generated.
+                            expectedKey2VersionIds = res
+                                .map(r => r.VersionId)
+                                .slice(0, 2)
+                                .reverse();
+                            return next(err);
+                        },
+                    ),
+                next => {
+                    date = new Date(Date.now()).toISOString();
+                    return async.times(
+                        5,
+                        (n, cb) => {
+                            s3.send(
+                                new PutObjectCommand({
+                                    Bucket: testBucket,
+                                    Key: 'key1',
+                                    Body: '123',
+                                    Tagging: 'mykey=myvalue',
+                                }),
+                            )
+                                .then(() => cb())
+                                .catch(cb);
+                        },
+                        next,
+                    );
+                },
+                next =>
+                    async.times(
+                        5,
+                        (n, cb) => {
+                            s3.send(
+                                new PutObjectCommand({
+                                    Bucket: testBucket,
+                                    Key: 'key2',
+                                    Body: '123',
+                                    Tagging: 'mykey=myvalue',
+                                }),
+                            )
+                                .then(() => cb())
+                                .catch(cb);
+                        },
+                        next,
+                    ),
+            ],
+            done,
+        ),
+    );
 
     after(async () => {
         await removeAllVersionsPromise({ Bucket: testBucket });
@@ -173,579 +219,668 @@ describe('listLifecycleNonCurrents', () => {
     });
 
     it('should return empty list of noncurrent versions if bucket is empty', done => {
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: emptyBucket,
-            queryObj: { 'list-type': 'noncurrent' },
-            authCredentials: credentials,
-        }, (err, response) => {
-            assert.ifError(err);
-            assert.strictEqual(response.statusCode, 200);
-            const data = JSON.parse(response.body);
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: emptyBucket,
+                queryObj: { 'list-type': 'noncurrent' },
+                authCredentials: credentials,
+            },
+            (err, response) => {
+                assert.ifError(err);
+                assert.strictEqual(response.statusCode, 200);
+                const data = JSON.parse(response.body);
 
-            assert.strictEqual(data.IsTruncated, false);
-            assert(!data.NextKeyMarker);
-            assert.strictEqual(data.MaxKeys, 1000);
-            assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
-            assert.strictEqual(data.Contents.length, 0);
-            return done();
-        });
+                assert.strictEqual(data.IsTruncated, false);
+                assert(!data.NextKeyMarker);
+                assert.strictEqual(data.MaxKeys, 1000);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
+                assert.strictEqual(data.Contents.length, 0);
+                return done();
+            },
+        );
     });
 
     it('should return empty list of noncurrent versions if prefix does not apply', done => {
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: testBucket,
-            queryObj: { 'list-type': 'noncurrent', 'prefix': 'unknown' },
-            authCredentials: credentials,
-        }, (err, response) => {
-            assert.ifError(err);
-            assert.strictEqual(response.statusCode, 200);
-            const data = JSON.parse(response.body);
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: { 'list-type': 'noncurrent', prefix: 'unknown' },
+                authCredentials: credentials,
+            },
+            (err, response) => {
+                assert.ifError(err);
+                assert.strictEqual(response.statusCode, 200);
+                const data = JSON.parse(response.body);
 
-            assert.strictEqual(data.IsTruncated, false);
-            assert(!data.NextKeyMarker);
-            assert.strictEqual(data.MaxKeys, 1000);
-            assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
-            assert.strictEqual(data.Contents.length, 0);
-            return done();
-        });
+                assert.strictEqual(data.IsTruncated, false);
+                assert(!data.NextKeyMarker);
+                assert.strictEqual(data.MaxKeys, 1000);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
+                assert.strictEqual(data.Contents.length, 0);
+                return done();
+            },
+        );
     });
 
     it('should return empty list if max-keys is set to 0', done => {
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: testBucket,
-            queryObj: { 'list-type': 'noncurrent', 'max-keys': '0' },
-            authCredentials: credentials,
-        }, (err, response) => {
-            assert.ifError(err);
-            assert.strictEqual(response.statusCode, 200);
-            const data = JSON.parse(response.body);
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: { 'list-type': 'noncurrent', 'max-keys': '0' },
+                authCredentials: credentials,
+            },
+            (err, response) => {
+                assert.ifError(err);
+                assert.strictEqual(response.statusCode, 200);
+                const data = JSON.parse(response.body);
 
-            assert.strictEqual(data.IsTruncated, false);
-            assert(!data.NextMarker);
-            assert.strictEqual(data.MaxKeys, 0);
-            assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
-            assert.strictEqual(data.Contents.length, 0);
+                assert.strictEqual(data.IsTruncated, false);
+                assert(!data.NextMarker);
+                assert.strictEqual(data.MaxKeys, 0);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
+                assert.strictEqual(data.Contents.length, 0);
 
-            return done();
-        });
+                return done();
+            },
+        );
     });
 
     it('should return error if bucket does not exist', done => {
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: 'idonotexist',
-            queryObj: { 'list-type': 'noncurrent' },
-            authCredentials: credentials,
-        }, err => {
-            assert.strictEqual(err.code, 'NoSuchBucket');
-            return done();
-        });
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: 'idonotexist',
+                queryObj: { 'list-type': 'noncurrent' },
+                authCredentials: credentials,
+            },
+            err => {
+                assert.strictEqual(err.code, 'NoSuchBucket');
+                return done();
+            },
+        );
     });
 
     it('should return BadRequest error if list type is empty', done => {
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: testBucket,
-            queryObj: { 'list-type': '' },
-            authCredentials: credentials,
-        }, err => {
-            assert.strictEqual(err.code, 'BadRequest');
-            return done();
-        });
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: { 'list-type': '' },
+                authCredentials: credentials,
+            },
+            err => {
+                assert.strictEqual(err.code, 'BadRequest');
+                return done();
+            },
+        );
     });
 
     it('should return BadRequest error if list type is invalid', done => {
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: testBucket,
-            queryObj: { 'list-type': 'invalid' },
-            authCredentials: credentials,
-        }, err => {
-            assert.strictEqual(err.code, 'BadRequest');
-            return done();
-        });
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: { 'list-type': 'invalid' },
+                authCredentials: credentials,
+            },
+            err => {
+                assert.strictEqual(err.code, 'BadRequest');
+                return done();
+            },
+        );
     });
 
     it('should return InvalidArgument error if max-keys is invalid', done => {
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: testBucket,
-            queryObj: { 'list-type': 'noncurrent', 'max-keys': 'a' },
-            authCredentials: credentials,
-        }, err => {
-            assert.strictEqual(err.code, 'InvalidArgument');
-            return done();
-        });
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: { 'list-type': 'noncurrent', 'max-keys': 'a' },
+                authCredentials: credentials,
+            },
+            err => {
+                assert.strictEqual(err.code, 'InvalidArgument');
+                return done();
+            },
+        );
     });
 
     it('should return InvalidArgument error if max-scanned-lifecycle-listing-entries is invalid', done => {
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: testBucket,
-            queryObj: { 'list-type': 'noncurrent', 'max-scanned-lifecycle-listing-entries': 'a' },
-            authCredentials: credentials,
-        }, err => {
-            assert.strictEqual(err.code, 'InvalidArgument');
-            return done();
-        });
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: { 'list-type': 'noncurrent', 'max-scanned-lifecycle-listing-entries': 'a' },
+                authCredentials: credentials,
+            },
+            err => {
+                assert.strictEqual(err.code, 'InvalidArgument');
+                return done();
+            },
+        );
     });
 
     it('should return InvalidArgument error if max-scanned-lifecycle-listing-entries is set to 0', done => {
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: testBucket,
-            queryObj: { 'list-type': 'noncurrent', 'max-scanned-lifecycle-listing-entries': '0' },
-            authCredentials: credentials,
-        }, err => {
-            assert.strictEqual(err.code, 'InvalidArgument');
-            return done();
-        });
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: { 'list-type': 'noncurrent', 'max-scanned-lifecycle-listing-entries': '0' },
+                authCredentials: credentials,
+            },
+            err => {
+                assert.strictEqual(err.code, 'InvalidArgument');
+                return done();
+            },
+        );
     });
 
     it('should return InvalidArgument error if max-scanned-lifecycle-listing-entries is set to 2', done => {
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: testBucket,
-            queryObj: { 'list-type': 'noncurrent', 'max-scanned-lifecycle-listing-entries': '2' },
-            authCredentials: credentials,
-        }, err => {
-            assert.strictEqual(err.code, 'InvalidArgument');
-            return done();
-        });
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: { 'list-type': 'noncurrent', 'max-scanned-lifecycle-listing-entries': '2' },
+                authCredentials: credentials,
+            },
+            err => {
+                assert.strictEqual(err.code, 'InvalidArgument');
+                return done();
+            },
+        );
     });
 
     it('should return InvalidArgument if max-scanned-lifecycle-listing-entries exceeds the default value', done => {
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: testBucket,
-            queryObj: { 'list-type': 'noncurrent', 'max-scanned-lifecycle-listing-entries':
-                (config.maxScannedLifecycleListingEntries + 1).toString() },
-            authCredentials: credentials,
-        }, err => {
-            assert.strictEqual(err.code, 'InvalidArgument');
-            return done();
-        });
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: {
+                    'list-type': 'noncurrent',
+                    'max-scanned-lifecycle-listing-entries': (config.maxScannedLifecycleListingEntries + 1).toString(),
+                },
+                authCredentials: credentials,
+            },
+            err => {
+                assert.strictEqual(err.code, 'InvalidArgument');
+                return done();
+            },
+        );
     });
 
     it('should return InvalidArgument error if version-id-marker is malformed', done => {
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: testBucket,
-            queryObj: {
-                'list-type': 'noncurrent',
-                'key-marker': 'key1',
-                'version-id-marker': 'notavalidversionid',
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: {
+                    'list-type': 'noncurrent',
+                    'key-marker': 'key1',
+                    'version-id-marker': 'notavalidversionid',
+                },
+                authCredentials: credentials,
             },
-            authCredentials: credentials,
-        }, err => {
-            // A non-null, undecodable marker must be rejected with a 400
-            // rather than reaching _encodeVersionId and crashing the worker.
-            assert(err);
-            assert.strictEqual(err.code, 'InvalidArgument');
-            assert.strictEqual(err.statusCode, 400);
-            return done();
-        });
+            err => {
+                // A non-null, undecodable marker must be rejected with a 400
+                // rather than reaching _encodeVersionId and crashing the worker.
+                assert(err);
+                assert.strictEqual(err.code, 'InvalidArgument');
+                assert.strictEqual(err.statusCode, 400);
+                return done();
+            },
+        );
     });
 
     it('should return error if bucket not versioned', done => {
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: nonVersionedBucket,
-            queryObj: { 'list-type': 'noncurrent' },
-            authCredentials: credentials,
-        }, err => {
-            assert.strictEqual(err.code, 'InvalidRequest');
-            return done();
-        });
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: nonVersionedBucket,
+                queryObj: { 'list-type': 'noncurrent' },
+                authCredentials: credentials,
+            },
+            err => {
+                assert.strictEqual(err.code, 'InvalidRequest');
+                return done();
+            },
+        );
     });
 
     it('should return all the noncurrent versions', done => {
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: testBucket,
-            queryObj: { 'list-type': 'noncurrent' },
-            authCredentials: credentials,
-        }, (err, response) => {
-            assert.ifError(err);
-            assert.strictEqual(response.statusCode, 200);
-            const data = JSON.parse(response.body);
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: { 'list-type': 'noncurrent' },
+                authCredentials: credentials,
+            },
+            (err, response) => {
+                assert.ifError(err);
+                assert.strictEqual(response.statusCode, 200);
+                const data = JSON.parse(response.body);
 
-            assert.strictEqual(data.IsTruncated, false);
-            assert(!data.NextKeyMarker);
-            assert.strictEqual(data.MaxKeys, 1000);
-            assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
+                assert.strictEqual(data.IsTruncated, false);
+                assert(!data.NextKeyMarker);
+                assert.strictEqual(data.MaxKeys, 1000);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
 
-            const contents = data.Contents;
-            assert.strictEqual(contents.length, 14);
-            checkContents(contents);
+                const contents = data.Contents;
+                assert.strictEqual(contents.length, 14);
+                checkContents(contents);
 
-            return done();
-        });
+                return done();
+            },
+        );
     });
 
     it('should return all the noncurrent versions scanned before max scanned entries value is reached', done => {
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: testBucket,
-            queryObj: { 'list-type': 'noncurrent', 'max-scanned-lifecycle-listing-entries': '9' },
-            authCredentials: credentials,
-        }, (err, response) => {
-            assert.ifError(err);
-            assert.strictEqual(response.statusCode, 200);
-            const data = JSON.parse(response.body);
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: { 'list-type': 'noncurrent', 'max-scanned-lifecycle-listing-entries': '9' },
+                authCredentials: credentials,
+            },
+            (err, response) => {
+                assert.ifError(err);
+                assert.strictEqual(response.statusCode, 200);
+                const data = JSON.parse(response.body);
 
-            assert.strictEqual(data.IsTruncated, true);
-            assert.strictEqual(data.NextKeyMarker, 'key1');
-            assert.strictEqual(data.MaxKeys, 1000);
-            assert.strictEqual(data.MaxScannedLifecycleListingEntries, 9);
+                assert.strictEqual(data.IsTruncated, true);
+                assert.strictEqual(data.NextKeyMarker, 'key1');
+                assert.strictEqual(data.MaxKeys, 1000);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, 9);
 
-            const contents = data.Contents;
-            // only return the first 7 entries as the master version is denoted by 2 entries.
-            assert.strictEqual(contents.length, 7);
-            assert(contents.every(c => c.Key === 'key1'));
-            checkContents(contents);
+                const contents = data.Contents;
+                // only return the first 7 entries as the master version is denoted by 2 entries.
+                assert.strictEqual(contents.length, 7);
+                assert(contents.every(c => c.Key === 'key1'));
+                checkContents(contents);
 
-            return done();
-        });
+                return done();
+            },
+        );
     });
 
     it('should return all the noncurrent versions with prefix key1', done => {
         const prefix = 'key1';
 
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: testBucket,
-            queryObj: { 'list-type': 'noncurrent', prefix },
-            authCredentials: credentials,
-        }, (err, response) => {
-            assert.ifError(err);
-            assert.strictEqual(response.statusCode, 200);
-            const data = JSON.parse(response.body);
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: { 'list-type': 'noncurrent', prefix },
+                authCredentials: credentials,
+            },
+            (err, response) => {
+                assert.ifError(err);
+                assert.strictEqual(response.statusCode, 200);
+                const data = JSON.parse(response.body);
 
-            assert.strictEqual(data.IsTruncated, false);
-            assert(!data.NextKeyMarker);
-            assert.strictEqual(data.MaxKeys, 1000);
-            assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
-            assert.strictEqual(data.Prefix, prefix);
+                assert.strictEqual(data.IsTruncated, false);
+                assert(!data.NextKeyMarker);
+                assert.strictEqual(data.MaxKeys, 1000);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
+                assert.strictEqual(data.Prefix, prefix);
 
-            const contents = data.Contents;
-            assert.strictEqual(contents.length, 7);
-            assert(contents.every(d => d.Key === 'key1'));
-            checkContents(contents);
+                const contents = data.Contents;
+                assert.strictEqual(contents.length, 7);
+                assert(contents.every(d => d.Key === 'key1'));
+                checkContents(contents);
 
-            return done();
-        });
+                return done();
+            },
+        );
     });
 
     it('should return all the noncurrent versions with prefix key1 before a defined date', done => {
         const prefix = 'key1';
 
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: testBucket,
-            queryObj: { 'list-type': 'noncurrent', prefix, 'before-date': date },
-            authCredentials: credentials,
-        }, (err, response) => {
-            assert.ifError(err);
-            assert.strictEqual(response.statusCode, 200);
-            const data = JSON.parse(response.body);
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: { 'list-type': 'noncurrent', prefix, 'before-date': date },
+                authCredentials: credentials,
+            },
+            (err, response) => {
+                assert.ifError(err);
+                assert.strictEqual(response.statusCode, 200);
+                const data = JSON.parse(response.body);
 
-            assert.strictEqual(data.IsTruncated, false);
-            assert(!data.NextKeyMarker);
-            assert.strictEqual(data.MaxKeys, 1000);
-            assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
-            assert.strictEqual(data.Prefix, prefix);
+                assert.strictEqual(data.IsTruncated, false);
+                assert(!data.NextKeyMarker);
+                assert.strictEqual(data.MaxKeys, 1000);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
+                assert.strictEqual(data.Prefix, prefix);
 
-            const contents = data.Contents;
-            assert.strictEqual(contents.length, 2);
-            assert(contents.every(d => d.Key === 'key1'));
+                const contents = data.Contents;
+                assert.strictEqual(contents.length, 2);
+                assert(contents.every(d => d.Key === 'key1'));
 
-            assert.deepStrictEqual(contents.map(v => v.VersionId), expectedKey1VersionIds);
+                assert.deepStrictEqual(
+                    contents.map(v => v.VersionId),
+                    expectedKey1VersionIds,
+                );
 
-            checkContents(contents);
+                checkContents(contents);
 
-            return done();
-        });
+                return done();
+            },
+        );
     });
 
     it('should return the noncurrent version with prefix, before a defined date and after key-marker', done => {
         const prefix = 'key2';
 
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: testBucket,
-            queryObj: {
-                'list-type': 'noncurrent',
-                prefix,
-                'before-date': date,
-                'key-marker': 'key1',
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: {
+                    'list-type': 'noncurrent',
+                    prefix,
+                    'before-date': date,
+                    'key-marker': 'key1',
+                },
+                authCredentials: credentials,
             },
-            authCredentials: credentials,
-        }, (err, response) => {
-            assert.ifError(err);
-            assert.strictEqual(response.statusCode, 200);
-            const data = JSON.parse(response.body);
+            (err, response) => {
+                assert.ifError(err);
+                assert.strictEqual(response.statusCode, 200);
+                const data = JSON.parse(response.body);
 
-            assert.strictEqual(data.IsTruncated, false);
-            assert(!data.NextKeyMarker);
-            assert.strictEqual(data.MaxKeys, 1000);
-            assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
-            assert.strictEqual(data.Prefix, prefix);
+                assert.strictEqual(data.IsTruncated, false);
+                assert(!data.NextKeyMarker);
+                assert.strictEqual(data.MaxKeys, 1000);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
+                assert.strictEqual(data.Prefix, prefix);
 
-            const contents = data.Contents;
-            assert.strictEqual(contents.length, 2);
-            assert(contents.every(d => d.Key === 'key2'));
+                const contents = data.Contents;
+                assert.strictEqual(contents.length, 2);
+                assert(contents.every(d => d.Key === 'key2'));
 
-            assert.deepStrictEqual(contents.map(v => v.VersionId), expectedKey2VersionIds);
+                assert.deepStrictEqual(
+                    contents.map(v => v.VersionId),
+                    expectedKey2VersionIds,
+                );
 
-            checkContents(contents);
+                checkContents(contents);
 
-            return done();
-        });
+                return done();
+            },
+        );
     });
 
     it('should return the noncurrent version with prefix, before a defined date, and after version-id-marker', done => {
         const prefix = 'key2';
 
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: testBucket,
-            queryObj: {
-                'list-type': 'noncurrent',
-                prefix,
-                'before-date': date,
-                'key-marker': 'key2',
-                'version-id-marker': expectedKey2VersionIds[0],
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: {
+                    'list-type': 'noncurrent',
+                    prefix,
+                    'before-date': date,
+                    'key-marker': 'key2',
+                    'version-id-marker': expectedKey2VersionIds[0],
+                },
+                authCredentials: credentials,
             },
-            authCredentials: credentials,
-        }, (err, response) => {
-            assert.ifError(err);
-            assert.strictEqual(response.statusCode, 200);
-            const data = JSON.parse(response.body);
+            (err, response) => {
+                assert.ifError(err);
+                assert.strictEqual(response.statusCode, 200);
+                const data = JSON.parse(response.body);
 
-            assert.strictEqual(data.IsTruncated, false);
-            assert(!data.NextKeyMarker);
-            assert.strictEqual(data.MaxKeys, 1000);
-            assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
-            assert.strictEqual(data.Prefix, prefix);
+                assert.strictEqual(data.IsTruncated, false);
+                assert(!data.NextKeyMarker);
+                assert.strictEqual(data.MaxKeys, 1000);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
+                assert.strictEqual(data.Prefix, prefix);
 
-            const contents = data.Contents;
-            assert.strictEqual(contents.length, 1);
-            assert(contents.every(d => d.Key === 'key2'));
-            contents[0].Key = 'key2';
-            contents[0].VersionId = expectedKey2VersionIds[1];
+                const contents = data.Contents;
+                assert.strictEqual(contents.length, 1);
+                assert(contents.every(d => d.Key === 'key2'));
+                contents[0].Key = 'key2';
+                contents[0].VersionId = expectedKey2VersionIds[1];
 
-            checkContents(contents);
+                checkContents(contents);
 
-            return done();
-        });
+                return done();
+            },
+        );
     });
 
     it('should return the non current versions before a defined date', done => {
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: testBucket,
-            queryObj: { 'list-type': 'noncurrent', 'before-date': date },
-            authCredentials: credentials,
-        }, (err, response) => {
-            assert.ifError(err);
-            assert.strictEqual(response.statusCode, 200);
-            const data = JSON.parse(response.body);
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: { 'list-type': 'noncurrent', 'before-date': date },
+                authCredentials: credentials,
+            },
+            (err, response) => {
+                assert.ifError(err);
+                assert.strictEqual(response.statusCode, 200);
+                const data = JSON.parse(response.body);
 
-            assert.strictEqual(data.IsTruncated, false);
-            assert(!data.NextKeyMarker);
-            assert.strictEqual(data.MaxKeys, 1000);
-            assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
-            assert.strictEqual(data.BeforeDate, date);
+                assert.strictEqual(data.IsTruncated, false);
+                assert(!data.NextKeyMarker);
+                assert.strictEqual(data.MaxKeys, 1000);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
+                assert.strictEqual(data.BeforeDate, date);
 
-            const contents = data.Contents;
-            assert.strictEqual(contents.length, 4);
-            checkContents(contents);
+                const contents = data.Contents;
+                assert.strictEqual(contents.length, 4);
+                checkContents(contents);
 
-            const key1Versions = contents.filter(c => c.Key === 'key1');
-            assert.strictEqual(key1Versions.length, 2);
+                const key1Versions = contents.filter(c => c.Key === 'key1');
+                assert.strictEqual(key1Versions.length, 2);
 
-            const key2Versions = contents.filter(c => c.Key === 'key2');
-            assert.strictEqual(key2Versions.length, 2);
+                const key2Versions = contents.filter(c => c.Key === 'key2');
+                assert.strictEqual(key2Versions.length, 2);
 
-            assert.deepStrictEqual(key1Versions.map(v => v.VersionId), expectedKey1VersionIds);
-            assert.deepStrictEqual(key2Versions.map(v => v.VersionId), expectedKey2VersionIds);
+                assert.deepStrictEqual(
+                    key1Versions.map(v => v.VersionId),
+                    expectedKey1VersionIds,
+                );
+                assert.deepStrictEqual(
+                    key2Versions.map(v => v.VersionId),
+                    expectedKey2VersionIds,
+                );
 
-            return done();
-        });
+                return done();
+            },
+        );
     });
 
     it('should truncate list of non current versions before a defined date', done => {
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: testBucket,
-            queryObj: { 'list-type': 'noncurrent', 'before-date': date, 'max-keys': '1' },
-            authCredentials: credentials,
-        }, (err, response) => {
-            assert.ifError(err);
-            assert.strictEqual(response.statusCode, 200);
-            const data = JSON.parse(response.body);
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: { 'list-type': 'noncurrent', 'before-date': date, 'max-keys': '1' },
+                authCredentials: credentials,
+            },
+            (err, response) => {
+                assert.ifError(err);
+                assert.strictEqual(response.statusCode, 200);
+                const data = JSON.parse(response.body);
 
-            assert.strictEqual(data.IsTruncated, true);
-            assert.strictEqual(data.NextKeyMarker, 'key1');
-            assert.strictEqual(data.NextVersionIdMarker, expectedKey1VersionIds[0]);
-            assert.strictEqual(data.MaxKeys, 1);
-            assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
-            assert.strictEqual(data.BeforeDate, date);
-            assert.strictEqual(data.Contents.length, 1);
+                assert.strictEqual(data.IsTruncated, true);
+                assert.strictEqual(data.NextKeyMarker, 'key1');
+                assert.strictEqual(data.NextVersionIdMarker, expectedKey1VersionIds[0]);
+                assert.strictEqual(data.MaxKeys, 1);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
+                assert.strictEqual(data.BeforeDate, date);
+                assert.strictEqual(data.Contents.length, 1);
 
-            const contents = data.Contents;
-            checkContents(contents);
-            assert.strictEqual(contents[0].Key, 'key1');
-            assert.strictEqual(contents[0].VersionId, expectedKey1VersionIds[0]);
-            return done();
-        });
+                const contents = data.Contents;
+                checkContents(contents);
+                assert.strictEqual(contents[0].Key, 'key1');
+                assert.strictEqual(contents[0].VersionId, expectedKey1VersionIds[0]);
+                return done();
+            },
+        );
     });
 
     it('should return the first following list of noncurrent versions before a defined date', done => {
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: testBucket,
-            queryObj: {
-                'list-type': 'noncurrent',
-                'before-date': date,
-                'max-keys': '1',
-                'key-marker': 'key1',
-                'version-id-marker': expectedKey1VersionIds[0],
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: {
+                    'list-type': 'noncurrent',
+                    'before-date': date,
+                    'max-keys': '1',
+                    'key-marker': 'key1',
+                    'version-id-marker': expectedKey1VersionIds[0],
+                },
+                authCredentials: credentials,
             },
-            authCredentials: credentials,
-        }, (err, response) => {
-            assert.ifError(err);
-            assert.strictEqual(response.statusCode, 200);
-            const data = JSON.parse(response.body);
+            (err, response) => {
+                assert.ifError(err);
+                assert.strictEqual(response.statusCode, 200);
+                const data = JSON.parse(response.body);
 
-            assert.strictEqual(data.IsTruncated, true);
-            assert.strictEqual(data.KeyMarker, 'key1');
-            assert.strictEqual(data.VersionIdMarker, expectedKey1VersionIds[0]);
-            assert.strictEqual(data.NextKeyMarker, 'key1');
-            assert.strictEqual(data.NextVersionIdMarker, expectedKey1VersionIds[1]);
-            assert.strictEqual(data.MaxKeys, 1);
-            assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
-            assert.strictEqual(data.BeforeDate, date);
-            assert.strictEqual(data.Contents.length, 1);
+                assert.strictEqual(data.IsTruncated, true);
+                assert.strictEqual(data.KeyMarker, 'key1');
+                assert.strictEqual(data.VersionIdMarker, expectedKey1VersionIds[0]);
+                assert.strictEqual(data.NextKeyMarker, 'key1');
+                assert.strictEqual(data.NextVersionIdMarker, expectedKey1VersionIds[1]);
+                assert.strictEqual(data.MaxKeys, 1);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
+                assert.strictEqual(data.BeforeDate, date);
+                assert.strictEqual(data.Contents.length, 1);
 
-            const contents = data.Contents;
-            checkContents(contents);
-            assert.strictEqual(contents[0].Key, 'key1');
-            assert.strictEqual(contents[0].VersionId, expectedKey1VersionIds[1]);
-            return done();
-        });
+                const contents = data.Contents;
+                checkContents(contents);
+                assert.strictEqual(contents[0].Key, 'key1');
+                assert.strictEqual(contents[0].VersionId, expectedKey1VersionIds[1]);
+                return done();
+            },
+        );
     });
 
     it('should return the second following list of noncurrent versions before a defined date', done => {
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: testBucket,
-            queryObj: {
-                'list-type': 'noncurrent',
-                'before-date': date,
-                'max-keys': '1',
-                'key-marker': 'key1',
-                'version-id-marker': expectedKey1VersionIds[1],
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: {
+                    'list-type': 'noncurrent',
+                    'before-date': date,
+                    'max-keys': '1',
+                    'key-marker': 'key1',
+                    'version-id-marker': expectedKey1VersionIds[1],
+                },
+                authCredentials: credentials,
             },
-            authCredentials: credentials,
-        }, (err, response) => {
-            assert.ifError(err);
-            assert.strictEqual(response.statusCode, 200);
-            const data = JSON.parse(response.body);
+            (err, response) => {
+                assert.ifError(err);
+                assert.strictEqual(response.statusCode, 200);
+                const data = JSON.parse(response.body);
 
-            assert.strictEqual(data.IsTruncated, true);
-            assert.strictEqual(data.KeyMarker, 'key1');
-            assert.strictEqual(data.VersionIdMarker, expectedKey1VersionIds[1]);
-            assert.strictEqual(data.NextKeyMarker, 'key2');
-            assert.strictEqual(data.NextVersionIdMarker, expectedKey2VersionIds[0]);
-            assert.strictEqual(data.MaxKeys, 1);
-            assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
-            assert.strictEqual(data.BeforeDate, date);
-            assert.strictEqual(data.Contents.length, 1);
+                assert.strictEqual(data.IsTruncated, true);
+                assert.strictEqual(data.KeyMarker, 'key1');
+                assert.strictEqual(data.VersionIdMarker, expectedKey1VersionIds[1]);
+                assert.strictEqual(data.NextKeyMarker, 'key2');
+                assert.strictEqual(data.NextVersionIdMarker, expectedKey2VersionIds[0]);
+                assert.strictEqual(data.MaxKeys, 1);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
+                assert.strictEqual(data.BeforeDate, date);
+                assert.strictEqual(data.Contents.length, 1);
 
-            const contents = data.Contents;
-            checkContents(contents);
-            assert.strictEqual(contents[0].Key, 'key2');
-            assert.strictEqual(contents[0].VersionId, expectedKey2VersionIds[0]);
-            return done();
-        });
+                const contents = data.Contents;
+                checkContents(contents);
+                assert.strictEqual(contents[0].Key, 'key2');
+                assert.strictEqual(contents[0].VersionId, expectedKey2VersionIds[0]);
+                return done();
+            },
+        );
     });
 
     it('should return the last and third following list of noncurrent versions before a defined date', done => {
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: testBucket,
-            queryObj: {
-                'list-type': 'noncurrent',
-                'before-date': date,
-                'max-keys': '1',
-                'key-marker': 'key2',
-                'version-id-marker': expectedKey2VersionIds[0],
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: {
+                    'list-type': 'noncurrent',
+                    'before-date': date,
+                    'max-keys': '1',
+                    'key-marker': 'key2',
+                    'version-id-marker': expectedKey2VersionIds[0],
+                },
+                authCredentials: credentials,
             },
-            authCredentials: credentials,
-        }, (err, response) => {
-            assert.ifError(err);
-            assert.strictEqual(response.statusCode, 200);
-            const data = JSON.parse(response.body);
+            (err, response) => {
+                assert.ifError(err);
+                assert.strictEqual(response.statusCode, 200);
+                const data = JSON.parse(response.body);
 
-            assert.strictEqual(data.IsTruncated, false);
-            assert.strictEqual(data.KeyMarker, 'key2');
-            assert.strictEqual(data.VersionIdMarker, expectedKey2VersionIds[0]);
-            assert(!data.NextKeyMarker);
-            assert(!data.NextVersionIdMarker);
-            assert.strictEqual(data.MaxKeys, 1);
-            assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
-            assert.strictEqual(data.BeforeDate, date);
-            assert.strictEqual(data.Contents.length, 1);
+                assert.strictEqual(data.IsTruncated, false);
+                assert.strictEqual(data.KeyMarker, 'key2');
+                assert.strictEqual(data.VersionIdMarker, expectedKey2VersionIds[0]);
+                assert(!data.NextKeyMarker);
+                assert(!data.NextVersionIdMarker);
+                assert.strictEqual(data.MaxKeys, 1);
+                assert.strictEqual(data.MaxScannedLifecycleListingEntries, config.maxScannedLifecycleListingEntries);
+                assert.strictEqual(data.BeforeDate, date);
+                assert.strictEqual(data.Contents.length, 1);
 
-            const contents = data.Contents;
-            checkContents(contents);
-            assert.strictEqual(contents[0].Key, 'key2');
-            assert.strictEqual(contents[0].VersionId, expectedKey2VersionIds[1]);
-            return done();
-        });
+                const contents = data.Contents;
+                checkContents(contents);
+                assert.strictEqual(contents[0].Key, 'key2');
+                assert.strictEqual(contents[0].VersionId, expectedKey2VersionIds[1]);
+                return done();
+            },
+        );
     });
 
     // Regression test: a scan-limit truncation that stops on a "bare master"
     // (a pre-versioning object with no internal versionId) returns a
-    // version-id-marker equals to 'null'. On the following listing, 
-    // CloudServer should treat it as "no marker" instead of decoding it. 
+    // version-id-marker equals to 'null'. On the following listing,
+    // CloudServer should treat it as "no marker" instead of decoding it.
     // Decoding it was throwing and crashing the worker.
     it('should treat a version-id-marker of "null" as no marker without crashing', done => {
-        makeBackbeatRequest({
-            method: 'GET',
-            bucket: testBucket,
-            queryObj: {
-                'list-type': 'noncurrent',
-                'before-date': date,
-                'key-marker': 'key1',
-                'version-id-marker': 'null',
+        makeBackbeatRequest(
+            {
+                method: 'GET',
+                bucket: testBucket,
+                queryObj: {
+                    'list-type': 'noncurrent',
+                    'before-date': date,
+                    'key-marker': 'key1',
+                    'version-id-marker': 'null',
+                },
+                authCredentials: credentials,
             },
-            authCredentials: credentials,
-        }, (err, response) => {
-            assert.ifError(err);
-            // Before the fix this request crashed the worker; assert it succeeds.
-            assert.strictEqual(response.statusCode, 200);
-            const data = JSON.parse(response.body);
+            (err, response) => {
+                assert.ifError(err);
+                // Before the fix this request crashed the worker; assert it succeeds.
+                assert.strictEqual(response.statusCode, 200);
+                const data = JSON.parse(response.body);
 
-            assert.strictEqual(data.KeyMarker, 'key1');
-            // 'null' is echoed back unchanged and treated as no marker, so the
-            // listing resumes after key1 and returns key2's noncurrent versions.
-            assert.strictEqual(data.IsTruncated, false);
-            assert(!data.NextKeyMarker);
+                assert.strictEqual(data.KeyMarker, 'key1');
+                // 'null' is echoed back unchanged and treated as no marker, so the
+                // listing resumes after key1 and returns key2's noncurrent versions.
+                assert.strictEqual(data.IsTruncated, false);
+                assert(!data.NextKeyMarker);
 
-            const contents = data.Contents;
-            checkContents(contents);
-            assert.strictEqual(contents.length, expectedKey2VersionIds.length);
-            contents.forEach((c, i) => {
-                assert.strictEqual(c.Key, 'key2');
-                assert.strictEqual(c.VersionId, expectedKey2VersionIds[i]);
-            });
-            return done();
-        });
+                const contents = data.Contents;
+                checkContents(contents);
+                assert.strictEqual(contents.length, expectedKey2VersionIds.length);
+                contents.forEach((c, i) => {
+                    assert.strictEqual(c.Key, 'key2');
+                    assert.strictEqual(c.VersionId, expectedKey2VersionIds[i]);
+                });
+                return done();
+            },
+        );
     });
 });

--- a/tests/unit/api/apiUtils/lifecycle.js
+++ b/tests/unit/api/apiUtils/lifecycle.js
@@ -1,7 +1,6 @@
 const assert = require('assert');
 const { versioning } = require('arsenal');
-const { validateMaxScannedEntries, decodeVersionIdMarker } =
-      require('../../../../lib/api/apiUtils/object/lifecycle');
+const { validateMaxScannedEntries, decodeVersionIdMarker } = require('../../../../lib/api/apiUtils/object/lifecycle');
 
 const versionIdUtils = versioning.VersionID;
 // A valid encoded marker that round-trips to this internal version id.

--- a/tests/unit/api/apiUtils/lifecycle.js
+++ b/tests/unit/api/apiUtils/lifecycle.js
@@ -1,6 +1,12 @@
 const assert = require('assert');
-const { validateMaxScannedEntries } =
+const { versioning } = require('arsenal');
+const { validateMaxScannedEntries, decodeVersionIdMarker } =
       require('../../../../lib/api/apiUtils/object/lifecycle');
+
+const versionIdUtils = versioning.VersionID;
+// A valid encoded marker that round-trips to this internal version id.
+const validInternalVid = '98765432109876999999PARIS00';
+const validEncodedMarker = versionIdUtils.encode(validInternalVid);
 
 const tests = [
     {
@@ -46,5 +52,25 @@ describe('validateMaxScannedEntries helper', () => {
             const result = validateMaxScannedEntries(t.params, t.config, t.minEntriesToBeScanned);
             assert.deepStrictEqual(result, t.expected);
         });
+    });
+});
+
+describe('decodeVersionIdMarker helper', () => {
+    ['null', '', undefined].forEach(vid => {
+        it(`should treat ${JSON.stringify(vid)} as no marker`, () => {
+            assert.strictEqual(decodeVersionIdMarker(vid), undefined);
+        });
+    });
+
+    it('should decode a valid encoded marker', () => {
+        assert.strictEqual(decodeVersionIdMarker(validEncodedMarker), validInternalVid);
+    });
+
+    it('should return InvalidArgument when decode returns an Error value', () => {
+        // a malformed (non-null) marker that decode rejects by returning an Error
+        const result = decodeVersionIdMarker('@@@bad@@@');
+        assert(result instanceof Error);
+        assert.strictEqual(result.message, 'InvalidArgument');
+        assert.strictEqual(result.description, 'Invalid version id marker specified');
     });
 });


### PR DESCRIPTION
**The bug in one sentence**
The lifecycle noncurrent listing returns the marker version-id-marker=null when a scan page stops on a "bare master" (an object with no internal versionId). CloudServer can't decode 'null', so the worker crashes. The bucket hasn't changed in months, so it crashes every cycle and the noncurrent versions are never expired.

**How a bare master (null master) gets created**

- bucket created, not versioned yet.

- PUT foo -> stored as a plain master key "foo", the value has NO versionId field (x-amz-version-id: "null"). <- this is the "bare master"

- versioning ENABLED later on the bucket.

- foo is NEVER re-PUT -> the bare master stays as-is, forever.
So a bare master = an object written before versioning, never re-PUT afterward. If it had been overwritten, the system would have converted it into a normal null version (id 99999...,isNull2:true), which is harmless. To trigger the bug the bare master never has to be overwritten (which is the case).

**How the noncurrent listing works in metadata (bucketd)**
The bucket-processor asks CloudServer for a DelimiterNonCurrent listing, which hits bucketd. 
bucketd scans the keys in order, newest->oldest per key.
For each key:
the first version seen = the current one -> not returned, but its last-modified is kept in memory.
the following versions = noncurrent -> returned, with a staleDate (= the in memory  last-modified).

The staleDate is the last-modified of the version that replaced it, ie the moment that version became noncurrent. It's this staleDate that gets compared to NoncurrentDays. A noncurrent is only returned if staleDate < beforeDate, ie old enough.

Two limits bound each page:

- max-keys (default 1000) -> number of noncurrent versions returned.

- maxScannedLifecycleListingEntries (default 10000) -> number of entries scanned, so that a bucket full of current objects but with few noncurrents still responds quickly.

When a limit is hit -> IsTruncated=true + a continuation marker (NextKeyMarker + NextVersionIdMarker), and backbeat re-requests the next page with those markers, until IsTruncated=false.

The NextVersionIdMarker is computed as getVersionId() || 'null'. And that's exactly where it goes wrong: on a bare master, getVersionId() is undefined -> the marker becomes the string 'null'.

**Example of the issue:**

  scan#    key                          kind                        marker becomes
  1        bar                          master (regular)            982...  (real id)
  2        bar \0 982...                current version             982...
  3        bar \0 981...                non-current -> expirable     981...
  ...      ... ~10k entries, all real ids ...
  10000    foo                          BARE master (no versionId)  getVersionId() || 'null' = "null"
           >>> STOP (scanned 10000): IsTruncated=true,
               NextKeyMarker="foo", NextVersionIdMarker="null"      <-- the poison marker
  10001    baz ...                      (next page - never reached)

The noncurrent versions to delete are on the next page, behind that marker. 
Condition to trigger the issue: the 10000th scanned entry is a bare master. 
If it were a normal version/master, the marker would be a valid id and nothing would break.

NOTE: Only scan-limit truncation can produce 'null', max-keys truncation always stops on a real noncurrent -> real id.

**Why it's a bug**
The marker round-trip is asymmetric. 'null' is guarded on the way out, not on the way in:
Page 1   version-id-marker= -> returns NextVersionIdMarker:"null"   (encode handle 'null' properly-> OK)
Page 2   version-id-marker=null-> decode("null") = Error (decode does NOT handle 'null' properly) -> encode(Error) -> TypeError -> CloudServer worker crash.

bucketd answers page 2 without any problem (HTTP 200). The crash is 100% on the CloudServer side, while re-encoding the version-id-marker=null from the request itself.

**Why it stays stuck**
The processor gives up after its retries and moves on to something else. But the versions to expire are on page 2, which crashes every time. The bucket doesn't change -> every cycle page 1 re-emits 'null', page 2 re-crashes.

Net progress = zero, indefinitely -> "noncurrent versions never removed".

**the fix** : treat version-id-marker=null as "no marker" instead of blindly decoding it.