### PR TITLE
CLDSRV-973: keep serving when the delete path throws synchronously

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -425,12 +425,25 @@ const services = {
         const objGetInfo = objectMD.location;
         // special case that prevents azure blocks from unecessary deletion
         // will return null if no need
-        return data.protectAzureBlocks(bucketName, objectKey, objGetInfo, log, err => {
-            if (err) {
-                return cb(err);
-            }
-            return deleteMDandData();
-        });
+        // A synchronous throw in the data layer (e.g. no backend client for a location
+        // that was removed from the overlay) must not escape into the promise machinery:
+        // it surfaces there as an unhandledRejection and takes the whole process down.
+        try {
+            return data.protectAzureBlocks(bucketName, objectKey, objGetInfo, log, err => {
+                if (err) {
+                    return cb(err);
+                }
+                return deleteMDandData();
+            });
+        } catch (err) {
+            log.error('deleteObject: error protecting azure blocks', {
+                method: 'services.deleteObject',
+                error: err.message,
+                bucketName,
+                objectKey,
+            });
+            return cb(errors.InternalError);
+        }
     },
 
     /**


### PR DESCRIPTION
Issue: [CLDSRV-973](https://scality.atlassian.net/browse/CLDSRV-973)

Draft — the containment fix is complete, but the broader question in **Open questions** should be settled before this merges.

## Problem

A synchronous throw in the data layer while deleting an object does not become a `500` for that request. It escapes into the promise machinery, crosses an `async` callback that has already fired, and produces:

```
{"name":"S3","action":"DeleteObjects","bucket":"im-bucket-001",
 "object":"QRh8XuQk/19.pQUofZcHqIeBa3E1.rnd",
 "error":"Cannot read properties of undefined (reading 'protectAzureBlocks')"}

unhandledRejection:
Error: Callback was already called.
    at node_modules/async/dist/async.js:969:32
    at .../mongoclient/MongoClientInterface.js:1125:28
{"name":"S3","error":"Callback was already called.","level":"fatal"}
```

Node's default for an unhandled rejection is to exit, so **one request kills the pod serving it**. Clients retry automatically, so the failure walks the deployment: in the field this took all 25 cloudserver pods into CrashLoopBackOff and the ARTESCA S3 endpoint fully offline, from a single `delete-objects` call. Found during the IronMountain XDM scale campaign (OS-1095) on ARTESCA 4.3.0-rc2 / `cloudserver:9.3.9`.

Note the first log line: the request-scoped error *was* caught and logged with full context. The process still died on the second one.

## Change

Contain it at the delete path in `services.deleteObject`: wrap the `data.protectAzureBlocks(...)` call so a synchronous throw is logged and returned as `InternalError` for that request, instead of escaping. The pod keeps serving traffic.

The specific trigger seen in the field (an unguarded backend-client lookup for a location removed from the overlay) is fixed separately in [scality/Arsenal#2686](https://github.com/scality/Arsenal/pull/2686) / ARSN-623. This PR is deliberately about the **blast radius** — so that the *next* throw on this path is a failed request rather than a fleet-wide outage.

## Open questions for review

1. **Is a local `try/catch` the right depth of fix?** It closes the path with a confirmed outage, but any other synchronous throw reachable from a request handler has the same consequence. A process-level `unhandledRejection` handler that logs and attributes the rejection to its request — rather than exiting — would address the class instead of this one instance. That is a deliberate availability-vs-fail-fast policy decision, so I have not made it here. `lib/server.js:89` already installs an `uncaughtException` handler; there is no `unhandledRejection` equivalent.
2. **Double-callback specifically.** `Callback was already called.` means the first callback already ran, i.e. the request *had* been answered. Arguably that case should always be logged and swallowed rather than escalated to fatal.
3. **Target branch.** Opened against `development/9.3` since 9.3.9 is the deployed version, so Bert-E forward-ports to 9.4.
4. No test added — reproducing this needs a data-layer client that throws synchronously, and the meaningful assertion (the process stays alive) is awkward in-process. Suggestions welcome; the Arsenal PR carries the unit-level regression test for the trigger.


[CLDSRV-973]: https://scality.atlassian.net/browse/CLDSRV-973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ