### PR TITLE
Bump arsenal to 8.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zenko/cloudserver",
-    "version": "9.4.0-preview.1",
+    "version": "9.4.0-preview.2",
     "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
     "main": "index.js",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@opentelemetry/instrumentation-ioredis": "~0.64.0",
         "@opentelemetry/instrumentation-mongodb": "~0.69.0",
         "@smithy/node-http-handler": "^3.0.0",
-        "arsenal": "git+https://github.com/scality/arsenal#8.5.0",
+        "arsenal": "git+https://github.com/scality/arsenal#8.5.2",
         "async": "2.6.4",
         "bucketclient": "scality/bucketclient#8.2.7",
         "bufferutil": "^4.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6595,9 +6595,9 @@ arraybuffer.prototype.slice@^1.0.4:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#8.5.0":
-  version "8.5.0"
-  resolved "git+https://github.com/scality/arsenal#016072dac337eb64d602f40588cd6c22cf185625"
+"arsenal@git+https://github.com/scality/arsenal#8.5.2":
+  version "8.5.2"
+  resolved "git+https://github.com/scality/arsenal#cd9ddfca043b522c9199a0edbf23a73dbc7973fd"
   dependencies:
     "@aws-sdk/client-kms" "^3.975.0"
     "@aws-sdk/client-s3" "^3.975.0"


### PR DESCRIPTION
## Summary

Bump arsenal pin to `8.5.2` and cloudserver version to `9.4.0-preview.2`.

`8.5.2` ships the ARSN-601 fix that promotes the OTEL SDK packages (`@opentelemetry/{sdk-node, sdk-trace-base, resources, exporter-trace-otlp-http}`) from `optionalDependencies` to `dependencies`, so cloudserver production images now have the SDK installed and OTEL works with `ENABLE_OTEL=true`.

The version bump to `9.4.0-preview.2` makes this consumable from Zenko #2378 for integration testing.

## Commits

1. `Bump arsenal to 8.5.2` — `package.json` + `yarn.lock`.
2. `Bump version to 9.4.0-preview.2` — `package.json`.

Issue: CLDSRV-884