### PR TITLE
CLDSRV-968: Expire idle keep-alive sockets in the functional test client

### DIFF
--- a/tests/functional/aws-node-sdk/test/support/config.js
+++ b/tests/functional/aws-node-sdk/test/support/config.js
@@ -30,6 +30,14 @@ const DEFAULT_GLOBAL_OPTIONS = {
 // timeout.
 const REQUEST_TIMEOUT = 30000;
 
+// Idle timeout for pooled keep-alive sockets, kept below the server's 5s
+// keep-alive so the client retires a socket before the server closes it.
+// A value is required: Node clamps this against the server's advertised
+// `Keep-Alive` hint, but only ever downwards from a non-zero timeout
+// (`agentTimeout = this.options.timeout || 0`), so leaving it unset means
+// pooled sockets never expire. See CLDSRV-968.
+const AGENT_IDLE_TIMEOUT = 4000;
+
 const DEFAULT_MEM_OPTIONS = {
     endpoint: `${transport}://127.0.0.1:8000`,
     port: 8000,
@@ -43,6 +51,7 @@ const DEFAULT_MEM_OPTIONS = {
             maxSockets: 200,
             keepAlive: true,
             keepAliveMsecs: 1000,
+            timeout: AGENT_IDLE_TIMEOUT,
         }),
     }),
 };
@@ -57,6 +66,7 @@ const DEFAULT_AWS_OPTIONS = {
             maxSockets: 200,
             keepAlive: true,
             keepAliveMsecs: 1000,
+            timeout: AGENT_IDLE_TIMEOUT,
         }),
     }),
 };


### PR DESCRIPTION
The functional test client keeps pooled keep-alive connections indefinitely, so after an idle gap it can send a request over a connection the server has already closed and fail with a spurious connection reset. Because the client also runs with retries disabled, one reset is enough to fail a hook and take a whole group of tests down with it, which surfaces as intermittent CI red on slower full-deployment environments where such idle gaps actually occur.

This makes the client expire its own idle connections before the server does, so the reuse race cannot arise.