### PR TITLE
CLDSRV-979: Stop retaining a request logger on rate limit token buckets

### DIFF
--- a/lib/api/apiUtils/rateLimit/refillJob.js
+++ b/lib/api/apiUtils/rateLimit/refillJob.js
@@ -38,7 +38,7 @@ async function refillTokenBuckets(logger) {
         checked++;
 
         // Trigger async refill if needed (non-blocking)
-        const promise = bucket.refillIfNeeded().then(bucketRefilled => {
+        const promise = bucket.refillIfNeeded(logger).then(bucketRefilled => {
             // Check if refill actually happened
             if (bucketRefilled) {
                 refilled++;

--- a/lib/api/apiUtils/rateLimit/refillJob.js
+++ b/lib/api/apiUtils/rateLimit/refillJob.js
@@ -3,14 +3,10 @@ const { getAllTokenBuckets, cleanupTokenBuckets } = require('./tokenBucket');
 let refillTimer = null;
 
 // Refill interval in milliseconds (how often to check and refill buckets)
-const REFILL_INTERVAL_MS = process.env.REFILL_INTERVAL_MS
-    ? parseInt(process.env.REFILL_INTERVAL_MS, 10)
-    : 100;
+const REFILL_INTERVAL_MS = process.env.REFILL_INTERVAL_MS ? parseInt(process.env.REFILL_INTERVAL_MS, 10) : 100;
 
 // Cleanup interval for expired buckets (every 10 seconds)
-const CLEANUP_INTERVAL_MS = process.env.CLEANUP_INTERVAL_MS
-    ? parseInt(process.env.CLEANUP_INTERVAL_MS, 10)
-    : 10000;
+const CLEANUP_INTERVAL_MS = process.env.CLEANUP_INTERVAL_MS ? parseInt(process.env.CLEANUP_INTERVAL_MS, 10) : 10000;
 
 let cleanupCounter = 0;
 
@@ -38,19 +34,22 @@ async function refillTokenBuckets(logger) {
         checked++;
 
         // Trigger async refill if needed (non-blocking)
-        const promise = bucket.refillIfNeeded(logger).then(bucketRefilled => {
-            // Check if refill actually happened
-            if (bucketRefilled) {
-                refilled++;
-            }
-        }).catch(err => {
-            logger.error('error refilling token bucket', {
-                bucketName,
-                method: 'rateLimit.refillTokenBuckets',
-                error: err.message,
-                stack: err.stack,
+        const promise = bucket
+            .refillIfNeeded(logger)
+            .then(bucketRefilled => {
+                // Check if refill actually happened
+                if (bucketRefilled) {
+                    refilled++;
+                }
+            })
+            .catch(err => {
+                logger.error('error refilling token bucket', {
+                    bucketName,
+                    method: 'rateLimit.refillTokenBuckets',
+                    error: err.message,
+                    stack: err.stack,
+                });
             });
-        });
 
         refillPromises.push(promise);
     }

--- a/lib/api/apiUtils/rateLimit/tokenBucket.js
+++ b/lib/api/apiUtils/rateLimit/tokenBucket.js
@@ -12,7 +12,7 @@
 
 const util = require('util');
 
-const { instance: redisClient } = require('./client');
+const rateLimitClient = require('./client');
 const { config } = require('../../../Config');
 const { calculateInterval } = require('./gcra');
 
@@ -102,6 +102,9 @@ class WorkerTokenBucket {
 
             // Calculate GCRA parameters
             let granted = requested;
+            // Read the instance at call time rather than destructuring it at
+            // module load, so tests can substitute a fake client.
+            const redisClient = rateLimitClient.instance;
             if (redisClient.isReady()) {
                 // Request tokens from Redis (atomic GCRA enforcement)
                 granted = await util.promisify(redisClient.grantTokens.bind(redisClient))(

--- a/lib/api/apiUtils/rateLimit/tokenBucket.js
+++ b/lib/api/apiUtils/rateLimit/tokenBucket.js
@@ -23,12 +23,11 @@ const tokenBuckets = new Map();
  * Per-resourceClass+resourceID+measure token bucket for a single worker
  */
 class WorkerTokenBucket {
-    constructor(resourceClass, resourceId, measure, limitConfig, log) {
+    constructor(resourceClass, resourceId, measure, limitConfig) {
         this.resourceClass = resourceClass;
         this.resourceId = resourceId;
         this.measure = measure;
         this.limitConfig = limitConfig;
-        this.log = log;
 
         this.bufferSize = config.rateLimiting?.tokenBucketBufferSize; // Max tokens to hold
         this.refillThreshold = config.rateLimiting?.tokenBucketRefillThreshold; // Trigger refill when below this
@@ -73,9 +72,13 @@ class WorkerTokenBucket {
      * Check if refill is needed and trigger async refill
      * Called by background job every 100ms
      *
+     * The logger is deliberately taken per call and never stored on the
+     * bucket: a retained request logger buffers entries forever.
+     *
+     * @param {object} log - Logger instance, supplied by the caller
      * @returns {Promise<boolean>}
      */
-    async refillIfNeeded() {
+    async refillIfNeeded(log) {
         // Already refilling, skip
         if (this.refillInProgress) {
             return false;
@@ -113,7 +116,7 @@ class WorkerTokenBucket {
                 // Connection to redis has failed in some way.
                 // Client will be reconnecting in the background.
                 // We grant the requested amount of tokens anyway to avoid degrading service availability.
-                this.log.warn(
+                log.warn(
                     'rate limit redis client not connected. granting tokens anyway to avoid service degradation',
                     {
                         resourceClass: this.resourceClass,
@@ -129,7 +132,7 @@ class WorkerTokenBucket {
             this.lastRefillTime = Date.now();
             const duration = this.lastRefillTime - startTime;
 
-            this.log.debug('Token refill completed', {
+            log.debug('Token refill completed', {
                 resourceClass: this.resourceClass,
                 resourceId: this.resourceId,
                 measure: this.measure,
@@ -141,7 +144,7 @@ class WorkerTokenBucket {
 
             // Warn if refill took too long or granted too few
             if (duration > 100) {
-                this.log.warn('Slow token refill detected', {
+                log.warn('Slow token refill detected', {
                     resourceClass: this.resourceClass,
                     resourceId: this.resourceId,
                     measure: this.measure,
@@ -150,7 +153,7 @@ class WorkerTokenBucket {
             }
 
             if (granted === 0 && requested > 0) {
-                this.log.trace('Token refill denied - quota exhausted', {
+                log.trace('Token refill denied - quota exhausted', {
                     resourceClass: this.resourceClass,
                     resourceId: this.resourceId,
                     measure: this.measure,
@@ -162,7 +165,7 @@ class WorkerTokenBucket {
 
             return true;
         } catch (err) {
-            this.log.error('Token refill failed', {
+            log.error('Token refill failed', {
                 resourceClass: this.resourceClass,
                 resourceId: this.resourceId,
                 measure: this.measure,
@@ -190,7 +193,7 @@ function getTokenBucket(resourceClass, resourceId, measure, limitConfig, log) {
     const cacheKey = `${resourceClass}:${resourceId}:${measure}`;
     let bucket = tokenBuckets.get(cacheKey);
     if (!bucket) {
-        bucket = new WorkerTokenBucket(resourceClass, resourceId, measure, limitConfig, log);
+        bucket = new WorkerTokenBucket(resourceClass, resourceId, measure, limitConfig);
         tokenBuckets.set(cacheKey, bucket);
 
         log.debug('Created token bucket', {

--- a/lib/api/apiUtils/rateLimit/tokenBucket.js
+++ b/lib/api/apiUtils/rateLimit/tokenBucket.js
@@ -42,7 +42,8 @@ class WorkerTokenBucket {
     }
 
     updateLimit(updatedConfig) {
-        if (this.limitConfig.limit !== updatedConfig.limit ||
+        if (
+            this.limitConfig.limit !== updatedConfig.limit ||
             this.limitConfig.burstCapacity !== updatedConfig.burstCapacity
         ) {
             const oldConfig = this.limitConfig;
@@ -119,14 +120,11 @@ class WorkerTokenBucket {
                 // Connection to redis has failed in some way.
                 // Client will be reconnecting in the background.
                 // We grant the requested amount of tokens anyway to avoid degrading service availability.
-                log.warn(
-                    'rate limit redis client not connected. granting tokens anyway to avoid service degradation',
-                    {
-                        resourceClass: this.resourceClass,
-                        resourceId: this.resourceId,
-                        measure: this.measure,
-                    },
-                );
+                log.warn('rate limit redis client not connected. granting tokens anyway to avoid service degradation', {
+                    resourceClass: this.resourceClass,
+                    resourceId: this.resourceId,
+                    measure: this.measure,
+                });
             }
 
             // Add granted tokens to buffer

--- a/lib/api/apiUtils/rateLimit/tokenBucket.js
+++ b/lib/api/apiUtils/rateLimit/tokenBucket.js
@@ -231,7 +231,7 @@ function getAllTokenBuckets() {
  * Clean up expired token buckets
  * Called periodically by cleanup job
  *
- * @param {number} maxIdleMs - Remove buckets idle for more than this duration
+ * @param {number} maxIdleMs - Remove buckets unused by any request for more than this duration
  * @returns {number} Number of buckets removed
  */
 function cleanupTokenBuckets(maxIdleMs = 60000) {
@@ -240,7 +240,7 @@ function cleanupTokenBuckets(maxIdleMs = 60000) {
 
     for (const [key, bucket] of tokenBuckets.entries()) {
         const idleTime = now - bucket.lastRefillTime;
-        if (idleTime > maxIdleMs && bucket.tokens === 0) {
+        if (idleTime > maxIdleMs) {
             toRemove.push(key);
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zenko/cloudserver",
-    "version": "9.3.18",
+    "version": "9.3.19",
     "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
     "main": "index.js",
     "engines": {

--- a/tests/unit/api/apiUtils/rateLimit/tokenBucket.js
+++ b/tests/unit/api/apiUtils/rateLimit/tokenBucket.js
@@ -182,7 +182,7 @@ describe('WorkerTokenBucket', () => {
                 'bucket', 'test-bucket', 'rps', { limit: 100 }, mockLog);
             bucket.tokens = 30; // Above threshold of 20
 
-            await bucket.refillIfNeeded();
+            await bucket.refillIfNeeded(mockLog);
 
             // refillInProgress was never set (no refill attempted)
             assert.ok(!bucket.refillInProgress);
@@ -194,7 +194,7 @@ describe('WorkerTokenBucket', () => {
             bucket.tokens = 10; // Below threshold
             bucket.refillInProgress = true;
 
-            await bucket.refillIfNeeded();
+            await bucket.refillIfNeeded(mockLog);
 
             // Still true — function returned early without clearing it
             assert.strictEqual(bucket.refillInProgress, true);
@@ -205,7 +205,7 @@ describe('WorkerTokenBucket', () => {
                 'bucket', 'test-bucket', 'rps', { limit: 100, burstCapacity: 1000 }, mockLog);
             bucket.tokens = 10; // Below threshold of 20
 
-            await bucket.refillIfNeeded();
+            await bucket.refillIfNeeded(mockLog);
 
             // refillInProgress is cleared in finally block regardless of outcome
             assert.strictEqual(bucket.refillInProgress, false);

--- a/tests/unit/api/apiUtils/rateLimit/tokenBucket.js
+++ b/tests/unit/api/apiUtils/rateLimit/tokenBucket.js
@@ -146,7 +146,12 @@ describe('WorkerTokenBucket', () => {
     describe('updateLimit', () => {
         it('should update limitConfig and interval when limit changes', () => {
             const bucket = new tokenBucket.WorkerTokenBucket(
-                'bucket', 'test-bucket', 'rps', { limit: 100, burstCapacity: 1000 }, mockLog);
+                'bucket',
+                'test-bucket',
+                'rps',
+                { limit: 100, burstCapacity: 1000 },
+                mockLog,
+            );
             const oldInterval = bucket.interval;
 
             const result = bucket.updateLimit({ limit: 200, burstCapacity: 1000 });
@@ -159,7 +164,12 @@ describe('WorkerTokenBucket', () => {
 
         it('should update limitConfig when burstCapacity changes', () => {
             const bucket = new tokenBucket.WorkerTokenBucket(
-                'bucket', 'test-bucket', 'rps', { limit: 100, burstCapacity: 1000 }, mockLog);
+                'bucket',
+                'test-bucket',
+                'rps',
+                { limit: 100, burstCapacity: 1000 },
+                mockLog,
+            );
 
             const result = bucket.updateLimit({ limit: 100, burstCapacity: 2000 });
 
@@ -169,7 +179,12 @@ describe('WorkerTokenBucket', () => {
 
         it('should return updated: false when config is unchanged', () => {
             const bucket = new tokenBucket.WorkerTokenBucket(
-                'bucket', 'test-bucket', 'rps', { limit: 100, burstCapacity: 1000 }, mockLog);
+                'bucket',
+                'test-bucket',
+                'rps',
+                { limit: 100, burstCapacity: 1000 },
+                mockLog,
+            );
 
             const result = bucket.updateLimit({ limit: 100, burstCapacity: 1000 });
 
@@ -179,8 +194,7 @@ describe('WorkerTokenBucket', () => {
 
     describe('refillIfNeeded', () => {
         it('should skip refill when above threshold', async () => {
-            const bucket = new tokenBucket.WorkerTokenBucket(
-                'bucket', 'test-bucket', 'rps', { limit: 100 }, mockLog);
+            const bucket = new tokenBucket.WorkerTokenBucket('bucket', 'test-bucket', 'rps', { limit: 100 }, mockLog);
             bucket.tokens = 30; // Above threshold of 20
 
             await bucket.refillIfNeeded(mockLog);
@@ -190,8 +204,7 @@ describe('WorkerTokenBucket', () => {
         });
 
         it('should skip refill when already in progress', async () => {
-            const bucket = new tokenBucket.WorkerTokenBucket(
-                'bucket', 'test-bucket', 'rps', { limit: 100 }, mockLog);
+            const bucket = new tokenBucket.WorkerTokenBucket('bucket', 'test-bucket', 'rps', { limit: 100 }, mockLog);
             bucket.tokens = 10; // Below threshold
             bucket.refillInProgress = true;
 
@@ -203,7 +216,12 @@ describe('WorkerTokenBucket', () => {
 
         it('should trigger refill when below threshold', async () => {
             const bucket = new tokenBucket.WorkerTokenBucket(
-                'bucket', 'test-bucket', 'rps', { limit: 100, burstCapacity: 1000 }, mockLog);
+                'bucket',
+                'test-bucket',
+                'rps',
+                { limit: 100, burstCapacity: 1000 },
+                mockLog,
+            );
             bucket.tokens = 10; // Below threshold of 20
 
             await bucket.refillIfNeeded(mockLog);
@@ -230,7 +248,12 @@ describe('WorkerTokenBucket', () => {
 
         function makeBucketBelowThreshold() {
             const bucket = new tokenBucket.WorkerTokenBucket(
-                'bucket', 'test-bucket', 'rps', { limit: 100, burstCapacity: 1000 }, mockLog);
+                'bucket',
+                'test-bucket',
+                'rps',
+                { limit: 100, burstCapacity: 1000 },
+                mockLog,
+            );
             bucket.tokens = 10; // Below refill threshold of 20
             return bucket;
         }
@@ -238,8 +261,8 @@ describe('WorkerTokenBucket', () => {
         it('should add granted tokens to the buffer and log the refill', async () => {
             rateLimitClient.instance = {
                 isReady: () => true,
-                grantTokens: (resourceClass, resourceId, measure, requested,
-                    interval, burstCapacity, callback) => callback(null, requested),
+                grantTokens: (resourceClass, resourceId, measure, requested, interval, burstCapacity, callback) =>
+                    callback(null, requested),
             };
             const bucket = makeBucketBelowThreshold();
 
@@ -253,8 +276,8 @@ describe('WorkerTokenBucket', () => {
         it('should trace a denial when Redis grants zero tokens', async () => {
             rateLimitClient.instance = {
                 isReady: () => true,
-                grantTokens: (resourceClass, resourceId, measure, requested,
-                    interval, burstCapacity, callback) => callback(null, 0),
+                grantTokens: (resourceClass, resourceId, measure, requested, interval, burstCapacity, callback) =>
+                    callback(null, 0),
             };
             const bucket = makeBucketBelowThreshold();
 
@@ -279,15 +302,17 @@ describe('WorkerTokenBucket', () => {
             // fail-open: full requested amount granted locally
             assert.strictEqual(refilled, true);
             assert.strictEqual(bucket.tokens, bucket.bufferSize);
-            assert.ok(mockLog.warn.calledWithMatch(
-                'rate limit redis client not connected. granting tokens anyway to avoid service degradation'));
+            assert.ok(
+                mockLog.warn.calledWithMatch(
+                    'rate limit redis client not connected. granting tokens anyway to avoid service degradation',
+                ),
+            );
         });
 
         it('should warn when a refill takes longer than 100ms', async () => {
             rateLimitClient.instance = {
                 isReady: () => true,
-                grantTokens: (resourceClass, resourceId, measure, requested,
-                    interval, burstCapacity, callback) =>
+                grantTokens: (resourceClass, resourceId, measure, requested, interval, burstCapacity, callback) =>
                     setTimeout(() => callback(null, requested), 110),
             };
             const bucket = makeBucketBelowThreshold();
@@ -301,8 +326,7 @@ describe('WorkerTokenBucket', () => {
         it('should log and return false when the grant throws', async () => {
             rateLimitClient.instance = {
                 isReady: () => true,
-                grantTokens: (resourceClass, resourceId, measure, requested,
-                    interval, burstCapacity, callback) =>
+                grantTokens: (resourceClass, resourceId, measure, requested, interval, burstCapacity, callback) =>
                     callback(new Error('redis exploded')),
             };
             const bucket = makeBucketBelowThreshold();
@@ -394,11 +418,21 @@ describe('Token bucket management functions', () => {
 
         it('should update limitConfig when limit changes', () => {
             const bucket1 = tokenBucket.getTokenBucket(
-                'bucket', 'test-bucket', 'rps', { limit: 100, source: 'bucket' }, mockLog);
+                'bucket',
+                'test-bucket',
+                'rps',
+                { limit: 100, source: 'bucket' },
+                mockLog,
+            );
             assert.strictEqual(bucket1.limitConfig.limit, 100);
 
             const bucket2 = tokenBucket.getTokenBucket(
-                'bucket', 'test-bucket', 'rps', { limit: 200, source: 'bucket' }, mockLog);
+                'bucket',
+                'test-bucket',
+                'rps',
+                { limit: 200, source: 'bucket' },
+                mockLog,
+            );
 
             assert.strictEqual(bucket1, bucket2);
             assert.strictEqual(bucket2.limitConfig.limit, 200);

--- a/tests/unit/api/apiUtils/rateLimit/tokenBucket.js
+++ b/tests/unit/api/apiUtils/rateLimit/tokenBucket.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const sinon = require('sinon');
 
 const tokenBucket = require('../../../../../lib/api/apiUtils/rateLimit/tokenBucket');
+const rateLimitClient = require('../../../../../lib/api/apiUtils/rateLimit/client');
 const { config } = require('../../../../../lib/Config');
 
 describe('WorkerTokenBucket', () => {
@@ -209,6 +210,108 @@ describe('WorkerTokenBucket', () => {
 
             // refillInProgress is cleared in finally block regardless of outcome
             assert.strictEqual(bucket.refillInProgress, false);
+        });
+    });
+
+    describe('refillIfNeeded against a fake Redis client', () => {
+        // In the unit environment rateLimitClient.instance is undefined
+        // (rate limiting is disabled at Config load), so every test above
+        // exercises only the error path. A fake instance reaches the grant,
+        // denial, disconnected and slow paths.
+        let savedRedisClientInstance;
+
+        beforeEach(() => {
+            savedRedisClientInstance = rateLimitClient.instance;
+        });
+
+        afterEach(() => {
+            rateLimitClient.instance = savedRedisClientInstance;
+        });
+
+        function makeBucketBelowThreshold() {
+            const bucket = new tokenBucket.WorkerTokenBucket(
+                'bucket', 'test-bucket', 'rps', { limit: 100, burstCapacity: 1000 }, mockLog);
+            bucket.tokens = 10; // Below refill threshold of 20
+            return bucket;
+        }
+
+        it('should add granted tokens to the buffer and log the refill', async () => {
+            rateLimitClient.instance = {
+                isReady: () => true,
+                grantTokens: (resourceClass, resourceId, measure, requested,
+                    interval, burstCapacity, callback) => callback(null, requested),
+            };
+            const bucket = makeBucketBelowThreshold();
+
+            const refilled = await bucket.refillIfNeeded(mockLog);
+
+            assert.strictEqual(refilled, true);
+            assert.strictEqual(bucket.tokens, bucket.bufferSize);
+            assert.ok(mockLog.debug.calledWithMatch('Token refill completed'));
+        });
+
+        it('should trace a denial when Redis grants zero tokens', async () => {
+            rateLimitClient.instance = {
+                isReady: () => true,
+                grantTokens: (resourceClass, resourceId, measure, requested,
+                    interval, burstCapacity, callback) => callback(null, 0),
+            };
+            const bucket = makeBucketBelowThreshold();
+
+            const refilled = await bucket.refillIfNeeded(mockLog);
+
+            assert.strictEqual(refilled, false);
+            assert.strictEqual(bucket.tokens, 10);
+            assert.ok(mockLog.trace.calledWithMatch('Token refill denied - quota exhausted'));
+        });
+
+        it('should grant the requested tokens and warn when Redis is not connected', async () => {
+            rateLimitClient.instance = {
+                isReady: () => false,
+                grantTokens: () => {
+                    throw new Error('must not be called while disconnected');
+                },
+            };
+            const bucket = makeBucketBelowThreshold();
+
+            const refilled = await bucket.refillIfNeeded(mockLog);
+
+            // fail-open: full requested amount granted locally
+            assert.strictEqual(refilled, true);
+            assert.strictEqual(bucket.tokens, bucket.bufferSize);
+            assert.ok(mockLog.warn.calledWithMatch(
+                'rate limit redis client not connected. granting tokens anyway to avoid service degradation'));
+        });
+
+        it('should warn when a refill takes longer than 100ms', async () => {
+            rateLimitClient.instance = {
+                isReady: () => true,
+                grantTokens: (resourceClass, resourceId, measure, requested,
+                    interval, burstCapacity, callback) =>
+                    setTimeout(() => callback(null, requested), 110),
+            };
+            const bucket = makeBucketBelowThreshold();
+
+            const refilled = await bucket.refillIfNeeded(mockLog);
+
+            assert.strictEqual(refilled, true);
+            assert.ok(mockLog.warn.calledWithMatch('Slow token refill detected'));
+        });
+
+        it('should log and return false when the grant throws', async () => {
+            rateLimitClient.instance = {
+                isReady: () => true,
+                grantTokens: (resourceClass, resourceId, measure, requested,
+                    interval, burstCapacity, callback) =>
+                    callback(new Error('redis exploded')),
+            };
+            const bucket = makeBucketBelowThreshold();
+
+            const refilled = await bucket.refillIfNeeded(mockLog);
+
+            assert.strictEqual(refilled, false);
+            assert.strictEqual(bucket.refillInProgress, false);
+            assert.ok(mockLog.error.calledWithMatch('Token refill failed'));
         });
     });
 });

--- a/tests/unit/api/apiUtils/rateLimit/tokenBucket.js
+++ b/tests/unit/api/apiUtils/rateLimit/tokenBucket.js
@@ -455,7 +455,7 @@ describe('Token bucket management functions', () => {
     });
 
     describe('cleanupTokenBuckets', () => {
-        it('should remove idle buckets with no tokens', () => {
+        it('should remove buckets unused for longer than maxIdleMs', () => {
             const bucket1 = tokenBucket.getTokenBucket('bucket', 'bucket-1', 'rps', { limit: 100 }, mockLog);
             const bucket2 = tokenBucket.getTokenBucket('bucket', 'bucket-2', 'rps', { limit: 200 }, mockLog);
 
@@ -473,16 +473,16 @@ describe('Token bucket management functions', () => {
             assert(!tokenBucket.getAllTokenBuckets().has('bucket:bucket-1:rps'));
         });
 
-        it('should not remove idle buckets with tokens', () => {
+        it('should remove unused buckets whatever the remaining token count', () => {
             const bucket = tokenBucket.getTokenBucket('bucket', 'test-bucket', 'rps', { limit: 100 }, mockLog);
 
             bucket.lastRefillTime = Date.now() - 120000;
-            bucket.tokens = 10;
+            bucket.tokens = bucket.bufferSize;
 
             const removed = tokenBucket.cleanupTokenBuckets(60000);
 
-            assert.strictEqual(removed, 0);
-            assert.strictEqual(tokenBucket.getAllTokenBuckets().size, 1);
+            assert.strictEqual(removed, 1);
+            assert.strictEqual(tokenBucket.getAllTokenBuckets().size, 0);
         });
 
         it('should not remove recently active buckets', () => {

--- a/tests/unit/api/apiUtils/rateLimit/tokenBucketRetention.js
+++ b/tests/unit/api/apiUtils/rateLimit/tokenBucketRetention.js
@@ -1,0 +1,78 @@
+const assert = require('assert');
+const sinon = require('sinon');
+
+const tokenBucket = require('../../../../../lib/api/apiUtils/rateLimit/tokenBucket');
+const { config } = require('../../../../../lib/Config');
+
+function makeLog() {
+    return {
+        trace: sinon.stub(),
+        debug: sinon.stub(),
+        info: sinon.stub(),
+        warn: sinon.stub(),
+        error: sinon.stub(),
+    };
+}
+
+function logCallCount(log) {
+    return log.trace.callCount + log.debug.callCount + log.info.callCount
+        + log.warn.callCount + log.error.callCount;
+}
+
+/**
+ * Regression tests: token buckets used to retain the request logger that
+ * created them, and the refill job logged through it forever - werelogs
+ * buffers those entries until an error-level write, so memory grew per
+ * resource until process restart.
+ */
+describe('rate limit token bucket retention', () => {
+    let sandbox;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        sandbox.stub(config, 'rateLimiting').value({
+            enabled: true,
+            nodes: 1,
+            tokenBucketBufferSize: 50,
+            tokenBucketRefillThreshold: 20,
+        });
+        tokenBucket.getAllTokenBuckets().clear();
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+        tokenBucket.getAllTokenBuckets().clear();
+    });
+
+    it('should not retain the request logger that created the bucket', () => {
+        const requestLog = makeLog();
+
+        const bucket = tokenBucket.getTokenBucket(
+            'account', 'acct-retention-1', 'rps', { limit: 60, burstCapacity: 1000 }, requestLog);
+
+        const retained = Object.keys(bucket).filter(key => bucket[key] === requestLog);
+
+        assert.deepStrictEqual(retained, [],
+            `token bucket must not hold the per-request logger (held on: ${retained.join(', ')})`);
+    });
+
+    it('should log refill activity to the caller-supplied logger, not the creating request logger', async () => {
+        const requestLog = makeLog();
+        const jobLog = makeLog();
+
+        const bucket = tokenBucket.getTokenBucket(
+            'account', 'acct-retention-2', 'rps', { limit: 60, burstCapacity: 1000 }, requestLog);
+
+        // ignore the "Created token bucket" line, which is legitimately
+        // request-scoped and dies with the request
+        requestLog.debug.resetHistory();
+
+        bucket.tokens = 0; // below refill threshold, forces a refill
+        await bucket.refillIfNeeded(jobLog);
+
+        assert.strictEqual(logCallCount(requestLog), 0,
+            'refill must not log through the request logger that created the bucket');
+        assert.ok(logCallCount(jobLog) > 0,
+            'refill must log through the logger supplied by the refill job');
+    });
+});

--- a/tests/unit/api/apiUtils/rateLimit/tokenBucketRetention.js
+++ b/tests/unit/api/apiUtils/rateLimit/tokenBucketRetention.js
@@ -75,4 +75,18 @@ describe('rate limit token bucket retention', () => {
         assert.ok(logCallCount(jobLog) > 0,
             'refill must log through the logger supplied by the refill job');
     });
+
+    it('should evict buckets idle longer than maxIdleMs even when they still hold tokens', () => {
+        const requestLog = makeLog();
+
+        const bucket = tokenBucket.getTokenBucket(
+            'account', 'acct-retention-3', 'rps', { limit: 60, burstCapacity: 1000 }, requestLog);
+
+        bucket.lastRefillTime = Date.now() - 120000;
+
+        const removed = tokenBucket.cleanupTokenBuckets(60000);
+
+        assert.strictEqual(removed, 1, 'idle bucket must be evicted even with a full token buffer');
+        assert.strictEqual(tokenBucket.getAllTokenBuckets().size, 0);
+    });
 });

--- a/tests/unit/api/apiUtils/rateLimit/tokenBucketRetention.js
+++ b/tests/unit/api/apiUtils/rateLimit/tokenBucketRetention.js
@@ -15,8 +15,7 @@ function makeLog() {
 }
 
 function logCallCount(log) {
-    return log.trace.callCount + log.debug.callCount + log.info.callCount
-        + log.warn.callCount + log.error.callCount;
+    return log.trace.callCount + log.debug.callCount + log.info.callCount + log.warn.callCount + log.error.callCount;
 }
 
 /**
@@ -48,12 +47,20 @@ describe('rate limit token bucket retention', () => {
         const requestLog = makeLog();
 
         const bucket = tokenBucket.getTokenBucket(
-            'account', 'acct-retention-1', 'rps', { limit: 60, burstCapacity: 1000 }, requestLog);
+            'account',
+            'acct-retention-1',
+            'rps',
+            { limit: 60, burstCapacity: 1000 },
+            requestLog,
+        );
 
         const retained = Object.keys(bucket).filter(key => bucket[key] === requestLog);
 
-        assert.deepStrictEqual(retained, [],
-            `token bucket must not hold the per-request logger (held on: ${retained.join(', ')})`);
+        assert.deepStrictEqual(
+            retained,
+            [],
+            `token bucket must not hold the per-request logger (held on: ${retained.join(', ')})`,
+        );
     });
 
     it('should log refill activity to the caller-supplied logger, not the creating request logger', async () => {
@@ -61,7 +68,12 @@ describe('rate limit token bucket retention', () => {
         const jobLog = makeLog();
 
         const bucket = tokenBucket.getTokenBucket(
-            'account', 'acct-retention-2', 'rps', { limit: 60, burstCapacity: 1000 }, requestLog);
+            'account',
+            'acct-retention-2',
+            'rps',
+            { limit: 60, burstCapacity: 1000 },
+            requestLog,
+        );
 
         // ignore the "Created token bucket" line, which is legitimately
         // request-scoped and dies with the request
@@ -70,17 +82,24 @@ describe('rate limit token bucket retention', () => {
         bucket.tokens = 0; // below refill threshold, forces a refill
         await bucket.refillIfNeeded(jobLog);
 
-        assert.strictEqual(logCallCount(requestLog), 0,
-            'refill must not log through the request logger that created the bucket');
-        assert.ok(logCallCount(jobLog) > 0,
-            'refill must log through the logger supplied by the refill job');
+        assert.strictEqual(
+            logCallCount(requestLog),
+            0,
+            'refill must not log through the request logger that created the bucket',
+        );
+        assert.ok(logCallCount(jobLog) > 0, 'refill must log through the logger supplied by the refill job');
     });
 
     it('should evict buckets idle longer than maxIdleMs even when they still hold tokens', () => {
         const requestLog = makeLog();
 
         const bucket = tokenBucket.getTokenBucket(
-            'account', 'acct-retention-3', 'rps', { limit: 60, burstCapacity: 1000 }, requestLog);
+            'account',
+            'acct-retention-3',
+            'rps',
+            { limit: 60, burstCapacity: 1000 },
+            requestLog,
+        );
 
         bucket.lastRefillTime = Date.now() - 120000;
 


### PR DESCRIPTION
## Intent: why does this change exist?

With account rate limiting on, cloudserver held about 80MB per account per connector and only gave it back on restart (RD-2240). The retained bytes turned out to be buffered werelogs entries, not rate limiting state.

## what's affected, including downstream?

`lib/api/apiUtils/rateLimit/` only — token buckets and the refill job, for both the account and bucket resource classes. `refillIfNeeded()` now takes the logger as an argument; the refill job is its only production caller. Nothing else in the request path changes, and there is no config, schema or dependency change.

## Intended change: what's different after this PR?

Token buckets no longer store the request-scoped logger; the refill job passes the long-lived server logger, which writes through instead of buffering. Idle eviction is keyed on the last request that consulted a bucket rather than on `lastRefillTime` and an empty buffer, both of which the refill job itself kept from ever being true.

Two consequences worth flagging. Eviction becoming reachable also makes the pre-existing fail-open-on-create path reachable: a resource idle more than 60s gets `bufferSize` local tokens before its first Redis grant, about 0.8 RPS of slack against a 60 RPS limit, with Redis still holding the GCRA `emptyAt` state. And it removes a latent log bomb, a single error-level write on a pinned logger used to flush its whole buffer at once (measured: 20,000 buffered debug calls emit nothing, one `error()` emits 20,001 lines), which `refillIfNeeded`'s own catch block could trigger on any Redis failure.

## Verification: how do we know this worked, or how would we know if it didn't?

Reproduced end-to-end on `development/9.3` with a local Vault-free stack (the platform-default limit path, which is RD-2240's TS16 case) plus Redis, then measured buffered entries in-process across every worker.

At `clusters=10` with 50 accounts, stock held 500 token buckets all pinning a logger, 838,638 buffered entries and 950MB of worker heap growth, releasing none of it. Patched: same 500 peak buckets, 0 pinned loggers, 0 buffered entries, 4MB growth, and all 500 buckets evicted after idle. Single-worker RSS over 4 minutes went from an unbounded 247→1873MB to a flat plateau at 559MB.

Five new regression tests were written first and confirmed failing against stock. Rate limit suite 186 passing; full unit suite 5119 passing against a 5114 baseline, with the same 15 pre-existing unrelated failures (`bucketPut` quota seeding, `ScubaClientImpl`); lint clean.