### PR TITLE
CLDSRV-978: Stop installing tcpdump in the kmip cluster job

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -877,8 +877,11 @@ jobs:
           python-version: 3.9
       - name: Setup CI environment
         uses: ./.github/actions/setup-ci
-      - name: Install tcpdump to analyze traffic on kmip cluster interfaces
-        run: sudo apt-get update && sudo apt-get install -y tcpdump
+      # tcpdump is already present on the runner image, and the apt mirrors are
+      # unreliable enough to hang a job for hours, so we don't install it.
+      # Uncomment if a runner or image change ever drops the package.
+      # - name: Install tcpdump to analyze traffic on kmip cluster interfaces
+      #   run: sudo apt-get install -y tcpdump
       - name: Copy KMIP certs
         run: cp -r ./certs /tmp/ssl-kmip
         working-directory: .github/pykmip


### PR DESCRIPTION
The KMIP cluster functional test job was hanging for hours on installing tcpdump, because of an unreliable Azure-hosted Ubuntu mirror. tcpdump already ships with the runner image, so the install was never needed - dropping it removes our exposure to that mirror.

The step is commented out rather than deleted, so it can be restored quickly if a future runner or image change drops the package.