### PR TITLE
CLDSRV-976: bump arsenal to 8.4.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zenko/cloudserver",
-    "version": "9.3.17",
+    "version": "9.3.18",
     "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
     "main": "index.js",
     "engines": {
@@ -30,7 +30,7 @@
         "@azure/storage-blob": "^12.28.0",
         "@hapi/joi": "^17.1.1",
         "@smithy/node-http-handler": "^3.0.0",
-        "arsenal": "git+https://github.com/scality/Arsenal#8.4.23",
+        "arsenal": "git+https://github.com/scality/Arsenal#8.4.24",
         "async": "2.6.4",
         "bucketclient": "scality/bucketclient#8.2.7",
         "bufferutil": "^4.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6591,9 +6591,9 @@ arraybuffer.prototype.slice@^1.0.4:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/Arsenal#8.4.23":
-  version "8.4.23"
-  resolved "git+https://github.com/scality/Arsenal#c3f156440b27ac722240e86679de80ad2c43a45e"
+"arsenal@git+https://github.com/scality/Arsenal#8.4.24":
+  version "8.4.24"
+  resolved "git+https://github.com/scality/Arsenal#8c136afde33cac95a5df62b0aab7f5a9805d4004"
   dependencies:
     "@aws-sdk/client-kms" "^3.975.0"
     "@aws-sdk/client-s3" "^3.975.0"
@@ -6632,7 +6632,7 @@ arraybuffer.prototype.slice@^1.0.4:
     simple-glob "^0.2.0"
     socket.io "^4.8.0"
     socket.io-client "^4.8.0"
-    sproxydclient "github:scality/sproxydclient#8.2.1"
+    sproxydclient "github:scality/sproxydclient#8.2.2"
     utf8 "^3.0.0"
     uuid "^10.0.0"
     werelogs scality/werelogs#8.2.4
@@ -11874,9 +11874,9 @@ sprintf-js@~1.0.2:
     httpagent "github:scality/httpagent#1.1.0"
     werelogs scality/werelogs#8.2.0
 
-"sproxydclient@github:scality/sproxydclient#8.2.1":
-  version "8.2.1"
-  resolved "https://codeload.github.com/scality/sproxydclient/tar.gz/501829f5521787e7e946de6792f5806ffa6ec437"
+"sproxydclient@github:scality/sproxydclient#8.2.2":
+  version "8.2.2"
+  resolved "https://codeload.github.com/scality/sproxydclient/tar.gz/62d3aac1c844beda2286f33a1a7c7f2a31937579"
   dependencies:
     async "^3.2.6"
     httpagent "github:scality/httpagent#1.1.0"


### PR DESCRIPTION
sproxyd now answers DELETE and batch-delete requests with 204 No Content, and the sproxyd client carried by the previous Arsenal only accepted 200 and 206 as success. Deletes were therefore retried and eventually surfaced to S3 clients as internal errors. This picks up the Arsenal version carrying the fixed client so deletes succeed again.