### PR TITLE
Bump werelogs to 8.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "@azure/storage-blob": "^12.28.0",
         "@hapi/joi": "^17.1.1",
         "@smithy/node-http-handler": "^3.0.0",
-        "arsenal": "git+https://github.com/scality/Arsenal#8.4.11",
+        "arsenal": "git+https://github.com/scality/Arsenal#8.4.13",
         "async": "2.6.4",
         "bucketclient": "scality/bucketclient#8.2.7",
         "bufferutil": "^4.0.8",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "utf8": "^3.0.0",
         "uuid": "^11.0.3",
         "vaultclient": "scality/vaultclient#8.5.3",
-        "werelogs": "scality/werelogs#8.2.2",
+        "werelogs": "scality/werelogs#semver:^8.2.4",
         "ws": "^8.18.0",
         "xml2js": "^0.6.2"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6591,9 +6591,9 @@ arraybuffer.prototype.slice@^1.0.4:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/Arsenal#8.4.11":
-  version "8.4.11"
-  resolved "git+https://github.com/scality/Arsenal#5981b88634cd528e14d3b9eb9463b81b22dde300"
+"arsenal@git+https://github.com/scality/Arsenal#8.4.13":
+  version "8.4.13"
+  resolved "git+https://github.com/scality/Arsenal#7fca398e36fe35a89bf7d50cbbfb2c5835be9067"
   dependencies:
     "@aws-sdk/client-kms" "^3.975.0"
     "@aws-sdk/client-s3" "^3.975.0"
@@ -6603,6 +6603,10 @@ arraybuffer.prototype.slice@^1.0.4:
     "@azure/storage-blob" "^12.31.0"
     "@js-sdsl/ordered-set" "^4.4.2"
     "@opentelemetry/api" "^1.9.1"
+    "@opentelemetry/exporter-trace-otlp-http" "^0.219.0"
+    "@opentelemetry/resources" "^2.8.0"
+    "@opentelemetry/sdk-node" "^0.219.0"
+    "@opentelemetry/sdk-trace-base" "^2.8.0"
     "@scality/hdclient" "^1.3.2"
     "@smithy/node-http-handler" "^4.3.0"
     "@smithy/protocol-http" "^5.3.5"
@@ -6631,13 +6635,9 @@ arraybuffer.prototype.slice@^1.0.4:
     sproxydclient "github:scality/sproxydclient#8.1.0"
     utf8 "^3.0.0"
     uuid "^10.0.0"
-    werelogs scality/werelogs#8.2.2
+    werelogs scality/werelogs#8.2.4
     xml2js "^0.6.2"
   optionalDependencies:
-    "@opentelemetry/exporter-trace-otlp-http" "^0.219.0"
-    "@opentelemetry/resources" "^2.8.0"
-    "@opentelemetry/sdk-node" "^0.219.0"
-    "@opentelemetry/sdk-trace-base" "^2.8.0"
     ioctl "^2.0.2"
 
 asn1@~0.2.3:
@@ -12614,7 +12614,7 @@ webidl-conversions@^7.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
-"werelogs@github:scality/werelogs#8.2.2", werelogs@scality/werelogs#8.2.0, werelogs@scality/werelogs#8.2.2, "werelogs@scality/werelogs#semver:^8.2.4":
+"werelogs@github:scality/werelogs#8.2.2", werelogs@scality/werelogs#8.2.0, werelogs@scality/werelogs#8.2.2, werelogs@scality/werelogs#8.2.4, "werelogs@scality/werelogs#semver:^8.2.4":
   version "8.2.4"
   resolved "https://codeload.github.com/scality/werelogs/tar.gz/a7bbb5917a08b035d3763b24b070d517483d6982"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -6508,55 +6508,6 @@ arraybuffer.prototype.slice@^1.0.4:
     get-intrinsic "^1.2.6"
     is-array-buffer "^3.0.4"
 
-"arsenal@git+https://github.com/scality/Arsenal#8.4.11":
-  version "8.4.11"
-  resolved "git+https://github.com/scality/Arsenal#5981b88634cd528e14d3b9eb9463b81b22dde300"
-  dependencies:
-    "@aws-sdk/client-kms" "^3.975.0"
-    "@aws-sdk/client-s3" "^3.975.0"
-    "@aws-sdk/credential-providers" "^3.975.0"
-    "@aws-sdk/lib-storage" "^3.975.0"
-    "@azure/identity" "^4.13.0"
-    "@azure/storage-blob" "^12.31.0"
-    "@js-sdsl/ordered-set" "^4.4.2"
-    "@opentelemetry/api" "^1.9.1"
-    "@scality/hdclient" "^1.3.2"
-    "@smithy/node-http-handler" "^4.3.0"
-    "@smithy/protocol-http" "^5.3.5"
-    JSONStream "^1.3.5"
-    agentkeepalive "^4.6.0"
-    ajv "6.12.3"
-    async "~2.6.4"
-    backo "^1.1.0"
-    base-x "3.0.8"
-    base62 "^2.0.2"
-    debug "^4.4.3"
-    fcntl "github:scality/node-fcntl#0.3.0"
-    httpagent scality/httpagent#1.1.0
-    https-proxy-agent "^7.0.6"
-    ioredis "^5.8.1"
-    ipaddr.js "^2.2.0"
-    joi "^18.0.1"
-    level "~5.0.1"
-    level-sublevel "~6.6.5"
-    mongodb "^6.20.0"
-    node-forge "^1.3.1"
-    prom-client "^15.1.3"
-    simple-glob "^0.2.0"
-    socket.io "^4.8.0"
-    socket.io-client "^4.8.0"
-    sproxydclient "github:scality/sproxydclient#8.1.0"
-    utf8 "^3.0.0"
-    uuid "^10.0.0"
-    werelogs scality/werelogs#8.2.2
-    xml2js "^0.6.2"
-  optionalDependencies:
-    "@opentelemetry/exporter-trace-otlp-http" "^0.219.0"
-    "@opentelemetry/resources" "^2.8.0"
-    "@opentelemetry/sdk-node" "^0.219.0"
-    "@opentelemetry/sdk-trace-base" "^2.8.0"
-    ioctl "^2.0.2"
-
 "arsenal@git+https://github.com/scality/Arsenal#8.2.28":
   version "8.2.28"
   resolved "git+https://github.com/scality/Arsenal#7df5088715bb26a62ff1db2045e611029ff17de1"
@@ -6638,6 +6589,55 @@ arraybuffer.prototype.slice@^1.0.4:
     werelogs scality/werelogs#8.2.2
     xml2js "^0.6.2"
   optionalDependencies:
+    ioctl "^2.0.2"
+
+"arsenal@git+https://github.com/scality/Arsenal#8.4.11":
+  version "8.4.11"
+  resolved "git+https://github.com/scality/Arsenal#5981b88634cd528e14d3b9eb9463b81b22dde300"
+  dependencies:
+    "@aws-sdk/client-kms" "^3.975.0"
+    "@aws-sdk/client-s3" "^3.975.0"
+    "@aws-sdk/credential-providers" "^3.975.0"
+    "@aws-sdk/lib-storage" "^3.975.0"
+    "@azure/identity" "^4.13.0"
+    "@azure/storage-blob" "^12.31.0"
+    "@js-sdsl/ordered-set" "^4.4.2"
+    "@opentelemetry/api" "^1.9.1"
+    "@scality/hdclient" "^1.3.2"
+    "@smithy/node-http-handler" "^4.3.0"
+    "@smithy/protocol-http" "^5.3.5"
+    JSONStream "^1.3.5"
+    agentkeepalive "^4.6.0"
+    ajv "6.12.3"
+    async "~2.6.4"
+    backo "^1.1.0"
+    base-x "3.0.8"
+    base62 "^2.0.2"
+    debug "^4.4.3"
+    fcntl "github:scality/node-fcntl#0.3.0"
+    httpagent scality/httpagent#1.1.0
+    https-proxy-agent "^7.0.6"
+    ioredis "^5.8.1"
+    ipaddr.js "^2.2.0"
+    joi "^18.0.1"
+    level "~5.0.1"
+    level-sublevel "~6.6.5"
+    mongodb "^6.20.0"
+    node-forge "^1.3.1"
+    prom-client "^15.1.3"
+    simple-glob "^0.2.0"
+    socket.io "^4.8.0"
+    socket.io-client "^4.8.0"
+    sproxydclient "github:scality/sproxydclient#8.1.0"
+    utf8 "^3.0.0"
+    uuid "^10.0.0"
+    werelogs scality/werelogs#8.2.2
+    xml2js "^0.6.2"
+  optionalDependencies:
+    "@opentelemetry/exporter-trace-otlp-http" "^0.219.0"
+    "@opentelemetry/resources" "^2.8.0"
+    "@opentelemetry/sdk-node" "^0.219.0"
+    "@opentelemetry/sdk-trace-base" "^2.8.0"
     ioctl "^2.0.2"
 
 asn1@~0.2.3:
@@ -12614,17 +12614,9 @@ webidl-conversions@^7.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
-"werelogs@github:scality/werelogs#8.2.2", werelogs@scality/werelogs#8.2.2:
-  version "8.2.2"
-  uid e53bef5145697bf8af940dcbe59408988d64854f
-  resolved "https://codeload.github.com/scality/werelogs/tar.gz/e53bef5145697bf8af940dcbe59408988d64854f"
-  dependencies:
-    fast-safe-stringify "^2.1.1"
-    safe-json-stringify "^1.2.0"
-
-werelogs@scality/werelogs#8.2.0:
-  version "8.2.0"
-  resolved "https://codeload.github.com/scality/werelogs/tar.gz/7bf334cea94002d118f27d7ec1c7a5af74b51b8d"
+"werelogs@github:scality/werelogs#8.2.2", werelogs@scality/werelogs#8.2.0, werelogs@scality/werelogs#8.2.2, "werelogs@scality/werelogs#semver:^8.2.4":
+  version "8.2.4"
+  resolved "https://codeload.github.com/scality/werelogs/tar.gz/a7bbb5917a08b035d3763b24b070d517483d6982"
   dependencies:
     fast-safe-stringify "^2.1.1"
     safe-json-stringify "^1.2.0"


### PR DESCRIPTION
Bump werelogs to 8.2.4 to make error logging work everywhere in cloudserver.

Issue: CLDSRV-939
