### PR TITLE
Send X-Scal-Request-Uids (not x-scal-request-id) on the management config poll

### DIFF
--- a/lib/management/poll.js
+++ b/lib/management/poll.js
@@ -16,7 +16,7 @@ function loadRemoteOverlay(managementEndpoint, instanceId, remoteToken, cachedOv
     const opts = {
         headers: {
             'x-instance-authentication-token': remoteToken,
-            'x-scal-request-id': log.getSerializedUids(),
+            'x-scal-request-uids': log.getSerializedUids(),
         },
         json: true,
     };
@@ -143,4 +143,5 @@ function startPollingManagementClient(managementEndpoint, instanceId, remoteToke
 
 module.exports = {
     startPollingManagementClient,
+    loadRemoteOverlay,
 };

--- a/lib/management/poll.js
+++ b/lib/management/poll.js
@@ -5,18 +5,13 @@ const request = require('../utilities/request');
 const _config = require('../Config').config;
 const logger = require('../utilities/logger');
 const metadata = require('../metadata/wrapper');
-const {
-    loadCachedOverlay,
-    patchConfiguration,
-    saveConfigurationVersion,
-} = require('./configuration');
+const { loadCachedOverlay, patchConfiguration, saveConfigurationVersion } = require('./configuration');
 const { reshapeExceptionError } = arsenal.errorUtils;
 
 const pushReportDelay = 30000;
 const pullConfigurationOverlayDelay = 60000;
 
-function loadRemoteOverlay(
-    managementEndpoint, instanceId, remoteToken, cachedOverlay, log, cb) {
+function loadRemoteOverlay(managementEndpoint, instanceId, remoteToken, cachedOverlay, log, cb) {
     log.debug('loading remote overlay');
     const opts = {
         headers: {
@@ -25,45 +20,48 @@ function loadRemoteOverlay(
         },
         json: true,
     };
-    request.get(`${managementEndpoint}/${instanceId}/config/overlay`, opts,
-        (error, response, body) => {
-            if (error) {
-                return cb(error);
-            }
-            if (response.statusCode === 200) {
-                return cb(null, cachedOverlay, body);
-            }
-            if (response.statusCode === 404) {
-                return cb(null, cachedOverlay, {});
-            }
-            return cb(arsenal.errors.AccessForbidden, cachedOverlay, {});
-        });
+    request.get(`${managementEndpoint}/${instanceId}/config/overlay`, opts, (error, response, body) => {
+        if (error) {
+            return cb(error);
+        }
+        if (response.statusCode === 200) {
+            return cb(null, cachedOverlay, body);
+        }
+        if (response.statusCode === 404) {
+            return cb(null, cachedOverlay, {});
+        }
+        return cb(arsenal.errors.AccessForbidden, cachedOverlay, {});
+    });
 }
 
 // TODO save only after successful patch
-function applyConfigurationOverlay(
-    managementEndpoint, instanceId, remoteToken, log) {
-    async.waterfall([
-        wcb => loadCachedOverlay(log, wcb),
-        (cachedOverlay, wcb) => patchConfiguration(cachedOverlay,
-            log, wcb),
-        (cachedOverlay, wcb) =>
-            loadRemoteOverlay(managementEndpoint, instanceId, remoteToken,
-                cachedOverlay, log, wcb),
-        (cachedOverlay, remoteOverlay, wcb) =>
-            saveConfigurationVersion(cachedOverlay, remoteOverlay, log, wcb),
-        (remoteOverlay, wcb) => patchConfiguration(remoteOverlay,
-            log, wcb),
-    ], error => {
-        if (error) {
-            log.error('could not apply managed configuration',
-                { error: reshapeExceptionError(error),
-                  method: 'applyConfigurationOverlay' });
-        }
-        setTimeout(applyConfigurationOverlay, pullConfigurationOverlayDelay,
-            managementEndpoint, instanceId, remoteToken,
-            logger.newRequestLogger());
-    });
+function applyConfigurationOverlay(managementEndpoint, instanceId, remoteToken, log) {
+    async.waterfall(
+        [
+            wcb => loadCachedOverlay(log, wcb),
+            (cachedOverlay, wcb) => patchConfiguration(cachedOverlay, log, wcb),
+            (cachedOverlay, wcb) =>
+                loadRemoteOverlay(managementEndpoint, instanceId, remoteToken, cachedOverlay, log, wcb),
+            (cachedOverlay, remoteOverlay, wcb) => saveConfigurationVersion(cachedOverlay, remoteOverlay, log, wcb),
+            (remoteOverlay, wcb) => patchConfiguration(remoteOverlay, log, wcb),
+        ],
+        error => {
+            if (error) {
+                log.error('could not apply managed configuration', {
+                    error: reshapeExceptionError(error),
+                    method: 'applyConfigurationOverlay',
+                });
+            }
+            setTimeout(
+                applyConfigurationOverlay,
+                pullConfigurationOverlayDelay,
+                managementEndpoint,
+                instanceId,
+                remoteToken,
+                logger.newRequestLogger(),
+            );
+        },
+    );
 }
 
 function postStats(managementEndpoint, instanceId, remoteToken, report, next) {
@@ -115,18 +113,11 @@ function pushStats(managementEndpoint, instanceId, remoteToken, next) {
         }
 
         logger.debug('report', { report });
-        postStats(
-            managementEndpoint,
-            instanceId,
-            remoteToken,
-            report,
-            next
-        );
+        postStats(managementEndpoint, instanceId, remoteToken, report, next);
         return;
     });
 
-    setTimeout(pushStats, pushReportDelay,
-        managementEndpoint, instanceId, remoteToken);
+    setTimeout(pushStats, pushReportDelay, managementEndpoint, instanceId, remoteToken);
 }
 
 /**
@@ -141,15 +132,13 @@ function pushStats(managementEndpoint, instanceId, remoteToken, next) {
  *
  * @returns {undefined}
  */
-function startPollingManagementClient(
-    managementEndpoint, instanceId, remoteToken) {
+function startPollingManagementClient(managementEndpoint, instanceId, remoteToken) {
     metadata.notifyBucketChange(() => {
         pushStats(managementEndpoint, instanceId, remoteToken);
     });
 
     pushStats(managementEndpoint, instanceId, remoteToken);
-    applyConfigurationOverlay(managementEndpoint, instanceId, remoteToken,
-        logger.newRequestLogger());
+    applyConfigurationOverlay(managementEndpoint, instanceId, remoteToken, logger.newRequestLogger());
 }
 
 module.exports = {

--- a/tests/unit/management/poll.js
+++ b/tests/unit/management/poll.js
@@ -1,0 +1,30 @@
+const assert = require('assert');
+const sinon = require('sinon');
+
+const request = require('../../../lib/utilities/request');
+const { loadRemoteOverlay } = require('../../../lib/management/poll');
+const { DummyRequestLogger } = require('../helpers');
+
+describe('management poll loadRemoteOverlay', () => {
+    const managementEndpoint = 'https://management.example.com';
+    const instanceId = 'instance-id';
+    const remoteToken = 'remote-token';
+    const log = new DummyRequestLogger();
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('should forward the werelogs request uids under the ' + 'x-scal-request-uids header', done => {
+        const getStub = sinon.stub(request, 'get').callsFake((url, opts, cb) => cb(null, { statusCode: 200 }, {}));
+
+        loadRemoteOverlay(managementEndpoint, instanceId, remoteToken, {}, log, err => {
+            assert.ifError(err);
+            assert(getStub.calledOnce);
+            const opts = getStub.firstCall.args[1];
+            assert.strictEqual(opts.headers['x-scal-request-uids'], log.getSerializedUids());
+            assert.strictEqual(opts.headers['x-scal-request-id'], undefined);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
The management config-overlay poll (`lib/management/poll.js`,
`loadRemoteOverlay`) sent the werelogs `req_id` chain under the wrong
header name `x-scal-request-id`. Rename the outgoing header to
`x-scal-request-uids`, which matches cloudserver's own reader in
`lib/server.js`. The value (`log.getSerializedUids()`) is unchanged.

Pure rename: no dual-send. Also exports `loadRemoteOverlay` and adds a
focused unit test asserting the outgoing request carries
`x-scal-request-uids` and not `x-scal-request-id`.

Part of the OS-1089 reqUids-propagation audit. Note: the receiving
`config/overlay` endpoint on pensieve-api doesn't declare this header in
its swagger params, but pensieve reads it via a global middleware
(`WithRequestId`), so it applies to every endpoint regardless. Related
pensieve-side reqUids work: PSVAPI-131.

Issue: CLDSRV-948
