### PR TITLE
Read the quota staleness window from the correct config key

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -250,6 +250,8 @@ const constants = {
         'bucketPutLogging',
         'bucketGetLogging',
     ],
+    // Default window beyond which quota metrics are considered stale
+    defaultQuotaMaxStalenessMS: 24 * 60 * 60 * 1000,
     // Rate limiting defaults
     rateLimitDefaultConfigCacheTTL: 30000, // 30 seconds
     rateLimitDefaultBurstCapacity: 1,

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1434,9 +1434,15 @@ class Config extends EventEmitter {
         if (this.scuba) {
             this.quotaEnabled = true;
         }
-        const maxStaleness =
-            Number(process.env.QUOTA_MAX_STALENESS_MS) || config.quota?.maxStatenessMS || 24 * 60 * 60 * 1000;
-        assert(Number.isInteger(maxStaleness), 'bad config: maxStalenessMS must be an integer');
+        let maxStaleness = constants.defaultQuotaMaxStalenessMS;
+        const overrideMaxStaleness = process.env.QUOTA_MAX_STALENESS_MS || config.quota?.maxStalenessMS;
+        if (overrideMaxStaleness !== undefined && overrideMaxStaleness !== null) {
+            maxStaleness = Number(overrideMaxStaleness);
+            assert(
+                Number.isInteger(maxStaleness) && maxStaleness > 0,
+                'bad config: quota.maxStalenessMS must be a positive integer',
+            );
+        }
         const enableInflights = process.env.QUOTA_ENABLE_INFLIGHTS === 'true' || config.quota?.enableInflights || false;
         this.quota = {
             maxStaleness,

--- a/tests/unit/Config.js
+++ b/tests/unit/Config.js
@@ -13,6 +13,7 @@ const {
 
 const { LOCATION_NAME_DMF } = require('../constants');
 const constants = require('../../constants');
+const allOptsQuota = require('./testConfigs/allOptsConfig/config.json').quota;
 
 const { ValidLifecycleRules: supportedLifecycleRules } = require('arsenal').models;
 
@@ -545,16 +546,29 @@ describe('Config', () => {
             process.env.S3_CONFIG_FILE = oldConfig;
         });
 
-        it('should set up quota', () => {
+        it('should set up quota from the config file', () => {
+            assert.notStrictEqual(allOptsQuota.maxStalenessMS, constants.defaultQuotaMaxStalenessMS);
+
             const config = new ConfigObject();
 
             assert.deepStrictEqual(config.quota, {
-                maxStaleness: 24 * 60 * 60 * 1000,
+                maxStaleness: allOptsQuota.maxStalenessMS,
                 enableInflights: false,
             });
         });
 
-        it('should use environment variables for scuba', () => {
+        it('should use the default when the config file does not set maxStalenessMS', () => {
+            setEnv('S3_CONFIG_FILE', 'config.json');
+
+            const config = new ConfigObject();
+
+            assert.deepStrictEqual(config.quota, {
+                maxStaleness: constants.defaultQuotaMaxStalenessMS,
+                enableInflights: false,
+            });
+        });
+
+        it('should use environment variables for quota', () => {
             setEnv('QUOTA_MAX_STALENESS_MS', 1234);
             setEnv('QUOTA_ENABLE_INFLIGHTS', 'true');
 
@@ -566,15 +580,22 @@ describe('Config', () => {
             });
         });
 
-        it('should use the default if the maxStaleness is not a number', () => {
-            setEnv('QUOTA_MAX_STALENESS_MS', 'notanumber');
-            setEnv('QUOTA_ENABLE_INFLIGHTS', 'true');
+        it('should fall back to the config file when QUOTA_MAX_STALENESS_MS is empty', () => {
+            setEnv('QUOTA_MAX_STALENESS_MS', '');
 
             const config = new ConfigObject();
 
             assert.deepStrictEqual(config.quota, {
-                maxStaleness: 24 * 60 * 60 * 1000,
-                enableInflights: true,
+                maxStaleness: allOptsQuota.maxStalenessMS,
+                enableInflights: false,
+            });
+        });
+
+        ['notanumber', '0', '-1', '1.5'].forEach(value => {
+            it(`should reject a maxStaleness of '${value}'`, () => {
+                setEnv('QUOTA_MAX_STALENESS_MS', value);
+
+                assert.throws(() => new ConfigObject(), /bad config: quota.maxStalenessMS must be a positive integer/);
             });
         });
     });

--- a/tests/unit/testConfigs/allOptsConfig/config.json
+++ b/tests/unit/testConfigs/allOptsConfig/config.json
@@ -106,7 +106,7 @@
         "port": 8100
     },
     "quota": {
-        "maxStalenessMS": 86400000
+        "maxStalenessMS": 3600000
     },
     "utapi": {
         "redis": {

--- a/tests/unit/testConfigs/allOptsConfig/config.json
+++ b/tests/unit/testConfigs/allOptsConfig/config.json
@@ -10,29 +10,34 @@
         "127.0.0.2": "us-east-1",
         "s3.amazonaws.com": "us-east-1"
     },
-    "websiteEndpoints": ["s3-website-us-east-1.amazonaws.com",
-                        "s3-website.us-east-2.amazonaws.com",
-                        "s3-website-us-west-1.amazonaws.com",
-                        "s3-website-us-west-2.amazonaws.com",
-                        "s3-website.ap-south-1.amazonaws.com",
-                        "s3-website.ap-northeast-2.amazonaws.com",
-                        "s3-website-ap-southeast-1.amazonaws.com",
-                        "s3-website-ap-southeast-2.amazonaws.com",
-                        "s3-website-ap-northeast-1.amazonaws.com",
-                        "s3-website.eu-central-1.amazonaws.com",
-                        "s3-website-eu-west-1.amazonaws.com",
-                        "s3-website-sa-east-1.amazonaws.com",
-                        "s3-website.localhost",
-                        "s3-website.scality.test",
-                        "zenkoazuretest.blob.core.windows.net"],
-    "replicationEndpoints": [{
-        "site": "zenko",
-        "servers": ["127.0.0.1:8000"],
-        "default": true
-    }, {
-        "site": "us-east-2",
-        "type": "aws_s3"
-    }],
+    "websiteEndpoints": [
+        "s3-website-us-east-1.amazonaws.com",
+        "s3-website.us-east-2.amazonaws.com",
+        "s3-website-us-west-1.amazonaws.com",
+        "s3-website-us-west-2.amazonaws.com",
+        "s3-website.ap-south-1.amazonaws.com",
+        "s3-website.ap-northeast-2.amazonaws.com",
+        "s3-website-ap-southeast-1.amazonaws.com",
+        "s3-website-ap-southeast-2.amazonaws.com",
+        "s3-website-ap-northeast-1.amazonaws.com",
+        "s3-website.eu-central-1.amazonaws.com",
+        "s3-website-eu-west-1.amazonaws.com",
+        "s3-website-sa-east-1.amazonaws.com",
+        "s3-website.localhost",
+        "s3-website.scality.test",
+        "zenkoazuretest.blob.core.windows.net"
+    ],
+    "replicationEndpoints": [
+        {
+            "site": "zenko",
+            "servers": ["127.0.0.1:8000"],
+            "default": true
+        },
+        {
+            "site": "us-east-2",
+            "type": "aws_s3"
+        }
+    ],
     "cdmi": {
         "host": "localhost",
         "port": 81,
@@ -75,11 +80,11 @@
         "recordLogName": "s3-recordlog"
     },
     "mongodb": {
-       "replicaSetHosts": "localhost:27017,localhost:27018,localhost:27019",
-       "writeConcern": "majority",
-       "replicaSet": "rs0",
-       "readPreference": "primary",
-       "database": "metadata"
+        "replicaSetHosts": "localhost:27017,localhost:27018,localhost:27019",
+        "writeConcern": "majority",
+        "replicaSet": "rs0",
+        "readPreference": "primary",
+        "database": "metadata"
     },
     "certFilePaths": {
         "key": "tests/unit/testConfigs/allOptsConfig/key.txt",


### PR DESCRIPTION
`lib/Config.js` read the quota staleness window from `quota.maxStatenessMS`
instead of `quota.maxStalenessMS`, so a value set in `config.json` was
silently ignored and the hardcoded 24h default was used instead. Only the
`QUOTA_MAX_STALENESS_MS` environment variable could change the window.

The setting is now validated like the options around it: apply the default,
then assert that an explicitly provided value is a positive integer rather
than silently falling back on a malformed one. The default moves to
`constants.js` as `defaultQuotaMaxStalenessMS`.

The existing test could not catch this. The fixture set the correctly
spelled key to `86400000`, which equals the default, so the assertion passed
through the fallback branch either way. It now uses a distinct value and
asserts that value differs from the default.

Issue: CLDSRV-970