### PR TITLE
CLDSRV-955: Cache node_modules instead of yarn download cache

### DIFF
--- a/.github/actions/setup-ci/action.yaml
+++ b/.github/actions/setup-ci/action.yaml
@@ -26,16 +26,29 @@ runs:
         set -exu;
         mkdir -p /tmp/coverage/${JOB_NAME}/;
     - uses: actions/setup-node@v4
+      id: node
       with:
         node-version: '22.23.1'
-        cache: 'yarn'
+    # Cache node_modules directly (not the yarn download cache) so the git
+    # dependencies' TypeScript compilation and relink are skipped on a hit.
+    # Key includes runner.os and the resolved Node version because node_modules
+    # can hold native addons compiled for a specific OS/Node; the Node version
+    # is taken from the setup-node output rather than hardcoded.
+    - name: Cache node_modules
+      id: cache-node-modules
+      uses: actions/cache@v6
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-${{ steps.node.outputs.node-version }}-modules-${{ hashFiles('yarn.lock') }}
     - name: install typescript
       shell: bash
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
       run: yarn global add typescript@4.9.5
     - name: install dependencies
       shell: bash
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
       run: yarn install --ignore-engines --frozen-lockfile --network-concurrency 1
-    - uses: actions/cache@v3
+    - uses: actions/cache@v6
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip

--- a/.github/actions/setup-ci/action.yaml
+++ b/.github/actions/setup-ci/action.yaml
@@ -1,6 +1,6 @@
 ---
-name: "Setup CI environment"
-description: "Setup Cloudserver CI environment"
+name: 'Setup CI environment'
+description: 'Setup Cloudserver CI environment'
 
 runs:
   using: composite

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -84,13 +84,21 @@ jobs:
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v4
+        id: node
         with:
           node-version: '22.23.1'
-          cache: yarn
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v6
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ steps.node.outputs.node-version }}-modules-${{ hashFiles('yarn.lock') }}
       - name: install typescript
         shell: bash
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: yarn global add typescript@4.9.5
       - name: install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile --network-concurrency 1
       - uses: actions/setup-python@v5
         with:
@@ -125,10 +133,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - uses: actions/setup-node@v4
+        id: node
         with:
           node-version: '22.23.1'
-          cache: yarn
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v6
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ steps.node.outputs.node-version }}-modules-${{ hashFiles('yarn.lock') }}
       - name: install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile --network-concurrency 1
       - name: Count async/await migration progress
         run: yarn run count-async
@@ -139,13 +154,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - uses: actions/setup-node@v4
+        id: node
         with:
           node-version: '22.23.1'
-          cache: yarn
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v6
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ steps.node.outputs.node-version }}-modules-${{ hashFiles('yarn.lock') }}
       - name: install typescript
         shell: bash
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: yarn global add typescript@4.9.5
       - name: install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile --network-concurrency 1
       - name: Unit Coverage
         run: |
@@ -1087,10 +1110,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - uses: actions/setup-node@v4
+        id: node
         with:
           node-version: '22.23.1'
-          cache: yarn
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v6
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ steps.node.outputs.node-version }}-modules-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile --network-concurrency 1
       - name: Delete stale GCP CI buckets
         run: yarn run cleanup_gcp_buckets


### PR DESCRIPTION
Speeds up CI by caching the installed dependency tree between runs instead of only the package-manager download cache. Because several dependencies compile TypeScript at install time, previous runs re-cloned, recompiled and relinked them on every job despite a "cache hit"; now a warm cache skips that work entirely and jobs reuse the prior install.

## Measured impact (warm run vs a development/9.3 baseline)

| Job | dependency setup before | after (warm) | job wall time |
|-----|-------------------------|--------------|---------------|
| `lint` | 61s | 9s | 116s → 49s |
| `unit-tests` | 54s | 10s | 114s → 64s |
| `file-ft-tests` | 84s | 41s | 750s → 722s |

- ~43–52s of dependency setup saved per job, across ~15 jobs (4 inline + ~11 functional via the `setup-ci` composite action).
- Jobs run in parallel, so end-to-end wall time drops modestly (critical-path bound, ~30–40s), but total CI compute falls ~10 min per run and the short feedback jobs (lint, unit) are >2× faster.
- Cache key is `${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}`; a lockfile bump invalidates it and the next run repopulates.

See the pinned comparison comment for full details.