### PR TITLE
CLDSRV-945: Support cross account rate limiting

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -91,6 +91,7 @@ const {
     buildRateChecksFromConfig,
     checkRateLimitsForRequest,
 } = require('./apiUtils/rateLimit/helpers');
+const rateLimitCache = require('./apiUtils/rateLimit/cache');
 
 const monitoringMap = policies.actionMaps.actionMonitoringMapS3;
 
@@ -287,6 +288,18 @@ function callApiHandler(apiMethod, apiHandler, request, response, log, callback)
     // Attach the names to the current request
     request.apiMethods = apiMethods;
 
+    // If we have a cached bucket owner for the targeted bucket, pass it to
+    // Vault as a hint so the returned rate limit config is the target account.
+    // Only included when the cache has a hit.
+    const authOptions = {};
+    if (request.bucketName) {
+        const cachedOwner = rateLimitCache.getCachedBucketOwner(request.bucketName);
+        if (cachedOwner) {
+            request.rateLimitTargetAccount = cachedOwner;
+            authOptions.targetAccount = cachedOwner;
+        }
+    }
+
     return async.waterfall([
         next => auth.server.doAuth(
             request, log, (err, userInfo, authorizationResults, streamingV4Params, infos) => {
@@ -301,7 +314,7 @@ function callApiHandler(apiMethod, apiHandler, request, response, log, callback)
                     return next(arsenalError);
                 }
                 return next(null, userInfo, authorizationResults, streamingV4Params, infos);
-            }, 's3', requestContexts),
+            }, 's3', requestContexts, authOptions),
         (userInfo, authorizationResults, streamingV4Params, infos, next) => {
             const authNames = { accountName: userInfo.getAccountDisplayName() };
             if (userInfo.isRequesterAnIAMUser()) {

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -69,8 +69,7 @@ const objectPutPart = require('./objectPutPart');
 const objectPutCopyPart = require('./objectPutCopyPart');
 const objectPutRetention = require('./objectPutRetention');
 const objectRestore = require('./objectRestore');
-const prepareRequestContexts
-    = require('./apiUtils/authorization/prepareRequestContexts');
+const prepareRequestContexts = require('./apiUtils/authorization/prepareRequestContexts');
 const serviceGet = require('./serviceGet');
 const vault = require('../auth/vault');
 const website = require('./website');
@@ -103,8 +102,7 @@ auth.setHandler(vault);
 // scan the args instead of relying on a fixed position.
 function hasCorsHeaders(callbackArgs) {
     for (const arg of callbackArgs) {
-        if (!arg || typeof arg !== 'object' || Array.isArray(arg)
-            || Buffer.isBuffer(arg)) {
+        if (!arg || typeof arg !== 'object' || Array.isArray(arg) || Buffer.isBuffer(arg)) {
             continue;
         }
         if ('access-control-allow-origin' in arg) {
@@ -138,22 +136,21 @@ function wrapCallbackWithErrorCorsHeaders(callback, request, response, log) {
         if (!bucket || response.headersSent) {
             return;
         }
-        const headers = collectCorsHeaders(
-            request.headers.origin, request.method, bucket);
+        const headers = collectCorsHeaders(request.headers.origin, request.method, bucket);
         Object.keys(headers).forEach(key => {
             try {
                 response.setHeader(key, headers[key]);
             } catch (e) {
                 log.debug('could not set CORS header on error', {
-                    header: key, error: e.message,
+                    header: key,
+                    error: e.message,
                 });
             }
         });
     }
 
     return (err, ...callbackArgs) => {
-        if (!err || !request.headers || !request.headers.origin
-            || !request.bucketName) {
+        if (!err || !request.headers || !request.headers.origin || !request.bucketName) {
             return callback(err, ...callbackArgs);
         }
         // Fast path: most post-auth failures come back with corsHeaders
@@ -195,8 +192,7 @@ function checkAuthResults(authResults, apiMethod, log) {
         isImplicitDeny[authResults[0].action] = authResults[0].isImplicit;
         // second item checks s3:GetObject(Version)Tagging action
         if (!authResults[1].isAllowed) {
-            log.trace('get tagging authorization denial ' +
-            'from Vault');
+            log.trace('get tagging authorization denial ' + 'from Vault');
             returnTagCount = false;
         }
     } else {
@@ -257,14 +253,15 @@ function callApiHandler(apiMethod, apiHandler, request, response, log, callback)
     }
 
     // no need to check auth on website or cors preflight requests
-    if (apiMethod === 'websiteGet' || apiMethod === 'websiteHead' ||
-    apiMethod === 'corsPreflight') {
+    if (apiMethod === 'websiteGet' || apiMethod === 'websiteHead' || apiMethod === 'corsPreflight') {
         request.actionImplicitDenies = false;
         return apiHandler(request, log, callback);
     }
 
-    const { sourceBucket, sourceObject, sourceVersionId, parsingError } =
-        parseCopySource(apiMethod, request.headers['x-amz-copy-source']);
+    const { sourceBucket, sourceObject, sourceVersionId, parsingError } = parseCopySource(
+        apiMethod,
+        request.headers['x-amz-copy-source'],
+    );
     if (parsingError) {
         log.debug('error parsing copy source', {
             error: parsingError,
@@ -280,8 +277,7 @@ function callApiHandler(apiMethod, apiHandler, request, response, log, callback)
         return process.nextTick(callback, httpHeadersSizeError);
     }
 
-    const requestContexts = prepareRequestContexts(apiMethod, request,
-        sourceBucket, sourceObject, sourceVersionId);
+    const requestContexts = prepareRequestContexts(apiMethod, request, sourceBucket, sourceObject, sourceVersionId);
 
     // Extract all the _apiMethods and store them in an array
     const apiMethods = requestContexts ? requestContexts.map(context => context._apiMethod) : [];
@@ -300,164 +296,179 @@ function callApiHandler(apiMethod, apiHandler, request, response, log, callback)
         }
     }
 
-    return async.waterfall([
-        next => auth.server.doAuth(
-            request, log, (err, userInfo, authorizationResults, streamingV4Params, infos) => {
+    return async.waterfall(
+        [
+            next =>
+                auth.server.doAuth(
+                    request,
+                    log,
+                    (err, userInfo, authorizationResults, streamingV4Params, infos) => {
+                        if (request.serverAccessLog) {
+                            request.serverAccessLog.authInfo = userInfo;
+                        }
+                        if (err) {
+                            // VaultClient returns standard errors, but the route requires
+                            // Arsenal errors
+                            const arsenalError = err.metadata ? err : errors[err.code] || errors.InternalError;
+                            log.trace('authentication error', { error: err });
+                            return next(arsenalError);
+                        }
+                        return next(null, userInfo, authorizationResults, streamingV4Params, infos);
+                    },
+                    's3',
+                    requestContexts,
+                    authOptions,
+                ),
+            (userInfo, authorizationResults, streamingV4Params, infos, next) => {
+                const authNames = { accountName: userInfo.getAccountDisplayName() };
+                if (userInfo.isRequesterAnIAMUser()) {
+                    authNames.userName = userInfo.getIAMdisplayName();
+                }
+                if (isRequesterASessionUser(userInfo)) {
+                    authNames.sessionName = userInfo.getShortid().split(':')[1];
+                }
+                log.addDefaultFields(authNames);
                 if (request.serverAccessLog) {
-                    request.serverAccessLog.authInfo = userInfo;
+                    request.serverAccessLog.analyticsAccountName = authNames.accountName;
+                    request.serverAccessLog.analyticsUserName = authNames.userName;
                 }
-                if (err) {
-                    // VaultClient returns standard errors, but the route requires
-                    // Arsenal errors
-                    const arsenalError = err.metadata ? err : errors[err.code] || errors.InternalError;
-                    log.trace('authentication error', { error: err });
-                    return next(arsenalError);
+                if (apiMethod === 'objectPut' || apiMethod === 'objectPutPart') {
+                    const setStartTurnAroundTime = () => {
+                        if (request.serverAccessLog) {
+                            request.serverAccessLog.startTurnAroundTime = process.hrtime.bigint();
+                        }
+                    };
+                    // For 0-byte uploads, downstream handlers do not consume
+                    // the request stream, so 'end' never fires. Set
+                    // startTurnAroundTime synchronously in that case.
+                    if (request.headers['content-length'] === '0') {
+                        setStartTurnAroundTime();
+                    } else {
+                        request.on('end', setStartTurnAroundTime);
+                    }
+                    return next(null, userInfo, authorizationResults, streamingV4Params, infos);
                 }
-                return next(null, userInfo, authorizationResults, streamingV4Params, infos);
-            }, 's3', requestContexts, authOptions),
-        (userInfo, authorizationResults, streamingV4Params, infos, next) => {
-            const authNames = { accountName: userInfo.getAccountDisplayName() };
-            if (userInfo.isRequesterAnIAMUser()) {
-                authNames.userName = userInfo.getIAMdisplayName();
-            }
-            if (isRequesterASessionUser(userInfo)) {
-                authNames.sessionName = userInfo.getShortid().split(':')[1];
-            }
-            log.addDefaultFields(authNames);
-            if (request.serverAccessLog) {
-                request.serverAccessLog.analyticsAccountName = authNames.accountName;
-                request.serverAccessLog.analyticsUserName    = authNames.userName;
-            }
-            if (apiMethod === 'objectPut' || apiMethod === 'objectPutPart') {
-                const setStartTurnAroundTime = () => {
+                // issue 100 Continue to the client
+                writeContinue(request, response);
+
+                const defaultMaxBodyLength =
+                    request.method === 'POST' ? constants.oneMegaBytes : constants.halfMegaBytes;
+                const MAX_BODY_LENGTH = config.apiBodySizeLimits[apiMethod] || defaultMaxBodyLength;
+                const post = [];
+                let bodyLength = 0;
+                request.on('data', chunk => {
+                    bodyLength += chunk.length;
+                    // Sanity check on post length
+                    if (bodyLength <= MAX_BODY_LENGTH) {
+                        post.push(chunk);
+                    }
+                });
+
+                request.on('error', err => {
+                    log.trace('error receiving request', {
+                        error: err,
+                    });
+                    return next(errors.InternalError);
+                });
+
+                request.on('end', () => {
                     if (request.serverAccessLog) {
                         request.serverAccessLog.startTurnAroundTime = process.hrtime.bigint();
                     }
-                };
-                // For 0-byte uploads, downstream handlers do not consume
-                // the request stream, so 'end' never fires. Set
-                // startTurnAroundTime synchronously in that case.
-                if (request.headers['content-length'] === '0') {
-                    setStartTurnAroundTime();
-                } else {
-                    request.on('end', setStartTurnAroundTime);
-                }
-                return next(null, userInfo, authorizationResults, streamingV4Params, infos);
-            }
-            // issue 100 Continue to the client
-            writeContinue(request, response);
 
-            const defaultMaxBodyLength = request.method === 'POST' ?
-                    constants.oneMegaBytes : constants.halfMegaBytes;
-            const MAX_BODY_LENGTH = config.apiBodySizeLimits[apiMethod] || defaultMaxBodyLength;
-            const post = [];
-            let bodyLength = 0;
-            request.on('data', chunk => {
-                bodyLength += chunk.length;
-                // Sanity check on post length
-                if (bodyLength <= MAX_BODY_LENGTH) {
-                    post.push(chunk);
-                }
-            });
+                    if (bodyLength > MAX_BODY_LENGTH) {
+                        log.error('body length is too long for request type', { bodyLength });
+                        return next(errors.InvalidRequest);
+                    }
 
-            request.on('error', err => {
-                log.trace('error receiving request', {
-                    error: err,
+                    const buff = Buffer.concat(post, bodyLength);
+
+                    const err = validateMethodChecksumNoChunking(request, buff, log);
+                    if (err) {
+                        return next(err);
+                    }
+
+                    // Convert array of post buffers into one string
+                    request.post = buff.toString();
+                    return next(null, userInfo, authorizationResults, streamingV4Params, infos);
                 });
-                return next(errors.InternalError);
-            });
-
-            request.on('end', () => {
-                if (request.serverAccessLog) {
-                    request.serverAccessLog.startTurnAroundTime = process.hrtime.bigint();
-                }
-
-                if (bodyLength > MAX_BODY_LENGTH) {
-                    log.error('body length is too long for request type',
-                                { bodyLength });
-                    return next(errors.InvalidRequest);
-                }
-
-                const buff = Buffer.concat(post, bodyLength);
-
-                const err = validateMethodChecksumNoChunking(request, buff, log);
-                if (err) {
-                    return next(err);
-                }
-
-                // Convert array of post buffers into one string
-                request.post = buff.toString();
-                return next(null, userInfo, authorizationResults, streamingV4Params, infos);
-            });
-            return undefined;
-        },
-        // Tag condition keys require information from CloudServer for evaluation
-        (userInfo, authorizationResults, streamingV4Params, infos, next) => tagConditionKeyAuth(
-            authorizationResults,
-            request,
-            requestContexts,
-            apiMethod,
-            log,
-            (err, authResultsWithTags) => {
-                if (err) {
-                    log.trace('tag authentication error', { error: err });
-                    return next(err);
-                }
-                return next(null, userInfo, authResultsWithTags, streamingV4Params, infos);
+                return undefined;
             },
-        ),
-        (userInfo, authorizationResults, streamingV4Params, infos, next) => handleAuthorizationResults(
-            request, authorizationResults, apiMethod, returnTagCount, log, (err, res) => {
-                request.accountQuotas = infos?.accountQuota;
-                request.accountLimits = infos?.limits;
-                if (err) {
-                    return next(err);
-                }
-                returnTagCount = res.returnTagCount;
-                return next(null, userInfo, authorizationResults, streamingV4Params);
-            }),
-    ], (err, userInfo, authorizationResults, streamingV4Params) => {
-        if (err) {
-            return callback(err);
-        }
-        const methodCallback = (err, ...results) => async.forEachLimit(request.finalizerHooks, 5,
-                (hook, done) => hook(err, done),
-                () => callback(err, ...results));
+            // Tag condition keys require information from CloudServer for evaluation
+            (userInfo, authorizationResults, streamingV4Params, infos, next) =>
+                tagConditionKeyAuth(
+                    authorizationResults,
+                    request,
+                    requestContexts,
+                    apiMethod,
+                    log,
+                    (err, authResultsWithTags) => {
+                        if (err) {
+                            log.trace('tag authentication error', { error: err });
+                            return next(err);
+                        }
+                        return next(null, userInfo, authResultsWithTags, streamingV4Params, infos);
+                    },
+                ),
+            (userInfo, authorizationResults, streamingV4Params, infos, next) =>
+                handleAuthorizationResults(
+                    request,
+                    authorizationResults,
+                    apiMethod,
+                    returnTagCount,
+                    log,
+                    (err, res) => {
+                        request.accountQuotas = infos?.accountQuota;
+                        request.accountLimits = infos?.limits;
+                        if (err) {
+                            return next(err);
+                        }
+                        returnTagCount = res.returnTagCount;
+                        return next(null, userInfo, authorizationResults, streamingV4Params);
+                    },
+                ),
+        ],
+        (err, userInfo, authorizationResults, streamingV4Params) => {
+            if (err) {
+                return callback(err);
+            }
+            const methodCallback = (err, ...results) =>
+                async.forEachLimit(
+                    request.finalizerHooks,
+                    5,
+                    (hook, done) => hook(err, done),
+                    () => callback(err, ...results),
+                );
 
-        if (apiMethod === 'objectPut' || apiMethod === 'objectPutPart') {
-            request._response = response;
-            return apiHandler(userInfo, request, streamingV4Params,
-                log, methodCallback, authorizationResults);
-        }
-        if (apiMethod === 'objectCopy' || apiMethod === 'objectPutCopyPart') {
-            return apiHandler(userInfo, request, sourceBucket,
-                sourceObject, sourceVersionId, log, methodCallback);
-        }
-        if (apiMethod === 'objectGet') {
-            // remove objectGetTagging/objectGetTaggingVersion from apiMethods, these were added by
-            // prepareRequestContexts to determine the value of returnTagCount.
-            request.apiMethods = request.apiMethods.filter(methodName => !methodName.includes('Tagging'));
-            return apiHandler(userInfo, request, returnTagCount, log, callback);
-        }
-        return apiHandler(userInfo, request, log, methodCallback);
-    });
+            if (apiMethod === 'objectPut' || apiMethod === 'objectPutPart') {
+                request._response = response;
+                return apiHandler(userInfo, request, streamingV4Params, log, methodCallback, authorizationResults);
+            }
+            if (apiMethod === 'objectCopy' || apiMethod === 'objectPutCopyPart') {
+                return apiHandler(userInfo, request, sourceBucket, sourceObject, sourceVersionId, log, methodCallback);
+            }
+            if (apiMethod === 'objectGet') {
+                // remove objectGetTagging/objectGetTaggingVersion from apiMethods, these were added by
+                // prepareRequestContexts to determine the value of returnTagCount.
+                request.apiMethods = request.apiMethods.filter(methodName => !methodName.includes('Tagging'));
+                return apiHandler(userInfo, request, returnTagCount, log, callback);
+            }
+            return apiHandler(userInfo, request, log, methodCallback);
+        },
+    );
 }
 
 const api = {
     callApiMethod(apiMethod, request, response, log, callback) {
         // Attach the apiMethod method to the request, so it can used by monitoring in the server
         request.apiMethod = apiMethod;
-        callback = wrapCallbackWithErrorCorsHeaders(
-            callback, request, response, log);
+        callback = wrapCallbackWithErrorCorsHeaders(callback, request, response, log);
         // Array of end of API callbacks, used to perform some logic
         // at the end of an API.
         request.finalizerHooks = [];
 
         const actionLog = monitoringMap[apiMethod];
-        if (!actionLog &&
-            apiMethod !== 'websiteGet' &&
-            apiMethod !== 'websiteHead' &&
-            apiMethod !== 'corsPreflight') {
+        if (!actionLog && apiMethod !== 'websiteGet' && apiMethod !== 'websiteHead' && apiMethod !== 'corsPreflight') {
             log.error('callApiMethod(): No actionLog for this api method', {
                 apiMethod,
             });

--- a/lib/metadata/metadataUtils.js
+++ b/lib/metadata/metadataUtils.js
@@ -269,6 +269,8 @@ function checkRateLimitIfNeeded(request, authInfo, bucketMD, log, callback) {
     const checks = [];
     const rateLimitConfig = extractRateLimitConfigFromRequest(request, authInfo, bucketMD, log);
 
+    cache.setCachedBucketOwner(bucketMD.getName(), bucketMD.getOwner(), config.rateLimiting.bucket.configCacheTTL);
+
     if (!request.rateLimitBucketAlreadyChecked && rateLimitConfig.bucket !== undefined) {
         cache.setCachedConfig(
             cache.namespace.bucket,
@@ -276,20 +278,27 @@ function checkRateLimitIfNeeded(request, authInfo, bucketMD, log, callback) {
             rateLimitConfig.bucket,
             config.rateLimiting.bucket.configCacheTTL
         );
-        cache.setCachedBucketOwner(bucketMD.getName(), bucketMD.getOwner(), config.rateLimiting.bucket.configCacheTTL);
         checks.push(...buildRateChecksFromConfig('bucket', bucketMD.getName(), rateLimitConfig.bucket));
         // eslint-disable-next-line no-param-reassign
         request.rateLimitBucketAlreadyChecked = true;
     }
 
-    if (!request.rateLimitAccountAlreadyChecked && rateLimitConfig.account !== undefined) {
+    if (
+        !request.rateLimitAccountAlreadyChecked
+        && rateLimitConfig.account !== undefined
+        && !(authInfo.isRequesterPublicUser && authInfo.isRequesterPublicUser())
+    ) {
+        const targetAccount = request.rateLimitTargetAccount
+            ? request.rateLimitTargetAccount
+            : authInfo.getCanonicalID();
+
         cache.setCachedConfig(
             cache.namespace.account,
-            authInfo.getCanonicalID(),
+            targetAccount,
             rateLimitConfig.account,
             config.rateLimiting.account.configCacheTTL
         );
-        checks.push(...buildRateChecksFromConfig('account', authInfo.getCanonicalID(), rateLimitConfig.account));
+        checks.push(...buildRateChecksFromConfig('account', targetAccount, rateLimitConfig.account));
         // eslint-disable-next-line no-param-reassign
         request.rateLimitAccountAlreadyChecked = true;
     }

--- a/lib/metadata/metadataUtils.js
+++ b/lib/metadata/metadataUtils.js
@@ -5,8 +5,7 @@ const { errors } = require('arsenal');
 const metadata = require('./wrapper');
 const BucketInfo = require('arsenal').models.BucketInfo;
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
-const { isBucketAuthorized, isObjAuthorized } =
-    require('../api/apiUtils/authorization/permissionChecks');
+const { isBucketAuthorized, isObjAuthorized } = require('../api/apiUtils/authorization/permissionChecks');
 const { isRateLimitServiceUser } = require('../api/apiUtils/authorization/serviceUser');
 const bucketShield = require('../api/apiUtils/bucket/bucketShield');
 const { onlyOwnerAllowed } = require('../../constants');
@@ -93,35 +92,38 @@ function storeServerAccessLogInfo(request, bucket, raftSessionId, options = {}) 
  * @return {undefined}
  */
 function getNullVersionFromMaster(bucketName, objectKey, log, cb) {
-    async.waterfall([
-        next => metadata.getObjectMD(bucketName, objectKey, {}, log, next),
-        (masterMD, next) => {
-            if (masterMD.isNull || !masterMD.versionId) {
-                log.debug('null version is master version');
-                return process.nextTick(() => next(null, masterMD));
+    async.waterfall(
+        [
+            next => metadata.getObjectMD(bucketName, objectKey, {}, log, next),
+            (masterMD, next) => {
+                if (masterMD.isNull || !masterMD.versionId) {
+                    log.debug('null version is master version');
+                    return process.nextTick(() => next(null, masterMD));
+                }
+                if (masterMD.nullVersionId) {
+                    // the latest version is not the null version, but null version exists
+                    // NOTE: for backward-compat with old null version scheme
+                    log.debug('get the null version via nullVersionId');
+                    const getOptions = {
+                        versionId: masterMD.nullVersionId,
+                    };
+                    return metadata.getObjectMD(bucketName, objectKey, getOptions, log, next);
+                }
+                return next(errors.NoSuchKey);
+            },
+        ],
+        (err, nullMD) => {
+            if (err && err.is && err.is.NoSuchKey) {
+                log.debug('could not find a null version');
+                return cb();
             }
-            if (masterMD.nullVersionId) {
-                // the latest version is not the null version, but null version exists
-                // NOTE: for backward-compat with old null version scheme
-                log.debug('get the null version via nullVersionId');
-                const getOptions = {
-                    versionId: masterMD.nullVersionId,
-                };
-                return metadata.getObjectMD(bucketName, objectKey, getOptions, log, next);
+            if (err) {
+                log.debug('err getting object MD from metadata', { error: err });
+                return cb(err);
             }
-            return next(errors.NoSuchKey);
+            return cb(null, nullMD);
         },
-    ], (err, nullMD) => {
-        if (err && err.is && err.is.NoSuchKey) {
-            log.debug('could not find a null version');
-            return cb();
-        }
-        if (err) {
-            log.debug('err getting object MD from metadata', { error: err });
-            return cb(err);
-        }
-        return cb(null, nullMD);
-    });
+    );
 }
 
 /** metadataGetObject - retrieves specified object or version from metadata
@@ -140,21 +142,20 @@ function metadataGetObject(bucketName, objectKey, versionId, cachedDocuments, lo
     if (cachedDocuments && cachedDocuments[objectKey]) {
         return cb(null, cachedDocuments[objectKey]);
     }
-    return metadata.getObjectMD(bucketName, objectKey, options, log,
-        (err, objMD) => {
-            if (err) {
-                if (err.is && err.is.NoSuchKey && versionId === 'null') {
-                    return getNullVersionFromMaster(bucketName, objectKey, log, cb);
-                }
-                if (err.is && err.is.NoSuchKey) {
-                    log.debug('object does not exist in metadata');
-                    return cb();
-                }
-                log.debug('err getting object MD from metadata', { error: err });
-                return cb(err);
+    return metadata.getObjectMD(bucketName, objectKey, options, log, (err, objMD) => {
+        if (err) {
+            if (err.is && err.is.NoSuchKey && versionId === 'null') {
+                return getNullVersionFromMaster(bucketName, objectKey, log, cb);
             }
-            return cb(null, objMD);
-        });
+            if (err.is && err.is.NoSuchKey) {
+                log.debug('object does not exist in metadata');
+                return cb();
+            }
+            log.debug('err getting object MD from metadata', { error: err });
+            return cb(err);
+        }
+        return cb(null, objMD);
+    });
 }
 
 /** metadataGetObjects - retrieves specified object or version from metadata. This
@@ -228,9 +229,10 @@ function validateBucket(bucket, params, log, actionImplicitDenies = {}) {
 
     // Skip checking bucket ownership if the requesting user is the rate limit service user
     // and the requestType is Get/Put/DeleteBucketRateLimit.
-    if (requestType.every(type => rateLimitApiActions.includes(type))
-        && config.rateLimiting.enabled
-        && isRateLimitServiceUser(authInfo)
+    if (
+        requestType.every(type => rateLimitApiActions.includes(type)) &&
+        config.rateLimiting.enabled &&
+        isRateLimitServiceUser(authInfo)
     ) {
         return null;
     }
@@ -238,8 +240,17 @@ function validateBucket(bucket, params, log, actionImplicitDenies = {}) {
     if (bucket.getOwner() !== canonicalID && requestType.some(type => onlyOwnerAllowed.includes(type))) {
         return errors.MethodNotAllowed;
     }
-    if (!isBucketAuthorized(bucket, (preciseRequestType || requestType), canonicalID,
-        authInfo, log, request, actionImplicitDenies)) {
+    if (
+        !isBucketAuthorized(
+            bucket,
+            preciseRequestType || requestType,
+            canonicalID,
+            authInfo,
+            log,
+            request,
+            actionImplicitDenies,
+        )
+    ) {
         log.debug('access denied for user on bucket', { requestType });
         return errors.AccessDenied;
     }
@@ -276,7 +287,7 @@ function checkRateLimitIfNeeded(request, authInfo, bucketMD, log, callback) {
             cache.namespace.bucket,
             bucketMD.getName(),
             rateLimitConfig.bucket,
-            config.rateLimiting.bucket.configCacheTTL
+            config.rateLimiting.bucket.configCacheTTL,
         );
         checks.push(...buildRateChecksFromConfig('bucket', bucketMD.getName(), rateLimitConfig.bucket));
         // eslint-disable-next-line no-param-reassign
@@ -284,9 +295,9 @@ function checkRateLimitIfNeeded(request, authInfo, bucketMD, log, callback) {
     }
 
     if (
-        !request.rateLimitAccountAlreadyChecked
-        && rateLimitConfig.account !== undefined
-        && !(authInfo.isRequesterPublicUser && authInfo.isRequesterPublicUser())
+        !request.rateLimitAccountAlreadyChecked &&
+        rateLimitConfig.account !== undefined &&
+        !(authInfo.isRequesterPublicUser && authInfo.isRequesterPublicUser())
     ) {
         const targetAccount = request.rateLimitTargetAccount
             ? request.rateLimitTargetAccount
@@ -296,7 +307,7 @@ function checkRateLimitIfNeeded(request, authInfo, bucketMD, log, callback) {
             cache.namespace.account,
             targetAccount,
             rateLimitConfig.account,
-            config.rateLimiting.account.configCacheTTL
+            config.rateLimiting.account.configCacheTTL,
         );
         checks.push(...buildRateChecksFromConfig('account', targetAccount, rateLimitConfig.account));
         // eslint-disable-next-line no-param-reassign
@@ -350,108 +361,157 @@ function standardMetadataValidateBucketAndObj(params, actionImplicitDenies, log,
         // eslint-disable-next-line no-param-reassign
         params.serverAccessLogOptions.savedAclRequired = request?.serverAccessLog?.aclRequired;
     }
-    async.waterfall([
-        next => {
-            // versionId may be 'null', which asks metadata to fetch the null key specifically
-            const getOptions = { versionId };
-            if (getDeleteMarker) {
-                getOptions.getDeleteMarker = true;
-            }
-            return metadata.getBucketAndObjectMD(bucketName, objectKey, getOptions, log,
-                (err, getResult, raftSessionId) => {
-                    if (err) {
-                        // if some implicit iamAuthzResults, return AccessDenied
-                        // before leaking any state information
-                        if (actionImplicitDenies && Object.values(actionImplicitDenies).some(v => v === true)) {
-                            return next(errors.AccessDenied);
+    async.waterfall(
+        [
+            next => {
+                // versionId may be 'null', which asks metadata to fetch the null key specifically
+                const getOptions = { versionId };
+                if (getDeleteMarker) {
+                    getOptions.getDeleteMarker = true;
+                }
+                return metadata.getBucketAndObjectMD(
+                    bucketName,
+                    objectKey,
+                    getOptions,
+                    log,
+                    (err, getResult, raftSessionId) => {
+                        if (err) {
+                            // if some implicit iamAuthzResults, return AccessDenied
+                            // before leaking any state information
+                            if (actionImplicitDenies && Object.values(actionImplicitDenies).some(v => v === true)) {
+                                return next(errors.AccessDenied);
+                            }
+                            return next(err);
                         }
-                        return next(err);
+                        return next(null, getResult, raftSessionId);
+                    },
+                );
+            },
+            (getResult, raftSessionId, next) => {
+                const bucket = getResult.bucket ? BucketInfo.deSerialize(getResult.bucket) : undefined;
+                if (!bucket) {
+                    log.debug('bucketAttrs is undefined', {
+                        bucket: bucketName,
+                        method: 'metadataValidateBucketAndObj',
+                    });
+                    return next(errors.NoSuchBucket, raftSessionId);
+                }
+                const validationError = validateBucket(bucket, params, log, actionImplicitDenies);
+                if (validationError) {
+                    return next(validationError, bucket, raftSessionId);
+                }
+
+                // Rate limiting check if not already done in api.js
+                return checkRateLimitIfNeeded(request, authInfo, bucket, log, err => {
+                    if (err) {
+                        return next(err, bucket);
                     }
-                    return next(null, getResult, raftSessionId);
-                });
-        },
-        (getResult, raftSessionId, next) => {
-            const bucket = getResult.bucket ?
-                  BucketInfo.deSerialize(getResult.bucket) : undefined;
-            if (!bucket) {
-                log.debug('bucketAttrs is undefined', {
-                    bucket: bucketName,
-                    method: 'metadataValidateBucketAndObj',
-                });
-                return next(errors.NoSuchBucket, raftSessionId);
-            }
-            const validationError = validateBucket(bucket, params, log, actionImplicitDenies);
-            if (validationError) {
-                return next(validationError, bucket, raftSessionId);
-            }
 
-            // Rate limiting check if not already done in api.js
-            return checkRateLimitIfNeeded(request, authInfo, bucket, log, err => {
-                if (err) {
-                    return next(err, bucket);
+                    // Continue with object metadata processing
+                    const objMD = getResult.obj ? JSON.parse(getResult.obj) : undefined;
+                    if (!objMD && versionId === 'null') {
+                        return getNullVersionFromMaster(bucketName, objectKey, log, (err, nullVer) =>
+                            next(err, bucket, nullVer, raftSessionId),
+                        );
+                    }
+                    return next(null, bucket, objMD, raftSessionId);
+                });
+            },
+            (bucket, objMD, raftSessionId, next) => {
+                const objMetadata = objMD;
+                const canonicalID = authInfo.getCanonicalID();
+                if (
+                    !isObjAuthorized(
+                        bucket,
+                        objMetadata,
+                        requestType,
+                        canonicalID,
+                        authInfo,
+                        log,
+                        request,
+                        actionImplicitDenies,
+                    )
+                ) {
+                    log.debug('access denied for user on object', { requestType });
+                    return next(errors.AccessDenied, bucket, undefined, raftSessionId);
                 }
 
-                // Continue with object metadata processing
-                const objMD = getResult.obj ? JSON.parse(getResult.obj) : undefined;
-                if (!objMD && versionId === 'null') {
-                    return getNullVersionFromMaster(bucketName, objectKey, log,
-                         (err, nullVer) => next(err, bucket, nullVer, raftSessionId));
+                if (!objMetadata) {
+                    return next(null, bucket, objMetadata, raftSessionId);
                 }
-                return next(null, bucket, objMD, raftSessionId);
-            });
-        },
-        (bucket, objMD, raftSessionId, next) => {
-            const objMetadata = objMD;
-            const canonicalID = authInfo.getCanonicalID();
-            if (!isObjAuthorized(bucket, objMetadata, requestType, canonicalID, authInfo, log, request,
-                actionImplicitDenies)) {
-                log.debug('access denied for user on object', { requestType });
-                return next(errors.AccessDenied, bucket, undefined, raftSessionId);
-            }
 
-            if (!objMetadata) {
+                let returnTagCount = false;
+                if (params.returnTagCount) {
+                    // If returnTagCount is true we know that Vault authorized the request so it is not an implicitDeny.
+                    const implicitDeny = false;
+                    if (requestType.some(r => r === 'objectGet')) {
+                        returnTagCount = isObjAuthorized(
+                            bucket,
+                            objMetadata,
+                            ['objectGetTagging'],
+                            canonicalID,
+                            authInfo,
+                            log,
+                            request,
+                            implicitDeny,
+                        );
+                    } else if (requestType.some(r => r === 'objectGetVersion')) {
+                        returnTagCount = isObjAuthorized(
+                            bucket,
+                            objMetadata,
+                            ['objectGetTaggingVersion'],
+                            canonicalID,
+                            authInfo,
+                            log,
+                            request,
+                            implicitDeny,
+                        );
+                    }
+
+                    objMetadata.returnTagCount = returnTagCount;
+                }
                 return next(null, bucket, objMetadata, raftSessionId);
-            }
-
-            let returnTagCount = false;
-            if (params.returnTagCount) {
-                // If returnTagCount is true we know that Vault authorized the request so it is not an implicitDeny.
-                const implicitDeny = false;
-                if (requestType.some(r => r === 'objectGet')) {
-                    returnTagCount = isObjAuthorized(bucket, objMetadata, ['objectGetTagging'], canonicalID, authInfo,
-                        log, request, implicitDeny);
-                } else if (requestType.some(r => r === 'objectGetVersion')) {
-                    returnTagCount = isObjAuthorized(bucket, objMetadata, ['objectGetTaggingVersion'],
-                        canonicalID, authInfo, log, request, implicitDeny);
+            },
+            (bucket, objMD, raftSessionId, next) => {
+                const needQuotaCheck = requestType =>
+                    requestType.some(type => actionNeedQuotaCheck[type] || actionWithDataDeletion[type]);
+                const checkQuota = params.checkQuota === undefined ? needQuotaCheck(requestType) : params.checkQuota;
+                // withVersionId cover cases when an object is being restored with a specific version ID.
+                // In this case, the storage space was already accounted for when the RestoreObject API call
+                // was made, so we don't need to add any inflight, but quota must be evaluated.
+                if (!checkQuota) {
+                    return next(null, bucket, objMD, raftSessionId);
                 }
-
-                objMetadata.returnTagCount = returnTagCount;
+                const contentLength = processBytesToWrite(
+                    request.apiMethod,
+                    bucket,
+                    versionId,
+                    request?.parsedContentLength || 0,
+                    objMD,
+                    params.destObjMD,
+                );
+                return validateQuotas(
+                    request,
+                    bucket,
+                    request.accountQuotas,
+                    requestType,
+                    request.apiMethod,
+                    contentLength,
+                    withVersionId,
+                    log,
+                    err => next(err, bucket, objMD, raftSessionId),
+                );
+            },
+        ],
+        (err, bucket, objMD, raftSessionId) => {
+            storeServerAccessLogInfo(request, bucket, raftSessionId, params.serverAccessLogOptions);
+            if (err) {
+                // still return bucket for cors headers
+                return callback(err, bucket);
             }
-            return next(null, bucket, objMetadata, raftSessionId);
+            return callback(null, bucket, objMD);
         },
-        (bucket, objMD, raftSessionId, next) => {
-            const needQuotaCheck = requestType => requestType.some(type => actionNeedQuotaCheck[type] ||
-                actionWithDataDeletion[type]);
-            const checkQuota = params.checkQuota === undefined ? needQuotaCheck(requestType) : params.checkQuota;
-            // withVersionId cover cases when an object is being restored with a specific version ID.
-            // In this case, the storage space was already accounted for when the RestoreObject API call
-            // was made, so we don't need to add any inflight, but quota must be evaluated.
-            if (!checkQuota) {
-                return next(null, bucket, objMD, raftSessionId);
-            }
-            const contentLength = processBytesToWrite(request.apiMethod, bucket, versionId,
-                request?.parsedContentLength || 0, objMD, params.destObjMD);
-            return validateQuotas(request, bucket, request.accountQuotas, requestType, request.apiMethod,
-                contentLength, withVersionId, log, err => next(err, bucket, objMD, raftSessionId));
-        },
-    ], (err, bucket, objMD, raftSessionId) => {
-        storeServerAccessLogInfo(request, bucket, raftSessionId, params.serverAccessLogOptions);
-        if (err) {
-            // still return bucket for cors headers
-            return callback(err, bucket);
-        }
-        return callback(null, bucket, objMD);
-    });
+    );
 }
 // When the validate function returns (err, bucket) - which it does even on
 // post-load failures like ACL denials - we want the bucket to flow through
@@ -463,13 +523,11 @@ function standardMetadataValidateBucketAndObj(params, actionImplicitDenies, log,
 // err.additionalResHeaders on the fast path.
 function attachCorsHeadersToError(err, bucket, params) {
     const request = params && params.request;
-    if (!err || !bucket || !request || !request.headers
-        || !request.headers.origin) {
+    if (!err || !bucket || !request || !request.headers || !request.headers.origin) {
         return err;
     }
     // eslint-disable-next-line no-param-reassign
-    err.additionalResHeaders = collectCorsHeaders(
-        request.headers.origin, request.method, bucket);
+    err.additionalResHeaders = collectCorsHeaders(request.headers.origin, request.method, bucket);
     return err;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zenko/cloudserver",
-    "version": "9.3.13",
+    "version": "9.3.14",
     "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
     "main": "index.js",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "@azure/storage-blob": "^12.28.0",
         "@hapi/joi": "^17.1.1",
         "@smithy/node-http-handler": "^3.0.0",
-        "arsenal": "git+https://github.com/scality/Arsenal#8.4.16",
+        "arsenal": "git+https://github.com/scality/Arsenal#8.4.19",
         "async": "2.6.4",
         "bucketclient": "scality/bucketclient#8.2.7",
         "bufferutil": "^4.0.8",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "utf-8-validate": "^6.0.5",
         "utf8": "^3.0.0",
         "uuid": "^11.0.3",
-        "vaultclient": "scality/vaultclient#8.5.3",
+        "vaultclient": "scality/vaultclient#8.5.7",
         "werelogs": "scality/werelogs#semver:^8.2.4",
         "ws": "^8.18.0",
         "xml2js": "^0.6.2"

--- a/tests/unit/api/api.js
+++ b/tests/unit/api/api.js
@@ -25,23 +25,32 @@ describe('api.callApiMethod', () => {
 
         response = {
             write: sandbox.stub(),
-            end: sandbox.stub()
+            end: sandbox.stub(),
         };
 
         log = {
             addDefaultFields: sandbox.stub(),
             trace: sandbox.stub(),
             error: sandbox.stub(),
-            debug: sandbox.stub()
+            debug: sandbox.stub(),
         };
 
         authServer = {
-            doAuth: sandbox.stub().callsArgWith(2, null, new AuthInfo({}), [{
-                isAllowed: true,
-                isImplicit: false,
-            }], null, {
-                accountQuota: 5000,
-            }),
+            doAuth: sandbox.stub().callsArgWith(
+                2,
+                null,
+                new AuthInfo({}),
+                [
+                    {
+                        isAllowed: true,
+                        isImplicit: false,
+                    },
+                ],
+                null,
+                {
+                    accountQuota: 5000,
+                },
+            ),
         };
 
         sandbox.stub(auth, 'server').value(authServer);
@@ -50,7 +59,6 @@ describe('api.callApiMethod', () => {
     afterEach(() => {
         sandbox.restore();
     });
-
 
     it('should attach apiMethod to request', done => {
         const testMethod = 'bucketGet';
@@ -101,8 +109,7 @@ describe('api.callApiMethod', () => {
             assert.strictEqual(requestContexts[0]._needQuota, true);
             done();
         });
-        sandbox.stub(api, 'completeMultipartUpload').callsFake(
-            (userInfo, _request, streamingV4Params, log, cb) => cb);
+        sandbox.stub(api, 'completeMultipartUpload').callsFake((userInfo, _request, streamingV4Params, log, cb) => cb);
         api.callApiMethod('completeMultipartUpload', request, response, log);
     });
 
@@ -111,21 +118,19 @@ describe('api.callApiMethod', () => {
             assert.strictEqual(requestContexts[0]._needQuota, true);
             done();
         });
-        sandbox.stub(api, 'multipartDelete').callsFake(
-            (userInfo, _request, streamingV4Params, log, cb) => cb);
+        sandbox.stub(api, 'multipartDelete').callsFake((userInfo, _request, streamingV4Params, log, cb) => cb);
         api.callApiMethod('multipartDelete', request, response, log);
     });
 
     ['objectPut', 'objectPutPart'].forEach(method => {
         it(`should set startTurnAroundTime on request end for ${method}`, done => {
-            sandbox.stub(api, method).callsFake(
-                (userInfo, _request, streamingV4Params, _log, cb) => {
-                    request.on('end', () => {
-                        assert.strictEqual(typeof request.serverAccessLog.startTurnAroundTime, 'bigint');
-                        cb();
-                    });
-                    request.resume();
+            sandbox.stub(api, method).callsFake((userInfo, _request, streamingV4Params, _log, cb) => {
+                request.on('end', () => {
+                    assert.strictEqual(typeof request.serverAccessLog.startTurnAroundTime, 'bigint');
+                    cb();
                 });
+                request.resume();
+            });
             request.objectKey = 'testobject';
             request.serverAccessLog = {};
             api.callApiMethod(method, request, response, log, err => {
@@ -135,11 +140,10 @@ describe('api.callApiMethod', () => {
         });
 
         it(`should set startTurnAroundTime synchronously for 0-byte ${method}`, done => {
-            sandbox.stub(api, method).callsFake(
-                (userInfo, _request, streamingV4Params, _log, cb) => {
-                    assert.strictEqual(typeof request.serverAccessLog.startTurnAroundTime, 'bigint');
-                    cb();
-                });
+            sandbox.stub(api, method).callsFake((userInfo, _request, streamingV4Params, _log, cb) => {
+                assert.strictEqual(typeof request.serverAccessLog.startTurnAroundTime, 'bigint');
+                cb();
+            });
             request.objectKey = 'testobject';
             request.serverAccessLog = {};
             request.headers = Object.assign({}, request.headers, { 'content-length': '0' });
@@ -194,7 +198,7 @@ describe('api.callApiMethod', () => {
     describe('MD5 checksum validation', () => {
         const methodsWithChecksumValidation = [
             'bucketPutACL',
-            'bucketPutCors', 
+            'bucketPutCors',
             'bucketPutEncryption',
             'bucketPutLifecycle',
             'bucketPutNotification',
@@ -207,7 +211,7 @@ describe('api.callApiMethod', () => {
             'objectPutACL',
             'objectPutLegalHold',
             'objectPutTagging',
-            'objectPutRetention'
+            'objectPutRetention',
         ];
 
         methodsWithChecksumValidation.forEach(method => {
@@ -215,15 +219,18 @@ describe('api.callApiMethod', () => {
                 const body = '<xml></xml>';
                 const headers = {
                     'content-md5': 'badchecksum123=', // Invalid MD5
-                    'content-length': body.length.toString()
+                    'content-length': body.length.toString(),
                 };
-                
-                const requestWithBody = new DummyRequest({
-                    headers,
-                    query: {},
-                    socket: { remoteAddress: '127.0.0.1', destroy: sandbox.stub() }
-                }, body);
-                
+
+                const requestWithBody = new DummyRequest(
+                    {
+                        headers,
+                        query: {},
+                        socket: { remoteAddress: '127.0.0.1', destroy: sandbox.stub() },
+                    },
+                    body,
+                );
+
                 sandbox.stub(api, method).callsFake(() => {
                     done(new Error(`${method} was called despite bad checksum`));
                 });
@@ -242,15 +249,18 @@ describe('api.callApiMethod', () => {
                 const correctMd5 = crypto.createHash('md5').update(body).digest('base64');
                 const headers = {
                     'content-md5': correctMd5,
-                    'content-length': body.length.toString()
+                    'content-length': body.length.toString(),
                 };
-                
-                const requestWithBody = new DummyRequest({
-                    headers,
-                    query: {},
-                    socket: { remoteAddress: '127.0.0.1', destroy: sandbox.stub() }
-                }, body);
-                
+
+                const requestWithBody = new DummyRequest(
+                    {
+                        headers,
+                        query: {},
+                        socket: { remoteAddress: '127.0.0.1', destroy: sandbox.stub() },
+                    },
+                    body,
+                );
+
                 sandbox.stub(api, method).callsFake((userInfo, _request, log, cb) => {
                     cb();
                 });
@@ -267,15 +277,18 @@ describe('api.callApiMethod', () => {
                 const body = '<xml></xml>';
                 const headers = {
                     'content-md5': '',
-                    'content-length': body.length.toString()
+                    'content-length': body.length.toString(),
                 };
-                
-                const requestWithBody = new DummyRequest({
-                    headers,
-                    query: {},
-                    socket: { remoteAddress: '127.0.0.1', destroy: sandbox.stub() }
-                }, body);
-                
+
+                const requestWithBody = new DummyRequest(
+                    {
+                        headers,
+                        query: {},
+                        socket: { remoteAddress: '127.0.0.1', destroy: sandbox.stub() },
+                    },
+                    body,
+                );
+
                 sandbox.stub(api, method).callsFake((userInfo, _request, log, cb) => {
                     cb();
                 });

--- a/tests/unit/api/api.js
+++ b/tests/unit/api/api.js
@@ -1,6 +1,7 @@
 const sinon = require('sinon');
 const { errors, auth } = require('arsenal');
 const api = require('../../../lib/api/api');
+const rateLimitCache = require('../../../lib/api/apiUtils/rateLimit/cache');
 const DummyRequest = require('../DummyRequest');
 const { default: AuthInfo } = require('arsenal/build/lib/auth/AuthInfo');
 const assert = require('assert');
@@ -146,6 +147,47 @@ describe('api.callApiMethod', () => {
                 assert.ifError(err);
                 done();
             });
+        });
+    });
+
+    describe('cross-account rate limiting target account', () => {
+        afterEach(() => {
+            rateLimitCache.bucketOwnerCache.clear();
+        });
+
+        it('should pass the cached bucket owner to doAuth as targetAccount', done => {
+            request.bucketName = 'rl-bucket';
+            rateLimitCache.setCachedBucketOwner('rl-bucket', 'owner-canonical-id', 30000);
+            // Reset the default callsArgWith behavior so only the fake runs
+            authServer.doAuth.resetBehavior();
+            authServer.doAuth.callsFake((req, log, cb, awsService, requestContexts, authOptions) => {
+                assert.strictEqual(authOptions.targetAccount, 'owner-canonical-id');
+                assert.strictEqual(request.rateLimitTargetAccount, 'owner-canonical-id');
+                done();
+            });
+            api.callApiMethod('bucketGet', request, response, log);
+        });
+
+        it('should not set targetAccount when no bucket owner is cached', done => {
+            request.bucketName = 'rl-bucket';
+            authServer.doAuth.resetBehavior();
+            authServer.doAuth.callsFake((req, log, cb, awsService, requestContexts, authOptions) => {
+                assert.deepStrictEqual(authOptions, {});
+                assert.strictEqual(request.rateLimitTargetAccount, undefined);
+                done();
+            });
+            api.callApiMethod('bucketGet', request, response, log);
+        });
+
+        it('should not set targetAccount when the request has no bucket name', done => {
+            rateLimitCache.setCachedBucketOwner('rl-bucket', 'owner-canonical-id', 30000);
+            authServer.doAuth.resetBehavior();
+            authServer.doAuth.callsFake((req, log, cb, awsService, requestContexts, authOptions) => {
+                assert.deepStrictEqual(authOptions, {});
+                assert.strictEqual(request.rateLimitTargetAccount, undefined);
+                done();
+            });
+            api.callApiMethod('bucketGet', request, response, log);
         });
     });
 

--- a/tests/unit/metadata/metadataUtils.spec.js
+++ b/tests/unit/metadata/metadataUtils.spec.js
@@ -10,8 +10,7 @@ const authInfo = makeAuthInfo('accessKey');
 const otherAuthInfo = makeAuthInfo('otherAccessKey');
 const ownerCanonicalId = authInfo.getCanonicalID();
 
-const bucket = new BucketInfo('niftyBucket', ownerCanonicalId,
-    authInfo.getAccountDisplayName(), creationDate);
+const bucket = new BucketInfo('niftyBucket', ownerCanonicalId, authInfo.getAccountDisplayName(), creationDate);
 const log = new DummyRequestLogger();
 
 const {
@@ -29,38 +28,58 @@ const tokenBucket = require('../../../lib/api/apiUtils/rateLimit/tokenBucket');
 
 describe('validateBucket', () => {
     it('action bucketPutPolicy by bucket owner', () => {
-        const validationResult = validateBucket(bucket, {
-            authInfo,
-            requestType: 'bucketPutPolicy',
-            request: null,
-        }, log, false);
+        const validationResult = validateBucket(
+            bucket,
+            {
+                authInfo,
+                requestType: 'bucketPutPolicy',
+                request: null,
+            },
+            log,
+            false,
+        );
         assert.ifError(validationResult);
     });
     it('action bucketPutPolicy by other than bucket owner', () => {
-        const validationResult = validateBucket(bucket, {
-            authInfo: otherAuthInfo,
-            requestType: 'bucketPutPolicy',
-            request: null,
-        }, log, false);
+        const validationResult = validateBucket(
+            bucket,
+            {
+                authInfo: otherAuthInfo,
+                requestType: 'bucketPutPolicy',
+                request: null,
+            },
+            log,
+            false,
+        );
         assert(validationResult);
         assert(validationResult.is.MethodNotAllowed);
     });
 
     it('action bucketGet by bucket owner', () => {
-        const validationResult = validateBucket(bucket, {
-            authInfo,
-            requestType: 'bucketGet',
-            request: null,
-        }, log, false);
+        const validationResult = validateBucket(
+            bucket,
+            {
+                authInfo,
+                requestType: 'bucketGet',
+                request: null,
+            },
+            log,
+            false,
+        );
         assert.ifError(validationResult);
     });
 
     it('action bucketGet by other than bucket owner', () => {
-        const validationResult = validateBucket(bucket, {
-            authInfo: otherAuthInfo,
-            requestType: 'bucketGet',
-            request: null,
-        }, log, false);
+        const validationResult = validateBucket(
+            bucket,
+            {
+                authInfo: otherAuthInfo,
+                requestType: 'bucketGet',
+                request: null,
+            },
+            log,
+            false,
+        );
         assert(validationResult);
         assert(validationResult.is.AccessDenied);
     });
@@ -124,7 +143,8 @@ describe('metadataGetObject', () => {
     it('should return the cached document if provided', done => {
         const cachedDoc = {
             [objectKey.inPlay.key]: {
-                key: 'objectKey1', versionId: 'versionId1',
+                key: 'objectKey1',
+                versionId: 'versionId1',
             },
         };
         metadataGetObject('bucketName', objectKey.inPlay.key, objectKey.versionId, cachedDoc, log, (err, result) => {
@@ -231,12 +251,17 @@ describe('checkRateLimitIfNeeded cross-account rate limiting', () => {
     // still get AccessDenied from validateBucket afterwards; these tests
     // assert on the rate limit side effects, not the final auth outcome.
     function validateBucketRequest(requesterAuthInfo, cb) {
-        standardMetadataValidateBucket({
-            authInfo: requesterAuthInfo,
-            bucketName: bucket.getName(),
-            requestType: 'bucketGet',
-            request,
-        }, false, log, cb);
+        standardMetadataValidateBucket(
+            {
+                authInfo: requesterAuthInfo,
+                bucketName: bucket.getName(),
+                requestType: 'bucketGet',
+                request,
+            },
+            false,
+            log,
+            cb,
+        );
     }
 
     it('should cache the bucket owner even when the bucket config was already checked', done => {
@@ -269,7 +294,8 @@ describe('checkRateLimitIfNeeded cross-account rate limiting', () => {
             assert(rateLimitCache.getCachedConfig(rateLimitCache.namespace.account, ownerCanonicalId));
             assert.strictEqual(
                 rateLimitCache.getCachedConfig(rateLimitCache.namespace.account, otherCanonicalId),
-                undefined);
+                undefined,
+            );
             assert(tokenBucket.getAllTokenBuckets().has(`account:${ownerCanonicalId}:rps`));
             assert(!tokenBucket.getAllTokenBuckets().has(`account:${otherCanonicalId}:rps`));
             done();
@@ -280,7 +306,12 @@ describe('checkRateLimitIfNeeded cross-account rate limiting', () => {
         request.accountLimits = { RequestsPerSecond: { Limit: 100 } };
         request.rateLimitTargetAccount = ownerCanonicalId;
         const ownerBucket = tokenBucket.getTokenBucket(
-            'account', ownerCanonicalId, 'rps', { limit: 100, burstCapacity: 1000 }, log);
+            'account',
+            ownerCanonicalId,
+            'rps',
+            { limit: 100, burstCapacity: 1000 },
+            log,
+        );
         ownerBucket.tokens = 0;
         validateBucketRequest(otherAuthInfo, err => {
             assert(err);
@@ -292,7 +323,12 @@ describe('checkRateLimitIfNeeded cross-account rate limiting', () => {
     it('should rate limit against the requester account when no target account is present', done => {
         request.accountLimits = { RequestsPerSecond: { Limit: 100 } };
         const ownerBucket = tokenBucket.getTokenBucket(
-            'account', ownerCanonicalId, 'rps', { limit: 100, burstCapacity: 1000 }, log);
+            'account',
+            ownerCanonicalId,
+            'rps',
+            { limit: 100, burstCapacity: 1000 },
+            log,
+        );
         ownerBucket.tokens = 0;
         validateBucketRequest(otherAuthInfo, err => {
             // The exhausted owner account bucket must not affect the request:
@@ -310,7 +346,8 @@ describe('checkRateLimitIfNeeded cross-account rate limiting', () => {
             assert.strictEqual(request.rateLimitAccountAlreadyChecked, undefined);
             assert.strictEqual(
                 rateLimitCache.getCachedConfig(rateLimitCache.namespace.account, constants.publicId),
-                undefined);
+                undefined,
+            );
             // The bucket owner is still cached for later cross-account attribution
             assert.strictEqual(rateLimitCache.getCachedBucketOwner(bucket.getName()), ownerCanonicalId);
             done();
@@ -325,7 +362,8 @@ describe('checkRateLimitIfNeeded cross-account rate limiting', () => {
             assert.strictEqual(request.rateLimitAccountAlreadyChecked, undefined);
             assert.strictEqual(
                 rateLimitCache.getCachedConfig(rateLimitCache.namespace.account, ownerCanonicalId),
-                undefined);
+                undefined,
+            );
             done();
         });
     });

--- a/tests/unit/metadata/metadataUtils.spec.js
+++ b/tests/unit/metadata/metadataUtils.spec.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const sinon = require('sinon');
 
-const { models } = require('arsenal');
+const { errors, models } = require('arsenal');
 const { BucketInfo } = models;
 const { DummyRequestLogger, makeAuthInfo } = require('../helpers');
 
@@ -19,8 +19,13 @@ const {
     metadataGetObjects,
     metadataGetObject,
     storeServerAccessLogInfo,
+    standardMetadataValidateBucket,
 } = require('../../../lib/metadata/metadataUtils');
 const metadata = require('../../../lib/metadata/wrapper');
+const { config } = require('../../../lib/Config');
+const constants = require('../../../constants');
+const rateLimitCache = require('../../../lib/api/apiUtils/rateLimit/cache');
+const tokenBucket = require('../../../lib/api/apiUtils/rateLimit/tokenBucket');
 
 describe('validateBucket', () => {
     it('action bucketPutPolicy by bucket owner', () => {
@@ -181,5 +186,147 @@ describe('storeServerAccessLogInfo - copySource aclRequired', () => {
         storeServerAccessLogInfo(request, null, null, options);
         assert.strictEqual(request.sourceServerAccessLog.aclRequired, 'Yes');
         assert.strictEqual(request.serverAccessLog.aclRequired, undefined);
+    });
+});
+
+describe('checkRateLimitIfNeeded cross-account rate limiting', () => {
+    let sandbox;
+    let request;
+
+    const otherCanonicalId = otherAuthInfo.getCanonicalID();
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        sandbox.stub(config, 'rateLimiting').value({
+            enabled: true,
+            serviceUserArn: 'arn:aws:iam::000000000000:user/rate-limit-service-user',
+            nodes: 1,
+            tokenBucketBufferSize: 50,
+            tokenBucketRefillThreshold: 20,
+            error: errors.SlowDown,
+            bucket: {
+                configCacheTTL: 30000,
+                defaultConfig: { RequestsPerSecond: { BurstCapacity: 1 } },
+            },
+            account: {
+                configCacheTTL: 30000,
+                defaultConfig: { RequestsPerSecond: { BurstCapacity: 1 } },
+            },
+        });
+        sandbox.stub(metadata, 'getBucket').yields(null, bucket);
+        rateLimitCache.configCache.clear();
+        rateLimitCache.bucketOwnerCache.clear();
+        tokenBucket.getAllTokenBuckets().clear();
+        request = { apiMethod: 'bucketGet', bucketName: bucket.getName() };
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+        rateLimitCache.configCache.clear();
+        rateLimitCache.bucketOwnerCache.clear();
+        tokenBucket.getAllTokenBuckets().clear();
+    });
+
+    // Rate limiting runs before bucket authorization, so the requester may
+    // still get AccessDenied from validateBucket afterwards; these tests
+    // assert on the rate limit side effects, not the final auth outcome.
+    function validateBucketRequest(requesterAuthInfo, cb) {
+        standardMetadataValidateBucket({
+            authInfo: requesterAuthInfo,
+            bucketName: bucket.getName(),
+            requestType: 'bucketGet',
+            request,
+        }, false, log, cb);
+    }
+
+    it('should cache the bucket owner even when the bucket config was already checked', done => {
+        request.rateLimitBucketAlreadyChecked = true;
+        validateBucketRequest(authInfo, err => {
+            assert.ifError(err);
+            assert.strictEqual(rateLimitCache.getCachedBucketOwner(bucket.getName()), ownerCanonicalId);
+            done();
+        });
+    });
+
+    it('should key the account rate limit under the requester canonical ID by default', done => {
+        request.accountLimits = { RequestsPerSecond: { Limit: 100 } };
+        validateBucketRequest(authInfo, err => {
+            assert.ifError(err);
+            const cached = rateLimitCache.getCachedConfig(rateLimitCache.namespace.account, ownerCanonicalId);
+            assert.deepStrictEqual(cached, {
+                RequestsPerSecond: { BurstCapacity: 1, Limit: 100, source: 'resource' },
+            });
+            assert(tokenBucket.getAllTokenBuckets().has(`account:${ownerCanonicalId}:rps`));
+            assert.strictEqual(request.rateLimitAccountAlreadyChecked, true);
+            done();
+        });
+    });
+
+    it('should key the account rate limit under the target account when the request carries one', done => {
+        request.accountLimits = { RequestsPerSecond: { Limit: 100 } };
+        request.rateLimitTargetAccount = ownerCanonicalId;
+        validateBucketRequest(otherAuthInfo, () => {
+            assert(rateLimitCache.getCachedConfig(rateLimitCache.namespace.account, ownerCanonicalId));
+            assert.strictEqual(
+                rateLimitCache.getCachedConfig(rateLimitCache.namespace.account, otherCanonicalId),
+                undefined);
+            assert(tokenBucket.getAllTokenBuckets().has(`account:${ownerCanonicalId}:rps`));
+            assert(!tokenBucket.getAllTokenBuckets().has(`account:${otherCanonicalId}:rps`));
+            done();
+        });
+    });
+
+    it('should deny a cross-account request when the target account limit is exhausted', done => {
+        request.accountLimits = { RequestsPerSecond: { Limit: 100 } };
+        request.rateLimitTargetAccount = ownerCanonicalId;
+        const ownerBucket = tokenBucket.getTokenBucket(
+            'account', ownerCanonicalId, 'rps', { limit: 100, burstCapacity: 1000 }, log);
+        ownerBucket.tokens = 0;
+        validateBucketRequest(otherAuthInfo, err => {
+            assert(err);
+            assert(err.is.SlowDown);
+            done();
+        });
+    });
+
+    it('should rate limit against the requester account when no target account is present', done => {
+        request.accountLimits = { RequestsPerSecond: { Limit: 100 } };
+        const ownerBucket = tokenBucket.getTokenBucket(
+            'account', ownerCanonicalId, 'rps', { limit: 100, burstCapacity: 1000 }, log);
+        ownerBucket.tokens = 0;
+        validateBucketRequest(otherAuthInfo, err => {
+            // The exhausted owner account bucket must not affect the request:
+            // the requester is limited against their own account.
+            assert(!err || !err.is.SlowDown);
+            assert(tokenBucket.getAllTokenBuckets().has(`account:${otherCanonicalId}:rps`));
+            done();
+        });
+    });
+
+    it('should skip the account rate limit check for public requesters', done => {
+        const publicAuthInfo = makeAuthInfo(constants.publicId);
+        request.accountLimits = { RequestsPerSecond: { Limit: 100 } };
+        validateBucketRequest(publicAuthInfo, () => {
+            assert.strictEqual(request.rateLimitAccountAlreadyChecked, undefined);
+            assert.strictEqual(
+                rateLimitCache.getCachedConfig(rateLimitCache.namespace.account, constants.publicId),
+                undefined);
+            // The bucket owner is still cached for later cross-account attribution
+            assert.strictEqual(rateLimitCache.getCachedBucketOwner(bucket.getName()), ownerCanonicalId);
+            done();
+        });
+    });
+
+    it('should skip the account rate limit check for public requesters even with a target account', done => {
+        const publicAuthInfo = makeAuthInfo(constants.publicId);
+        request.accountLimits = { RequestsPerSecond: { Limit: 100 } };
+        request.rateLimitTargetAccount = ownerCanonicalId;
+        validateBucketRequest(publicAuthInfo, () => {
+            assert.strictEqual(request.rateLimitAccountAlreadyChecked, undefined);
+            assert.strictEqual(
+                rateLimitCache.getCachedConfig(rateLimitCache.namespace.account, ownerCanonicalId),
+                undefined);
+            done();
+        });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6591,9 +6591,9 @@ arraybuffer.prototype.slice@^1.0.4:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/Arsenal#8.4.16":
-  version "8.4.16"
-  resolved "git+https://github.com/scality/Arsenal#65223fdfc37f4471332c44775def9e985b320855"
+"arsenal@git+https://github.com/scality/Arsenal#8.4.19":
+  version "8.4.19"
+  resolved "git+https://github.com/scality/Arsenal#059ecf4a3c49b0b0d2c0f9ec0b01dc76fea7b767"
   dependencies:
     "@aws-sdk/client-kms" "^3.975.0"
     "@aws-sdk/client-s3" "^3.975.0"
@@ -12595,6 +12595,17 @@ vary@^1, vary@~1.1.2:
 vaultclient@scality/vaultclient#8.5.3:
   version "8.5.3"
   resolved "https://codeload.github.com/scality/vaultclient/tar.gz/24e33cfe2a98cc4545ddc615371bfd8d2f2e98d1"
+  dependencies:
+    "@aws-crypto/sha256-universal" "^5.2.0"
+    "@smithy/signature-v4" "^4.1.0"
+    commander "^11.0.0"
+    httpagent "git+https://github.com/scality/httpagent#1.1.0"
+    werelogs scality/werelogs#8.2.0
+    xml2js "^0.6.2"
+
+vaultclient@scality/vaultclient#8.5.7:
+  version "8.5.7"
+  resolved "https://codeload.github.com/scality/vaultclient/tar.gz/f1022abcaa164c5d6046371491a1a310bb13bf4d"
   dependencies:
     "@aws-crypto/sha256-universal" "^5.2.0"
     "@smithy/signature-v4" "^4.1.0"


### PR DESCRIPTION
- Cloudserver now passes the bucket owner canonicalId to Vault using `targetAccount` if it has been previously cached.
  - (Vault's side) If `targetAccount` differs from the requesting account targetAccount's rate limit config is retrieved and returned in response