### PR TITLE
CLDSRV-940: pin CI Node to 22.23.1 to fix node-fetch@2 premature-close regression

### DIFF
--- a/.github/actions/setup-ci/action.yaml
+++ b/.github/actions/setup-ci/action.yaml
@@ -27,7 +27,7 @@ runs:
         mkdir -p /tmp/coverage/${JOB_NAME}/;
     - uses: actions/setup-node@v4
       with:
-        node-version: '22'
+        node-version: '22.23.1'
         cache: 'yarn'
     - name: install typescript
       shell: bash

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -82,7 +82,7 @@ jobs:
       uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '22'
+        node-version: '22.23.1'
         cache: yarn
     - name: install typescript
       shell: bash
@@ -111,7 +111,7 @@ jobs:
       uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '22'
+        node-version: '22.23.1'
         cache: yarn
     - name: install typescript
       shell: bash


### PR DESCRIPTION
CI functional‑test jobs (sur-tests, file-ft-tests, mongo-*-ft-tests) started failing intermittently around 2026‑06‑22 on ~12–15 bucket quota and rate‑limit tests, always with FetchError: … Premature close rather than an assertion. The root cause is a regression in the Node.js 22.23.0 / 24.17.0 security releases (nodejs/node#63989, node-fetch/node-fetch#1767) that breaks node-fetch@2 on reused keep‑alive pooled sockets under load, surfacing as a premature close while reading the response body. It hit globally and on the same day because the GitHub ubuntu-24.04 runner image bumped Node 22.22.3 → 22.23.0 and our CI selects Node via actions/setup-node with node-version: '22' (which floats to the latest 22.x), so every branch's runner picked up the broken release at once; only the bespoke node-fetch@2‑based quota/rate‑limit test tooling is affected (the AWS SDK v3 tests use a different HTTP stack, and the server itself is uninvolved — every request returns 200 and the process never crashes).

Pin the node-version to 22.23.1 to fix the issue.