### PR TITLE
CLDSRV-980: Make stopRefillJob actually stop the refill job

### DIFF
--- a/lib/api/apiUtils/rateLimit/refillJob.js
+++ b/lib/api/apiUtils/rateLimit/refillJob.js
@@ -1,6 +1,7 @@
 const { getAllTokenBuckets, cleanupTokenBuckets } = require('./tokenBucket');
 
 let refillTimer = null;
+let refillJobRunning = false;
 
 // Refill interval in milliseconds (how often to check and refill buckets)
 const REFILL_INTERVAL_MS = process.env.REFILL_INTERVAL_MS
@@ -68,11 +69,26 @@ async function refillTokenBuckets(logger) {
  * Main refill job loop
  * Runs periodically to proactively refill token buckets
  */
-function startRefillJob(logger) {
+function startRefillJob(logger, options = {}) {
+    if (refillJobRunning) {
+        logger.warn('token refill job already running');
+        return;
+    }
+
+    refillJobRunning = true;
     logger.info('starting token refill job', {
         refillIntervalMs: REFILL_INTERVAL_MS,
         cleanupIntervalMs: CLEANUP_INTERVAL_MS,
     });
+
+    const arm = () => {
+        refillTimer = setTimeout(tick, REFILL_INTERVAL_MS);
+        // Prevent the refill job from keeping the process alive, as the
+        // cleanup job already does. Skipped in tests using fake timers.
+        if (!options.skipUnref) {
+            refillTimer.unref();
+        }
+    };
 
     const tick = async () => {
         try {
@@ -101,11 +117,18 @@ function startRefillJob(logger) {
             });
         }
 
-        refillTimer = setTimeout(tick, REFILL_INTERVAL_MS);
+        // A tick that was awaiting when stopRefillJob() ran must not re-arm:
+        // it would replace the timer that stop just cleared and the job would
+        // carry on for the rest of the process lifetime.
+        if (!refillJobRunning) {
+            return;
+        }
+
+        arm();
     };
 
     // Start timer
-    refillTimer = setTimeout(tick, REFILL_INTERVAL_MS);
+    arm();
 }
 
 /**
@@ -113,9 +136,15 @@ function startRefillJob(logger) {
  * Used during graceful shutdown
  */
 function stopRefillJob(logger) {
+    const wasRunning = refillJobRunning;
+    refillJobRunning = false;
+
     if (refillTimer) {
         clearTimeout(refillTimer);
         refillTimer = null;
+    }
+
+    if (wasRunning) {
         logger.info('stopped token refill job');
     }
 }

--- a/tests/unit/api/apiUtils/rateLimit/refillJob.js
+++ b/tests/unit/api/apiUtils/rateLimit/refillJob.js
@@ -232,4 +232,55 @@ describe('Token refill job', () => {
             assert.strictEqual(stub3.calledOnce, true);
         });
     });
+
+    describe('stopRefillJob with a tick in flight', () => {
+        it('should not re-arm the timer when stopped mid-tick', async () => {
+            let stopped = false;
+            let callsAfterStop = 0;
+
+            // refill takes longer than the tick interval, so a tick is
+            // guaranteed to be awaiting when stopRefillJob() runs
+            tokenBucket.getAllTokenBuckets().set('account:slow:rps', {
+                tokens: 0,
+                refillIfNeeded: async () => {
+                    if (stopped) {
+                        callsAfterStop++;
+                    }
+                    await new Promise(resolve => setTimeout(resolve, 120));
+                    return false;
+                },
+            });
+
+            refillJob.startRefillJob(logger, { skipUnref: true });
+            await new Promise(resolve => setTimeout(resolve, 150));
+
+            stopped = true;
+            refillJob.stopRefillJob(logger);
+            await new Promise(resolve => setTimeout(resolve, 500));
+
+            assert.strictEqual(callsAfterStop, 0,
+                'refill job kept running after stopRefillJob() returned');
+        });
+
+        it('should refuse to start a second concurrent job', async () => {
+            let calls = 0;
+            tokenBucket.getAllTokenBuckets().set('account:counted:rps', {
+                tokens: 0,
+                refillIfNeeded: async () => { calls++; return false; },
+            });
+
+            // a second start must not orphan the first timer and leave two
+            // independent tick loops running at double the refill rate
+            refillJob.startRefillJob(logger, { skipUnref: true });
+            refillJob.startRefillJob(logger, { skipUnref: true });
+
+            await new Promise(resolve => setTimeout(resolve, 450));
+            refillJob.stopRefillJob(logger);
+
+            // ~4 ticks for one loop over 450ms at a 100ms interval; two loops
+            // would roughly double it
+            assert.ok(calls <= 6,
+                `expected a single refill loop, saw ${calls} refills in 450ms`);
+        });
+    });
 });


### PR DESCRIPTION
## Intent: why does this change exist?

`stopRefillJob()` did not stop the rate limit refill job. Found while investigating RD-2240; unrelated to that memory leak beyond sharing the module.

## System impact: what's affected, including downstream?

`lib/api/apiUtils/rateLimit/refillJob.js` only. `startRefillJob` gains an optional `options` argument (`{ skipUnref }`), mirroring `startCleanupJob`; the single production caller in `lib/server.js` is unchanged and takes the new default. The refill timer is now `unref()`'d, so it no longer holds the event loop open — the HTTP servers keep the process alive, as they already did for the cleanup job.

## Preserved behavior: what explicitly stays the same?

Refill cadence, cleanup cadence, and everything the job does per tick. Start, stop, repeated stop and restart-after-stop all behave as before.

## Intended change: what's different after this PR?

A `running` flag gates the re-arm at the end of `tick`, so a tick that was mid-`await` when stop ran no longer replaces the timer stop just cleared. `startRefillJob` also refuses a second concurrent start instead of orphaning the first timer, and warns.

Production impact was limited before this, because `cleanUp()` ends in `process.exit(0)` and overrides a live handle. What it did mean is that the job kept hitting Redis and mutating token buckets through the shutdown window, and leaked a live timer into any test that started it.

## Verification: how do we know this worked, or how would we know if it didn't?

Two regression tests, written first and confirmed failing against stock. The mid-tick one uses a refill slower than the tick interval so a tick is guaranteed to be in flight at stop; on stock it reports the job still running, and the double-start one measured 12 refills in 450ms where a single loop gives about 4 — roughly three overlapping loops.

Rate limit suite 183 passing, 0 failing. Lint clean apart from two pre-existing `prefer-await-to-then` warnings on untouched lines.