### PR TITLE
Seed zero-value quota metric on bucket create / quota enable (9.3 backport)

### DIFF
--- a/lib/api/apiUtils/bucket/bucketCreation.js
+++ b/lib/api/apiUtils/bucket/bucketCreation.js
@@ -85,6 +85,18 @@ function removeTransientOrDeletedLabel(bucket, log, callback) {
     return metadata.updateBucket(bucketName, bucket, log, callback);
 }
 
+function seedBucketQuotaCapacity(bucket, log, done) {
+    if (!config.isQuotaEnabled()) {
+        return done();
+    }
+    return metadata.initializeBucketCapacity(bucket.getName(), bucket.getCreationDate(), log, err => {
+        if (err) {
+            log.error('error seeding bucket quota capacity metric', { error: err });
+        }
+        return done();
+    });
+}
+
 function freshStartCreateBucket(bucket, canonicalID, log, callback) {
     const bucketName = bucket.getName();
     metadata.createBucket(bucketName, bucket, log, err => {
@@ -103,7 +115,12 @@ function freshStartCreateBucket(bucket, canonicalID, log, callback) {
             if (err) {
                 return callback(err);
             }
-            return removeTransientOrDeletedLabel(bucket, log, callback);
+            return removeTransientOrDeletedLabel(bucket, log, labelErr => {
+                if (labelErr) {
+                    return callback(labelErr);
+                }
+                return seedBucketQuotaCapacity(bucket, log, () => callback(null));
+            });
         });
     });
 }
@@ -126,7 +143,12 @@ function cleanUpBucket(bucketMD, canonicalID, log, callback) {
         if (err) {
             return callback(err);
         }
-        return removeTransientOrDeletedLabel(bucketMD, log, callback);
+        return removeTransientOrDeletedLabel(bucketMD, log, labelErr => {
+            if (labelErr) {
+                return callback(labelErr);
+            }
+            return seedBucketQuotaCapacity(bucketMD, log, () => callback(null));
+        });
     });
 }
 

--- a/lib/api/apiUtils/bucket/bucketCreation.js
+++ b/lib/api/apiUtils/bucket/bucketCreation.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const async = require('async');
+const { promisify } = require('util');
 const { errors } = require('arsenal');
 
 const acl = require('../../../metadata/acl');
@@ -85,44 +86,46 @@ function removeTransientOrDeletedLabel(bucket, log, callback) {
     return metadata.updateBucket(bucketName, bucket, log, callback);
 }
 
-function seedBucketQuotaCapacity(bucket, log, done) {
+const createBucketMD = promisify((...args) => metadata.createBucket(...args));
+const initializeBucketCapacity = promisify((...args) => metadata.initializeBucketCapacity(...args));
+const addToUsersBucketAsync = promisify(addToUsersBucket);
+const removeTransientOrDeletedLabelAsync = promisify(removeTransientOrDeletedLabel);
+
+async function seedBucketQuotaCapacity(bucket, log) {
     if (!config.isQuotaEnabled()) {
-        return done();
+        return;
     }
-    return metadata.initializeBucketCapacity(bucket.getName(), bucket.getCreationDate(), log, err => {
-        if (err) {
-            log.error('error seeding bucket quota capacity metric', { error: err });
-        }
-        return done();
-    });
+    try {
+        await initializeBucketCapacity(bucket.getName(), bucket.getCreationDate(), log);
+    } catch (err) {
+        // Best-effort: a missing metric self-heals at the next count-items run,
+        // so a seeding failure must never fail the bucket operation.
+        log.warn('error seeding bucket quota capacity metric', { error: err });
+    }
 }
 
-function freshStartCreateBucket(bucket, canonicalID, log, callback) {
+async function freshStartCreateBucket(bucket, canonicalID, log, callback) {
+    if (callback) {
+        return freshStartCreateBucket(bucket, canonicalID, log).then(() => callback(null), callback);
+    }
     const bucketName = bucket.getName();
-    metadata.createBucket(bucketName, bucket, log, err => {
+    try {
+        await createBucketMD(bucketName, bucket, log);
+    } catch (err) {
         if (err?.is?.BucketAlreadyExists) {
             // The concurrent creator owns users-bucket registration and
             // cleanup of the transient flag.
             log.trace('bucket already exists in metadata');
-            return callback();
+            return undefined;
         }
-        if (err) {
-            log.debug('error from metadata', { error: err });
-            return callback(err);
-        }
-        log.trace('created bucket in metadata');
-        return addToUsersBucket(canonicalID, bucketName, bucket, log, err => {
-            if (err) {
-                return callback(err);
-            }
-            return removeTransientOrDeletedLabel(bucket, log, labelErr => {
-                if (labelErr) {
-                    return callback(labelErr);
-                }
-                return seedBucketQuotaCapacity(bucket, log, () => callback(null));
-            });
-        });
-    });
+        throw err;
+    }
+    log.trace('created bucket in metadata');
+    await addToUsersBucketAsync(canonicalID, bucketName, bucket, log);
+    // Seed before clearing the transient/deleted flag so the bucket is never usable without its metric doc.
+    await seedBucketQuotaCapacity(bucket, log);
+    await removeTransientOrDeletedLabelAsync(bucket, log);
+    return undefined;
 }
 
 /**
@@ -137,19 +140,16 @@ function freshStartCreateBucket(bucket, canonicalID, log, callback) {
  * @param {function} callback - callback with error or null as arguments
  * @return {undefined}
  */
-function cleanUpBucket(bucketMD, canonicalID, log, callback) {
+async function cleanUpBucket(bucketMD, canonicalID, log, callback) {
+    if (callback) {
+        return cleanUpBucket(bucketMD, canonicalID, log).then(() => callback(null), callback);
+    }
     const bucketName = bucketMD.getName();
-    return addToUsersBucket(canonicalID, bucketName, bucketMD, log, err => {
-        if (err) {
-            return callback(err);
-        }
-        return removeTransientOrDeletedLabel(bucketMD, log, labelErr => {
-            if (labelErr) {
-                return callback(labelErr);
-            }
-            return seedBucketQuotaCapacity(bucketMD, log, () => callback(null));
-        });
-    });
+    await addToUsersBucketAsync(canonicalID, bucketName, bucketMD, log);
+    // Seed before clearing the transient/deleted flag so the bucket is never usable without its metric doc.
+    await seedBucketQuotaCapacity(bucketMD, log);
+    await removeTransientOrDeletedLabelAsync(bucketMD, log);
+    return undefined;
 }
 
 /**

--- a/lib/api/bucketUpdateQuota.js
+++ b/lib/api/bucketUpdateQuota.js
@@ -6,6 +6,7 @@ const metadata = require('../metadata/wrapper');
 const { pushMetric } = require('../utapi/utilities');
 const monitoring = require('../utilities/monitoringHandler');
 const { parseString } = require('xml2js');
+const { config } = require('../Config');
 
 function validateBucketQuotaProperty(requestBody, next) {
     let quota = requestBody.quota;
@@ -45,6 +46,30 @@ function parseRequestBody(requestBody, contentType, next) {
     }
 }
 
+function seedEmptyBucketCapacity(bucket, log, done) {
+    if (!config.isQuotaEnabled()) {
+        return done();
+    }
+    const bucketName = bucket.getName();
+    return metadata.listObject(bucketName, { maxKeys: 1, listingType: 'DelimiterVersions' }, log, (err, list) => {
+        if (err) {
+            log.error('error listing bucket for quota capacity seed', { error: err });
+            return done();
+        }
+        const isEmpty =
+            (list.Versions ? list.Versions.length : 0) + (list.DeleteMarkers ? list.DeleteMarkers.length : 0) === 0;
+        if (!isEmpty) {
+            return done();
+        }
+        return metadata.initializeBucketCapacity(bucketName, bucket.getCreationDate(), log, seedErr => {
+            if (seedErr) {
+                log.error('error seeding bucket quota capacity metric', { error: seedErr });
+            }
+            return done();
+        });
+    });
+}
+
 function bucketUpdateQuota(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'bucketUpdateQuota' });
 
@@ -71,8 +96,9 @@ function bucketUpdateQuota(authInfo, request, log, callback) {
                 validateBucketQuotaProperty(requestBody, (err, quotaValue) => next(err, bucket, quotaValue)),
             (bucket, quotaValue, next) => {
                 bucket.setQuota(quotaValue);
-                return metadata.updateBucket(bucket.getName(), bucket, log, next);
+                return metadata.updateBucket(bucket.getName(), bucket, log, (err, res) => next(err, bucket, res));
             },
+            (bucket, res, next) => seedEmptyBucketCapacity(bucket, log, () => next(null, res)),
         ],
         (err, bucket) => {
             const corsHeaders = collectCorsHeaders(request.headers.origin, request.method, bucket);

--- a/lib/api/bucketUpdateQuota.js
+++ b/lib/api/bucketUpdateQuota.js
@@ -1,4 +1,4 @@
-const { waterfall } = require('async');
+const { promisify } = require('util');
 const { errorInstances } = require('arsenal');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const { standardMetadataValidateBucket } = require('../metadata/metadataUtils');
@@ -7,72 +7,97 @@ const { pushMetric } = require('../utapi/utilities');
 const monitoring = require('../utilities/monitoringHandler');
 const { parseString } = require('xml2js');
 const { config } = require('../Config');
+const constants = require('../../constants');
 
-function validateBucketQuotaProperty(requestBody, next) {
+const listObjects = promisify((...args) => metadata.listObject(...args));
+const updateBucketMD = promisify((...args) => metadata.updateBucket(...args));
+const initializeBucketCapacity = promisify((...args) => metadata.initializeBucketCapacity(...args));
+const validateBucket = promisify(standardMetadataValidateBucket);
+const parseStringAsync = promisify(parseString);
+
+function validateBucketQuotaProperty(requestBody) {
     let quota = requestBody.quota;
     if (quota === undefined) {
         quota = requestBody.QuotaConfiguration?.Quota;
     }
     const quotaValue = parseInt(quota, 10);
     if (Number.isNaN(quotaValue)) {
-        return next(errorInstances.InvalidArgument.customizeDescription('Quota Value should be a number'));
+        throw errorInstances.InvalidArgument.customizeDescription('Quota Value should be a number');
     }
     if (quotaValue <= 0) {
-        return next(errorInstances.InvalidArgument.customizeDescription('Quota value must be a positive number'));
+        throw errorInstances.InvalidArgument.customizeDescription('Quota value must be a positive number');
     }
-    return next(null, quotaValue);
+    return quotaValue;
 }
 
-function parseRequestBody(requestBody, contentType, next) {
-    switch (contentType) {
-        case 'application/xml':
-            return parseString(requestBody, { explicitArray: false }, (xmlError, xmlData) => {
-                if (xmlError) {
-                    return next(errorInstances.InvalidArgument.customizeDescription('Invalid XML format'));
-                }
-                return next(null, xmlData);
-            });
-        case 'application/json':
-        default:
-            try {
-                const jsonData = JSON.parse(requestBody);
-                if (typeof jsonData !== 'object') {
-                    throw new Error('Invalid JSON');
-                }
-                return next(null, jsonData);
-            } catch {
-                return next(errorInstances.InvalidArgument.customizeDescription('Request body must be a JSON object'));
-            }
+async function parseRequestBody(requestBody, contentType) {
+    if (contentType === 'application/xml') {
+        try {
+            return await parseStringAsync(requestBody, { explicitArray: false });
+        } catch {
+            throw errorInstances.InvalidArgument.customizeDescription('Invalid XML format');
+        }
+    }
+    try {
+        const jsonData = JSON.parse(requestBody);
+        if (typeof jsonData !== 'object') {
+            throw new Error('Invalid JSON');
+        }
+        return jsonData;
+    } catch {
+        throw errorInstances.InvalidArgument.customizeDescription('Request body must be a JSON object');
     }
 }
 
-function seedEmptyBucketCapacity(bucket, log, done) {
+async function bucketHasInProgressMpus(bucketName, log) {
+    const mpuBucketName = `${constants.mpuBucketPrefix}${bucketName}`;
+    try {
+        // Mirror bucketDelete's check: one overview key per in-progress upload,
+        // bounded to a single key. A missing shadow bucket means none.
+        const list = await listObjects(mpuBucketName, { prefix: 'overview', maxKeys: 1 }, log);
+        return (list.Contents?.length ?? 0) > 0;
+    } catch (err) {
+        if (err.is?.NoSuchBucket) {
+            return false;
+        }
+        throw err;
+    }
+}
+
+async function seedEmptyBucketCapacity(bucket, log) {
     if (!config.isQuotaEnabled()) {
-        return done();
+        return;
     }
     const bucketName = bucket.getName();
-    return metadata.listObject(bucketName, { maxKeys: 1, listingType: 'DelimiterVersions' }, log, (err, list) => {
-        if (err) {
-            log.error('error listing bucket for quota capacity seed', { error: err });
-            return done();
+    try {
+        const list = await listObjects(bucketName, { maxKeys: 1, listingType: 'DelimiterVersions' }, log);
+        const hasObjects = (list.Versions?.length ?? 0) + (list.DeleteMarkers?.length ?? 0) > 0;
+        if (hasObjects) {
+            return;
         }
-        const isEmpty =
-            (list.Versions ? list.Versions.length : 0) + (list.DeleteMarkers ? list.DeleteMarkers.length : 0) === 0;
-        if (!isEmpty) {
-            return done();
+        // A DelimiterVersions listing does not see in-progress MPU parts (shadow
+        // bucket), which hold real storage and are counted by count-items; seeding
+        // zero for a bucket with only uncommitted uploads would under-enforce.
+        if (await bucketHasInProgressMpus(bucketName, log)) {
+            return;
         }
-        return metadata.initializeBucketCapacity(bucketName, bucket.getCreationDate(), log, seedErr => {
-            if (seedErr) {
-                log.error('error seeding bucket quota capacity metric', { error: seedErr });
-            }
-            return done();
-        });
-    });
+        await initializeBucketCapacity(bucketName, bucket.getCreationDate(), log);
+    } catch (err) {
+        // Best-effort: a missing metric self-heals at the next count-items run,
+        // so a seeding failure must never fail the quota update.
+        log.warn('error seeding bucket quota capacity metric', { error: err });
+    }
 }
 
-function bucketUpdateQuota(authInfo, request, log, callback) {
-    log.debug('processing request', { method: 'bucketUpdateQuota' });
+async function bucketUpdateQuota(authInfo, request, log, callback) {
+    if (callback) {
+        return bucketUpdateQuota(authInfo, request, log).then(
+            corsHeaders => callback(null, corsHeaders),
+            err => callback(err, err.code, err.additionalResHeaders),
+        );
+    }
 
+    log.debug('processing request', { method: 'bucketUpdateQuota' });
     const { bucketName } = request;
     const metadataValParams = {
         authInfo,
@@ -80,44 +105,35 @@ function bucketUpdateQuota(authInfo, request, log, callback) {
         requestType: request.apiMethods || 'bucketUpdateQuota',
         request,
     };
-    let bucket = null;
-    return waterfall(
-        [
-            next =>
-                standardMetadataValidateBucket(metadataValParams, request.actionImplicitDenies, log, (err, b) => {
-                    bucket = b;
-                    return next(err, bucket);
-                }),
-            (bucket, next) =>
-                parseRequestBody(request.post, request.headers['content-type'], (err, requestBody) =>
-                    next(err, bucket, requestBody),
-                ),
-            (bucket, requestBody, next) =>
-                validateBucketQuotaProperty(requestBody, (err, quotaValue) => next(err, bucket, quotaValue)),
-            (bucket, quotaValue, next) => {
-                bucket.setQuota(quotaValue);
-                return metadata.updateBucket(bucket.getName(), bucket, log, (err, res) => next(err, bucket, res));
-            },
-            (bucket, res, next) => seedEmptyBucketCapacity(bucket, log, () => next(null, res)),
-        ],
-        (err, bucket) => {
-            const corsHeaders = collectCorsHeaders(request.headers.origin, request.method, bucket);
-            if (err) {
-                log.debug('error processing request', {
-                    error: err,
-                    method: 'bucketUpdateQuota',
-                });
-                monitoring.promMetrics('PUT', bucketName, err.code, 'updateBucketQuota');
-                return callback(err, err.code, corsHeaders);
-            }
-            monitoring.promMetrics('PUT', bucketName, '200', 'updateBucketQuota');
-            pushMetric('updateBucketQuota', log, {
-                authInfo,
-                bucket: bucketName,
-            });
-            return callback(null, corsHeaders);
-        },
-    );
+
+    let bucket;
+    try {
+        bucket = await validateBucket(metadataValParams, request.actionImplicitDenies, log);
+        const requestBody = await parseRequestBody(request.post, request.headers['content-type']);
+        const quotaValue = validateBucketQuotaProperty(requestBody);
+        // Seed before enabling the quota so the metric exists before quotas are enforced. A PUT racing
+        // between the emptiness check and this call leaves a stale zero that self-heals at the next count-items run.
+        await seedEmptyBucketCapacity(bucket, log);
+        bucket.setQuota(quotaValue);
+        await updateBucketMD(bucket.getName(), bucket, log);
+    } catch (err) {
+        const corsHeaders = collectCorsHeaders(request.headers.origin, request.method, bucket);
+        log.debug('error processing request', {
+            error: err,
+            method: 'bucketUpdateQuota',
+        });
+        monitoring.promMetrics('PUT', bucketName, err.code, 'updateBucketQuota');
+        err.additionalResHeaders = err.additionalResHeaders || corsHeaders;
+        throw err;
+    }
+
+    const corsHeaders = collectCorsHeaders(request.headers.origin, request.method, bucket);
+    monitoring.promMetrics('PUT', bucketName, '200', 'updateBucketQuota');
+    pushMetric('updateBucketQuota', log, {
+        authInfo,
+        bucket: bucketName,
+    });
+    return corsHeaders;
 }
 
 module.exports = bucketUpdateQuota;

--- a/lib/api/bucketUpdateQuota.js
+++ b/lib/api/bucketUpdateQuota.js
@@ -56,40 +56,42 @@ function bucketUpdateQuota(authInfo, request, log, callback) {
         request,
     };
     let bucket = null;
-    return waterfall([
-        next => standardMetadataValidateBucket(metadataValParams, request.actionImplicitDenies, log,
-            (err, b) => {
-                bucket = b;
-                return next(err, bucket);
-            }),
-        (bucket, next) => parseRequestBody(request.post, request.headers['content-type'], (err, requestBody) =>
-            next(err, bucket, requestBody)),
-        (bucket, requestBody, next) => validateBucketQuotaProperty(requestBody, (err, quotaValue) =>
-            next(err, bucket, quotaValue)),
-        (bucket, quotaValue, next) => {
-            bucket.setQuota(quotaValue);
-            return metadata.updateBucket(bucket.getName(), bucket, log, next);
-        },
-    ], (err, bucket) => {
-        const corsHeaders = collectCorsHeaders(request.headers.origin,
-            request.method, bucket);
-        if (err) {
-            log.debug('error processing request', {
-                error: err,
-                method: 'bucketUpdateQuota'
+    return waterfall(
+        [
+            next =>
+                standardMetadataValidateBucket(metadataValParams, request.actionImplicitDenies, log, (err, b) => {
+                    bucket = b;
+                    return next(err, bucket);
+                }),
+            (bucket, next) =>
+                parseRequestBody(request.post, request.headers['content-type'], (err, requestBody) =>
+                    next(err, bucket, requestBody),
+                ),
+            (bucket, requestBody, next) =>
+                validateBucketQuotaProperty(requestBody, (err, quotaValue) => next(err, bucket, quotaValue)),
+            (bucket, quotaValue, next) => {
+                bucket.setQuota(quotaValue);
+                return metadata.updateBucket(bucket.getName(), bucket, log, next);
+            },
+        ],
+        (err, bucket) => {
+            const corsHeaders = collectCorsHeaders(request.headers.origin, request.method, bucket);
+            if (err) {
+                log.debug('error processing request', {
+                    error: err,
+                    method: 'bucketUpdateQuota',
+                });
+                monitoring.promMetrics('PUT', bucketName, err.code, 'updateBucketQuota');
+                return callback(err, err.code, corsHeaders);
+            }
+            monitoring.promMetrics('PUT', bucketName, '200', 'updateBucketQuota');
+            pushMetric('updateBucketQuota', log, {
+                authInfo,
+                bucket: bucketName,
             });
-            monitoring.promMetrics('PUT', bucketName, err.code,
-                'updateBucketQuota');
-            return callback(err, err.code, corsHeaders);
-        }
-        monitoring.promMetrics(
-            'PUT', bucketName, '200', 'updateBucketQuota');
-        pushMetric('updateBucketQuota', log, {
-            authInfo,
-            bucket: bucketName,
-        });
-        return callback(null, corsHeaders);
-    });
+            return callback(null, corsHeaders);
+        },
+    );
 }
 
 module.exports = bucketUpdateQuota;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "@azure/storage-blob": "^12.28.0",
         "@hapi/joi": "^17.1.1",
         "@smithy/node-http-handler": "^3.0.0",
-        "arsenal": "git+https://github.com/scality/Arsenal#8.4.21",
+        "arsenal": "git+https://github.com/scality/Arsenal#8.4.22",
         "async": "2.6.4",
         "bucketclient": "scality/bucketclient#8.2.7",
         "bufferutil": "^4.0.8",

--- a/tests/unit/api/bucketPut.js
+++ b/tests/unit/api/bucketPut.js
@@ -904,3 +904,50 @@ describe('bucketPut API with SSE Configurations', () => {
         });
     });
 });
+
+describe('bucketPut API quota metric seeding', () => {
+    afterEach(() => {
+        sinon.restore();
+        cleanup();
+    });
+
+    it('should seed a zero-value quota metric on bucket creation when quotas are enabled', done => {
+        sinon.stub(config, 'isQuotaEnabled').returns(true);
+        const initStub = sinon
+            .stub(metadata, 'initializeBucketCapacity')
+            .callsFake((name, creationDate, l, cb) => cb(null));
+        bucketPut(authInfo, testRequest, log, err => {
+            assert.ifError(err);
+            assert(initStub.calledOnce, 'expected initializeBucketCapacity to be called once');
+            assert.strictEqual(initStub.firstCall.args[0], bucketName);
+            done();
+        });
+    });
+
+    it('should still create the bucket if seeding the quota metric fails', done => {
+        sinon.stub(config, 'isQuotaEnabled').returns(true);
+        sinon
+            .stub(metadata, 'initializeBucketCapacity')
+            .callsFake((name, creationDate, l, cb) => cb(errors.InternalError));
+        bucketPut(authInfo, testRequest, log, err => {
+            assert.ifError(err);
+            return metadata.getBucket(bucketName, log, (getErr, md) => {
+                assert.ifError(getErr);
+                assert.strictEqual(md.getName(), bucketName);
+                done();
+            });
+        });
+    });
+
+    it('should not seed a quota metric when quotas are disabled', done => {
+        sinon.stub(config, 'isQuotaEnabled').returns(false);
+        const initStub = sinon
+            .stub(metadata, 'initializeBucketCapacity')
+            .callsFake((name, creationDate, l, cb) => cb(null));
+        bucketPut(authInfo, testRequest, log, err => {
+            assert.ifError(err);
+            assert(initStub.notCalled, 'expected no seeding when quotas are disabled');
+            done();
+        });
+    });
+});

--- a/tests/unit/api/bucketPut.js
+++ b/tests/unit/api/bucketPut.js
@@ -12,10 +12,7 @@ const metadata = require('../metadataswitch');
 const { cleanup, DummyRequestLogger, makeAuthInfo } = require('../helpers');
 const originalLCs = Object.assign({}, config.locationConstraints);
 
-const {
-    LOCATION_NAME_DMF,
-    LOCATION_NAME_CRR,
-} = require('../../constants');
+const { LOCATION_NAME_DMF, LOCATION_NAME_CRR } = require('../../constants');
 
 const log = new DummyRequestLogger();
 const accessKey = 'accessKey1';
@@ -100,27 +97,27 @@ describe('checkLocationConstraint function', () => {
         config.backends.data = initialConfigData;
     });
     testChecks.forEach(testCheck => {
-        const returnText = testCheck.isError ? `${testCheck.expectedError} error`
-        : 'the appropriate location constraint';
-        it(`with data backend: "${testCheck.data}", ` +
-        `location: "${testCheck.locationSent}",` +
-        ` and host: "${testCheck.parsedHost}", should return ${returnText} `,
-        done => {
-            config.backends.data = testCheck.data;
-            request.parsedHost = testCheck.parsedHost;
-            const checkLocation = checkLocationConstraint(request,
-              testCheck.locationSent, log);
-            if (testCheck.isError) {
-                assert.notEqual(checkLocation.error, null,
-                  'Expected failure but got success');
-                assert(checkLocation.error.is[testCheck.expectedError]);
-            } else {
-                assert.ifError(checkLocation.error);
-                assert.strictEqual(checkLocation.locationConstraint,
-                  testCheck.locationReturn);
-            }
-            done();
-        });
+        const returnText = testCheck.isError
+            ? `${testCheck.expectedError} error`
+            : 'the appropriate location constraint';
+        it(
+            `with data backend: "${testCheck.data}", ` +
+                `location: "${testCheck.locationSent}",` +
+                ` and host: "${testCheck.parsedHost}", should return ${returnText} `,
+            done => {
+                config.backends.data = testCheck.data;
+                request.parsedHost = testCheck.parsedHost;
+                const checkLocation = checkLocationConstraint(request, testCheck.locationSent, log);
+                if (testCheck.isError) {
+                    assert.notEqual(checkLocation.error, null, 'Expected failure but got success');
+                    assert(checkLocation.error.is[testCheck.expectedError]);
+                } else {
+                    assert.ifError(checkLocation.error);
+                    assert.strictEqual(checkLocation.locationConstraint, testCheck.locationReturn);
+                }
+                done();
+            },
+        );
     });
 });
 
@@ -132,11 +129,10 @@ describe('bucketPut API', () => {
     it('should return an error if bucket already exists', done => {
         const otherAuthInfo = makeAuthInfo('accessKey2');
         bucketPut(authInfo, testRequest, log, () => {
-            bucketPut(otherAuthInfo, testRequest,
-                log, err => {
-                    assert.strictEqual(err.is.BucketAlreadyExists, true);
-                    done();
-                });
+            bucketPut(otherAuthInfo, testRequest, log, err => {
+                assert.strictEqual(err.is.BucketAlreadyExists, true);
+                done();
+            });
         });
     });
 
@@ -149,12 +145,10 @@ describe('bucketPut API', () => {
                 assert.strictEqual(md.getName(), bucketName);
                 assert.strictEqual(md.getOwner(), canonicalID);
                 const prefix = `${canonicalID}${splitter}`;
-                metadata.listObject(usersBucket, { prefix },
-                    log, (err, listResponse) => {
-                        assert.strictEqual(listResponse.Contents[0].key,
-                            `${canonicalID}${splitter}${bucketName}`);
-                        done();
-                    });
+                metadata.listObject(usersBucket, { prefix }, log, (err, listResponse) => {
+                    assert.strictEqual(listResponse.Contents[0].key, `${canonicalID}${splitter}${bucketName}`);
+                    done();
+                });
             });
         });
     });
@@ -165,7 +159,7 @@ describe('bucketPut API', () => {
         url: '/',
         post: '',
         headers: {
-            'host': `${bucketName}.s3.amazonaws.com`,
+            host: `${bucketName}.s3.amazonaws.com`,
             'x-amz-bucket-object-lock-enabled': `${status}`,
         },
     });
@@ -202,16 +196,13 @@ describe('bucketPut API', () => {
         });
     });
 
-    it('should return an error if ACL set in header ' +
-       'with an invalid group URI', done => {
+    it('should return an error if ACL set in header ' + 'with an invalid group URI', done => {
         const testRequest = {
             bucketName,
             namespace,
             headers: {
-                'host': `${bucketName}.s3.amazonaws.com`,
-                'x-amz-grant-full-control':
-                    'uri="http://acs.amazonaws.com/groups/' +
-                    'global/NOTAVALIDGROUP"',
+                host: `${bucketName}.s3.amazonaws.com`,
+                'x-amz-grant-full-control': 'uri="http://acs.amazonaws.com/groups/' + 'global/NOTAVALIDGROUP"',
             },
             url: '/',
             post: '',
@@ -225,13 +216,12 @@ describe('bucketPut API', () => {
         });
     });
 
-    it('should return an error if ACL set in header ' +
-       'with an invalid canned ACL', done => {
+    it('should return an error if ACL set in header ' + 'with an invalid canned ACL', done => {
         const testRequest = {
             bucketName,
             namespace,
             headers: {
-                'host': `${bucketName}.s3.amazonaws.com`,
+                host: `${bucketName}.s3.amazonaws.com`,
                 'x-amz-acl': 'not-valid-option',
             },
             url: '/',
@@ -246,15 +236,13 @@ describe('bucketPut API', () => {
         });
     });
 
-    it('should return an error if ACL set in header ' +
-       'with an invalid email address', done => {
+    it('should return an error if ACL set in header ' + 'with an invalid email address', done => {
         const testRequest = {
             bucketName,
             namespace,
             headers: {
-                'host': `${bucketName}.s3.amazonaws.com`,
-                'x-amz-grant-read':
-                    'emailaddress="fake@faking.com"',
+                host: `${bucketName}.s3.amazonaws.com`,
+                'x-amz-grant-read': 'emailaddress="fake@faking.com"',
             },
             url: '/',
             post: '',
@@ -268,15 +256,13 @@ describe('bucketPut API', () => {
         });
     });
 
-    it('should set a canned ACL while creating bucket' +
-        ' if option set out in header', done => {
+    it('should set a canned ACL while creating bucket' + ' if option set out in header', done => {
         const testRequest = {
             bucketName,
             namespace,
             headers: {
-                'host': `${bucketName}.s3.amazonaws.com`,
-                'x-amz-acl':
-                    'public-read',
+                host: `${bucketName}.s3.amazonaws.com`,
+                'x-amz-acl': 'public-read',
             },
             url: '/',
             post: '',
@@ -291,45 +277,33 @@ describe('bucketPut API', () => {
         });
     });
 
-    it('should set specific ACL grants while creating bucket' +
-        ' if options set out in header', done => {
+    it('should set specific ACL grants while creating bucket' + ' if options set out in header', done => {
         const testRequest = {
             bucketName,
             namespace,
             headers: {
-                'host': `${bucketName}.s3.amazonaws.com`,
+                host: `${bucketName}.s3.amazonaws.com`,
                 'x-amz-grant-full-control':
-                    'emailaddress="sampleaccount1@sampling.com"' +
-                    ',emailaddress="sampleaccount2@sampling.com"',
+                    'emailaddress="sampleaccount1@sampling.com"' + ',emailaddress="sampleaccount2@sampling.com"',
                 'x-amz-grant-read': `uri=${constants.logId}`,
                 'x-amz-grant-write': `uri=${constants.publicId}`,
-                'x-amz-grant-read-acp':
-                    'id=79a59df900b949e55d96a1e698fbacedfd6e09d98eac' +
-                    'f8f8d5218e7cd47ef2be',
-                'x-amz-grant-write-acp':
-                    'id=79a59df900b949e55d96a1e698fbacedfd6e09d98eac' +
-                    'f8f8d5218e7cd47ef2bf',
+                'x-amz-grant-read-acp': 'id=79a59df900b949e55d96a1e698fbacedfd6e09d98eac' + 'f8f8d5218e7cd47ef2be',
+                'x-amz-grant-write-acp': 'id=79a59df900b949e55d96a1e698fbacedfd6e09d98eac' + 'f8f8d5218e7cd47ef2bf',
             },
             url: '/',
             post: '',
         };
-        const canonicalIDforSample1 =
-            '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be';
-        const canonicalIDforSample2 =
-            '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2bf';
+        const canonicalIDforSample1 = '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be';
+        const canonicalIDforSample2 = '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2bf';
         bucketPut(authInfo, testRequest, log, err => {
             assert.strictEqual(err, null, 'Error creating bucket');
             metadata.getBucket(bucketName, log, (err, md) => {
                 assert.strictEqual(md.getAcl().READ[0], constants.logId);
                 assert.strictEqual(md.getAcl().WRITE[0], constants.publicId);
-                assert(md.getAcl()
-                       .FULL_CONTROL.indexOf(canonicalIDforSample1) > -1);
-                assert(md.getAcl()
-                       .FULL_CONTROL.indexOf(canonicalIDforSample2) > -1);
-                assert(md.getAcl()
-                       .READ_ACP.indexOf(canonicalIDforSample1) > -1);
-                assert(md.getAcl()
-                       .WRITE_ACP.indexOf(canonicalIDforSample2) > -1);
+                assert(md.getAcl().FULL_CONTROL.indexOf(canonicalIDforSample1) > -1);
+                assert(md.getAcl().FULL_CONTROL.indexOf(canonicalIDforSample2) > -1);
+                assert(md.getAcl().READ_ACP.indexOf(canonicalIDforSample1) > -1);
+                assert(md.getAcl().WRITE_ACP.indexOf(canonicalIDforSample2) > -1);
                 done();
             });
         });
@@ -361,8 +335,7 @@ describe('bucketPut API', () => {
             assert.deepStrictEqual(err, null);
             metadata.getBucket(bucketName, log, (err, bucketInfo) => {
                 assert.deepStrictEqual(err, null);
-                assert.deepStrictEqual(newLocation,
-                    bucketInfo.getLocationConstraint());
+                assert.deepStrictEqual(newLocation, bucketInfo.getLocationConstraint());
                 done();
             });
         });
@@ -427,21 +400,25 @@ describe('bucketPut API', () => {
         const newLCs = Object.assign({}, config.locationConstraints, newLC);
         const req = Object.assign({}, testRequest, {
             bucketName,
-            post: '<?xml version="1.0" encoding="UTF-8"?>' +
+            post:
+                '<?xml version="1.0" encoding="UTF-8"?>' +
                 '<CreateBucketConfiguration ' +
                 'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
-                    `<LocationConstraint>${newLCKey}</LocationConstraint>` +
+                `<LocationConstraint>${newLCKey}</LocationConstraint>` +
                 '</CreateBucketConfiguration>',
         });
 
         afterEach(() => config.setLocationConstraints(originalLCs));
 
-        it('should return error if location constraint config is not updated',
-            done => bucketPut(authInfo, req, log, err => {
+        it('should return error if location constraint config is not updated', done =>
+            bucketPut(authInfo, req, log, err => {
                 assert.strictEqual(err.is.InvalidLocationConstraint, true);
-                assert.strictEqual(err.description, 'value of the location you are ' +
-                    `attempting to set - ${newLCKey} - is not listed in the ` +
-                    'locationConstraint config');
+                assert.strictEqual(
+                    err.description,
+                    'value of the location you are ' +
+                        `attempting to set - ${newLCKey} - is not listed in the ` +
+                        'locationConstraint config',
+                );
                 done();
             }));
 
@@ -472,12 +449,7 @@ describe('bucketPut API', () => {
             {
                 description: 'many allowed auth',
                 error: undefined,
-                results: [
-                    { isAllowed: true },
-                    { isAllowed: true },
-                    { isAllowed: true },
-                    { isAllowed: true },
-                ],
+                results: [{ isAllowed: true }, { isAllowed: true }, { isAllowed: true }, { isAllowed: true }],
                 calledWith: [null, constraint],
             },
             {
@@ -511,20 +483,17 @@ describe('bucketPut API', () => {
             {
                 description: 'one not allowed auth of many',
                 error: undefined,
-                results: [
-                    { isAllowed: true },
-                    { isAllowed: true },
-                    { isAllowed: false },
-                    { isAllowed: true },
-                ],
+                results: [{ isAllowed: true }, { isAllowed: true }, { isAllowed: false }, { isAllowed: true }],
                 calledWith: [errors.AccessDenied],
             },
-        ].forEach(tc => it(tc.description, () => {
-            const cb = sinon.fake();
-            const handler = _handleAuthResults(constraint, log, cb);
-            handler(tc.error, tc.results);
-            assert.deepStrictEqual(cb.getCalls()[0].args, tc.calledWith);
-        }));
+        ].forEach(tc =>
+            it(tc.description, () => {
+                const cb = sinon.fake();
+                const handler = _handleAuthResults(constraint, log, cb);
+                handler(tc.error, tc.results);
+                assert.deepStrictEqual(cb.getCalls()[0].args, tc.calledWith);
+            }),
+        );
     });
 });
 
@@ -544,7 +513,7 @@ describe('bucketPut API with bucket-level encryption', () => {
         const testRequestWithEncryption = {
             ...testRequest,
             headers: {
-                'host': `${bucketName}.s3.amazonaws.com`,
+                host: `${bucketName}.s3.amazonaws.com`,
                 'x-amz-scal-server-side-encryption': 'AES256',
             },
         };
@@ -568,7 +537,7 @@ describe('bucketPut API with bucket-level encryption', () => {
         const testRequestWithEncryption = {
             ...testRequest,
             headers: {
-                'host': `${bucketName}.s3.amazonaws.com`,
+                host: `${bucketName}.s3.amazonaws.com`,
                 'x-amz-scal-server-side-encryption': 'aws:kms',
             },
         };
@@ -593,7 +562,7 @@ describe('bucketPut API with bucket-level encryption', () => {
         const testRequestWithEncryption = {
             ...testRequest,
             headers: {
-                'host': `${bucketName}.s3.amazonaws.com`,
+                host: `${bucketName}.s3.amazonaws.com`,
                 'x-amz-scal-server-side-encryption': 'aws:kms',
                 'x-amz-scal-server-side-encryption-aws-kms-key-id': keyId,
             },
@@ -622,7 +591,7 @@ describe('bucketPut API with bucket-level encryption', () => {
         const testRequestWithEncryption = {
             ...testRequest,
             headers: {
-                'host': `${bucketName}.s3.amazonaws.com`,
+                host: `${bucketName}.s3.amazonaws.com`,
                 'x-amz-scal-server-side-encryption': 'AES256',
                 'x-amz-scal-server-side-encryption-aws-kms-key-id': keyId,
             },
@@ -652,7 +621,7 @@ describe('bucketPut API with account level encryption', () => {
         const testRequestWithEncryption = {
             ...testRequest,
             headers: {
-                'host': `${bucketName}.s3.amazonaws.com`,
+                host: `${bucketName}.s3.amazonaws.com`,
                 'x-amz-scal-server-side-encryption': 'AES256',
             },
         };
@@ -677,7 +646,7 @@ describe('bucketPut API with account level encryption', () => {
         const testRequestWithEncryption = {
             ...testRequest,
             headers: {
-                'host': `${bucketName}.s3.amazonaws.com`,
+                host: `${bucketName}.s3.amazonaws.com`,
                 'x-amz-scal-server-side-encryption': 'aws:kms',
             },
         };
@@ -703,7 +672,7 @@ describe('bucketPut API with account level encryption', () => {
         const testRequestWithEncryption = {
             ...testRequest,
             headers: {
-                'host': `${bucketName}.s3.amazonaws.com`,
+                host: `${bucketName}.s3.amazonaws.com`,
                 'x-amz-scal-server-side-encryption': 'aws:kms',
                 'x-amz-scal-server-side-encryption-aws-kms-key-id': keyId,
             },
@@ -739,7 +708,7 @@ describe('bucketPut API with failed encryption service', () => {
         const testRequestWithEncryption = {
             ...testRequest,
             headers: {
-                'host': `${bucketName}.s3.amazonaws.com`,
+                host: `${bucketName}.s3.amazonaws.com`,
                 'x-amz-scal-server-side-encryption': 'AES256',
             },
         };
@@ -753,8 +722,9 @@ describe('bucketPut API with failed encryption service', () => {
 describe('bucketPut API with failed vault service', () => {
     beforeEach(() => {
         sinon.stub(inMemory, 'supportsDefaultKeyPerAccount').value(true);
-        sinon.stub(vault, 'getOrCreateEncryptionKeyId').callsFake((accountCanonicalId, log, cb) =>
-            cb(errors.ServiceFailure));
+        sinon
+            .stub(vault, 'getOrCreateEncryptionKeyId')
+            .callsFake((accountCanonicalId, log, cb) => cb(errors.ServiceFailure));
     });
 
     afterEach(() => {
@@ -766,7 +736,7 @@ describe('bucketPut API with failed vault service', () => {
         const testRequestWithEncryption = {
             ...testRequest,
             headers: {
-                'host': `${bucketName}.s3.amazonaws.com`,
+                host: `${bucketName}.s3.amazonaws.com`,
                 'x-amz-scal-server-side-encryption': 'AES256',
             },
         };

--- a/tests/unit/api/bucketPut.js
+++ b/tests/unit/api/bucketPut.js
@@ -920,7 +920,15 @@ describe('bucketPut API quota metric seeding', () => {
             assert.ifError(err);
             assert(initStub.calledOnce, 'expected initializeBucketCapacity to be called once');
             assert.strictEqual(initStub.firstCall.args[0], bucketName);
-            done();
+            return metadata.getBucket(bucketName, log, (getErr, md) => {
+                assert.ifError(getErr);
+                assert.strictEqual(
+                    initStub.firstCall.args[1],
+                    md.getCreationDate(),
+                    'must seed with the metastore creationDate used by quota lookups',
+                );
+                done();
+            });
         });
     });
 
@@ -947,6 +955,57 @@ describe('bucketPut API quota metric seeding', () => {
         bucketPut(authInfo, testRequest, log, err => {
             assert.ifError(err);
             assert(initStub.notCalled, 'expected no seeding when quotas are disabled');
+            done();
+        });
+    });
+
+    it('should seed on the transient/deleted cleanup path with the new creationDate', done => {
+        sinon.stub(config, 'isQuotaEnabled').returns(true);
+        const initStub = sinon
+            .stub(metadata, 'initializeBucketCapacity')
+            .callsFake((name, creationDate, l, cb) => cb(null));
+        // Create the bucket, then mark it transient so the next PUT takes the
+        // cleanUpBucket re-creation path.
+        bucketPut(authInfo, testRequest, log, err => {
+            assert.ifError(err);
+            return metadata.getBucket(bucketName, log, (getErr, md) => {
+                assert.ifError(getErr);
+                md.addTransientFlag();
+                return metadata.updateBucket(bucketName, md, log, updErr => {
+                    assert.ifError(updErr);
+                    initStub.resetHistory();
+                    return bucketPut(authInfo, testRequest, log, err2 => {
+                        assert.ifError(err2);
+                        assert(initStub.calledOnce, 'expected seeding on the cleanup path');
+                        return metadata.getBucket(bucketName, log, (getErr2, md2) => {
+                            assert.ifError(getErr2);
+                            assert.strictEqual(
+                                initStub.firstCall.args[1],
+                                md2.getCreationDate(),
+                                'cleanup path must seed with the re-created bucket metastore creationDate',
+                            );
+                            done();
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    it('should seed the metric before clearing the transient/deleted flag', done => {
+        sinon.stub(config, 'isQuotaEnabled').returns(true);
+        const initStub = sinon
+            .stub(metadata, 'initializeBucketCapacity')
+            .callsFake((name, creationDate, l, cb) => cb(null));
+        const updateSpy = sinon.spy(metadata, 'updateBucket');
+        bucketPut(authInfo, testRequest, log, err => {
+            assert.ifError(err);
+            assert(initStub.calledOnce, 'expected seeding');
+            assert(updateSpy.called, 'expected the transient/deleted flag to be cleared via updateBucket');
+            assert(
+                initStub.calledBefore(updateSpy),
+                'metric must be seeded before the transient/deleted flag is cleared',
+            );
             done();
         });
     });

--- a/tests/unit/api/bucketUpdateQuota.js
+++ b/tests/unit/api/bucketUpdateQuota.js
@@ -1,0 +1,122 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const { errors } = require('arsenal');
+
+const { bucketPut } = require('../../../lib/api/bucketPut');
+const bucketUpdateQuota = require('../../../lib/api/bucketUpdateQuota');
+const objectPut = require('../../../lib/api/objectPut');
+const { config } = require('../../../lib/Config');
+const DummyRequest = require('../DummyRequest');
+const metadata = require('../metadataswitch');
+const { cleanup, DummyRequestLogger, makeAuthInfo } = require('../helpers');
+
+const log = new DummyRequestLogger();
+const authInfo = makeAuthInfo('accessKey1');
+const namespace = 'default';
+const bucketName = 'quotabucketname';
+
+const bucketPutRequest = {
+    bucketName,
+    headers: { host: `${bucketName}.s3.amazonaws.com` },
+    url: '/',
+    actionImplicitDenies: false,
+};
+
+const updateQuotaRequest = {
+    bucketName,
+    headers: {
+        host: `${bucketName}.s3.amazonaws.com`,
+        'content-type': 'application/json',
+    },
+    post: '{"quota": 1000}',
+    actionImplicitDenies: false,
+};
+
+function putObject(objectName, cb) {
+    const request = new DummyRequest(
+        {
+            bucketName,
+            namespace,
+            objectKey: objectName,
+            headers: {},
+            url: `/${bucketName}/${objectName}`,
+        },
+        Buffer.from('body content', 'utf8'),
+    );
+    return objectPut(authInfo, request, undefined, log, cb);
+}
+
+describe('bucketUpdateQuota API quota metric seeding', () => {
+    beforeEach(() => {
+        sinon.stub(config, 'isQuotaEnabled').returns(true);
+    });
+
+    afterEach(() => {
+        sinon.restore();
+        cleanup();
+    });
+
+    it('should seed a zero-value metric when a quota is enabled on an empty bucket', done => {
+        const initStub = sinon
+            .stub(metadata, 'initializeBucketCapacity')
+            .callsFake((name, creationDate, l, cb) => process.nextTick(() => cb(null)));
+        bucketPut(authInfo, bucketPutRequest, log, err => {
+            assert.ifError(err);
+            initStub.resetHistory();
+            return bucketUpdateQuota(authInfo, updateQuotaRequest, log, err => {
+                assert.ifError(err);
+                assert(initStub.calledOnce, 'expected seeding for an empty bucket');
+                assert.strictEqual(initStub.firstCall.args[0], bucketName);
+                done();
+            });
+        });
+    });
+
+    it('should not seed a metric when the bucket is not empty', done => {
+        const initStub = sinon
+            .stub(metadata, 'initializeBucketCapacity')
+            .callsFake((name, creationDate, l, cb) => process.nextTick(() => cb(null)));
+        bucketPut(authInfo, bucketPutRequest, log, err => {
+            assert.ifError(err);
+            return putObject('someobject', err => {
+                assert.ifError(err);
+                initStub.resetHistory();
+                return bucketUpdateQuota(authInfo, updateQuotaRequest, log, err => {
+                    assert.ifError(err);
+                    assert(initStub.notCalled, 'expected no seeding for a non-empty bucket');
+                    done();
+                });
+            });
+        });
+    });
+
+    it('should still update the quota if seeding the metric fails', done => {
+        bucketPut(authInfo, bucketPutRequest, log, err => {
+            assert.ifError(err);
+            sinon
+                .stub(metadata, 'initializeBucketCapacity')
+                .callsFake((name, creationDate, l, cb) => process.nextTick(() => cb(errors.InternalError)));
+            return bucketUpdateQuota(authInfo, updateQuotaRequest, log, err => {
+                assert.ifError(err);
+                done();
+            });
+        });
+    });
+
+    it('should not seed a metric when quotas are disabled', done => {
+        config.isQuotaEnabled.restore();
+        sinon.stub(config, 'isQuotaEnabled').returns(false);
+        const initStub = sinon
+            .stub(metadata, 'initializeBucketCapacity')
+            .callsFake((name, creationDate, l, cb) => process.nextTick(() => cb(null)));
+        bucketPut(authInfo, bucketPutRequest, log, err => {
+            assert.ifError(err);
+            initStub.resetHistory();
+            return bucketUpdateQuota(authInfo, updateQuotaRequest, log, err => {
+                assert.ifError(err);
+                assert(initStub.notCalled, 'expected no seeding when quotas are disabled');
+                done();
+            });
+        });
+    });
+});

--- a/tests/unit/api/bucketUpdateQuota.js
+++ b/tests/unit/api/bucketUpdateQuota.js
@@ -67,7 +67,15 @@ describe('bucketUpdateQuota API quota metric seeding', () => {
                 assert.ifError(err);
                 assert(initStub.calledOnce, 'expected seeding for an empty bucket');
                 assert.strictEqual(initStub.firstCall.args[0], bucketName);
-                done();
+                return metadata.getBucket(bucketName, log, (getErr, md) => {
+                    assert.ifError(getErr);
+                    assert.strictEqual(
+                        initStub.firstCall.args[1],
+                        md.getCreationDate(),
+                        'must seed with the metastore creationDate used by quota lookups',
+                    );
+                    done();
+                });
             });
         });
     });
@@ -98,6 +106,54 @@ describe('bucketUpdateQuota API quota metric seeding', () => {
                 .callsFake((name, creationDate, l, cb) => process.nextTick(() => cb(errors.InternalError)));
             return bucketUpdateQuota(authInfo, updateQuotaRequest, log, err => {
                 assert.ifError(err);
+                return metadata.getBucket(bucketName, log, (getErr, bucket) => {
+                    assert.ifError(getErr);
+                    assert.strictEqual(bucket.getQuota(), 1000n, 'quota must be updated even if seeding fails');
+                    done();
+                });
+            });
+        });
+    });
+
+    it('should still update the quota if listing the bucket fails', done => {
+        const initStub = sinon
+            .stub(metadata, 'initializeBucketCapacity')
+            .callsFake((name, creationDate, l, cb) => process.nextTick(() => cb(null)));
+        bucketPut(authInfo, bucketPutRequest, log, err => {
+            assert.ifError(err);
+            initStub.resetHistory();
+            sinon
+                .stub(metadata, 'listObject')
+                .callsFake((name, params, l, cb) => process.nextTick(() => cb(errors.InternalError)));
+            return bucketUpdateQuota(authInfo, updateQuotaRequest, log, err => {
+                assert.ifError(err);
+                assert(initStub.notCalled, 'expected no seeding when the listing fails');
+                return metadata.getBucket(bucketName, log, (getErr, bucket) => {
+                    assert.ifError(getErr);
+                    assert.strictEqual(bucket.getQuota(), 1000n, 'quota must be updated even if listing fails');
+                    done();
+                });
+            });
+        });
+    });
+
+    it('should not seed a metric when the bucket has an in-progress multipart upload', done => {
+        const initStub = sinon
+            .stub(metadata, 'initializeBucketCapacity')
+            .callsFake((name, creationDate, l, cb) => process.nextTick(() => cb(null)));
+        bucketPut(authInfo, bucketPutRequest, log, err => {
+            assert.ifError(err);
+            initStub.resetHistory();
+            // empty object listing, but an overview key in the MPU shadow bucket
+            sinon.stub(metadata, 'listObject').callsFake((name, params, l, cb) => {
+                if (params && params.prefix === 'overview') {
+                    return process.nextTick(() => cb(null, { Contents: [{ key: 'ongoing' }] }));
+                }
+                return process.nextTick(() => cb(null, { Versions: [], DeleteMarkers: [] }));
+            });
+            return bucketUpdateQuota(authInfo, updateQuotaRequest, log, err => {
+                assert.ifError(err);
+                assert(initStub.notCalled, 'expected no seeding while an MPU is in progress');
                 done();
             });
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6591,9 +6591,9 @@ arraybuffer.prototype.slice@^1.0.4:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/Arsenal#8.4.21":
-  version "8.4.21"
-  resolved "git+https://github.com/scality/Arsenal#83072fd8790ec85b37030a88841caa3d2b912e72"
+"arsenal@git+https://github.com/scality/Arsenal#8.4.22":
+  version "8.4.22"
+  resolved "git+https://github.com/scality/Arsenal#64484bec1e2b8948f7834f65d29ddc7461560afd"
   dependencies:
     "@aws-sdk/client-kms" "^3.975.0"
     "@aws-sdk/client-s3" "^3.975.0"


### PR DESCRIPTION
Backport of CLDSRV-949 to `development/9.3`, prefixed with the arsenal dependency bump it requires.

- `Bump arsenal to 8.4.22` + lock regeneration — brings `MongoClientInterface.initializeBucketCapacity` (ARSN-610, backported in scality/Arsenal#2680) to the 8.4 line used by 9.3.
- The three CLDSRV-949 commits cherry-picked **byte-for-byte** from `development/9.4` (PR #6221): prettier pre-commit, the seed itself, and the async/await migration. All four touched files are identical between 9.3 and the 9.4 base, so `git merge-tree` toward `development/9.4` shows conflicts only on `package.json` (arsenal pin / version) — the usual cascade resolution; the code merges as a no-op.

Seeding a zero-value bucket metric document in `__infostore` at bucket creation (and quota-enable of a verifiably-empty bucket) makes bucket quota checks enforceable immediately instead of waiting up to 24h for count-items (ARTESCA-17063), and makes the Veeam SOSAPI `capacity.xml` report correct capacity from the first read on new repositories (RD-2109) — complementing the s3utils-side seeding backported in scality/s3utils#406.

Issue: CLDSRV-949