### PR TITLE
CLDSRV-941: Bump arsenal for sproxyd chordCos=0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zenko/cloudserver",
-    "version": "9.3.12",
+    "version": "9.3.13",
     "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
     "main": "index.js",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "@azure/storage-blob": "^12.28.0",
         "@hapi/joi": "^17.1.1",
         "@smithy/node-http-handler": "^3.0.0",
-        "arsenal": "git+https://github.com/scality/Arsenal#8.4.13",
+        "arsenal": "git+https://github.com/scality/Arsenal#8.4.16",
         "async": "2.6.4",
         "bucketclient": "scality/bucketclient#8.2.7",
         "bufferutil": "^4.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6591,9 +6591,9 @@ arraybuffer.prototype.slice@^1.0.4:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/Arsenal#8.4.13":
-  version "8.4.13"
-  resolved "git+https://github.com/scality/Arsenal#7fca398e36fe35a89bf7d50cbbfb2c5835be9067"
+"arsenal@git+https://github.com/scality/Arsenal#8.4.16":
+  version "8.4.16"
+  resolved "git+https://github.com/scality/Arsenal#65223fdfc37f4471332c44775def9e985b320855"
   dependencies:
     "@aws-sdk/client-kms" "^3.975.0"
     "@aws-sdk/client-s3" "^3.975.0"
@@ -6632,7 +6632,7 @@ arraybuffer.prototype.slice@^1.0.4:
     simple-glob "^0.2.0"
     socket.io "^4.8.0"
     socket.io-client "^4.8.0"
-    sproxydclient "github:scality/sproxydclient#8.1.0"
+    sproxydclient "github:scality/sproxydclient#8.2.1"
     utf8 "^3.0.0"
     uuid "^10.0.0"
     werelogs scality/werelogs#8.2.4
@@ -11869,6 +11869,14 @@ sprintf-js@~1.0.2:
 "sproxydclient@github:scality/sproxydclient#8.1.0":
   version "8.1.0"
   resolved "https://codeload.github.com/scality/sproxydclient/tar.gz/8f26d4e256780aa85c5a6b7f9a358773d22f3193"
+  dependencies:
+    async "^3.2.6"
+    httpagent "github:scality/httpagent#1.1.0"
+    werelogs scality/werelogs#8.2.0
+
+"sproxydclient@github:scality/sproxydclient#8.2.1":
+  version "8.2.1"
+  resolved "https://codeload.github.com/scality/sproxydclient/tar.gz/501829f5521787e7e946de6792f5806ffa6ec437"
   dependencies:
     async "^3.2.6"
     httpagent "github:scality/httpagent#1.1.0"


### PR DESCRIPTION
For S3C 9.5.3

branch dev/9.4 does not introduce these change, it will have it with the next release and bump of arsenal (S3C doesn't use branch dev/9.4 for now)