### PR TITLE
docs: fix typo (continous->continuous (x1))

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ yarn install
 yarn dev
 ```
 
-This will start the developement server, watching for changes and restarting
+This will start the development server, watching for changes and restarting
 as needed.
 
 ### Formatting

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ CloudServer provides a single AWS S3 API interface to access multiple
 backend data storage both on-premise or public in the cloud.
 
 CloudServer is useful for Developers, either to run as part of a
-continous integration test environment to emulate the AWS S3 service locally
+continuous integration test environment to emulate the AWS S3 service locally
 or as an abstraction layer to develop object storage enabled
 application on the go.
 

--- a/docs/INTEGRATIONS.rst
+++ b/docs/INTEGRATIONS.rst
@@ -271,7 +271,7 @@ Off you go!
 ~~~~~~~~~~~
 
 Let us know how you use this and if you'd like any specific developments 
-around it. Even better: come and contribute to our `Github repository 
+around it. Even better: come and contribute to our `GitHub repository 
 <https://github.com/scality/s3/>`__! We look forward to meeting you!
 
 S3FS

--- a/docs/developers/getting-started.rst
+++ b/docs/developers/getting-started.rst
@@ -39,7 +39,7 @@ Openstack Swift                               x
 ================= ========== ============ ===========
 
 .. important:: Should you want to request for a new backend to be
-               supported, please do so by opening a `Github issue`_,
+               supported, please do so by opening a `GitHub issue`_,
                and filling out the "Feature Request" section of our
                template.
 
@@ -47,7 +47,7 @@ To add support for a new backend support to CloudServer official
 repository, please follow these steps:
 
 - familiarize yourself with our `Contributing Guidelines`_
-- open a `Github issue`_ and fill out Feature Request form, and
+- open a `GitHub issue`_ and fill out Feature Request form, and
   specify you would like to contribute it yourself;
 - wait for our core team to get back to you with an answer on whether
   we are interested in taking that contribution in (and hence


### PR DESCRIPTION
## Summary
Fixes spelling/typo issues found in this project's documentation.

**Details:** Fix documentation typos: continous->continuous (x1); developement->development (x1); Github->GitHub (x3)

**Files:**
- `README.md`
- `CONTRIBUTING.md`
- `docs/INTEGRATIONS.rst`
- `docs/developers/getting-started.rst`

Documentation-only; no functional code changes.
