### PR TITLE
CLDSRV-982: Guard against storing a request logger on a long-lived object

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -74,4 +74,26 @@ export default [...compat.extends('@scality/scality'), {
         "promise/prefer-await-to-then": "warn",
         "n/callback-return": "warn",
     },
+}, {
+    // A werelogs RequestLogger buffers every entry it is handed in
+    // RequestLogger.entries and only flushes when something logs at or above
+    // the dump threshold ('error'). That is safe for the duration of one
+    // request and a memory leak for anything that outlives it: a background
+    // timer logging through a stored RequestLogger grows it until the process
+    // restarts, and a single error-level write then dumps the whole buffer to
+    // the log at once.
+    files: ["lib/**/*.js"],
+
+    rules: {
+        "no-restricted-syntax": ["error", {
+            selector:
+                "AssignmentExpression[left.object.type='ThisExpression']"
+                + "[right.type='Identifier'][right.name=/^_?log(ger)?$/]",
+            message:
+                "Do not store a logger on an object. If the object outlives the request, "
+                + "require lib/utilities/logger and use that instead - it writes through "
+                + "rather than buffering. If the object really is per-request (a stream "
+                + "transform, say), disable this rule on the line and say why.",
+        }],
+    },
 }];

--- a/lib/auth/streamingV4/V4Transform.js
+++ b/lib/auth/streamingV4/V4Transform.js
@@ -31,6 +31,9 @@ class V4Transform extends Transform {
         const { accessKey, signatureFromRequest, region, scopeDate, timestamp,
             credentialScope } = streamingV4Params;
         super({});
+        // This transform is constructed per request and destroyed with it,
+        // so holding the request logger cannot outlive the request.
+        // eslint-disable-next-line no-restricted-syntax
         this.log = log;
         this.errCb = errCb;
         this.accessKey = accessKey;

--- a/lib/auth/streamingV4/trailingChecksumTransform.js
+++ b/lib/auth/streamingV4/trailingChecksumTransform.js
@@ -15,6 +15,9 @@ class TrailingChecksumTransform extends Transform {
      */
     constructor(log) {
         super({});
+        // This transform is constructed per request and destroyed with it,
+        // so holding the request logger cannot outlive the request.
+        // eslint-disable-next-line no-restricted-syntax
         this.log = log;
         this.chunkSizeBuffer = Buffer.alloc(0);
         this.bytesToDiscard = 0; // when trailing \r\n are present, we discard them but they can be in different chunks

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -1,6 +1,7 @@
 const crypto = require('crypto');
 const assert = require('assert');
 const { storage } = require('arsenal');
+const { Werelogs } = require('werelogs');
 
 const AuthInfo = require('arsenal').auth.AuthInfo;
 const { RequestContext } = require('arsenal').policies;
@@ -521,6 +522,36 @@ function createRequestContext(apiMethod, request) {
         '127.0.0.1', false, apiMethod, 's3');
 }
 
+/**
+ * A real werelogs RequestLogger.
+ *
+ * DummyRequestLogger records calls but has no entries buffer, so it cannot
+ * show what werelogs actually does with the entries it is handed - which is
+ * how real leaks have gone unnoticed. Use this wherever a test needs to
+ * observe buffering, and assert with bufferedEntryCount().
+ *
+ * @param {object} [options] - level, dump and name overrides
+ * @returns {object} a werelogs RequestLogger
+ */
+function makeRealRequestLogger(options = {}) {
+    const werelogs = new Werelogs({
+        level: options.level || 'info',
+        dump: options.dump || 'error',
+    });
+    return new werelogs.Logger(options.name || 'test').newRequestLogger();
+}
+
+/**
+ * How many log entries werelogs is currently holding in memory for a request
+ * logger. A count that grows without bound is a leak.
+ *
+ * @param {object} log - a werelogs RequestLogger
+ * @returns {number} buffered entry count
+ */
+function bufferedEntryCount(log) {
+    return Array.isArray(log.entries) ? log.entries.length : 0;
+}
+
 module.exports = {
     testsRangeOnEmptyFile,
     makeid,
@@ -529,6 +560,8 @@ module.exports = {
     createAlteredRequest,
     cleanup,
     DummyRequestLogger,
+    makeRealRequestLogger,
+    bufferedEntryCount,
     makeAuthInfo,
     WebsiteConfig,
     CorsConfigTester,

--- a/tests/unit/utils/requestLoggerBuffering.js
+++ b/tests/unit/utils/requestLoggerBuffering.js
@@ -1,0 +1,67 @@
+const assert = require('assert');
+
+const { makeRealRequestLogger, bufferedEntryCount } = require('../helpers');
+// lib/utilities/logger initializes Config on load; the unit environment
+// (CI=true, S3BACKEND=mem) is set before mocha loads any test file, so this
+// is safe at the top level, same as every test that pulls in helpers.
+const serverLogger = require('../../../lib/utilities/logger');
+
+/**
+ * Pins the werelogs RequestLogger behaviour that the no-restricted-syntax rule
+ * in eslint.config.mjs exists to protect against.
+ *
+ * A RequestLogger keeps every entry it is handed and only flushes when
+ * something logs at or above the dump threshold. That is deliberate - it lets
+ * an error carry the whole backstory of its request - and it is safe precisely
+ * because the logger is discarded when the request ends.
+ *
+ * Store one on an object that outlives the request and the buffer grows until
+ * the process restarts, and a single error-level write then dumps all of it
+ * at once. If werelogs ever changes this contract, these assertions are how
+ * we find out.
+ */
+describe('werelogs RequestLogger buffering', () => {
+    it('should buffer entries that are below the log level and never emitted', () => {
+        const log = makeRealRequestLogger({ level: 'info', dump: 'error' });
+
+        for (let i = 0; i < 100; i++) {
+            log.debug('background chatter', { i });
+        }
+
+        assert.strictEqual(bufferedEntryCount(log), 100,
+            'debug entries are retained even though logLevel info drops them from output');
+    });
+
+    it('should keep buffering without bound while nothing reaches the dump threshold', () => {
+        const log = makeRealRequestLogger({ level: 'info', dump: 'error' });
+
+        log.debug('one');
+        log.trace('two');
+        log.info('three');
+        log.warn('four');
+
+        assert.strictEqual(bufferedEntryCount(log), 4,
+            'trace through warn are all buffered; only error drains');
+    });
+
+    it('should flush the whole buffer on a single error-level write', () => {
+        const log = makeRealRequestLogger({ level: 'info', dump: 'error' });
+
+        for (let i = 0; i < 100; i++) {
+            log.debug('background chatter', { i });
+        }
+        assert.strictEqual(bufferedEntryCount(log), 100);
+
+        log.error('something failed');
+
+        assert.strictEqual(bufferedEntryCount(log), 0,
+            'one error emits every buffered entry at once and empties the buffer');
+    });
+
+    it('should give the plain server logger no buffer at all', () => {
+        // a werelogs Logger, not a RequestLogger: it writes through and drops
+        // sub-level entries. This is what long-lived objects must use.
+        assert.strictEqual(serverLogger.entries, undefined,
+            'the server logger must not accumulate entries');
+    });
+});


### PR DESCRIPTION
## Intent: why does this change exist?

CLDSRV-979 and CLDSRV-981 are the same mistake in two places, and both shipped with unit coverage of the module they lived in. The tests hand the code a stub logger, which has no entries buffer, so the werelogs behaviour that *is* the bug was never exercised. This adds the thing that would have caught them.

## System impact: what's affected, including downstream?

A `no-restricted-syntax` rule scoped to `lib/**`, plus two test helpers. No production code behaviour changes. `eslint.config.mjs` uses only built-in ESLint capability, so there is no new dependency or plugin.

**Merge order:** this must land after #6259 (CLDSRV-979) and #6261 (CLDSRV-981). Lint goes from 0 errors to 2 on `development/9.3`, and those 2 are exactly the tokenBucket and Scuba sites those PRs remove. Draft until then; it turns green on rebase with no further edits.

## Preserved behavior: what explicitly stays the same?

Everything at runtime. `DummyRequestLogger` stays as it is and every existing test using it is untouched — the new fixture sits alongside it for tests that need to observe buffering.

## Intended change: what's different after this PR?

`this.x = log` under `lib/` is a lint error, with a message naming the two correct choices: `lib/utilities/logger` for anything outliving the request, a `RequestLogger` for anything that does not. The two streamingV4 transforms are genuinely per-request and destroyed with the request, so they disable the rule on the line and say why — the point of the rule is to force that decision to be explicit rather than to ban the assignment.

Tests get `makeRealRequestLogger()` and `bufferedEntryCount()` in `tests/unit/helpers.js`, and `requestLoggerBuffering.js` pins the werelogs contract itself: sub-level entries are retained rather than dropped, everything below `error` keeps accumulating, one error-level write flushes the lot, and the plain server logger has no buffer at all.

## Verification: how do we know this worked, or how would we know if it didn't?

Checked the rule against the real tree rather than trusting the selector: it flags all four `this.x = log` sites on `development/9.3`, and after exempting the two per-request transforms exactly the two known bugs remain. `yarn lint` goes 0 errors → 2 errors with the same 2945 pre-existing warnings.

The four buffering tests pass and are the executable statement of why the rule exists. `tests/unit` 5118 passing, with the 15 pre-existing failures this branch inherits (`bucketPut`/`bucketUpdateQuota` quota metric seeding, `ScubaClientImpl` — the last four of which #6261 fixes).

One caveat worth stating: the rule is deliberately shallow. It catches assignment of an identifier named `log`, `logger` or `_log` to a `this` property, which is how both bugs were written, but it will not catch a logger arriving under another name or reached through a longer path. It raises the cost of the mistake rather than making it impossible.