### PR TITLE
Forward X-Scal-Request-Uids on Scuba quota requests

### DIFF
--- a/lib/api/apiUtils/quotas/quotaUtils.js
+++ b/lib/api/apiUtils/quotas/quotaUtils.js
@@ -1,11 +1,7 @@
 const async = require('async');
 const { errors } = require('arsenal');
 const monitoring = require('../../../utilities/monitoringHandler');
-const {
-    actionNeedQuotaCheckCopy,
-    actionNeedQuotaCheck,
-    actionWithDataDeletion,
-} = require('arsenal').policies;
+const { actionNeedQuotaCheckCopy, actionNeedQuotaCheck, actionWithDataDeletion } = require('arsenal').policies;
 const { config } = require('../../../Config');
 const QuotaService = require('../../../utilization/instance');
 
@@ -44,7 +40,7 @@ function processBytesToWrite(apiMethod, bucket, versionId, contentLength, objMD,
                 // but it also replaces the target, which decreases storage
                 bytes -= getHotContentLength(destObjMD);
             }
-        } else if (!bucket.isVersioningEnabled() || bucket.isVersioningEnabled() && versionId) {
+        } else if (!bucket.isVersioningEnabled() || (bucket.isVersioningEnabled() && versionId)) {
             // object is being deleted (non versioned) or hard-deleted (versioned, as indicated by
             // the `versionId` field)
             bytes = -getHotContentLength(objMD);
@@ -68,8 +64,7 @@ function processBytesToWrite(apiMethod, bucket, versionId, contentLength, objMD,
  * @returns {boolean} Returns true if the metric is stale, false otherwise.
  */
 function isMetricStale(metric, resourceType, resourceName, action, inflight, log) {
-    if (metric.date && Date.now() - new Date(metric.date).getTime() >
-        QuotaService.maxStaleness) {
+    if (metric.date && Date.now() - new Date(metric.date).getTime() > QuotaService.maxStaleness) {
         log.warn('Stale metrics from the quota service, allowing the request', {
             resourceType,
             resourceName,
@@ -110,70 +105,87 @@ function _evaluateQuotas(
     let bucketQuotaExceeded = false;
     let accountQuotaExceeded = false;
     const creationDate = new Date(bucket.getCreationDate()).getTime();
-    return async.parallel({
-        bucketQuota: parallelDone => {
-            if (bucketQuota > 0) {
-                return QuotaService.getUtilizationMetrics('bucket',
-                    `${bucket.getName()}_${creationDate}`, null, {
-                    action,
-                    inflight,
-                }, (err, bucketMetrics) => {
-                    if (err || inflight < 0) {
-                        return parallelDone(err);
-                    }
-                    if (!isMetricStale(bucketMetrics, 'bucket', bucket.getName(), action, inflight, log) &&
-                        BigInt(bucketMetrics.bytesTotal || 0) + BigInt(inflightForCheck || 0) > bucketQuota) {
-                        log.debug('Bucket quota exceeded', {
-                            bucket: bucket.getName(),
+    return async.parallel(
+        {
+            bucketQuota: parallelDone => {
+                if (bucketQuota > 0) {
+                    return QuotaService.getUtilizationMetrics(
+                        'bucket',
+                        `${bucket.getName()}_${creationDate}`,
+                        null,
+                        {
                             action,
                             inflight,
-                            quota: bucketQuota,
-                            bytesTotal: bucketMetrics.bytesTotal,
-                        });
-                        bucketQuotaExceeded = true;
-                    }
-                    return parallelDone();
-                });
-            }
-            return parallelDone();
-        },
-        accountQuota: parallelDone => {
-            if (accountQuota > 0 && account?.account) {
-                return QuotaService.getUtilizationMetrics('account',
-                    account.account, null, {
-                    action,
-                    inflight,
-                }, (err, accountMetrics) => {
-                    if (err || inflight < 0) {
-                        return parallelDone(err);
-                    }
-                    // Metrics are served as BigInt strings
-                    if (!isMetricStale(accountMetrics, 'account', account.account, action, inflight, log) &&
-                        BigInt(accountMetrics.bytesTotal || 0) + BigInt(inflightForCheck || 0) > accountQuota) {
-                        log.debug('Account quota exceeded', {
-                            accountId: account.account,
+                        },
+                        (err, bucketMetrics) => {
+                            if (err || inflight < 0) {
+                                return parallelDone(err);
+                            }
+                            if (
+                                !isMetricStale(bucketMetrics, 'bucket', bucket.getName(), action, inflight, log) &&
+                                BigInt(bucketMetrics.bytesTotal || 0) + BigInt(inflightForCheck || 0) > bucketQuota
+                            ) {
+                                log.debug('Bucket quota exceeded', {
+                                    bucket: bucket.getName(),
+                                    action,
+                                    inflight,
+                                    quota: bucketQuota,
+                                    bytesTotal: bucketMetrics.bytesTotal,
+                                });
+                                bucketQuotaExceeded = true;
+                            }
+                            return parallelDone();
+                        },
+                    );
+                }
+                return parallelDone();
+            },
+            accountQuota: parallelDone => {
+                if (accountQuota > 0 && account?.account) {
+                    return QuotaService.getUtilizationMetrics(
+                        'account',
+                        account.account,
+                        null,
+                        {
                             action,
                             inflight,
-                            quota: accountQuota,
-                            bytesTotal: accountMetrics.bytesTotal,
-                        });
-                        accountQuotaExceeded = true;
-                    }
-                    return parallelDone();
+                        },
+                        (err, accountMetrics) => {
+                            if (err || inflight < 0) {
+                                return parallelDone(err);
+                            }
+                            // Metrics are served as BigInt strings
+                            if (
+                                !isMetricStale(accountMetrics, 'account', account.account, action, inflight, log) &&
+                                BigInt(accountMetrics.bytesTotal || 0) + BigInt(inflightForCheck || 0) > accountQuota
+                            ) {
+                                log.debug('Account quota exceeded', {
+                                    accountId: account.account,
+                                    action,
+                                    inflight,
+                                    quota: accountQuota,
+                                    bytesTotal: accountMetrics.bytesTotal,
+                                });
+                                accountQuotaExceeded = true;
+                            }
+                            return parallelDone();
+                        },
+                    );
+                }
+                return parallelDone();
+            },
+        },
+        err => {
+            if (err) {
+                log.warn('Error evaluating quotas', {
+                    error: err.name,
+                    description: err.message,
+                    isInflightDeletion: inflight < 0,
                 });
             }
-            return parallelDone();
+            return callback(err, bucketQuotaExceeded, accountQuotaExceeded);
         },
-    }, err => {
-        if (err) {
-            log.warn('Error evaluating quotas', {
-                error: err.name,
-                description: err.message,
-                isInflightDeletion: inflight < 0,
-            });
-        }
-        return callback(err, bucketQuotaExceeded, accountQuotaExceeded);
-    });
+    );
 }
 
 /**
@@ -186,11 +198,13 @@ function _evaluateQuotas(
  * @returns {undefined} - Returns nothing.
  */
 function monitorQuotaEvaluationDuration(apiMethod, type, code, duration) {
-    monitoring.quotaEvaluationDuration.labels({
-        action: apiMethod,
-        type,
-        code,
-    }).observe(duration / 1e9);
+    monitoring.quotaEvaluationDuration
+        .labels({
+            action: apiMethod,
+            type,
+            code,
+        })
+        .observe(duration / 1e9);
 }
 
 /**
@@ -248,76 +262,103 @@ function validateQuotas(request, bucket, account, apiNames, apiMethod, inflight,
         inflight = 0;
     }
 
-    return async.forEach(apiNames, (apiName, done) => {
-        // Object copy operations first check the target object,
-        // meaning the source object, containing the current bytes,
-        // is checked second. This logic handles these APIs calls by
-        // ensuring the bytes are positives (i.e., not an object
-        // replacement).
-        if (actionNeedQuotaCheckCopy(apiName, apiMethod)) {
-            // eslint-disable-next-line no-param-reassign
-            inflight = Math.abs(inflight);
-        } else if (!actionNeedQuotaCheck[apiName] && !actionWithDataDeletion[apiName]) {
-            return done();
-        }
-        // When inflights are disabled, the sum of the current utilization metrics
-        // and the current bytes are compared with the quota. The current bytes
-        // are not sent to the utilization service. When inflights are enabled,
-        // the sum of the current utilization metrics only are compared with the
-        // quota. They include the current inflight bytes sent in the request.
-        let _inflights = shouldSendInflights ? inflight : undefined;
-        const inflightForCheck = shouldSendInflights ? 0 : inflight;
-        return _evaluateQuotas(bucketQuota, accountQuota, bucket, account, _inflights,
-            inflightForCheck, apiName, log,
-            (err, _bucketQuotaExceeded, _accountQuotaExceeded) => {
-                if (err) {
-                    return done(err);
-                }
-
-                bucketQuotaExceeded = _bucketQuotaExceeded;
-                accountQuotaExceeded = _accountQuotaExceeded;
-
-                // Inflights are inverted: in case of cleanup, we just re-issue
-                // the same API call.
-                if (_inflights) {
-                    _inflights = -_inflights;
-                }
-
-                request.finalizerHooks.push((errorFromAPI, _done) => {
-                    const code = (bucketQuotaExceeded || accountQuotaExceeded) ? 429 : 200;
-                    const quotaCleanUpStartTime = process.hrtime.bigint();
-                    // Quotas are cleaned only in case of error in the API
-                    async.waterfall([
-                        cb => {
-                            if (errorFromAPI) {
-                                return _evaluateQuotas(bucketQuota, accountQuota, bucket, account, _inflights,
-                                    null, apiName, log, cb);
-                            }
-                            return cb();
-                        },
-                    ], () => {
-                        monitorQuotaEvaluationDuration(apiMethod, type, code, quotaEvaluationDuration +
-                            Number(process.hrtime.bigint() - quotaCleanUpStartTime));
-                        return _done();
-                    });
-                });
-
+    return async.forEach(
+        apiNames,
+        (apiName, done) => {
+            // Object copy operations first check the target object,
+            // meaning the source object, containing the current bytes,
+            // is checked second. This logic handles these APIs calls by
+            // ensuring the bytes are positives (i.e., not an object
+            // replacement).
+            if (actionNeedQuotaCheckCopy(apiName, apiMethod)) {
+                // eslint-disable-next-line no-param-reassign
+                inflight = Math.abs(inflight);
+            } else if (!actionNeedQuotaCheck[apiName] && !actionWithDataDeletion[apiName]) {
                 return done();
-            });
-    }, err => {
-        quotaEvaluationDuration = Number(process.hrtime.bigint() - requestStartTime);
-        if (err) {
-            log.warn('Error getting metrics from the quota service, allowing the request', {
-                error: err.name,
-                description: err.message,
-            });
-        }
-        if (!actionWithDataDeletion[apiMethod] &&
-            (bucketQuotaExceeded || accountQuotaExceeded)) {
-            return callback(errors.QuotaExceeded);
-        }
-        return callback();
-    });
+            }
+            // When inflights are disabled, the sum of the current utilization metrics
+            // and the current bytes are compared with the quota. The current bytes
+            // are not sent to the utilization service. When inflights are enabled,
+            // the sum of the current utilization metrics only are compared with the
+            // quota. They include the current inflight bytes sent in the request.
+            let _inflights = shouldSendInflights ? inflight : undefined;
+            const inflightForCheck = shouldSendInflights ? 0 : inflight;
+            return _evaluateQuotas(
+                bucketQuota,
+                accountQuota,
+                bucket,
+                account,
+                _inflights,
+                inflightForCheck,
+                apiName,
+                log,
+                (err, _bucketQuotaExceeded, _accountQuotaExceeded) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    bucketQuotaExceeded = _bucketQuotaExceeded;
+                    accountQuotaExceeded = _accountQuotaExceeded;
+
+                    // Inflights are inverted: in case of cleanup, we just re-issue
+                    // the same API call.
+                    if (_inflights) {
+                        _inflights = -_inflights;
+                    }
+
+                    request.finalizerHooks.push((errorFromAPI, _done) => {
+                        const code = bucketQuotaExceeded || accountQuotaExceeded ? 429 : 200;
+                        const quotaCleanUpStartTime = process.hrtime.bigint();
+                        // Quotas are cleaned only in case of error in the API
+                        async.waterfall(
+                            [
+                                cb => {
+                                    if (errorFromAPI) {
+                                        return _evaluateQuotas(
+                                            bucketQuota,
+                                            accountQuota,
+                                            bucket,
+                                            account,
+                                            _inflights,
+                                            null,
+                                            apiName,
+                                            log,
+                                            cb,
+                                        );
+                                    }
+                                    return cb();
+                                },
+                            ],
+                            () => {
+                                monitorQuotaEvaluationDuration(
+                                    apiMethod,
+                                    type,
+                                    code,
+                                    quotaEvaluationDuration + Number(process.hrtime.bigint() - quotaCleanUpStartTime),
+                                );
+                                return _done();
+                            },
+                        );
+                    });
+
+                    return done();
+                },
+            );
+        },
+        err => {
+            quotaEvaluationDuration = Number(process.hrtime.bigint() - requestStartTime);
+            if (err) {
+                log.warn('Error getting metrics from the quota service, allowing the request', {
+                    error: err.name,
+                    description: err.message,
+                });
+            }
+            if (!actionWithDataDeletion[apiMethod] && (bucketQuotaExceeded || accountQuotaExceeded)) {
+                return callback(errors.QuotaExceeded);
+            }
+            return callback();
+        },
+    );
 }
 
 module.exports = {

--- a/lib/api/apiUtils/quotas/quotaUtils.js
+++ b/lib/api/apiUtils/quotas/quotaUtils.js
@@ -117,6 +117,7 @@ function _evaluateQuotas(
                             action,
                             inflight,
                         },
+                        log,
                         (err, bucketMetrics) => {
                             if (err || inflight < 0) {
                                 return parallelDone(err);
@@ -150,6 +151,7 @@ function _evaluateQuotas(
                             action,
                             inflight,
                         },
+                        log,
                         (err, accountMetrics) => {
                             if (err || inflight < 0) {
                                 return parallelDone(err);

--- a/lib/api/apiUtils/quotas/quotaUtils.js
+++ b/lib/api/apiUtils/quotas/quotaUtils.js
@@ -107,74 +107,68 @@ function _evaluateQuotas(
     const creationDate = new Date(bucket.getCreationDate()).getTime();
     return async.parallel(
         {
-            bucketQuota: parallelDone => {
-                if (bucketQuota > 0) {
-                    return QuotaService.getUtilizationMetrics(
-                        'bucket',
-                        `${bucket.getName()}_${creationDate}`,
-                        null,
-                        {
-                            action,
-                            inflight,
-                        },
-                        log,
-                        (err, bucketMetrics) => {
-                            if (err || inflight < 0) {
-                                return parallelDone(err);
-                            }
-                            if (
-                                !isMetricStale(bucketMetrics, 'bucket', bucket.getName(), action, inflight, log) &&
-                                BigInt(bucketMetrics.bytesTotal || 0) + BigInt(inflightForCheck || 0) > bucketQuota
-                            ) {
-                                log.debug('Bucket quota exceeded', {
-                                    bucket: bucket.getName(),
-                                    action,
-                                    inflight,
-                                    quota: bucketQuota,
-                                    bytesTotal: bucketMetrics.bytesTotal,
-                                });
-                                bucketQuotaExceeded = true;
-                            }
-                            return parallelDone();
-                        },
-                    );
+            bucketQuota: async () => {
+                if (bucketQuota <= 0) {
+                    return;
                 }
-                return parallelDone();
+                const bucketMetrics = await QuotaService.getUtilizationMetrics(
+                    'bucket',
+                    `${bucket.getName()}_${creationDate}`,
+                    null,
+                    {
+                        action,
+                        inflight,
+                    },
+                    log,
+                );
+                if (inflight < 0) {
+                    return;
+                }
+                if (
+                    !isMetricStale(bucketMetrics, 'bucket', bucket.getName(), action, inflight, log) &&
+                    BigInt(bucketMetrics.bytesTotal || 0) + BigInt(inflightForCheck || 0) > bucketQuota
+                ) {
+                    log.debug('Bucket quota exceeded', {
+                        bucket: bucket.getName(),
+                        action,
+                        inflight,
+                        quota: bucketQuota,
+                        bytesTotal: bucketMetrics.bytesTotal,
+                    });
+                    bucketQuotaExceeded = true;
+                }
             },
-            accountQuota: parallelDone => {
-                if (accountQuota > 0 && account?.account) {
-                    return QuotaService.getUtilizationMetrics(
-                        'account',
-                        account.account,
-                        null,
-                        {
-                            action,
-                            inflight,
-                        },
-                        log,
-                        (err, accountMetrics) => {
-                            if (err || inflight < 0) {
-                                return parallelDone(err);
-                            }
-                            // Metrics are served as BigInt strings
-                            if (
-                                !isMetricStale(accountMetrics, 'account', account.account, action, inflight, log) &&
-                                BigInt(accountMetrics.bytesTotal || 0) + BigInt(inflightForCheck || 0) > accountQuota
-                            ) {
-                                log.debug('Account quota exceeded', {
-                                    accountId: account.account,
-                                    action,
-                                    inflight,
-                                    quota: accountQuota,
-                                    bytesTotal: accountMetrics.bytesTotal,
-                                });
-                                accountQuotaExceeded = true;
-                            }
-                            return parallelDone();
-                        },
-                    );
+            accountQuota: async () => {
+                if (!(accountQuota > 0 && account?.account)) {
+                    return;
                 }
-                return parallelDone();
+                const accountMetrics = await QuotaService.getUtilizationMetrics(
+                    'account',
+                    account.account,
+                    null,
+                    {
+                        action,
+                        inflight,
+                    },
+                    log,
+                );
+                if (inflight < 0) {
+                    return;
+                }
+                // Metrics are served as BigInt strings
+                if (
+                    !isMetricStale(accountMetrics, 'account', account.account, action, inflight, log) &&
+                    BigInt(accountMetrics.bytesTotal || 0) + BigInt(inflightForCheck || 0) > accountQuota
+                ) {
+                    log.debug('Account quota exceeded', {
+                        accountId: account.account,
+                        action,
+                        inflight,
+                        quota: accountQuota,
+                        bytesTotal: accountMetrics.bytesTotal,
+                    });
+                    accountQuotaExceeded = true;
+                }
             },
         },
         err => {

--- a/lib/routes/veeam/utils.js
+++ b/lib/routes/veeam/utils.js
@@ -10,7 +10,6 @@ const UtilizationService = require('../../utilization/instance');
 const metadata = require('../../metadata/wrapper');
 
 const pipeline = promisify(streamPipeline);
-const getUtilizationMetrics = promisify((...args) => UtilizationService.getUtilizationMetrics(...args));
 const getBucket = promisify((...args) => metadata.getBucket(...args));
 
 /**
@@ -234,7 +233,7 @@ function getFileToBuild(request, data, inlineLastModified = false) {
 async function fetchCapacityMetrics(bucketMd, request, log) {
     const bucketKey = `${bucketMd._name}_${new Date(bucketMd._creationDate).getTime()}`;
     try {
-        return await getUtilizationMetrics('bucket', bucketKey, null, {}, log);
+        return await UtilizationService.getUtilizationMetrics('bucket', bucketKey, null, {}, log);
     } catch (err) {
         const statusCode = err.response?.status || err.statusCode || err.code;
         if (statusCode === 404) {

--- a/lib/routes/veeam/utils.js
+++ b/lib/routes/veeam/utils.js
@@ -37,12 +37,15 @@ async function receiveData(request, log) {
     // Prevent memory overloads by limiting the size of the
     // received data.
     if (parsedContentLength > ContentLengthThreshold) {
-        throw errorInstances.InvalidInput
-            .customizeDescription(`maximum allowed content-length is ${ContentLengthThreshold} bytes`);
+        throw errorInstances.InvalidInput.customizeDescription(
+            `maximum allowed content-length is ${ContentLengthThreshold} bytes`,
+        );
     }
     return await new Promise((resolve, reject) => {
         const settle = jsutil.once((err, result) => {
-            if (err) { return reject(err); }
+            if (err) {
+                return reject(err);
+            }
             return resolve(result);
         });
         let totalLength = 0;
@@ -51,8 +54,7 @@ async function receiveData(request, log) {
             write(chunk, _enc, cb) {
                 totalLength += chunk.length;
                 if (totalLength > parsedContentLength) {
-                    log.error('data stream exceed announced size',
-                        { parsedContentLength, overflow: totalLength });
+                    log.error('data stream exceed announced size', { parsedContentLength, overflow: totalLength });
                     return cb(errors.InternalError);
                 }
                 chunks.push(chunk);
@@ -88,17 +90,18 @@ function buildHeadXML(xmlContent) {
  * @returns {object} - response headers
  */
 function getResponseHeader(request, bucket, dataBuffer, lastModified, log) {
-    const corsHeaders = collectCorsHeaders(request.headers.origin,
-        request.method, bucket);
-    const responseMetaHeaders = collectResponseHeaders({
-        'last-modified': lastModified || new Date().toISOString(),
-        'content-md5': crypto
-            .createHash('md5')
-            .update(dataBuffer)
-            .digest('hex'),
-        'content-length': dataBuffer.byteLength,
-        'content-type': 'text/xml',
-    }, corsHeaders, null, false);
+    const corsHeaders = collectCorsHeaders(request.headers.origin, request.method, bucket);
+    const responseMetaHeaders = collectResponseHeaders(
+        {
+            'last-modified': lastModified || new Date().toISOString(),
+            'content-md5': crypto.createHash('md5').update(dataBuffer).digest('hex'),
+            'content-length': dataBuffer.byteLength,
+            'content-type': 'text/xml',
+        },
+        corsHeaders,
+        null,
+        false,
+    );
     responseMetaHeaders.versionId = 'null';
     responseMetaHeaders['x-amz-id-2'] = log.getSerializedUids();
     responseMetaHeaders['x-amz-request-id'] = log.getSerializedUids();
@@ -136,10 +139,10 @@ async function respondWithData(request, response, log, bucket, data, lastModifie
                 try {
                     response.setHeader(key, responseMetaHeaders[key]);
                 } catch (e) {
-                    log.debug('header can not be added ' +
-                        'to the response', {
+                    log.debug('header can not be added ' + 'to the response', {
                         header: responseMetaHeaders[key],
-                        error: e.stack, method: 'routeVeeam/respondWithData'
+                        error: e.stack,
+                        method: 'routeVeeam/respondWithData',
                     });
                 }
             }
@@ -199,7 +202,7 @@ function getFileToBuild(request, data, inlineLastModified = false) {
         return { error: errors.NoSuchKey };
     }
 
-    const modified = fileToBuild.LastModified || (new Date()).toISOString();
+    const modified = fileToBuild.LastModified || new Date().toISOString();
     const fieldName = _isSystemXML ? 'SystemInfo' : 'CapacityInfo';
 
     if (inlineLastModified) {
@@ -286,9 +289,11 @@ async function buildVeeamFileData(request, bucketMd, log) {
     }
 
     const modified = bucketMetrics.date;
-    if (bucketMetrics.bytesTotal !== undefined
-            && fileToBuild.value.CapacityInfo
-            && !fileToBuild.value.CapacityInfo.Used) {
+    if (
+        bucketMetrics.bytesTotal !== undefined &&
+        fileToBuild.value.CapacityInfo &&
+        !fileToBuild.value.CapacityInfo.Used
+    ) {
         fileToBuild.value.CapacityInfo.Used = Number(bucketMetrics.bytesTotal);
         fileToBuild.value.CapacityInfo.Available =
             Number(fileToBuild.value.CapacityInfo.Capacity) - Number(bucketMetrics.bytesTotal);

--- a/lib/routes/veeam/utils.js
+++ b/lib/routes/veeam/utils.js
@@ -234,7 +234,7 @@ function getFileToBuild(request, data, inlineLastModified = false) {
 async function fetchCapacityMetrics(bucketMd, request, log) {
     const bucketKey = `${bucketMd._name}_${new Date(bucketMd._creationDate).getTime()}`;
     try {
-        return await getUtilizationMetrics('bucket', bucketKey, null, {});
+        return await getUtilizationMetrics('bucket', bucketKey, null, {}, log);
     } catch (err) {
         const statusCode = err.response?.status || err.statusCode || err.code;
         if (statusCode === 404) {

--- a/lib/utilization/scuba/wrapper.js
+++ b/lib/utilization/scuba/wrapper.js
@@ -62,13 +62,7 @@ class ScubaClientImpl extends ScubaClient {
         );
     }
 
-    async getUtilizationMetrics(metricsClass, resourceName, options, body, log, callback) {
-        if (typeof callback === 'function') {
-            return this.getUtilizationMetrics(metricsClass, resourceName, options, body, log).then(
-                data => callback(null, data),
-                err => callback(err),
-            );
-        }
+    async getUtilizationMetrics(metricsClass, resourceName, options, body, log) {
         const requestStartTime = process.hrtime.bigint();
         const reqUids = log?.getSerializedUids?.();
         const mergedOptions = reqUids

--- a/lib/utilization/scuba/wrapper.js
+++ b/lib/utilization/scuba/wrapper.js
@@ -27,28 +27,30 @@ class ScubaClientImpl extends ScubaClient {
     }
 
     _healthCheck() {
-        return this.healthCheck().then(data => {
-            if (data?.date) {
-                const date = new Date(data.date);
-                if (Date.now() - date.getTime() > this.maxStaleness) {
-                    throw new Error('Data is stale, disabling quotas');
+        return this.healthCheck()
+            .then(data => {
+                if (data?.date) {
+                    const date = new Date(data.date);
+                    if (Date.now() - date.getTime() > this.maxStaleness) {
+                        throw new Error('Data is stale, disabling quotas');
+                    }
                 }
-            }
-            if (!this.enabled) {
-                this._log.info('Scuba health check passed, enabling quotas');
-            }
-            monitoring.utilizationServiceAvailable.set(1);
-            this.enabled = true;
-        }).catch(err => {
-            if (this.enabled) {
-                this._log.warn('Scuba health check failed, disabling quotas', {
-                    err: err.name,
-                    description: err.message,
-                });
-            }
-            monitoring.utilizationServiceAvailable.set(0);
-            this.enabled = false;
-        });
+                if (!this.enabled) {
+                    this._log.info('Scuba health check passed, enabling quotas');
+                }
+                monitoring.utilizationServiceAvailable.set(1);
+                this.enabled = true;
+            })
+            .catch(err => {
+                if (this.enabled) {
+                    this._log.warn('Scuba health check failed, disabling quotas', {
+                        err: err.name,
+                        description: err.message,
+                    });
+                }
+                monitoring.utilizationServiceAvailable.set(0);
+                this.enabled = false;
+            });
     }
 
     periodicHealthCheck() {
@@ -56,20 +58,24 @@ class ScubaClientImpl extends ScubaClient {
             clearInterval(this._healthCheckTimer);
         }
         this._healthCheck();
-        this._healthCheckTimer = setInterval(async () => {
-            this._healthCheck();
-        }, Number(process.env.SCUBA_HEALTHCHECK_FREQUENCY)
-            || externalBackendHealthCheckInterval);
+        this._healthCheckTimer = setInterval(
+            async () => {
+                this._healthCheck();
+            },
+            Number(process.env.SCUBA_HEALTHCHECK_FREQUENCY) || externalBackendHealthCheckInterval,
+        );
     }
 
     getUtilizationMetrics(metricsClass, resourceName, options, body, callback) {
         const requestStartTime = process.hrtime.bigint();
         return this._getLatestMetricsCallback(metricsClass, resourceName, options, body, (err, data) => {
             const responseTimeInNs = Number(process.hrtime.bigint() - requestStartTime);
-            monitoring.utilizationMetricsRetrievalDuration.labels({
-                code: err ? (err.statusCode || 500) : 200,
-                class: metricsClass,
-            }).observe(responseTimeInNs / 1e9);
+            monitoring.utilizationMetricsRetrievalDuration
+                .labels({
+                    code: err ? err.statusCode || 500 : 200,
+                    class: metricsClass,
+                })
+                .observe(responseTimeInNs / 1e9);
             return callback(err, data);
         });
     }

--- a/lib/utilization/scuba/wrapper.js
+++ b/lib/utilization/scuba/wrapper.js
@@ -24,31 +24,30 @@ class ScubaClientImpl extends ScubaClient {
         }
     }
 
-    _healthCheck() {
-        return this.healthCheck()
-            .then(data => {
-                if (data?.date) {
-                    const date = new Date(data.date);
-                    if (Date.now() - date.getTime() > this.maxStaleness) {
-                        throw new Error('Data is stale, disabling quotas');
-                    }
+    async _healthCheck() {
+        try {
+            const data = await this.healthCheck();
+            if (data?.date) {
+                const date = new Date(data.date);
+                if (Date.now() - date.getTime() > this.maxStaleness) {
+                    throw new Error('Data is stale, disabling quotas');
                 }
-                if (!this.enabled) {
-                    this._log.info('Scuba health check passed, enabling quotas');
-                }
-                monitoring.utilizationServiceAvailable.set(1);
-                this.enabled = true;
-            })
-            .catch(err => {
-                if (this.enabled) {
-                    this._log.warn('Scuba health check failed, disabling quotas', {
-                        err: err.name,
-                        description: err.message,
-                    });
-                }
-                monitoring.utilizationServiceAvailable.set(0);
-                this.enabled = false;
-            });
+            }
+            if (!this.enabled) {
+                this._log.info('Scuba health check passed, enabling quotas');
+            }
+            monitoring.utilizationServiceAvailable.set(1);
+            this.enabled = true;
+        } catch (err) {
+            if (this.enabled) {
+                this._log.warn('Scuba health check failed, disabling quotas', {
+                    err: err.name,
+                    description: err.message,
+                });
+            }
+            monitoring.utilizationServiceAvailable.set(0);
+            this.enabled = false;
+        }
     }
 
     periodicHealthCheck() {

--- a/lib/utilization/scuba/wrapper.js
+++ b/lib/utilization/scuba/wrapper.js
@@ -1,4 +1,3 @@
-const util = require('util');
 const { default: ScubaClient } = require('scubaclient');
 const { externalBackendHealthCheckInterval } = require('../../../constants');
 const monitoring = require('../../utilities/monitoringHandler');
@@ -10,7 +9,6 @@ class ScubaClientImpl extends ScubaClient {
         this.maxStaleness = config.quota.maxStaleness;
         this._healthCheckTimer = null;
         this._log = null;
-        this._getLatestMetricsCallback = util.callbackify(this.getLatestMetrics);
 
         if (config.scuba) {
             this.enabled = true;
@@ -59,29 +57,35 @@ class ScubaClientImpl extends ScubaClient {
         }
         this._healthCheck();
         this._healthCheckTimer = setInterval(
-            async () => {
-                this._healthCheck();
-            },
+            () => this._healthCheck(),
             Number(process.env.SCUBA_HEALTHCHECK_FREQUENCY) || externalBackendHealthCheckInterval,
         );
     }
 
-    getUtilizationMetrics(metricsClass, resourceName, options, body, log, callback) {
+    async getUtilizationMetrics(metricsClass, resourceName, options, body, log, callback) {
+        if (typeof callback === 'function') {
+            return this.getUtilizationMetrics(metricsClass, resourceName, options, body, log).then(
+                data => callback(null, data),
+                err => callback(err),
+            );
+        }
         const requestStartTime = process.hrtime.bigint();
-        const reqUids = log && typeof log.getSerializedUids === 'function' ? log.getSerializedUids() : undefined;
+        const reqUids = log?.getSerializedUids?.();
         const mergedOptions = reqUids
-            ? { ...options, headers: { ...(options && options.headers), 'X-Scal-Request-Uids': reqUids } }
+            ? { ...options, headers: { ...options?.headers, 'X-Scal-Request-Uids': reqUids } }
             : options;
-        return this._getLatestMetricsCallback(metricsClass, resourceName, mergedOptions, body, (err, data) => {
+        let code = 200;
+        try {
+            return await super.getLatestMetrics(metricsClass, resourceName, mergedOptions, body);
+        } catch (err) {
+            code = err.statusCode || 500;
+            throw err;
+        } finally {
             const responseTimeInNs = Number(process.hrtime.bigint() - requestStartTime);
             monitoring.utilizationMetricsRetrievalDuration
-                .labels({
-                    code: err ? err.statusCode || 500 : 200,
-                    class: metricsClass,
-                })
+                .labels({ code, class: metricsClass })
                 .observe(responseTimeInNs / 1e9);
-            return callback(err, data);
-        });
+        }
     }
 }
 

--- a/lib/utilization/scuba/wrapper.js
+++ b/lib/utilization/scuba/wrapper.js
@@ -66,9 +66,13 @@ class ScubaClientImpl extends ScubaClient {
         );
     }
 
-    getUtilizationMetrics(metricsClass, resourceName, options, body, callback) {
+    getUtilizationMetrics(metricsClass, resourceName, options, body, log, callback) {
         const requestStartTime = process.hrtime.bigint();
-        return this._getLatestMetricsCallback(metricsClass, resourceName, options, body, (err, data) => {
+        const reqUids = log && typeof log.getSerializedUids === 'function' ? log.getSerializedUids() : undefined;
+        const mergedOptions = reqUids
+            ? { ...options, headers: { ...(options && options.headers), 'X-Scal-Request-Uids': reqUids } }
+            : options;
+        return this._getLatestMetricsCallback(metricsClass, resourceName, mergedOptions, body, (err, data) => {
             const responseTimeInNs = Number(process.hrtime.bigint() - requestStartTime);
             monitoring.utilizationMetricsRetrievalDuration
                 .labels({

--- a/tests/unit/api/apiUtils/quotas/quotaUtils.js
+++ b/tests/unit/api/apiUtils/quotas/quotaUtils.js
@@ -8,6 +8,7 @@ const {
 } = require('../../../../../lib/api/apiUtils/quotas/quotaUtils');
 const QuotaService = require('../../../../../lib/utilization/instance');
 const BucketInfo = require('arsenal').models.BucketInfo;
+const { default: ScubaClient } = require('scubaclient');
 
 const mockLog = {
     warn: sinon.stub(),
@@ -27,6 +28,8 @@ const mockBucketNoQuota = {
 };
 
 describe('validateQuotas (buckets)', () => {
+    let getLatestMetricsStub;
+
     const request = {
         getQuota: () => 100n,
     };
@@ -42,7 +45,7 @@ describe('validateQuotas (buckets)', () => {
         };
         sinon.stub(config, 'isQuotaEnabled').returns(true);
         QuotaService.enabled = true;
-        QuotaService._getLatestMetricsCallback = sinon.stub().resolves({});
+        getLatestMetricsStub = sinon.stub(ScubaClient.prototype, 'getLatestMetrics').resolves({});
         request.finalizerHooks = [];
     });
 
@@ -53,7 +56,7 @@ describe('validateQuotas (buckets)', () => {
     it('should return null if quota is <= 0', done => {
         validateQuotas(request, mockBucketNoQuota, {}, [], '', false, false, mockLog, err => {
             assert.ifError(err);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.called, false);
+            assert.strictEqual(getLatestMetricsStub.called, false);
             done();
         });
     });
@@ -62,7 +65,7 @@ describe('validateQuotas (buckets)', () => {
         QuotaService.enabled = false;
         validateQuotas(request, mockBucket, {}, [], '', false, false, mockLog, err => {
             assert.ifError(err);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.called, false);
+            assert.strictEqual(getLatestMetricsStub.called, false);
             done();
         });
     });
@@ -70,13 +73,13 @@ describe('validateQuotas (buckets)', () => {
     it('should return null if metrics retrieval fails', done => {
         QuotaService.enabled = true;
         const error = new Error('Failed to get metrics');
-        QuotaService._getLatestMetricsCallback.yields(error);
+        getLatestMetricsStub.rejects(error);
 
         validateQuotas(request, mockBucket, {}, ['objectPut', 'getObject'], 'objectPut', 1, false, mockLog, err => {
             assert.ifError(err);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
+            assert.strictEqual(getLatestMetricsStub.calledOnce, true);
             assert.strictEqual(
-                QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
+                getLatestMetricsStub.calledWith('bucket', 'bucketName_1640995200000', null, {
                     action: 'objectPut',
                     inflight: 1,
                 }),
@@ -93,15 +96,15 @@ describe('validateQuotas (buckets)', () => {
         const result2 = {
             bytesTotal: BigInt(120),
         };
-        QuotaService._getLatestMetricsCallback.yields(null, result1);
-        QuotaService._getLatestMetricsCallback.yields(null, result2);
+        getLatestMetricsStub.resolves(result1);
+        getLatestMetricsStub.resolves(result2);
 
         validateQuotas(request, mockBucket, {}, ['objectPut', 'getObject'], 'objectPut', 1, false, mockLog, err => {
             assert.strictEqual(err.is.QuotaExceeded, true);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.callCount, 1);
+            assert.strictEqual(getLatestMetricsStub.callCount, 1);
             assert.strictEqual(request.finalizerHooks.length, 1);
             assert.strictEqual(
-                QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
+                getLatestMetricsStub.calledWith('bucket', 'bucketName_1640995200000', null, {
                     action: 'objectPut',
                     inflight: 1,
                 }),
@@ -118,14 +121,14 @@ describe('validateQuotas (buckets)', () => {
         const result2 = {
             bytesTotal: BigInt(120),
         };
-        QuotaService._getLatestMetricsCallback.yields(null, result1);
-        QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
+        getLatestMetricsStub.resolves(result1);
+        getLatestMetricsStub.onCall(1).resolves(result2);
 
         validateQuotas(request, mockBucket, {}, ['objectDelete'], 'objectDelete', 0, false, mockLog, err => {
             assert.ifError(err);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
+            assert.strictEqual(getLatestMetricsStub.calledOnce, true);
             assert.strictEqual(
-                QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
+                getLatestMetricsStub.calledWith('bucket', 'bucketName_1640995200000', null, {
                     action: 'objectDelete',
                     inflight: 0,
                 }),
@@ -142,14 +145,14 @@ describe('validateQuotas (buckets)', () => {
         const result2 = {
             bytesTotal: BigInt(120),
         };
-        QuotaService._getLatestMetricsCallback.yields(null, result1);
-        QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
+        getLatestMetricsStub.resolves(result1);
+        getLatestMetricsStub.onCall(1).resolves(result2);
 
         validateQuotas(request, mockBucket, {}, ['objectDelete'], 'objectDelete', -50, false, mockLog, err => {
             assert.ifError(err);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
+            assert.strictEqual(getLatestMetricsStub.calledOnce, true);
             assert.strictEqual(
-                QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
+                getLatestMetricsStub.calledWith('bucket', 'bucketName_1640995200000', null, {
                     action: 'objectDelete',
                     inflight: -50,
                 }),
@@ -166,14 +169,14 @@ describe('validateQuotas (buckets)', () => {
         const result2 = {
             bytesTotal: BigInt(120),
         };
-        QuotaService._getLatestMetricsCallback.yields(null, result1);
-        QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
+        getLatestMetricsStub.resolves(result1);
+        getLatestMetricsStub.onCall(1).resolves(result2);
 
         validateQuotas(request, mockBucket, {}, ['objectDelete'], 'objectDeleteVersion', -50, false, mockLog, err => {
             assert.ifError(err);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
+            assert.strictEqual(getLatestMetricsStub.calledOnce, true);
             assert.strictEqual(
-                QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
+                getLatestMetricsStub.calledWith('bucket', 'bucketName_1640995200000', null, {
                     action: 'objectDelete',
                     inflight: -50,
                 }),
@@ -190,14 +193,14 @@ describe('validateQuotas (buckets)', () => {
         const result2 = {
             bytesTotal: BigInt(120),
         };
-        QuotaService._getLatestMetricsCallback.yields(null, result1);
-        QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
+        getLatestMetricsStub.resolves(result1);
+        getLatestMetricsStub.onCall(1).resolves(result2);
 
         validateQuotas(request, mockBucket, {}, ['objectDelete'], 'objectDelete', -5000, false, mockLog, err => {
             assert.ifError(err);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
+            assert.strictEqual(getLatestMetricsStub.calledOnce, true);
             assert.strictEqual(
-                QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
+                getLatestMetricsStub.calledWith('bucket', 'bucketName_1640995200000', null, {
                     action: 'objectDelete',
                     inflight: -5000,
                 }),
@@ -214,8 +217,8 @@ describe('validateQuotas (buckets)', () => {
         const result2 = {
             bytesTotal: BigInt(90),
         };
-        QuotaService._getLatestMetricsCallback.yields(null, result1);
-        QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
+        getLatestMetricsStub.resolves(result1);
+        getLatestMetricsStub.onCall(1).resolves(result2);
 
         validateQuotas(
             request,
@@ -228,9 +231,9 @@ describe('validateQuotas (buckets)', () => {
             mockLog,
             err => {
                 assert.ifError(err);
-                assert.strictEqual(QuotaService._getLatestMetricsCallback.calledTwice, true);
+                assert.strictEqual(getLatestMetricsStub.calledTwice, true);
                 assert.strictEqual(
-                    QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
+                    getLatestMetricsStub.calledWith('bucket', 'bucketName_1640995200000', null, {
                         action: 'objectRestore',
                         inflight: true,
                     }),
@@ -249,8 +252,8 @@ describe('validateQuotas (buckets)', () => {
         const result2 = {
             bytesTotal: BigInt(90),
         };
-        QuotaService._getLatestMetricsCallback.yields(null, result1);
-        QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
+        getLatestMetricsStub.resolves(result1);
+        getLatestMetricsStub.onCall(1).resolves(result2);
 
         validateQuotas(
             request,
@@ -263,9 +266,9 @@ describe('validateQuotas (buckets)', () => {
             mockLog,
             err => {
                 assert.ifError(err);
-                assert.strictEqual(QuotaService._getLatestMetricsCallback.calledTwice, true);
+                assert.strictEqual(getLatestMetricsStub.calledTwice, true);
                 assert.strictEqual(
-                    QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
+                    getLatestMetricsStub.calledWith('bucket', 'bucketName_1640995200000', null, {
                         action: 'objectRestore',
                         inflight: undefined,
                     }),
@@ -283,14 +286,14 @@ describe('validateQuotas (buckets)', () => {
         const result2 = {
             bytesTotal: BigInt(90),
         };
-        QuotaService._getLatestMetricsCallback.yields(null, result1);
-        QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
+        getLatestMetricsStub.resolves(result1);
+        getLatestMetricsStub.onCall(1).resolves(result2);
 
         validateQuotas(request, mockBucket, {}, ['objectPut'], 'objectPut', true, true, mockLog, err => {
             assert.ifError(err);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
+            assert.strictEqual(getLatestMetricsStub.calledOnce, true);
             assert.strictEqual(
-                QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
+                getLatestMetricsStub.calledWith('bucket', 'bucketName_1640995200000', null, {
                     action: 'objectPut',
                     inflight: 0,
                 }),
@@ -305,7 +308,7 @@ describe('validateQuotas (buckets)', () => {
         const result1 = {
             bytesTotal: largeNumber,
         };
-        QuotaService._getLatestMetricsCallback.yields(null, result1);
+        getLatestMetricsStub.resolves(result1);
 
         validateQuotas(
             request,
@@ -321,9 +324,9 @@ describe('validateQuotas (buckets)', () => {
             mockLog,
             err => {
                 assert.ifError(err);
-                assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
+                assert.strictEqual(getLatestMetricsStub.calledOnce, true);
                 assert.strictEqual(
-                    QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
+                    getLatestMetricsStub.calledWith('bucket', 'bucketName_1640995200000', null, {
                         action: 'objectPut',
                         inflight: 1,
                     }),
@@ -339,7 +342,7 @@ describe('validateQuotas (buckets)', () => {
         const result1 = {
             bytesTotal: largeNumber,
         };
-        QuotaService._getLatestMetricsCallback.yields(null, result1);
+        getLatestMetricsStub.resolves(result1);
 
         validateQuotas(
             request,
@@ -355,7 +358,7 @@ describe('validateQuotas (buckets)', () => {
             mockLog,
             err => {
                 assert.strictEqual(err.is.QuotaExceeded, true);
-                assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
+                assert.strictEqual(getLatestMetricsStub.calledOnce, true);
                 assert.strictEqual(request.finalizerHooks.length, 1);
                 done();
             },
@@ -368,7 +371,7 @@ describe('validateQuotas (buckets)', () => {
         const result1 = {
             bytesTotal: largeNumber,
         };
-        QuotaService._getLatestMetricsCallback.yields(null, result1);
+        getLatestMetricsStub.resolves(result1);
 
         validateQuotas(
             request,
@@ -384,9 +387,9 @@ describe('validateQuotas (buckets)', () => {
             mockLog,
             err => {
                 assert.ifError(err);
-                assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
+                assert.strictEqual(getLatestMetricsStub.calledOnce, true);
                 assert.strictEqual(
-                    QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
+                    getLatestMetricsStub.calledWith('bucket', 'bucketName_1640995200000', null, {
                         action: 'objectPut',
                         inflight: undefined,
                     }),
@@ -399,6 +402,8 @@ describe('validateQuotas (buckets)', () => {
 });
 
 describe('validateQuotas (with accounts)', () => {
+    let getLatestMetricsStub;
+
     const request = {
         getQuota: () => 100n,
     };
@@ -415,7 +420,7 @@ describe('validateQuotas (with accounts)', () => {
         request.finalizerHooks = [];
         sinon.stub(config, 'isQuotaEnabled').returns(true);
         QuotaService.enabled = true;
-        QuotaService._getLatestMetricsCallback = sinon.stub().resolves({});
+        getLatestMetricsStub = sinon.stub(ScubaClient.prototype, 'getLatestMetrics').resolves({});
     });
 
     afterEach(() => {
@@ -437,7 +442,7 @@ describe('validateQuotas (with accounts)', () => {
             mockLog,
             err => {
                 assert.ifError(err);
-                assert.strictEqual(QuotaService._getLatestMetricsCallback.called, false);
+                assert.strictEqual(getLatestMetricsStub.called, false);
                 done();
             },
         );
@@ -458,7 +463,7 @@ describe('validateQuotas (with accounts)', () => {
             mockLog,
             err => {
                 assert.ifError(err);
-                assert.strictEqual(QuotaService._getLatestMetricsCallback.called, false);
+                assert.strictEqual(getLatestMetricsStub.called, false);
                 done();
             },
         );
@@ -480,7 +485,7 @@ describe('validateQuotas (with accounts)', () => {
             mockLog,
             err => {
                 assert.ifError(err);
-                assert.strictEqual(QuotaService._getLatestMetricsCallback.called, false);
+                assert.strictEqual(getLatestMetricsStub.called, false);
                 done();
             },
         );
@@ -489,7 +494,7 @@ describe('validateQuotas (with accounts)', () => {
     it('should return null if metrics retrieval fails', done => {
         QuotaService.enabled = true;
         const error = new Error('Failed to get metrics');
-        QuotaService._getLatestMetricsCallback.yields(error);
+        getLatestMetricsStub.rejects(error);
 
         validateQuotas(
             request,
@@ -505,9 +510,10 @@ describe('validateQuotas (with accounts)', () => {
             mockLog,
             err => {
                 assert.ifError(err);
-                assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
+                // Scuba resolves async in production, so the account branch runs even when the bucket branch errors.
+                assert.strictEqual(getLatestMetricsStub.calledTwice, true);
                 assert.strictEqual(
-                    QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
+                    getLatestMetricsStub.calledWith('bucket', 'bucketName_1640995200000', null, {
                         action: 'objectPut',
                         inflight: 1,
                     }),
@@ -525,8 +531,8 @@ describe('validateQuotas (with accounts)', () => {
         const result2 = {
             bytesTotal: BigInt(120),
         };
-        QuotaService._getLatestMetricsCallback.yields(null, result1);
-        QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
+        getLatestMetricsStub.resolves(result1);
+        getLatestMetricsStub.onCall(1).resolves(result2);
 
         validateQuotas(
             request,
@@ -542,10 +548,10 @@ describe('validateQuotas (with accounts)', () => {
             mockLog,
             err => {
                 assert.strictEqual(err.is.QuotaExceeded, true);
-                assert.strictEqual(QuotaService._getLatestMetricsCallback.callCount, 1);
+                assert.strictEqual(getLatestMetricsStub.callCount, 1);
                 assert.strictEqual(request.finalizerHooks.length, 1);
                 assert.strictEqual(
-                    QuotaService._getLatestMetricsCallback.calledWith('account', 'test_1', null, {
+                    getLatestMetricsStub.calledWith('account', 'test_1', null, {
                         action: 'objectPut',
                         inflight: 1,
                     }),
@@ -563,8 +569,8 @@ describe('validateQuotas (with accounts)', () => {
         const result2 = {
             bytesTotal: BigInt(120),
         };
-        QuotaService._getLatestMetricsCallback.yields(null, result1);
-        QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
+        getLatestMetricsStub.resolves(result1);
+        getLatestMetricsStub.onCall(1).resolves(result2);
 
         validateQuotas(
             request,
@@ -580,9 +586,9 @@ describe('validateQuotas (with accounts)', () => {
             mockLog,
             err => {
                 assert.ifError(err);
-                assert.strictEqual(QuotaService._getLatestMetricsCallback.callCount, 1);
+                assert.strictEqual(getLatestMetricsStub.callCount, 1);
                 assert.strictEqual(
-                    QuotaService._getLatestMetricsCallback.calledWith('account', 'test_1', null, {
+                    getLatestMetricsStub.calledWith('account', 'test_1', null, {
                         action: 'objectDelete',
                         inflight: -50,
                     }),
@@ -600,8 +606,8 @@ describe('validateQuotas (with accounts)', () => {
         const result2 = {
             bytesTotal: BigInt(120),
         };
-        QuotaService._getLatestMetricsCallback.yields(null, result1);
-        QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
+        getLatestMetricsStub.resolves(result1);
+        getLatestMetricsStub.onCall(1).resolves(result2);
 
         validateQuotas(
             request,
@@ -617,9 +623,9 @@ describe('validateQuotas (with accounts)', () => {
             mockLog,
             err => {
                 assert.ifError(err);
-                assert.strictEqual(QuotaService._getLatestMetricsCallback.callCount, 1);
+                assert.strictEqual(getLatestMetricsStub.callCount, 1);
                 assert.strictEqual(
-                    QuotaService._getLatestMetricsCallback.calledWith('account', 'test_1', null, {
+                    getLatestMetricsStub.calledWith('account', 'test_1', null, {
                         action: 'objectDelete',
                         inflight: -5000,
                     }),
@@ -637,8 +643,8 @@ describe('validateQuotas (with accounts)', () => {
         const result2 = {
             bytesTotal: BigInt(90),
         };
-        QuotaService._getLatestMetricsCallback.yields(null, result1);
-        QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
+        getLatestMetricsStub.resolves(result1);
+        getLatestMetricsStub.onCall(1).resolves(result2);
 
         validateQuotas(
             request,
@@ -654,9 +660,9 @@ describe('validateQuotas (with accounts)', () => {
             mockLog,
             err => {
                 assert.ifError(err);
-                assert.strictEqual(QuotaService._getLatestMetricsCallback.callCount, 4);
+                assert.strictEqual(getLatestMetricsStub.callCount, 4);
                 assert.strictEqual(
-                    QuotaService._getLatestMetricsCallback.calledWith('account', 'test_1', null, {
+                    getLatestMetricsStub.calledWith('account', 'test_1', null, {
                         action: 'objectRestore',
                         inflight: true,
                     }),
@@ -674,8 +680,8 @@ describe('validateQuotas (with accounts)', () => {
         const result2 = {
             bytesTotal: BigInt(120),
         };
-        QuotaService._getLatestMetricsCallback.yields(null, result1);
-        QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
+        getLatestMetricsStub.resolves(result1);
+        getLatestMetricsStub.onCall(1).resolves(result2);
 
         validateQuotas(
             request,
@@ -691,7 +697,7 @@ describe('validateQuotas (with accounts)', () => {
             mockLog,
             err => {
                 assert.strictEqual(err.is.QuotaExceeded, true);
-                assert.strictEqual(QuotaService._getLatestMetricsCallback.callCount, 2);
+                assert.strictEqual(getLatestMetricsStub.callCount, 2);
                 assert.strictEqual(request.finalizerHooks.length, 1);
                 done();
             },
@@ -705,8 +711,8 @@ describe('validateQuotas (with accounts)', () => {
         const result2 = {
             bytesTotal: BigInt(90),
         };
-        QuotaService._getLatestMetricsCallback.yields(null, result1);
-        QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
+        getLatestMetricsStub.resolves(result1);
+        getLatestMetricsStub.onCall(1).resolves(result2);
 
         validateQuotas(
             request,
@@ -722,9 +728,9 @@ describe('validateQuotas (with accounts)', () => {
             mockLog,
             err => {
                 assert.ifError(err);
-                assert.strictEqual(QuotaService._getLatestMetricsCallback.callCount, 4);
+                assert.strictEqual(getLatestMetricsStub.callCount, 4);
                 assert.strictEqual(
-                    QuotaService._getLatestMetricsCallback.calledWith('account', 'test_1', null, {
+                    getLatestMetricsStub.calledWith('account', 'test_1', null, {
                         action: 'objectRestore',
                         inflight: true,
                     }),
@@ -742,8 +748,8 @@ describe('validateQuotas (with accounts)', () => {
         const result2 = {
             bytesTotal: BigInt(90),
         };
-        QuotaService._getLatestMetricsCallback.yields(null, result1);
-        QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
+        getLatestMetricsStub.resolves(result1);
+        getLatestMetricsStub.onCall(1).resolves(result2);
 
         validateQuotas(
             request,
@@ -759,9 +765,9 @@ describe('validateQuotas (with accounts)', () => {
             mockLog,
             err => {
                 assert.ifError(err);
-                assert.strictEqual(QuotaService._getLatestMetricsCallback.calledTwice, true);
+                assert.strictEqual(getLatestMetricsStub.calledTwice, true);
                 assert.strictEqual(
-                    QuotaService._getLatestMetricsCallback.calledWith('account', 'test_1', null, {
+                    getLatestMetricsStub.calledWith('account', 'test_1', null, {
                         action: 'objectPut',
                         inflight: 0,
                     }),
@@ -777,7 +783,7 @@ describe('validateQuotas (with accounts)', () => {
         const result1 = {
             bytesTotal: largeNumber,
         };
-        QuotaService._getLatestMetricsCallback.yields(null, result1);
+        getLatestMetricsStub.resolves(result1);
 
         validateQuotas(
             request,
@@ -793,9 +799,9 @@ describe('validateQuotas (with accounts)', () => {
             mockLog,
             err => {
                 assert.ifError(err);
-                assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
+                assert.strictEqual(getLatestMetricsStub.calledOnce, true);
                 assert.strictEqual(
-                    QuotaService._getLatestMetricsCallback.calledWith('account', 'test_1', null, {
+                    getLatestMetricsStub.calledWith('account', 'test_1', null, {
                         action: 'objectPut',
                         inflight: 1,
                     }),
@@ -811,7 +817,7 @@ describe('validateQuotas (with accounts)', () => {
         const result1 = {
             bytesTotal: largeNumber,
         };
-        QuotaService._getLatestMetricsCallback.yields(null, result1);
+        getLatestMetricsStub.resolves(result1);
 
         validateQuotas(
             request,
@@ -827,7 +833,7 @@ describe('validateQuotas (with accounts)', () => {
             mockLog,
             err => {
                 assert.strictEqual(err.is.QuotaExceeded, true);
-                assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
+                assert.strictEqual(getLatestMetricsStub.calledOnce, true);
                 assert.strictEqual(request.finalizerHooks.length, 1);
                 done();
             },
@@ -840,7 +846,7 @@ describe('validateQuotas (with accounts)', () => {
         const result1 = {
             bytesTotal: largeNumber,
         };
-        QuotaService._getLatestMetricsCallback.yields(null, result1);
+        getLatestMetricsStub.resolves(result1);
 
         validateQuotas(
             request,
@@ -856,9 +862,9 @@ describe('validateQuotas (with accounts)', () => {
             mockLog,
             err => {
                 assert.ifError(err);
-                assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
+                assert.strictEqual(getLatestMetricsStub.calledOnce, true);
                 assert.strictEqual(
-                    QuotaService._getLatestMetricsCallback.calledWith('account', 'test_1', null, {
+                    getLatestMetricsStub.calledWith('account', 'test_1', null, {
                         action: 'objectPut',
                         inflight: undefined,
                     }),

--- a/tests/unit/api/apiUtils/quotas/quotaUtils.js
+++ b/tests/unit/api/apiUtils/quotas/quotaUtils.js
@@ -75,15 +75,13 @@ describe('validateQuotas (buckets)', () => {
         validateQuotas(request, mockBucket, {}, ['objectPut', 'getObject'], 'objectPut', 1, false, mockLog, err => {
             assert.ifError(err);
             assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledWith(
-                'bucket',
-                'bucketName_1640995200000',
-                null,
-                {
+            assert.strictEqual(
+                QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
                     action: 'objectPut',
                     inflight: 1,
-                }
-            ), true);
+                }),
+                true,
+            );
             done();
         });
     });
@@ -102,15 +100,13 @@ describe('validateQuotas (buckets)', () => {
             assert.strictEqual(err.is.QuotaExceeded, true);
             assert.strictEqual(QuotaService._getLatestMetricsCallback.callCount, 1);
             assert.strictEqual(request.finalizerHooks.length, 1);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledWith(
-                'bucket',
-                'bucketName_1640995200000',
-                null,
-                {
+            assert.strictEqual(
+                QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
                     action: 'objectPut',
                     inflight: 1,
-                }
-            ), true);
+                }),
+                true,
+            );
             done();
         });
     });
@@ -128,15 +124,13 @@ describe('validateQuotas (buckets)', () => {
         validateQuotas(request, mockBucket, {}, ['objectDelete'], 'objectDelete', 0, false, mockLog, err => {
             assert.ifError(err);
             assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledWith(
-                'bucket',
-                'bucketName_1640995200000',
-                null,
-                {
+            assert.strictEqual(
+                QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
                     action: 'objectDelete',
                     inflight: 0,
-                }
-            ), true);
+                }),
+                true,
+            );
             done();
         });
     });
@@ -154,15 +148,13 @@ describe('validateQuotas (buckets)', () => {
         validateQuotas(request, mockBucket, {}, ['objectDelete'], 'objectDelete', -50, false, mockLog, err => {
             assert.ifError(err);
             assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledWith(
-                'bucket',
-                'bucketName_1640995200000',
-                null,
-                {
+            assert.strictEqual(
+                QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
                     action: 'objectDelete',
                     inflight: -50,
-                }
-            ), true);
+                }),
+                true,
+            );
             done();
         });
     });
@@ -180,15 +172,13 @@ describe('validateQuotas (buckets)', () => {
         validateQuotas(request, mockBucket, {}, ['objectDelete'], 'objectDeleteVersion', -50, false, mockLog, err => {
             assert.ifError(err);
             assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledWith(
-                'bucket',
-                'bucketName_1640995200000',
-                null,
-                {
+            assert.strictEqual(
+                QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
                     action: 'objectDelete',
                     inflight: -50,
-                }
-            ), true);
+                }),
+                true,
+            );
             done();
         });
     });
@@ -206,15 +196,13 @@ describe('validateQuotas (buckets)', () => {
         validateQuotas(request, mockBucket, {}, ['objectDelete'], 'objectDelete', -5000, false, mockLog, err => {
             assert.ifError(err);
             assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledWith(
-                'bucket',
-                'bucketName_1640995200000',
-                null,
-                {
+            assert.strictEqual(
+                QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
                     action: 'objectDelete',
                     inflight: -5000,
-                }
-            ), true);
+                }),
+                true,
+            );
             done();
         });
     });
@@ -229,21 +217,28 @@ describe('validateQuotas (buckets)', () => {
         QuotaService._getLatestMetricsCallback.yields(null, result1);
         QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
 
-        validateQuotas(request, mockBucket, {}, ['objectRestore', 'objectPut'], 'objectRestore',
-            true, false, mockLog, err => {
+        validateQuotas(
+            request,
+            mockBucket,
+            {},
+            ['objectRestore', 'objectPut'],
+            'objectRestore',
+            true,
+            false,
+            mockLog,
+            err => {
                 assert.ifError(err);
                 assert.strictEqual(QuotaService._getLatestMetricsCallback.calledTwice, true);
-                assert.strictEqual(QuotaService._getLatestMetricsCallback.calledWith(
-                    'bucket',
-                    'bucketName_1640995200000',
-                    null,
-                    {
+                assert.strictEqual(
+                    QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
                         action: 'objectRestore',
                         inflight: true,
-                    }
-                ), true);
+                    }),
+                    true,
+                );
                 done();
-            });
+            },
+        );
     });
 
     it('should not include the inflights in the request if they are disabled', done => {
@@ -257,21 +252,28 @@ describe('validateQuotas (buckets)', () => {
         QuotaService._getLatestMetricsCallback.yields(null, result1);
         QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
 
-        validateQuotas(request, mockBucket, {}, ['objectRestore', 'objectPut'], 'objectRestore',
-            true, false, mockLog, err => {
+        validateQuotas(
+            request,
+            mockBucket,
+            {},
+            ['objectRestore', 'objectPut'],
+            'objectRestore',
+            true,
+            false,
+            mockLog,
+            err => {
                 assert.ifError(err);
                 assert.strictEqual(QuotaService._getLatestMetricsCallback.calledTwice, true);
-                assert.strictEqual(QuotaService._getLatestMetricsCallback.calledWith(
-                    'bucket',
-                    'bucketName_1640995200000',
-                    null,
-                    {
+                assert.strictEqual(
+                    QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
                         action: 'objectRestore',
                         inflight: undefined,
-                    }
-                ), true);
-            done();
-        });
+                    }),
+                    true,
+                );
+                done();
+            },
+        );
     });
 
     it('should evaluate the quotas and not update the inflights when isStorageReserved is true', done => {
@@ -284,21 +286,18 @@ describe('validateQuotas (buckets)', () => {
         QuotaService._getLatestMetricsCallback.yields(null, result1);
         QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
 
-        validateQuotas(request, mockBucket, {}, ['objectPut'], 'objectPut',
-            true, true, mockLog, err => {
-                assert.ifError(err);
-                assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
-                assert.strictEqual(QuotaService._getLatestMetricsCallback.calledWith(
-                    'bucket',
-                    'bucketName_1640995200000',
-                    null,
-                    {
-                        action: 'objectPut',
-                        inflight: 0,
-                    }
-                ), true);
-                done();
-            });
+        validateQuotas(request, mockBucket, {}, ['objectPut'], 'objectPut', true, true, mockLog, err => {
+            assert.ifError(err);
+            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
+            assert.strictEqual(
+                QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
+                    action: 'objectPut',
+                    inflight: 0,
+                }),
+                true,
+            );
+            done();
+        });
     });
 
     it('should handle numbers above MAX_SAFE_INTEGER when quota is not exceeded', done => {
@@ -308,23 +307,31 @@ describe('validateQuotas (buckets)', () => {
         };
         QuotaService._getLatestMetricsCallback.yields(null, result1);
 
-        validateQuotas(request, {
-            ...mockBucket,
-            getQuota: () => 9007199254740993n,
-        }, {}, ['objectPut'], 'objectPut', 1, false, mockLog, err => {
-            assert.ifError(err);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledWith(
-                'bucket',
-                'bucketName_1640995200000',
-                null,
-                {
-                    action: 'objectPut',
-                    inflight: 1,
-                },
-            ), true);
-            done();
-        });
+        validateQuotas(
+            request,
+            {
+                ...mockBucket,
+                getQuota: () => 9007199254740993n,
+            },
+            {},
+            ['objectPut'],
+            'objectPut',
+            1,
+            false,
+            mockLog,
+            err => {
+                assert.ifError(err);
+                assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
+                assert.strictEqual(
+                    QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
+                        action: 'objectPut',
+                        inflight: 1,
+                    }),
+                    true,
+                );
+                done();
+            },
+        );
     });
 
     it('should handle numbers above MAX_SAFE_INTEGER when quota is exceeded', done => {
@@ -334,15 +341,25 @@ describe('validateQuotas (buckets)', () => {
         };
         QuotaService._getLatestMetricsCallback.yields(null, result1);
 
-        validateQuotas(request, {
-            ...mockBucket,
-            getQuota: () => 9007199254740991n,
-        }, {}, ['objectPut'], 'objectPut', 1, false, mockLog, err => {
-            assert.strictEqual(err.is.QuotaExceeded, true);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
-            assert.strictEqual(request.finalizerHooks.length, 1);
-            done();
-        });
+        validateQuotas(
+            request,
+            {
+                ...mockBucket,
+                getQuota: () => 9007199254740991n,
+            },
+            {},
+            ['objectPut'],
+            'objectPut',
+            1,
+            false,
+            mockLog,
+            err => {
+                assert.strictEqual(err.is.QuotaExceeded, true);
+                assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
+                assert.strictEqual(request.finalizerHooks.length, 1);
+                done();
+            },
+        );
     });
 
     it('should handle numbers above MAX_SAFE_INTEGER with disabled inflights when quota is not exceeded', done => {
@@ -353,23 +370,31 @@ describe('validateQuotas (buckets)', () => {
         };
         QuotaService._getLatestMetricsCallback.yields(null, result1);
 
-        validateQuotas(request, {
-            ...mockBucket,
-            getQuota: () => 9007199254740993n,
-        }, {}, ['objectPut'], 'objectPut', 1, false, mockLog, err => {
-            assert.ifError(err);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledWith(
-                'bucket',
-                'bucketName_1640995200000',
-                null,
-                {
-                    action: 'objectPut',
-                    inflight: undefined,
-                },
-            ), true);
-            done();
-        });
+        validateQuotas(
+            request,
+            {
+                ...mockBucket,
+                getQuota: () => 9007199254740993n,
+            },
+            {},
+            ['objectPut'],
+            'objectPut',
+            1,
+            false,
+            mockLog,
+            err => {
+                assert.ifError(err);
+                assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
+                assert.strictEqual(
+                    QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
+                        action: 'objectPut',
+                        inflight: undefined,
+                    }),
+                    true,
+                );
+                done();
+            },
+        );
     });
 });
 
@@ -398,37 +423,67 @@ describe('validateQuotas (with accounts)', () => {
     });
 
     it('should return null if quota is <= 0', done => {
-        validateQuotas(request, mockBucketNoQuota, {
-            account: 'test_1',
-            quota: 0n,
-        }, [], '', false, false, mockLog, err => {
-            assert.ifError(err);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.called, false);
-            done();
-        });
+        validateQuotas(
+            request,
+            mockBucketNoQuota,
+            {
+                account: 'test_1',
+                quota: 0n,
+            },
+            [],
+            '',
+            false,
+            false,
+            mockLog,
+            err => {
+                assert.ifError(err);
+                assert.strictEqual(QuotaService._getLatestMetricsCallback.called, false);
+                done();
+            },
+        );
     });
 
     it('should not return null if bucket quota is <= 0 but account quota is > 0', done => {
-        validateQuotas(request, mockBucketNoQuota, {
-            account: 'test_1',
-            quota: 1000n,
-        }, [], '', false, false, mockLog, err => {
-            assert.ifError(err);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.called, false);
-            done();
-        });
+        validateQuotas(
+            request,
+            mockBucketNoQuota,
+            {
+                account: 'test_1',
+                quota: 1000n,
+            },
+            [],
+            '',
+            false,
+            false,
+            mockLog,
+            err => {
+                assert.ifError(err);
+                assert.strictEqual(QuotaService._getLatestMetricsCallback.called, false);
+                done();
+            },
+        );
     });
 
     it('should return null if scuba is disabled', done => {
         QuotaService.enabled = false;
-        validateQuotas(request, mockBucket, {
-            account: 'test_1',
-            quota: 1000n,
-        }, [], '', false, false, mockLog, err => {
-            assert.ifError(err);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.called, false);
-            done();
-        });
+        validateQuotas(
+            request,
+            mockBucket,
+            {
+                account: 'test_1',
+                quota: 1000n,
+            },
+            [],
+            '',
+            false,
+            false,
+            mockLog,
+            err => {
+                assert.ifError(err);
+                assert.strictEqual(QuotaService._getLatestMetricsCallback.called, false);
+                done();
+            },
+        );
     });
 
     it('should return null if metrics retrieval fails', done => {
@@ -436,23 +491,31 @@ describe('validateQuotas (with accounts)', () => {
         const error = new Error('Failed to get metrics');
         QuotaService._getLatestMetricsCallback.yields(error);
 
-        validateQuotas(request, mockBucket, {
-            account: 'test_1',
-            quota: 1000n,
-        }, ['objectPut', 'getObject'], 'objectPut', 1, false, mockLog, err => {
-            assert.ifError(err);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledWith(
-                'bucket',
-                'bucketName_1640995200000',
-                null,
-                {
-                    action: 'objectPut',
-                    inflight: 1,
-                }
-            ), true);
-            done();
-        });
+        validateQuotas(
+            request,
+            mockBucket,
+            {
+                account: 'test_1',
+                quota: 1000n,
+            },
+            ['objectPut', 'getObject'],
+            'objectPut',
+            1,
+            false,
+            mockLog,
+            err => {
+                assert.ifError(err);
+                assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
+                assert.strictEqual(
+                    QuotaService._getLatestMetricsCallback.calledWith('bucket', 'bucketName_1640995200000', null, {
+                        action: 'objectPut',
+                        inflight: 1,
+                    }),
+                    true,
+                );
+                done();
+            },
+        );
     });
 
     it('should return errors.QuotaExceeded if quota is exceeded', done => {
@@ -465,24 +528,32 @@ describe('validateQuotas (with accounts)', () => {
         QuotaService._getLatestMetricsCallback.yields(null, result1);
         QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
 
-        validateQuotas(request, mockBucketNoQuota, {
-            account: 'test_1',
-            quota: 100n,
-        }, ['objectPut', 'getObject'], 'objectPut', 1, false, mockLog, err => {
-            assert.strictEqual(err.is.QuotaExceeded, true);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.callCount, 1);
-            assert.strictEqual(request.finalizerHooks.length, 1);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledWith(
-                'account',
-                'test_1',
-                null,
-                {
-                    action: 'objectPut',
-                    inflight: 1,
-                }
-            ), true);
-            done();
-        });
+        validateQuotas(
+            request,
+            mockBucketNoQuota,
+            {
+                account: 'test_1',
+                quota: 100n,
+            },
+            ['objectPut', 'getObject'],
+            'objectPut',
+            1,
+            false,
+            mockLog,
+            err => {
+                assert.strictEqual(err.is.QuotaExceeded, true);
+                assert.strictEqual(QuotaService._getLatestMetricsCallback.callCount, 1);
+                assert.strictEqual(request.finalizerHooks.length, 1);
+                assert.strictEqual(
+                    QuotaService._getLatestMetricsCallback.calledWith('account', 'test_1', null, {
+                        action: 'objectPut',
+                        inflight: 1,
+                    }),
+                    true,
+                );
+                done();
+            },
+        );
     });
 
     it('should not return QuotaExceeded if the quotas are exceeded but operation is a delete', done => {
@@ -495,23 +566,31 @@ describe('validateQuotas (with accounts)', () => {
         QuotaService._getLatestMetricsCallback.yields(null, result1);
         QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
 
-        validateQuotas(request, mockBucketNoQuota, {
-            account: 'test_1',
-            quota: 1000n,
-        }, ['objectDelete'], 'objectDelete', -50, false, mockLog, err => {
-            assert.ifError(err);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.callCount, 1);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledWith(
-                'account',
-                'test_1',
-                null,
-                {
-                    action: 'objectDelete',
-                    inflight: -50,
-                }
-            ), true);
-            done();
-        });
+        validateQuotas(
+            request,
+            mockBucketNoQuota,
+            {
+                account: 'test_1',
+                quota: 1000n,
+            },
+            ['objectDelete'],
+            'objectDelete',
+            -50,
+            false,
+            mockLog,
+            err => {
+                assert.ifError(err);
+                assert.strictEqual(QuotaService._getLatestMetricsCallback.callCount, 1);
+                assert.strictEqual(
+                    QuotaService._getLatestMetricsCallback.calledWith('account', 'test_1', null, {
+                        action: 'objectDelete',
+                        inflight: -50,
+                    }),
+                    true,
+                );
+                done();
+            },
+        );
     });
 
     it('should decrease the inflights by deleting data, and go below 0 to unblock operations', done => {
@@ -524,23 +603,31 @@ describe('validateQuotas (with accounts)', () => {
         QuotaService._getLatestMetricsCallback.yields(null, result1);
         QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
 
-        validateQuotas(request, mockBucketNoQuota, {
-            account: 'test_1',
-            quota: 1000n,
-        }, ['objectDelete'], 'objectDelete', -5000, false, mockLog, err => {
-            assert.ifError(err);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.callCount, 1);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledWith(
-                'account',
-                'test_1',
-                null,
-                {
-                    action: 'objectDelete',
-                    inflight: -5000,
-                }
-            ), true);
-            done();
-        });
+        validateQuotas(
+            request,
+            mockBucketNoQuota,
+            {
+                account: 'test_1',
+                quota: 1000n,
+            },
+            ['objectDelete'],
+            'objectDelete',
+            -5000,
+            false,
+            mockLog,
+            err => {
+                assert.ifError(err);
+                assert.strictEqual(QuotaService._getLatestMetricsCallback.callCount, 1);
+                assert.strictEqual(
+                    QuotaService._getLatestMetricsCallback.calledWith('account', 'test_1', null, {
+                        action: 'objectDelete',
+                        inflight: -5000,
+                    }),
+                    true,
+                );
+                done();
+            },
+        );
     });
 
     it('should return null if quota is not exceeded', done => {
@@ -553,23 +640,31 @@ describe('validateQuotas (with accounts)', () => {
         QuotaService._getLatestMetricsCallback.yields(null, result1);
         QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
 
-        validateQuotas(request, mockBucket, {
-            account: 'test_1',
-            quota: 1000n,
-        }, ['objectRestore', 'objectPut'], 'objectRestore', true, false, mockLog, err => {
-            assert.ifError(err);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.callCount, 4);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledWith(
-                'account',
-                'test_1',
-                null,
-                {
-                    action: 'objectRestore',
-                    inflight: true,
-                }
-            ), true);
-            done();
-        });
+        validateQuotas(
+            request,
+            mockBucket,
+            {
+                account: 'test_1',
+                quota: 1000n,
+            },
+            ['objectRestore', 'objectPut'],
+            'objectRestore',
+            true,
+            false,
+            mockLog,
+            err => {
+                assert.ifError(err);
+                assert.strictEqual(QuotaService._getLatestMetricsCallback.callCount, 4);
+                assert.strictEqual(
+                    QuotaService._getLatestMetricsCallback.calledWith('account', 'test_1', null, {
+                        action: 'objectRestore',
+                        inflight: true,
+                    }),
+                    true,
+                );
+                done();
+            },
+        );
     });
 
     it('should return quota exceeded if account and bucket quotas are different', done => {
@@ -582,15 +677,25 @@ describe('validateQuotas (with accounts)', () => {
         QuotaService._getLatestMetricsCallback.yields(null, result1);
         QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
 
-        validateQuotas(request, mockBucket, {
-            account: 'test_1',
-            quota: 1000n,
-        }, ['objectPut', 'getObject'], 'objectPut', 1, false, mockLog, err => {
-            assert.strictEqual(err.is.QuotaExceeded, true);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.callCount, 2);
-            assert.strictEqual(request.finalizerHooks.length, 1);
-            done();
-        });
+        validateQuotas(
+            request,
+            mockBucket,
+            {
+                account: 'test_1',
+                quota: 1000n,
+            },
+            ['objectPut', 'getObject'],
+            'objectPut',
+            1,
+            false,
+            mockLog,
+            err => {
+                assert.strictEqual(err.is.QuotaExceeded, true);
+                assert.strictEqual(QuotaService._getLatestMetricsCallback.callCount, 2);
+                assert.strictEqual(request.finalizerHooks.length, 1);
+                done();
+            },
+        );
     });
 
     it('should update the request with one function per action to clear quota updates', done => {
@@ -603,23 +708,31 @@ describe('validateQuotas (with accounts)', () => {
         QuotaService._getLatestMetricsCallback.yields(null, result1);
         QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
 
-        validateQuotas(request, mockBucket, {
-            account: 'test_1',
-            quota: 1000n,
-        }, ['objectRestore', 'objectPut'], 'objectRestore', true, false, mockLog, err => {
-            assert.ifError(err);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.callCount, 4);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledWith(
-                'account',
-                'test_1',
-                null,
-                {
-                    action: 'objectRestore',
-                    inflight: true,
-                }
-            ), true);
-            done();
-        });
+        validateQuotas(
+            request,
+            mockBucket,
+            {
+                account: 'test_1',
+                quota: 1000n,
+            },
+            ['objectRestore', 'objectPut'],
+            'objectRestore',
+            true,
+            false,
+            mockLog,
+            err => {
+                assert.ifError(err);
+                assert.strictEqual(QuotaService._getLatestMetricsCallback.callCount, 4);
+                assert.strictEqual(
+                    QuotaService._getLatestMetricsCallback.calledWith('account', 'test_1', null, {
+                        action: 'objectRestore',
+                        inflight: true,
+                    }),
+                    true,
+                );
+                done();
+            },
+        );
     });
 
     it('should evaluate the quotas and not update the inflights when isStorageReserved is true', done => {
@@ -632,23 +745,31 @@ describe('validateQuotas (with accounts)', () => {
         QuotaService._getLatestMetricsCallback.yields(null, result1);
         QuotaService._getLatestMetricsCallback.onCall(1).yields(null, result2);
 
-        validateQuotas(request, mockBucket, {
-            account: 'test_1',
-            quota: 1000n,
-        }, ['objectPut'], 'objectPut', true, true, mockLog, err => {
-            assert.ifError(err);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledTwice, true);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledWith(
-                'account',
-                'test_1',
-                null,
-                {
-                    action: 'objectPut',
-                    inflight: 0,
-                }
-            ), true);
-            done();
-        });
+        validateQuotas(
+            request,
+            mockBucket,
+            {
+                account: 'test_1',
+                quota: 1000n,
+            },
+            ['objectPut'],
+            'objectPut',
+            true,
+            true,
+            mockLog,
+            err => {
+                assert.ifError(err);
+                assert.strictEqual(QuotaService._getLatestMetricsCallback.calledTwice, true);
+                assert.strictEqual(
+                    QuotaService._getLatestMetricsCallback.calledWith('account', 'test_1', null, {
+                        action: 'objectPut',
+                        inflight: 0,
+                    }),
+                    true,
+                );
+                done();
+            },
+        );
     });
 
     it('should handle account numbers above MAX_SAFE_INTEGER when quota is not exceeded', done => {
@@ -658,23 +779,31 @@ describe('validateQuotas (with accounts)', () => {
         };
         QuotaService._getLatestMetricsCallback.yields(null, result1);
 
-        validateQuotas(request, mockBucketNoQuota, {
-            account: 'test_1',
-            quota: 9007199254740993n,
-        }, ['objectPut'], 'objectPut', 1, false, mockLog, err => {
-            assert.ifError(err);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledWith(
-                'account',
-                'test_1',
-                null,
-                {
-                    action: 'objectPut',
-                    inflight: 1,
-                },
-            ), true);
-            done();
-        });
+        validateQuotas(
+            request,
+            mockBucketNoQuota,
+            {
+                account: 'test_1',
+                quota: 9007199254740993n,
+            },
+            ['objectPut'],
+            'objectPut',
+            1,
+            false,
+            mockLog,
+            err => {
+                assert.ifError(err);
+                assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
+                assert.strictEqual(
+                    QuotaService._getLatestMetricsCallback.calledWith('account', 'test_1', null, {
+                        action: 'objectPut',
+                        inflight: 1,
+                    }),
+                    true,
+                );
+                done();
+            },
+        );
     });
 
     it('should handle account numbers above MAX_SAFE_INTEGER when quota is exceeded', done => {
@@ -684,15 +813,25 @@ describe('validateQuotas (with accounts)', () => {
         };
         QuotaService._getLatestMetricsCallback.yields(null, result1);
 
-        validateQuotas(request, mockBucketNoQuota, {
-            account: 'test_1',
-            quota: 9007199254740991n,
-        }, ['objectPut'], 'objectPut', 1, false, mockLog, err => {
-            assert.strictEqual(err.is.QuotaExceeded, true);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
-            assert.strictEqual(request.finalizerHooks.length, 1);
-            done();
-        });
+        validateQuotas(
+            request,
+            mockBucketNoQuota,
+            {
+                account: 'test_1',
+                quota: 9007199254740991n,
+            },
+            ['objectPut'],
+            'objectPut',
+            1,
+            false,
+            mockLog,
+            err => {
+                assert.strictEqual(err.is.QuotaExceeded, true);
+                assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
+                assert.strictEqual(request.finalizerHooks.length, 1);
+                done();
+            },
+        );
     });
 
     it('should handle account numbers above MAX_SAFE_INTEGER with disabled inflights', done => {
@@ -703,23 +842,31 @@ describe('validateQuotas (with accounts)', () => {
         };
         QuotaService._getLatestMetricsCallback.yields(null, result1);
 
-        validateQuotas(request, mockBucketNoQuota, {
-            account: 'test_1',
-            quota: 9007199254740993n,
-        }, ['objectPut'], 'objectPut', 1, false, mockLog, err => {
-            assert.ifError(err);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
-            assert.strictEqual(QuotaService._getLatestMetricsCallback.calledWith(
-                'account',
-                'test_1',
-                null,
-                {
-                    action: 'objectPut',
-                    inflight: undefined,
-                },
-            ), true);
-            done();
-        });
+        validateQuotas(
+            request,
+            mockBucketNoQuota,
+            {
+                account: 'test_1',
+                quota: 9007199254740993n,
+            },
+            ['objectPut'],
+            'objectPut',
+            1,
+            false,
+            mockLog,
+            err => {
+                assert.ifError(err);
+                assert.strictEqual(QuotaService._getLatestMetricsCallback.calledOnce, true);
+                assert.strictEqual(
+                    QuotaService._getLatestMetricsCallback.calledWith('account', 'test_1', null, {
+                        action: 'objectPut',
+                        inflight: undefined,
+                    }),
+                    true,
+                );
+                done();
+            },
+        );
     });
 });
 
@@ -746,7 +893,7 @@ describe('processBytesToWrite', () => {
         ...hotObject,
         dataStoreName: 'glacier',
         archive: {
-            archiveInfo: '{archiveID,archiveVersion}'
+            archiveInfo: '{archiveID,archiveVersion}',
         },
     };
     const restoringObject = {

--- a/tests/unit/quotas/scuba/wrapper.js
+++ b/tests/unit/quotas/scuba/wrapper.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const sinon = require('sinon');
 const { ScubaClientImpl } = require('../../../../lib/utilization/scuba/wrapper');
+const { default: ScubaClient } = require('scubaclient');
 
 describe('ScubaClientImpl', () => {
     let client;
@@ -101,53 +102,42 @@ describe('ScubaClientImpl', () => {
     });
 
     describe('getUtilizationMetrics', () => {
-        it('should forward the werelogs req_id chain as the X-Scal-Request-Uids header', done => {
-            const metricsStub = sinon
-                .stub(client, '_getLatestMetricsCallback')
-                .callsArgWith(4, null, { bytesTotal: 0 });
+        it('should forward the werelogs req_id chain as the X-Scal-Request-Uids header', async () => {
+            const metricsStub = sinon.stub(ScubaClient.prototype, 'getLatestMetrics').resolves({ bytesTotal: 0 });
             const reqLog = { getSerializedUids: () => 'req1:req2' };
 
-            client.getUtilizationMetrics(
+            const data = await client.getUtilizationMetrics(
                 'bucket',
                 'k',
                 null,
                 { action: 'objectPut', inflight: 1 },
                 reqLog,
-                (err, data) => {
-                    assert.ifError(err);
-                    assert.deepStrictEqual(data, { bytesTotal: 0 });
-                    const forwardedOptions = metricsStub.getCall(0).args[2];
-                    assert.strictEqual(forwardedOptions.headers['X-Scal-Request-Uids'], 'req1:req2');
-                    done();
-                },
             );
+
+            assert.deepStrictEqual(data, { bytesTotal: 0 });
+            const forwardedOptions = metricsStub.getCall(0).args[2];
+            assert.strictEqual(forwardedOptions.headers['X-Scal-Request-Uids'], 'req1:req2');
         });
 
-        it('should not set X-Scal-Request-Uids when log lacks getSerializedUids', done => {
-            const metricsStub = sinon.stub(client, '_getLatestMetricsCallback').callsArgWith(4, null, {});
+        it('should not set X-Scal-Request-Uids when log lacks getSerializedUids', async () => {
+            const metricsStub = sinon.stub(ScubaClient.prototype, 'getLatestMetrics').resolves({});
 
-            client.getUtilizationMetrics('bucket', 'k', null, { action: 'objectPut', inflight: 1 }, {}, err => {
-                assert.ifError(err);
-                const forwardedOptions = metricsStub.getCall(0).args[2];
-                assert.strictEqual(forwardedOptions, null);
-                done();
-            });
+            await client.getUtilizationMetrics('bucket', 'k', null, { action: 'objectPut', inflight: 1 }, {});
+
+            const forwardedOptions = metricsStub.getCall(0).args[2];
+            assert.strictEqual(forwardedOptions, null);
         });
 
-        it('should merge X-Scal-Request-Uids with existing options headers', done => {
-            const metricsStub = sinon
-                .stub(client, '_getLatestMetricsCallback')
-                .callsArgWith(4, null, { bytesTotal: 0 });
+        it('should merge X-Scal-Request-Uids with existing options headers', async () => {
+            const metricsStub = sinon.stub(ScubaClient.prototype, 'getLatestMetrics').resolves({ bytesTotal: 0 });
             const reqLog = { getSerializedUids: () => 'req1:req2' };
             const options = { headers: { 'X-Existing': 'v' } };
 
-            client.getUtilizationMetrics('bucket', 'k', options, { action: 'objectPut', inflight: 1 }, reqLog, err => {
-                assert.ifError(err);
-                const forwardedOptions = metricsStub.getCall(0).args[2];
-                assert.strictEqual(forwardedOptions.headers['X-Existing'], 'v');
-                assert.strictEqual(forwardedOptions.headers['X-Scal-Request-Uids'], 'req1:req2');
-                done();
-            });
+            await client.getUtilizationMetrics('bucket', 'k', options, { action: 'objectPut', inflight: 1 }, reqLog);
+
+            const forwardedOptions = metricsStub.getCall(0).args[2];
+            assert.strictEqual(forwardedOptions.headers['X-Existing'], 'v');
+            assert.strictEqual(forwardedOptions.headers['X-Scal-Request-Uids'], 'req1:req2');
         });
     });
 });

--- a/tests/unit/quotas/scuba/wrapper.js
+++ b/tests/unit/quotas/scuba/wrapper.js
@@ -44,7 +44,7 @@ describe('ScubaClientImpl', () => {
         });
 
         it('should disable Scuba if health check returns non-stale data', async () => {
-            sinon.stub(client, 'healthCheck').resolves({ date: Date.now() - (12 * 60 * 60 * 1000) });
+            sinon.stub(client, 'healthCheck').resolves({ date: Date.now() - 12 * 60 * 60 * 1000 });
 
             await client._healthCheck();
 
@@ -52,7 +52,7 @@ describe('ScubaClientImpl', () => {
         });
 
         it('should disable Scuba if health check returns stale data', async () => {
-            sinon.stub(client, 'healthCheck').resolves({ date: Date.now() - (48 * 60 * 60 * 1000) });
+            sinon.stub(client, 'healthCheck').resolves({ date: Date.now() - 48 * 60 * 60 * 1000 });
 
             await client._healthCheck();
 

--- a/tests/unit/quotas/scuba/wrapper.js
+++ b/tests/unit/quotas/scuba/wrapper.js
@@ -99,4 +99,55 @@ describe('ScubaClientImpl', () => {
             assert(clearIntervalStub.calledOnceWith(123));
         });
     });
+
+    describe('getUtilizationMetrics', () => {
+        it('should forward the werelogs req_id chain as the X-Scal-Request-Uids header', done => {
+            const metricsStub = sinon
+                .stub(client, '_getLatestMetricsCallback')
+                .callsArgWith(4, null, { bytesTotal: 0 });
+            const reqLog = { getSerializedUids: () => 'req1:req2' };
+
+            client.getUtilizationMetrics(
+                'bucket',
+                'k',
+                null,
+                { action: 'objectPut', inflight: 1 },
+                reqLog,
+                (err, data) => {
+                    assert.ifError(err);
+                    assert.deepStrictEqual(data, { bytesTotal: 0 });
+                    const forwardedOptions = metricsStub.getCall(0).args[2];
+                    assert.strictEqual(forwardedOptions.headers['X-Scal-Request-Uids'], 'req1:req2');
+                    done();
+                },
+            );
+        });
+
+        it('should not set X-Scal-Request-Uids when log lacks getSerializedUids', done => {
+            const metricsStub = sinon.stub(client, '_getLatestMetricsCallback').callsArgWith(4, null, {});
+
+            client.getUtilizationMetrics('bucket', 'k', null, { action: 'objectPut', inflight: 1 }, {}, err => {
+                assert.ifError(err);
+                const forwardedOptions = metricsStub.getCall(0).args[2];
+                assert.strictEqual(forwardedOptions, null);
+                done();
+            });
+        });
+
+        it('should merge X-Scal-Request-Uids with existing options headers', done => {
+            const metricsStub = sinon
+                .stub(client, '_getLatestMetricsCallback')
+                .callsArgWith(4, null, { bytesTotal: 0 });
+            const reqLog = { getSerializedUids: () => 'req1:req2' };
+            const options = { headers: { 'X-Existing': 'v' } };
+
+            client.getUtilizationMetrics('bucket', 'k', options, { action: 'objectPut', inflight: 1 }, reqLog, err => {
+                assert.ifError(err);
+                const forwardedOptions = metricsStub.getCall(0).args[2];
+                assert.strictEqual(forwardedOptions.headers['X-Existing'], 'v');
+                assert.strictEqual(forwardedOptions.headers['X-Scal-Request-Uids'], 'req1:req2');
+                done();
+            });
+        });
+    });
 });

--- a/tests/unit/routes/veeam-routes.js
+++ b/tests/unit/routes/veeam-routes.js
@@ -105,7 +105,7 @@ describe('Veeam routes - comprehensive unit tests', () => {
     it('should handle 404 error from UtilizationService and return 200', async () => {
         const error404 = new Error('Not Found');
         error404.response = { status: 404 };
-        utilizationStub.callsArgWith(5, error404);
+        utilizationStub.rejects(error404);
 
         const request = createRequest();
         const response = createResponse();
@@ -124,7 +124,7 @@ describe('Veeam routes - comprehensive unit tests', () => {
     it('should handle 500 error from UtilizationService and return 500', async () => {
         const error500 = new Error('Internal Server Error');
         error500.response = { status: 500 };
-        utilizationStub.callsArgWith(5, error500);
+        utilizationStub.rejects(error500);
 
         const request = createRequest();
         const response = createResponse();
@@ -140,7 +140,7 @@ describe('Veeam routes - comprehensive unit tests', () => {
     it('should handle connection error from UtilizationService and return 500', async () => {
         const errorConn = new Error('Connection refused');
         errorConn.code = 'ECONNREFUSED';
-        utilizationStub.callsArgWith(5, errorConn);
+        utilizationStub.rejects(errorConn);
 
         const request = createRequest();
         const response = createResponse();
@@ -159,7 +159,7 @@ describe('Veeam routes - comprehensive unit tests', () => {
             bytesTotal: 123456789,
             date: metricsDate,
         };
-        utilizationStub.callsArgWith(5, null, bucketMetrics);
+        utilizationStub.resolves(bucketMetrics);
 
         const request = createRequest();
         const response = createResponse();
@@ -211,7 +211,7 @@ describe('Veeam routes - comprehensive unit tests', () => {
         // because no metrics are available yet
         const error404 = new Error('Not Found');
         error404.response = { status: 404 };
-        utilizationStub.callsArgWith(5, error404);
+        utilizationStub.rejects(error404);
 
         const request = createRequest();
         const response = createResponse();
@@ -352,7 +352,7 @@ describe('Veeam routes - HEAD request UtilizationService error handling', () => 
 
     it('should call UtilizationService for capacity.xml and use metrics date', async () => {
         const metricsDate = '2026-03-26T19:00:08.996Z';
-        utilizationStub.callsArgWith(5, null, { bytesTotal: 123456789, date: metricsDate });
+        utilizationStub.resolves({ bytesTotal: 123456789, date: metricsDate });
 
         const request = createRequest('.system-d26a9498-cb7c-4a87-a44a-8ae204f5ba6c/capacity.xml');
         const response = createResponse();
@@ -375,7 +375,7 @@ describe('Veeam routes - HEAD request UtilizationService error handling', () => 
     it('should handle 404 from UtilizationService on HEAD and return 200', async () => {
         const error404 = new Error('Not Found');
         error404.response = { status: 404 };
-        utilizationStub.callsArgWith(5, error404);
+        utilizationStub.rejects(error404);
 
         const request = createRequest('.system-d26a9498-cb7c-4a87-a44a-8ae204f5ba6c/capacity.xml');
         const response = createResponse();
@@ -392,7 +392,7 @@ describe('Veeam routes - HEAD request UtilizationService error handling', () => 
     it('should handle non-404 error from UtilizationService on HEAD and return 500', async () => {
         const error500 = new Error('Internal Server Error');
         error500.response = { status: 500 };
-        utilizationStub.callsArgWith(5, error500);
+        utilizationStub.rejects(error500);
 
         const request = createRequest('.system-d26a9498-cb7c-4a87-a44a-8ae204f5ba6c/capacity.xml');
         const response = createResponse();
@@ -408,7 +408,7 @@ describe('Veeam routes - HEAD request UtilizationService error handling', () => 
             _capabilities: {},
         };
         metadataStub.callsArgWith(2, null, bucketMdWithoutVeeam);
-        utilizationStub.callsArgWith(5, null, {});
+        utilizationStub.resolves({});
 
         const request = createRequest();
         const response = createResponse();
@@ -507,7 +507,7 @@ describe('Veeam routes - LIST request handling', () => {
 
     it('should list both system.xml and capacity.xml when both are present', async () => {
         const metricsDate = '2026-03-26T19:00:08.996Z';
-        utilizationStub.callsArgWith(5, null, { bytesTotal: 123456789, date: metricsDate });
+        utilizationStub.resolves({ bytesTotal: 123456789, date: metricsDate });
 
         const request = createRequest();
         const response = createResponse();
@@ -520,7 +520,7 @@ describe('Veeam routes - LIST request handling', () => {
     });
 
     it('should emit LastModified in ISO 8601 format in XML body', async () => {
-        utilizationStub.callsArgWith(5, null, { bytesTotal: 0, date: new Date().toISOString() });
+        utilizationStub.resolves({ bytesTotal: 0, date: new Date().toISOString() });
 
         const request = createRequest();
         const response = createResponse();
@@ -556,7 +556,7 @@ describe('Veeam routes - LIST request handling', () => {
     it('should handle 404 from UtilizationService on LIST and return 200', async () => {
         const error404 = new Error('Not Found');
         error404.response = { status: 404 };
-        utilizationStub.callsArgWith(5, error404);
+        utilizationStub.rejects(error404);
 
         const request = createRequest();
         const response = createResponse();
@@ -573,7 +573,7 @@ describe('Veeam routes - LIST request handling', () => {
     it('should handle non-404 error from UtilizationService on LIST and return 500', async () => {
         const error500 = new Error('Internal Server Error');
         error500.response = { status: 500 };
-        utilizationStub.callsArgWith(5, error500);
+        utilizationStub.rejects(error500);
 
         const request = createRequest();
         const response = createResponse();
@@ -584,7 +584,7 @@ describe('Veeam routes - LIST request handling', () => {
     });
 
     it('should handle versions query parameter', async () => {
-        utilizationStub.callsArgWith(5, null, { bytesTotal: 0, date: new Date().toISOString() });
+        utilizationStub.resolves({ bytesTotal: 0, date: new Date().toISOString() });
         const request = createRequest({ versions: '' });
         const response = createResponse();
 

--- a/tests/unit/routes/veeam-routes.js
+++ b/tests/unit/routes/veeam-routes.js
@@ -83,7 +83,8 @@ describe('Veeam routes - comprehensive unit tests', () => {
             response.end.called = true;
             response.headersSent = true;
             // Emit finish event when end is called
-            const finishHandlers = response.on.getCalls()
+            const finishHandlers = response.on
+                .getCalls()
                 .filter(call => call.args[0] === 'finish')
                 .map(call => call.args[1]);
             finishHandlers.forEach(handler => handler());
@@ -113,12 +114,10 @@ describe('Veeam routes - comprehensive unit tests', () => {
 
         assert(logWarnSpy.calledOnce, 'log.warn should have been called once');
         const warnCall = logWarnSpy.getCall(0);
-        assert(warnCall.args[0].includes('UtilizationService returned 404'),
-            'warning message should mention 404');
+        assert(warnCall.args[0].includes('UtilizationService returned 404'), 'warning message should mention 404');
         assert.strictEqual(warnCall.args[1].bucket, 'test-bucket');
 
-        assert(response.writeHead.calledWith(200),
-            'should return 200 despite 404 from UtilizationService');
+        assert(response.writeHead.calledWith(200), 'should return 200 despite 404 from UtilizationService');
         assert(response.end.called, 'response should be ended');
     });
 
@@ -132,8 +131,10 @@ describe('Veeam routes - comprehensive unit tests', () => {
 
         await getVeeamFile(request, response, bucketMd, log);
 
-        assert(response.headersSent || response.write.called || response.writeHead.called,
-            'should send error response for 500 errors');
+        assert(
+            response.headersSent || response.write.called || response.writeHead.called,
+            'should send error response for 500 errors',
+        );
     });
 
     it('should handle connection error from UtilizationService and return 500', async () => {
@@ -146,8 +147,10 @@ describe('Veeam routes - comprehensive unit tests', () => {
 
         await getVeeamFile(request, response, bucketMd, log);
 
-        assert(response.headersSent || response.write.called || response.writeHead.called,
-            'should send error response for connection errors');
+        assert(
+            response.headersSent || response.write.called || response.writeHead.called,
+            'should send error response for connection errors',
+        );
     });
 
     it('should successfully use metrics when UtilizationService returns data', async () => {
@@ -168,8 +171,7 @@ describe('Veeam routes - comprehensive unit tests', () => {
         assert(utilizationStub.calledOnce, 'should call UtilizationService once');
         assert(response.end.called, 'response should be ended');
 
-        const lastModifiedCall = response.setHeader.getCalls()
-            .find(call => call.args[0] === 'Last-Modified');
+        const lastModifiedCall = response.setHeader.getCalls().find(call => call.args[0] === 'Last-Modified');
 
         assert(lastModifiedCall, 'Last-Modified header should be set');
         assert.strictEqual(
@@ -217,8 +219,7 @@ describe('Veeam routes - comprehensive unit tests', () => {
         await getVeeamFile(request, response, bucketMd, log);
 
         assert(logWarnSpy.calledOnce, 'should log warning for 404');
-        assert(response.writeHead.calledWith(200),
-            'should return 200 with static capacity data for 404');
+        assert(response.writeHead.calledWith(200), 'should return 200 with static capacity data for 404');
         assert(response.end.called, 'response should be ended');
         const warnCall = logWarnSpy.getCall(0);
         assert(warnCall.args[0].includes('404'), 'warning should mention 404');
@@ -233,8 +234,10 @@ describe('Veeam routes - comprehensive unit tests', () => {
 
         await getVeeamFile(request, response, bucketMd, log);
 
-        assert(response.headersSent || response.write.called || response.writeHead.called,
-            'should send response for metadata errors');
+        assert(
+            response.headersSent || response.write.called || response.writeHead.called,
+            'should send response for metadata errors',
+        );
     });
 
     it('should handle tagging query parameter', async () => {
@@ -244,8 +247,7 @@ describe('Veeam routes - comprehensive unit tests', () => {
 
         await getVeeamFile(request, response, bucketMd, log);
 
-        assert(response.writeHead.calledWith(200),
-            'should return 200 for tagging query');
+        assert(response.writeHead.calledWith(200), 'should return 200 for tagging query');
         assert(response.end.called, 'response should be ended');
     });
 });
@@ -361,8 +363,7 @@ describe('Veeam routes - HEAD request UtilizationService error handling', () => 
         assert(response.setHeader.called, 'should set headers');
         assert(response.end.called, 'response should be ended');
 
-        const lastModifiedCall = response.setHeader.getCalls()
-            .find(call => call.args[0] === 'Last-Modified');
+        const lastModifiedCall = response.setHeader.getCalls().find(call => call.args[0] === 'Last-Modified');
         assert(lastModifiedCall, 'Last-Modified header should be set');
         assert.strictEqual(
             lastModifiedCall.args[1],
@@ -383,8 +384,7 @@ describe('Veeam routes - HEAD request UtilizationService error handling', () => 
 
         assert(logWarnSpy.calledOnce, 'log.warn should have been called once');
         const warnCall = logWarnSpy.getCall(0);
-        assert(warnCall.args[0].includes('UtilizationService returned 404'),
-            'warning message should mention 404');
+        assert(warnCall.args[0].includes('UtilizationService returned 404'), 'warning message should mention 404');
         assert(response.setHeader.called, 'should set headers');
         assert(response.end.called, 'response should be ended');
     });
@@ -496,7 +496,8 @@ describe('Veeam routes - LIST request handling', () => {
         response.once.returns(response);
         response.end.callsFake(() => {
             response.end.called = true;
-            const finishHandlers = response.on.getCalls()
+            const finishHandlers = response.on
+                .getCalls()
                 .filter(call => call.args[0] === 'finish')
                 .map(call => call.args[1]);
             finishHandlers.forEach(handler => handler());
@@ -544,12 +545,11 @@ describe('Veeam routes - LIST request handling', () => {
             matches.push(match[1]);
         }
 
-        assert.strictEqual(matches.length, 3,
-            'should have 3 LastModified entries (system.xml, capacity.xml, folder)');
+        assert.strictEqual(matches.length, 3, 'should have 3 LastModified entries (system.xml, capacity.xml, folder)');
 
         const iso8601Regex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
-        matches.forEach(
-            value => { assert(iso8601Regex.test(value), `LastModified "${value}" should be in ISO 8601 format`);
+        matches.forEach(value => {
+            assert(iso8601Regex.test(value), `LastModified "${value}" should be in ISO 8601 format`);
         });
     });
 
@@ -565,8 +565,7 @@ describe('Veeam routes - LIST request handling', () => {
 
         assert(logWarnSpy.calledOnce, 'log.warn should have been called once');
         const warnCall = logWarnSpy.getCall(0);
-        assert(warnCall.args[0].includes('UtilizationService returned 404'),
-            'warning message should mention 404');
+        assert(warnCall.args[0].includes('UtilizationService returned 404'), 'warning message should mention 404');
         assert(response.writeHead.calledWith(200), 'should return 200 despite 404');
         assert(response.end.called, 'response should be ended');
     });
@@ -615,31 +614,28 @@ describe('Veeam routes - LIST request handling', () => {
         assert(response.end.called, 'response should be ended');
     });
 
-    it(
-        'should list only available files when only SystemInfo is present, without calling UtilizationService',
-        async () => {
-            const bucketMdOnlySystem = {
-                ...bucketMd,
-                _capabilities: {
-                    VeeamSOSApi: {
-                        SystemInfo: {
-                            ProtocolVersion: '1.0',
-                            ModelName: 'ARTESCA',
-                            LastModified: '2024-01-01T00:00:00.000Z',
-                        },
+    it('should list available files when only SystemInfo is present, without calling UtilizationService', async () => {
+        const bucketMdOnlySystem = {
+            ...bucketMd,
+            _capabilities: {
+                VeeamSOSApi: {
+                    SystemInfo: {
+                        ProtocolVersion: '1.0',
+                        ModelName: 'ARTESCA',
+                        LastModified: '2024-01-01T00:00:00.000Z',
                     },
                 },
-            };
-            metadataStub.callsArgWith(2, null, bucketMdOnlySystem);
+            },
+        };
+        metadataStub.callsArgWith(2, null, bucketMdOnlySystem);
 
-            const request = createRequest();
-            const response = createResponse();
+        const request = createRequest();
+        const response = createResponse();
 
-            await listVeeamFiles(request, response, bucketMdOnlySystem, log);
+        await listVeeamFiles(request, response, bucketMdOnlySystem, log);
 
-            assert(!utilizationStub.called, 'should not call UtilizationService without CapacityInfo');
-            assert(response.writeHead.calledWith(200), 'should return 200');
-            assert(response.end.called, 'response should be ended');
-        },
-    );
+        assert(!utilizationStub.called, 'should not call UtilizationService without CapacityInfo');
+        assert(response.writeHead.calledWith(200), 'should return 200');
+        assert(response.end.called, 'response should be ended');
+    });
 });

--- a/tests/unit/routes/veeam-routes.js
+++ b/tests/unit/routes/veeam-routes.js
@@ -105,7 +105,7 @@ describe('Veeam routes - comprehensive unit tests', () => {
     it('should handle 404 error from UtilizationService and return 200', async () => {
         const error404 = new Error('Not Found');
         error404.response = { status: 404 };
-        utilizationStub.callsArgWith(4, error404);
+        utilizationStub.callsArgWith(5, error404);
 
         const request = createRequest();
         const response = createResponse();
@@ -124,7 +124,7 @@ describe('Veeam routes - comprehensive unit tests', () => {
     it('should handle 500 error from UtilizationService and return 500', async () => {
         const error500 = new Error('Internal Server Error');
         error500.response = { status: 500 };
-        utilizationStub.callsArgWith(4, error500);
+        utilizationStub.callsArgWith(5, error500);
 
         const request = createRequest();
         const response = createResponse();
@@ -140,7 +140,7 @@ describe('Veeam routes - comprehensive unit tests', () => {
     it('should handle connection error from UtilizationService and return 500', async () => {
         const errorConn = new Error('Connection refused');
         errorConn.code = 'ECONNREFUSED';
-        utilizationStub.callsArgWith(4, errorConn);
+        utilizationStub.callsArgWith(5, errorConn);
 
         const request = createRequest();
         const response = createResponse();
@@ -159,7 +159,7 @@ describe('Veeam routes - comprehensive unit tests', () => {
             bytesTotal: 123456789,
             date: metricsDate,
         };
-        utilizationStub.callsArgWith(4, null, bucketMetrics);
+        utilizationStub.callsArgWith(5, null, bucketMetrics);
 
         const request = createRequest();
         const response = createResponse();
@@ -211,7 +211,7 @@ describe('Veeam routes - comprehensive unit tests', () => {
         // because no metrics are available yet
         const error404 = new Error('Not Found');
         error404.response = { status: 404 };
-        utilizationStub.callsArgWith(4, error404);
+        utilizationStub.callsArgWith(5, error404);
 
         const request = createRequest();
         const response = createResponse();
@@ -352,7 +352,7 @@ describe('Veeam routes - HEAD request UtilizationService error handling', () => 
 
     it('should call UtilizationService for capacity.xml and use metrics date', async () => {
         const metricsDate = '2026-03-26T19:00:08.996Z';
-        utilizationStub.callsArgWith(4, null, { bytesTotal: 123456789, date: metricsDate });
+        utilizationStub.callsArgWith(5, null, { bytesTotal: 123456789, date: metricsDate });
 
         const request = createRequest('.system-d26a9498-cb7c-4a87-a44a-8ae204f5ba6c/capacity.xml');
         const response = createResponse();
@@ -375,7 +375,7 @@ describe('Veeam routes - HEAD request UtilizationService error handling', () => 
     it('should handle 404 from UtilizationService on HEAD and return 200', async () => {
         const error404 = new Error('Not Found');
         error404.response = { status: 404 };
-        utilizationStub.callsArgWith(4, error404);
+        utilizationStub.callsArgWith(5, error404);
 
         const request = createRequest('.system-d26a9498-cb7c-4a87-a44a-8ae204f5ba6c/capacity.xml');
         const response = createResponse();
@@ -392,7 +392,7 @@ describe('Veeam routes - HEAD request UtilizationService error handling', () => 
     it('should handle non-404 error from UtilizationService on HEAD and return 500', async () => {
         const error500 = new Error('Internal Server Error');
         error500.response = { status: 500 };
-        utilizationStub.callsArgWith(4, error500);
+        utilizationStub.callsArgWith(5, error500);
 
         const request = createRequest('.system-d26a9498-cb7c-4a87-a44a-8ae204f5ba6c/capacity.xml');
         const response = createResponse();
@@ -408,7 +408,7 @@ describe('Veeam routes - HEAD request UtilizationService error handling', () => 
             _capabilities: {},
         };
         metadataStub.callsArgWith(2, null, bucketMdWithoutVeeam);
-        utilizationStub.callsArgWith(4, null, {});
+        utilizationStub.callsArgWith(5, null, {});
 
         const request = createRequest();
         const response = createResponse();
@@ -507,7 +507,7 @@ describe('Veeam routes - LIST request handling', () => {
 
     it('should list both system.xml and capacity.xml when both are present', async () => {
         const metricsDate = '2026-03-26T19:00:08.996Z';
-        utilizationStub.callsArgWith(4, null, { bytesTotal: 123456789, date: metricsDate });
+        utilizationStub.callsArgWith(5, null, { bytesTotal: 123456789, date: metricsDate });
 
         const request = createRequest();
         const response = createResponse();
@@ -520,7 +520,7 @@ describe('Veeam routes - LIST request handling', () => {
     });
 
     it('should emit LastModified in ISO 8601 format in XML body', async () => {
-        utilizationStub.callsArgWith(4, null, { bytesTotal: 0, date: new Date().toISOString() });
+        utilizationStub.callsArgWith(5, null, { bytesTotal: 0, date: new Date().toISOString() });
 
         const request = createRequest();
         const response = createResponse();
@@ -556,7 +556,7 @@ describe('Veeam routes - LIST request handling', () => {
     it('should handle 404 from UtilizationService on LIST and return 200', async () => {
         const error404 = new Error('Not Found');
         error404.response = { status: 404 };
-        utilizationStub.callsArgWith(4, error404);
+        utilizationStub.callsArgWith(5, error404);
 
         const request = createRequest();
         const response = createResponse();
@@ -573,7 +573,7 @@ describe('Veeam routes - LIST request handling', () => {
     it('should handle non-404 error from UtilizationService on LIST and return 500', async () => {
         const error500 = new Error('Internal Server Error');
         error500.response = { status: 500 };
-        utilizationStub.callsArgWith(4, error500);
+        utilizationStub.callsArgWith(5, error500);
 
         const request = createRequest();
         const response = createResponse();
@@ -584,7 +584,7 @@ describe('Veeam routes - LIST request handling', () => {
     });
 
     it('should handle versions query parameter', async () => {
-        utilizationStub.callsArgWith(4, null, { bytesTotal: 0, date: new Date().toISOString() });
+        utilizationStub.callsArgWith(5, null, { bytesTotal: 0, date: new Date().toISOString() });
         const request = createRequest({ versions: '' });
         const response = createResponse();
 

--- a/tests/unit/routes/veeam-utils.js
+++ b/tests/unit/routes/veeam-utils.js
@@ -35,7 +35,7 @@ describe('fetchCapacityMetrics', () => {
     });
 
     it('should call UtilizationService with the correct bucket key', async () => {
-        utilizationStub.callsArgWith(5, null, {});
+        utilizationStub.resolves({});
 
         await fetchCapacityMetrics(bucketMd, request, log);
 
@@ -46,7 +46,7 @@ describe('fetchCapacityMetrics', () => {
 
     it('should resolve with metrics on success', async () => {
         const bucketMetrics = { bytesTotal: 42, date: '2026-03-26T19:00:08.996Z' };
-        utilizationStub.callsArgWith(5, null, bucketMetrics);
+        utilizationStub.resolves(bucketMetrics);
 
         const metrics = await fetchCapacityMetrics(bucketMd, request, log);
 
@@ -58,7 +58,7 @@ describe('fetchCapacityMetrics', () => {
     it('should resolve with no error and a default date on 404', async () => {
         const error404 = new Error('Not Found');
         error404.response = { status: 404 };
-        utilizationStub.callsArgWith(5, error404);
+        utilizationStub.rejects(error404);
 
         const metrics = await fetchCapacityMetrics(bucketMd, request, log);
 
@@ -72,7 +72,7 @@ describe('fetchCapacityMetrics', () => {
     it('should also handle 404 via statusCode property', async () => {
         const error404 = new Error('Not Found');
         error404.statusCode = 404;
-        utilizationStub.callsArgWith(5, error404);
+        utilizationStub.rejects(error404);
 
         const metrics = await fetchCapacityMetrics(bucketMd, request, log);
 
@@ -83,7 +83,7 @@ describe('fetchCapacityMetrics', () => {
     it('should reject with error on non-404 failures', async () => {
         const error500 = new Error('Internal Server Error');
         error500.response = { status: 500 };
-        utilizationStub.callsArgWith(5, error500);
+        utilizationStub.rejects(error500);
 
         await assert.rejects(fetchCapacityMetrics(bucketMd, request, log), err => err === error500);
 
@@ -96,7 +96,7 @@ describe('fetchCapacityMetrics', () => {
     it('should reject with error on connection errors', async () => {
         const connError = new Error('Connection refused');
         connError.code = 'ECONNREFUSED';
-        utilizationStub.callsArgWith(5, connError);
+        utilizationStub.rejects(connError);
 
         await assert.rejects(fetchCapacityMetrics(bucketMd, request, log), err => err === connError);
 
@@ -184,7 +184,7 @@ describe('buildVeeamFileData', () => {
         metadataStub.callsArgWith(2, null, bucketMd);
         const error500 = new Error('Internal Server Error');
         error500.response = { status: 500 };
-        utilizationStub.callsArgWith(5, error500);
+        utilizationStub.rejects(error500);
 
         await assert.rejects(
             buildVeeamFileData(createRequest(capacityObjectKey), bucketMd, log),
@@ -195,7 +195,7 @@ describe('buildVeeamFileData', () => {
     it('should build capacity.xml with SUR metrics date and applied Used/Available', async () => {
         const metricsDate = new Date('2026-03-26T19:00:08.996Z');
         metadataStub.callsArgWith(2, null, bucketMd);
-        utilizationStub.callsArgWith(5, null, { date: metricsDate, bytesTotal: 100 });
+        utilizationStub.resolves({ date: metricsDate, bytesTotal: 100 });
 
         const result = await buildVeeamFileData(createRequest(capacityObjectKey), bucketMd, log);
 
@@ -213,7 +213,7 @@ describe('buildVeeamFileData', () => {
         metadataStub.callsArgWith(2, null, bucketMd);
         const error404 = new Error('Not Found');
         error404.response = { status: 404 };
-        utilizationStub.callsArgWith(5, error404);
+        utilizationStub.rejects(error404);
 
         const result = await buildVeeamFileData(createRequest(capacityObjectKey), bucketMd, log);
 
@@ -251,7 +251,7 @@ describe('buildVeeamFileData', () => {
             },
         };
         metadataStub.callsArgWith(2, null, bucketMdWithUsed);
-        utilizationStub.callsArgWith(5, null, { date: new Date(), bytesTotal: 999 });
+        utilizationStub.resolves({ date: new Date(), bytesTotal: 999 });
 
         const result = await buildVeeamFileData(createRequest(capacityObjectKey), bucketMdWithUsed, log);
 

--- a/tests/unit/routes/veeam-utils.js
+++ b/tests/unit/routes/veeam-utils.js
@@ -35,7 +35,7 @@ describe('fetchCapacityMetrics', () => {
     });
 
     it('should call UtilizationService with the correct bucket key', async () => {
-        utilizationStub.callsArgWith(4, null, {});
+        utilizationStub.callsArgWith(5, null, {});
 
         await fetchCapacityMetrics(bucketMd, request, log);
 
@@ -46,7 +46,7 @@ describe('fetchCapacityMetrics', () => {
 
     it('should resolve with metrics on success', async () => {
         const bucketMetrics = { bytesTotal: 42, date: '2026-03-26T19:00:08.996Z' };
-        utilizationStub.callsArgWith(4, null, bucketMetrics);
+        utilizationStub.callsArgWith(5, null, bucketMetrics);
 
         const metrics = await fetchCapacityMetrics(bucketMd, request, log);
 
@@ -58,7 +58,7 @@ describe('fetchCapacityMetrics', () => {
     it('should resolve with no error and a default date on 404', async () => {
         const error404 = new Error('Not Found');
         error404.response = { status: 404 };
-        utilizationStub.callsArgWith(4, error404);
+        utilizationStub.callsArgWith(5, error404);
 
         const metrics = await fetchCapacityMetrics(bucketMd, request, log);
 
@@ -72,7 +72,7 @@ describe('fetchCapacityMetrics', () => {
     it('should also handle 404 via statusCode property', async () => {
         const error404 = new Error('Not Found');
         error404.statusCode = 404;
-        utilizationStub.callsArgWith(4, error404);
+        utilizationStub.callsArgWith(5, error404);
 
         const metrics = await fetchCapacityMetrics(bucketMd, request, log);
 
@@ -83,7 +83,7 @@ describe('fetchCapacityMetrics', () => {
     it('should reject with error on non-404 failures', async () => {
         const error500 = new Error('Internal Server Error');
         error500.response = { status: 500 };
-        utilizationStub.callsArgWith(4, error500);
+        utilizationStub.callsArgWith(5, error500);
 
         await assert.rejects(fetchCapacityMetrics(bucketMd, request, log), err => err === error500);
 
@@ -96,7 +96,7 @@ describe('fetchCapacityMetrics', () => {
     it('should reject with error on connection errors', async () => {
         const connError = new Error('Connection refused');
         connError.code = 'ECONNREFUSED';
-        utilizationStub.callsArgWith(4, connError);
+        utilizationStub.callsArgWith(5, connError);
 
         await assert.rejects(fetchCapacityMetrics(bucketMd, request, log), err => err === connError);
 
@@ -184,7 +184,7 @@ describe('buildVeeamFileData', () => {
         metadataStub.callsArgWith(2, null, bucketMd);
         const error500 = new Error('Internal Server Error');
         error500.response = { status: 500 };
-        utilizationStub.callsArgWith(4, error500);
+        utilizationStub.callsArgWith(5, error500);
 
         await assert.rejects(
             buildVeeamFileData(createRequest(capacityObjectKey), bucketMd, log),
@@ -195,7 +195,7 @@ describe('buildVeeamFileData', () => {
     it('should build capacity.xml with SUR metrics date and applied Used/Available', async () => {
         const metricsDate = new Date('2026-03-26T19:00:08.996Z');
         metadataStub.callsArgWith(2, null, bucketMd);
-        utilizationStub.callsArgWith(4, null, { date: metricsDate, bytesTotal: 100 });
+        utilizationStub.callsArgWith(5, null, { date: metricsDate, bytesTotal: 100 });
 
         const result = await buildVeeamFileData(createRequest(capacityObjectKey), bucketMd, log);
 
@@ -213,7 +213,7 @@ describe('buildVeeamFileData', () => {
         metadataStub.callsArgWith(2, null, bucketMd);
         const error404 = new Error('Not Found');
         error404.response = { status: 404 };
-        utilizationStub.callsArgWith(4, error404);
+        utilizationStub.callsArgWith(5, error404);
 
         const result = await buildVeeamFileData(createRequest(capacityObjectKey), bucketMd, log);
 
@@ -251,7 +251,7 @@ describe('buildVeeamFileData', () => {
             },
         };
         metadataStub.callsArgWith(2, null, bucketMdWithUsed);
-        utilizationStub.callsArgWith(4, null, { date: new Date(), bytesTotal: 999 });
+        utilizationStub.callsArgWith(5, null, { date: new Date(), bytesTotal: 999 });
 
         const result = await buildVeeamFileData(createRequest(capacityObjectKey), bucketMdWithUsed, log);
 

--- a/tests/unit/routes/veeam-utils.js
+++ b/tests/unit/routes/veeam-utils.js
@@ -85,10 +85,7 @@ describe('fetchCapacityMetrics', () => {
         error500.response = { status: 500 };
         utilizationStub.callsArgWith(4, error500);
 
-        await assert.rejects(
-            fetchCapacityMetrics(bucketMd, request, log),
-            err => err === error500,
-        );
+        await assert.rejects(fetchCapacityMetrics(bucketMd, request, log), err => err === error500);
 
         assert(logErrorSpy.calledOnce);
         assert.strictEqual(logErrorSpy.getCall(0).args[1].bucket, 'test-bucket');
@@ -101,10 +98,7 @@ describe('fetchCapacityMetrics', () => {
         connError.code = 'ECONNREFUSED';
         utilizationStub.callsArgWith(4, connError);
 
-        await assert.rejects(
-            fetchCapacityMetrics(bucketMd, request, log),
-            err => err === connError,
-        );
+        await assert.rejects(fetchCapacityMetrics(bucketMd, request, log), err => err === connError);
 
         assert(logErrorSpy.calledOnce);
         assert.strictEqual(logErrorSpy.getCall(0).args[1].statusCode, 'ECONNREFUSED');


### PR DESCRIPTION
Forward the werelogs req_id chain (`log.getSerializedUids()`) as the `X-Scal-Request-Uids` header on cloudserver's Scuba utilization requests, so Scuba can correlate quota lookups back to the originating cloudserver request. `traceparent` already flows; the req_id chain did not.

`ScubaClientImpl.getUtilizationMetrics` now takes a `log` parameter and, when the logger exposes `getSerializedUids()`, merges the header into the per-call options (arsenal `RESTClient` convention). A missing/mock logger never sends an undefined header. The quota (`_evaluateQuotas`) and Veeam capacity-metrics call sites pass `log`; the background health-check path is intentionally left untouched.

Issue: CLDSRV-946