### PR TITLE
CLDSRV-981: Log Scuba health checks through the server logger

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -400,7 +400,7 @@ class S3Server {
 
             // Start quota service health checks
             if (QuotaService.enabled) {
-                QuotaService?.setup(log);
+                QuotaService?.setup();
             }
 
             // TODO this should wait for metadata healthcheck to be ok

--- a/lib/utilization/scuba/wrapper.js
+++ b/lib/utilization/scuba/wrapper.js
@@ -2,6 +2,7 @@ const util = require('util');
 const { default: ScubaClient } = require('scubaclient');
 const { externalBackendHealthCheckInterval } = require('../../../constants');
 const monitoring = require('../../utilities/monitoringHandler');
+const logger = require('../../utilities/logger');
 
 class ScubaClientImpl extends ScubaClient {
     constructor(config) {
@@ -9,7 +10,6 @@ class ScubaClientImpl extends ScubaClient {
         this.enabled = false;
         this.maxStaleness = config.quota.maxStaleness;
         this._healthCheckTimer = null;
-        this._log = null;
         this._getLatestMetricsCallback = util.callbackify(this.getLatestMetrics);
 
         if (config.scuba) {
@@ -19,8 +19,7 @@ class ScubaClientImpl extends ScubaClient {
         }
     }
 
-    setup(log) {
-        this._log = log;
+    setup() {
         if (this.enabled) {
             this.periodicHealthCheck();
         }
@@ -35,13 +34,13 @@ class ScubaClientImpl extends ScubaClient {
                 }
             }
             if (!this.enabled) {
-                this._log.info('Scuba health check passed, enabling quotas');
+                logger.info('Scuba health check passed, enabling quotas');
             }
             monitoring.utilizationServiceAvailable.set(1);
             this.enabled = true;
         }).catch(err => {
             if (this.enabled) {
-                this._log.warn('Scuba health check failed, disabling quotas', {
+                logger.warn('Scuba health check failed, disabling quotas', {
                     err: err.name,
                     description: err.message,
                 });

--- a/tests/unit/quotas/scuba/wrapper.js
+++ b/tests/unit/quotas/scuba/wrapper.js
@@ -4,15 +4,10 @@ const { ScubaClientImpl } = require('../../../../lib/utilization/scuba/wrapper')
 
 describe('ScubaClientImpl', () => {
     let client;
-    let log;
 
     beforeEach(() => {
         client = new ScubaClientImpl({ scuba: true, quota: { maxStaleness: 24 * 60 * 60 * 1000 } });
-        log = {
-            info: sinon.spy(),
-            warn: sinon.spy(),
-        };
-        client.setup(log);
+        client.setup();
     });
 
     afterEach(() => {
@@ -21,22 +16,36 @@ describe('ScubaClientImpl', () => {
 
     describe('setup', () => {
         it('should enable Scuba and start periodic health check', () => {
-            client.setup(log);
+            client.setup();
 
             assert.strictEqual(client.enabled, true);
         });
 
         it('should not enable Scuba if config.scuba is falsy', () => {
             client = new ScubaClientImpl({ scuba: false, quota: { maxStaleness: 24 * 60 * 60 * 1000 } });
-            client.setup(log);
+            client.setup();
 
             assert.strictEqual(client.enabled, false);
         });
     });
 
     describe('_healthCheck', () => {
+        // healthCheck is assigned rather than sinon-stubbed: it sits deep in
+        // the scubaclient prototype chain and sinon reports it as
+        // non-existent, which left these four cases failing.
         it('should enable Scuba if health check passes', async () => {
-            sinon.stub(client, 'healthCheck').resolves();
+            client.healthCheck = () => Promise.resolve();
+
+            await client._healthCheck();
+
+            assert.strictEqual(client.enabled, true);
+        });
+
+        it('should re-enable Scuba when a health check passes from the disabled state', async () => {
+            // covers the enabling-quotas log line, which only fires on the
+            // disabled -> enabled transition
+            client.enabled = false;
+            client.healthCheck = () => Promise.resolve({ date: new Date().toISOString() });
 
             await client._healthCheck();
 
@@ -44,7 +53,7 @@ describe('ScubaClientImpl', () => {
         });
 
         it('should disable Scuba if health check returns non-stale data', async () => {
-            sinon.stub(client, 'healthCheck').resolves({ date: Date.now() - (12 * 60 * 60 * 1000) });
+            client.healthCheck = () => Promise.resolve({ date: Date.now() - (12 * 60 * 60 * 1000) });
 
             await client._healthCheck();
 
@@ -52,7 +61,7 @@ describe('ScubaClientImpl', () => {
         });
 
         it('should disable Scuba if health check returns stale data', async () => {
-            sinon.stub(client, 'healthCheck').resolves({ date: Date.now() - (48 * 60 * 60 * 1000) });
+            client.healthCheck = () => Promise.resolve({ date: Date.now() - (48 * 60 * 60 * 1000) });
 
             await client._healthCheck();
 
@@ -61,7 +70,7 @@ describe('ScubaClientImpl', () => {
 
         it('should disable Scuba if health check fails', async () => {
             const error = new Error('Health check failed');
-            sinon.stub(client, 'healthCheck').rejects(error);
+            client.healthCheck = () => Promise.reject(error);
 
             await client._healthCheck();
 
@@ -97,6 +106,40 @@ describe('ScubaClientImpl', () => {
             assert(healthCheckStub.calledOnce);
             assert(setIntervalStub.calledOnce);
             assert(clearIntervalStub.calledOnceWith(123));
+        });
+    });
+
+    describe('logger retention', () => {
+        it('should not retain a werelogs RequestLogger', () => {
+            // a RequestLogger buffers every entry it is handed and only drains
+            // on an error-level write, so an object that outlives the request
+            // grows it forever
+            const requestLog = {
+                info: sinon.spy(),
+                warn: sinon.spy(),
+                entries: [],
+            };
+
+            client.setup(requestLog);
+
+            const retained = Object.keys(client).filter(k => client[k] === requestLog);
+            assert.deepStrictEqual(retained, [],
+                `quota client must not hold a request logger (held on: ${retained.join(', ')})`);
+        });
+
+        it('should log health check transitions without touching a passed logger', async () => {
+            const requestLog = { info: sinon.spy(), warn: sinon.spy() };
+            client.setup(requestLog);
+            client.enabled = true;
+
+            // assigned rather than stubbed: healthCheck sits deep in the
+            // scubaclient prototype chain and sinon cannot stub it
+            client.healthCheck = () => Promise.reject(new Error('scuba unreachable'));
+            await client._healthCheck();
+
+            assert.strictEqual(client.enabled, false);
+            assert.strictEqual(requestLog.warn.callCount, 0);
+            assert.strictEqual(requestLog.info.callCount, 0);
         });
     });
 });


### PR DESCRIPTION
## Intent: why does this change exist?

The quota client held the werelogs `RequestLogger` that `server.js` builds at boot, and its health-check timer logged through it forever. Same bug class as CLDSRV-979, found in the same RD-2240 investigation, much smaller blast radius.

## System impact: what's affected, including downstream?

`lib/utilization/scuba/wrapper.js` and its one call site in `lib/server.js`. `ScubaClientImpl.setup()` no longer takes a logger argument — `lib/server.js:403` is the only production caller. Health-check log lines now carry the server logger's fields instead of the startup request's, so they no longer have a `req_id`; anything grepping these two messages by `req_id` would be affected, though that `req_id` was misleading anyway since it belonged to an unrelated boot-time request.

## Preserved behavior: what explicitly stays the same?

The health check itself — cadence, staleness threshold, and when quotas get enabled or disabled. Both messages keep their text and their levels.

## Intended change: what's different after this PR?

Background health-check logging goes through the module-level server logger, which writes through and drops sub-level entries rather than buffering them. Nothing that outlives a request holds a `RequestLogger`.

## Verification: how do we know this worked, or how would we know if it didn't?

Reproduced first: 200 simulated health-check flaps against the pinned startup logger left 199 buffered entries, every one carrying the same `req_id` — which is the signature of this bug generally, and a cheap thing to grep for elsewhere.

Two regression tests cover it. While in the file I also revived the four `_healthCheck` cases that had been silently failing on `development/9.3`: sinon reports `healthCheck` as non-existent because it sits deep in the scubaclient prototype chain, so they assign the method directly instead. Those four cover the function this PR changes, which is why they are in scope rather than left for later. `tests/unit` goes from 5114 passing / 15 failing to 5120 / 11; the remaining 11 are the pre-existing `bucketPut` and `bucketUpdateQuota` quota-metric-seeding failures, untouched by this. Lint clean, 0 errors.