### PR TITLE
Allow enabling versioning on buckets with a GCP location constraint

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -153,7 +153,10 @@ const constants = {
     // for external backends, don't call unless at least 1 minute
     // (60,000 milliseconds) since last call
     externalBackendHealthCheckInterval: 60000,
-    versioningNotImplBackends: { azure: true, gcp: true },
+    versioningNotImplBackends: { azure: true },
+    externalVersioningErrorMessage:
+        'We do not currently support putting a versioned object to a location-constraint of type Azure.',
+    locationVersioningErrorMessage: 'Versioning is not supported for this location constraint.',
     mpuMDStoredExternallyBackend: { aws_s3: true, gcp: true },
     skipBatchDeleteBackends: { azure: true, gcp: true },
     s3HandledBackends: { azure: true, gcp: true },

--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -22,10 +22,7 @@ const {
     areChecksumsEnabled,
 } = require('../integrity/validateChecksums');
 
-const { externalBackends, versioningNotImplBackends } = constants;
-
-const externalVersioningErrorMessage =
-    'We do not currently support putting a versioned object to a location-constraint of type Azure or GCP.';
+const { externalBackends, versioningNotImplBackends, externalVersioningErrorMessage } = constants;
 
 /**
  * Validate and compute the checksum for a zero-size object body.

--- a/lib/api/bucketPutVersioning.js
+++ b/lib/api/bucketPutVersioning.js
@@ -6,23 +6,23 @@ const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const metadata = require('../metadata/wrapper');
 const { standardMetadataValidateBucket } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
-const versioningNotImplBackends =
-    require('../../constants').versioningNotImplBackends;
+const versioningNotImplBackends = require('../../constants').versioningNotImplBackends;
 const { config } = require('../Config');
 const monitoring = require('../utilities/monitoringHandler');
 
-const externalVersioningErrorMessage = 'We do not currently support putting ' +
-'a versioned object to a location-constraint of type Azure or GCP.';
+const externalVersioningErrorMessage =
+    'We do not currently support putting ' + 'a versioned object to a location-constraint of type Azure or GCP.';
 
-const replicationVersioningErrorMessage = 'A replication configuration is ' +
-'present on this bucket, so you cannot change the versioning state. To ' +
-'change the versioning state, first delete the replication configuration.';
+const replicationVersioningErrorMessage =
+    'A replication configuration is ' +
+    'present on this bucket, so you cannot change the versioning state. To ' +
+    'change the versioning state, first delete the replication configuration.';
 
-const ingestionVersioningErrorMessage = 'Versioning cannot be suspended for '
-+ 'buckets setup with Out of Band updates from a location';
+const ingestionVersioningErrorMessage =
+    'Versioning cannot be suspended for ' + 'buckets setup with Out of Band updates from a location';
 
-const objectLockErrorMessage = 'An Object Lock configuration is present on ' +
-  'this bucket, so the versioning state cannot be changed.';
+const objectLockErrorMessage =
+    'An Object Lock configuration is present on ' + 'this bucket, so the versioning state cannot be changed.';
 
 /**
  * Format of xml request:
@@ -47,21 +47,17 @@ function _parseXML(request, log, cb) {
             return cb(errors.MalformedXML);
         }
         const versioningConf = result.VersioningConfiguration;
-        const status = versioningConf.Status ?
-            versioningConf.Status[0] : undefined;
-        const mfaDelete = versioningConf.MfaDelete ?
-            versioningConf.MfaDelete[0] : undefined;
+        const status = versioningConf.Status ? versioningConf.Status[0] : undefined;
+        const mfaDelete = versioningConf.MfaDelete ? versioningConf.MfaDelete[0] : undefined;
         const validStatuses = ['Enabled', 'Suspended'];
         const validMfaDeletes = [undefined, 'Enabled', 'Disabled'];
-        if (validStatuses.indexOf(status) < 0 ||
-            validMfaDeletes.indexOf(mfaDelete) < 0) {
+        if (validStatuses.indexOf(status) < 0 || validMfaDeletes.indexOf(mfaDelete) < 0) {
             log.debug('illegal versioning configuration');
             return cb(errors.IllegalVersioningConfigurationException);
         }
         if (versioningConf && mfaDelete === 'Enabled') {
             log.debug('mfa deletion is not implemented');
-            return cb(errorInstances.NotImplemented
-                .customizeDescription('MFA Deletion is not supported yet.'));
+            return cb(errorInstances.NotImplemented.customizeDescription('MFA Deletion is not supported yet.'));
         }
         return process.nextTick(() => cb(null));
     });
@@ -103,90 +99,89 @@ function bucketPutVersioning(authInfo, request, log, callback) {
         requestType: request.apiMethods || 'bucketPutVersioning',
         request,
     };
-    return waterfall([
-        next => _parseXML(request, log, next),
-        next => standardMetadataValidateBucket(metadataValParams, request.actionImplicitDenies, log,
-            (err, bucket) => next(err, bucket)), // ignore extra null object,
-        (bucket, next) => parseString(request.post, (err, result) => {
-            // just for linting; there should not be any parsing error here
+    return waterfall(
+        [
+            next => _parseXML(request, log, next),
+            next =>
+                standardMetadataValidateBucket(metadataValParams, request.actionImplicitDenies, log, (err, bucket) =>
+                    next(err, bucket),
+                ), // ignore extra null object,
+            (bucket, next) =>
+                parseString(request.post, (err, result) => {
+                    // just for linting; there should not be any parsing error here
+                    if (err) {
+                        return next(err, bucket);
+                    }
+                    // prevent enabling versioning on an nfs exported bucket
+                    if (bucket.isNFS()) {
+                        const error = new Error();
+                        error.code = 'NFSBUCKET';
+                        return next(error);
+                    }
+                    // _checkBackendVersioningImplemented returns false if versioning
+                    // is not implemented on the bucket backend
+                    if (!_checkBackendVersioningImplemented(bucket)) {
+                        log.debug(externalVersioningErrorMessage, {
+                            method: 'bucketPutVersioning',
+                            error: errors.NotImplemented,
+                        });
+                        const error =
+                            errorInstances.NotImplemented.customizeDescription(externalVersioningErrorMessage);
+                        return next(error, bucket);
+                    }
+                    const versioningConfiguration = {};
+                    if (result.VersioningConfiguration.Status) {
+                        versioningConfiguration.Status = result.VersioningConfiguration.Status[0];
+                    }
+                    if (result.VersioningConfiguration.MfaDelete) {
+                        versioningConfiguration.MfaDelete = result.VersioningConfiguration.MfaDelete[0];
+                    }
+                    // the configuration has been checked before
+                    return next(null, bucket, versioningConfiguration);
+                }),
+            (bucket, versioningConfiguration, next) => {
+                // check if replication is enabled if versioning is being suspended
+                const replicationConfig = bucket.getReplicationConfiguration();
+                const isIngestionBucket = bucket.isIngestionBucket && bucket.isIngestionBucket();
+                const invalidAction =
+                    versioningConfiguration.Status === 'Suspended' &&
+                    (isIngestionBucket || replicationConfig?.rules?.some(r => r.enabled));
+                if (invalidAction) {
+                    const errorMsg = isIngestionBucket
+                        ? ingestionVersioningErrorMessage
+                        : replicationVersioningErrorMessage;
+                    next(errorInstances.InvalidBucketState.customizeDescription(errorMsg));
+                    return;
+                }
+                const objectLockEnabled = bucket.isObjectLockEnabled();
+                if (objectLockEnabled) {
+                    next(errorInstances.InvalidBucketState.customizeDescription(objectLockErrorMessage));
+                    return;
+                }
+                bucket.setVersioningConfiguration(versioningConfiguration);
+                // TODO all metadata updates of bucket should be using CAS
+                metadata.updateBucket(bucket.getName(), bucket, log, err => next(err, bucket));
+            },
+        ],
+        (err, bucket) => {
+            const corsHeaders = collectCorsHeaders(request.headers.origin, request.method, bucket);
+            if (err && err.code === 'NFSBUCKET') {
+                log.trace('skipping versioning for nfs exported bucket');
+                return callback(null, corsHeaders);
+            }
             if (err) {
-                return next(err, bucket);
+                log.trace('error processing request', { error: err, method: 'bucketPutVersioning' });
+                monitoring.promMetrics('PUT', bucketName, err.code, 'putBucketVersioning');
+            } else {
+                pushMetric('putBucketVersioning', log, {
+                    authInfo,
+                    bucket: bucketName,
+                });
+                monitoring.promMetrics('PUT', bucketName, '200', 'putBucketVersioning');
             }
-            // prevent enabling versioning on an nfs exported bucket
-            if (bucket.isNFS()) {
-                const error = new Error();
-                error.code = 'NFSBUCKET';
-                return next(error);
-            }
-            // _checkBackendVersioningImplemented returns false if versioning
-            // is not implemented on the bucket backend
-            if (!_checkBackendVersioningImplemented(bucket)) {
-                log.debug(externalVersioningErrorMessage,
-                    { method: 'bucketPutVersioning',
-                    error: errors.NotImplemented });
-                const error = errorInstances.NotImplemented.customizeDescription(
-                    externalVersioningErrorMessage);
-                return next(error, bucket);
-            }
-            const versioningConfiguration = {};
-            if (result.VersioningConfiguration.Status) {
-                versioningConfiguration.Status =
-                    result.VersioningConfiguration.Status[0];
-            }
-            if (result.VersioningConfiguration.MfaDelete) {
-                versioningConfiguration.MfaDelete =
-                    result.VersioningConfiguration.MfaDelete[0];
-            }
-            // the configuration has been checked before
-            return next(null, bucket, versioningConfiguration);
-        }),
-        (bucket, versioningConfiguration, next) => {
-            // check if replication is enabled if versioning is being suspended
-            const replicationConfig = bucket.getReplicationConfiguration();
-            const isIngestionBucket = bucket.isIngestionBucket && bucket.isIngestionBucket();
-            const invalidAction =
-                versioningConfiguration.Status === 'Suspended'
-                && (isIngestionBucket || replicationConfig?.rules?.some(r => r.enabled));
-            if (invalidAction) {
-                const errorMsg = isIngestionBucket ?
-                    ingestionVersioningErrorMessage : replicationVersioningErrorMessage;
-                next(errorInstances.InvalidBucketState
-                    .customizeDescription(errorMsg));
-                return;
-            }
-            const objectLockEnabled = bucket.isObjectLockEnabled();
-            if (objectLockEnabled) {
-                next(errorInstances.InvalidBucketState
-                    .customizeDescription(objectLockErrorMessage));
-                return;
-            }
-            bucket.setVersioningConfiguration(versioningConfiguration);
-            // TODO all metadata updates of bucket should be using CAS
-            metadata.updateBucket(bucket.getName(), bucket, log, err =>
-                next(err, bucket));
+            return callback(err, corsHeaders);
         },
-    ], (err, bucket) => {
-        const corsHeaders = collectCorsHeaders(request.headers.origin,
-            request.method, bucket);
-        if (err && err.code === 'NFSBUCKET') {
-            log.trace('skipping versioning for nfs exported bucket');
-            return callback(null, corsHeaders);
-        }
-        if (err) {
-            log.trace('error processing request', { error: err,
-                method: 'bucketPutVersioning' });
-            monitoring.promMetrics(
-                'PUT', bucketName, err.code, 'putBucketVersioning');
-        } else {
-            pushMetric('putBucketVersioning', log, {
-                authInfo,
-                bucket: bucketName,
-            });
-            monitoring.promMetrics(
-                'PUT', bucketName, '200', 'putBucketVersioning');
-        }
-        return callback(err, corsHeaders);
-    });
+    );
 }
 
 module.exports = bucketPutVersioning;

--- a/lib/api/bucketPutVersioning.js
+++ b/lib/api/bucketPutVersioning.js
@@ -6,12 +6,13 @@ const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const metadata = require('../metadata/wrapper');
 const { standardMetadataValidateBucket } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
-const versioningNotImplBackends = require('../../constants').versioningNotImplBackends;
+const {
+    versioningNotImplBackends,
+    externalVersioningErrorMessage,
+    locationVersioningErrorMessage,
+} = require('../../constants');
 const { config } = require('../Config');
 const monitoring = require('../utilities/monitoringHandler');
-
-const externalVersioningErrorMessage =
-    'We do not currently support putting ' + 'a versioned object to a location-constraint of type Azure or GCP.';
 
 const replicationVersioningErrorMessage =
     'A replication configuration is ' +
@@ -63,22 +64,24 @@ function _parseXML(request, log, cb) {
     });
 }
 
+// returns the error message to report if versioning is not implemented
+// on the bucket backend, or null if it is supported
 function _checkBackendVersioningImplemented(bucket) {
     const bucketLocation = bucket.getLocationConstraint();
     const bucketLocationType = config.getLocationConstraintType(bucketLocation);
 
     // backend types known not to support versioning
     if (versioningNotImplBackends[bucketLocationType]) {
-        return false;
+        return externalVersioningErrorMessage;
     }
 
     // versioning disabled per-location constraint
     const lc = config.getLocationConstraint(bucketLocation);
     if (lc.details && !lc.details.supportsVersioning) {
-        return false;
+        return locationVersioningErrorMessage;
     }
 
-    return true;
+    return null;
 }
 
 /**
@@ -118,15 +121,13 @@ function bucketPutVersioning(authInfo, request, log, callback) {
                         error.code = 'NFSBUCKET';
                         return next(error);
                     }
-                    // _checkBackendVersioningImplemented returns false if versioning
-                    // is not implemented on the bucket backend
-                    if (!_checkBackendVersioningImplemented(bucket)) {
-                        log.debug(externalVersioningErrorMessage, {
+                    const versioningErrorMessage = _checkBackendVersioningImplemented(bucket);
+                    if (versioningErrorMessage) {
+                        log.debug(versioningErrorMessage, {
                             method: 'bucketPutVersioning',
                             error: errors.NotImplemented,
                         });
-                        const error =
-                            errorInstances.NotImplemented.customizeDescription(externalVersioningErrorMessage);
+                        const error = errorInstances.NotImplemented.customizeDescription(versioningErrorMessage);
                         return next(error, bucket);
                     }
                     const versioningConfiguration = {};

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -39,8 +39,7 @@ const kms = require('../kms/wrapper');
 const versionIdUtils = versioning.VersionID;
 const locationHeader = constants.objectLocationConstraintHeader;
 const versioningNotImplBackends = constants.versioningNotImplBackends;
-const externalVersioningErrorMessage =
-    'We do not currently support putting a versioned object to a location-constraint of type AWS or Azure or GCP.';
+const externalVersioningErrorMessage = constants.externalVersioningErrorMessage;
 
 /**
  * Compute the prior data locations that are orphaned.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "@opentelemetry/instrumentation-ioredis": "~0.64.0",
         "@opentelemetry/instrumentation-mongodb": "~0.69.0",
         "@smithy/node-http-handler": "^3.0.0",
-        "arsenal": "git+https://github.com/scality/arsenal#8.5.15",
+        "arsenal": "git+https://github.com/scality/arsenal#23293b993b12c30fc0f564d7f00327363e027599",
         "async": "2.6.4",
         "aws-crt": "^1.24.0",
         "bucketclient": "scality/bucketclient#8.2.7",

--- a/tests/unit/api/bucketPutVersioning.js
+++ b/tests/unit/api/bucketPutVersioning.js
@@ -6,46 +6,44 @@ const { bucketPut } = require('../../../lib/api/bucketPut');
 const bucketPutVersioning = require('../../../lib/api/bucketPutVersioning');
 const bucketPutReplication = require('../../../lib/api/bucketPutReplication');
 
-const { cleanup,
-    DummyRequestLogger,
-    makeAuthInfo } = require('../helpers');
+const { cleanup, DummyRequestLogger, makeAuthInfo } = require('../helpers');
 const metadata = require('../../../lib/metadata/wrapper');
 
 const xmlEnableVersioning =
-'<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
-'<Status>Enabled</Status>' +
-'</VersioningConfiguration>';
+    '<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+    '<Status>Enabled</Status>' +
+    '</VersioningConfiguration>';
 
 const xmlSuspendVersioning =
-'<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
-'<Status>Suspended</Status>' +
-'</VersioningConfiguration>';
+    '<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+    '<Status>Suspended</Status>' +
+    '</VersioningConfiguration>';
 
 const locConstraintVersioned =
-'<CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
-'<LocationConstraint>withversioning</LocationConstraint>' +
-'</CreateBucketConfiguration>';
+    '<CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+    '<LocationConstraint>withversioning</LocationConstraint>' +
+    '</CreateBucketConfiguration>';
 
 const locConstraintNonVersioned =
-'<CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
-'<LocationConstraint>withoutversioning</LocationConstraint>' +
-'</CreateBucketConfiguration>';
+    '<CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+    '<LocationConstraint>withoutversioning</LocationConstraint>' +
+    '</CreateBucketConfiguration>';
 
 const xmlReplicationConfiguration =
-'<ReplicationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+    '<ReplicationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
     '<Role>arn:aws:iam::account-id:role/src-resource</Role>' +
     '<Rule>' +
-        '<Prefix></Prefix>' +
-        '<Status>Enabled</Status>' +
-        '<Destination>' +
-            '<Bucket>arn:aws:s3:::destination-bucket</Bucket>' +
-            '<StorageClass>us-east-2</StorageClass>' +
-        '</Destination>' +
+    '<Prefix></Prefix>' +
+    '<Status>Enabled</Status>' +
+    '<Destination>' +
+    '<Bucket>arn:aws:s3:::destination-bucket</Bucket>' +
+    '<StorageClass>us-east-2</StorageClass>' +
+    '</Destination>' +
     '</Rule>' +
-'</ReplicationConfiguration>';
+    '</ReplicationConfiguration>';
 
-const externalVersioningErrorMessage = 'We do not currently support putting ' +
-'a versioned object to a location-constraint of type Azure or GCP.';
+const externalVersioningErrorMessage =
+    'We do not currently support putting ' + 'a versioned object to a location-constraint of type Azure or GCP.';
 
 const log = new DummyRequestLogger();
 const bucketName = 'bucketname';
@@ -94,55 +92,58 @@ describe('bucketPutVersioning API', () => {
 
         const tests = [
             {
-                msg: 'should successfully enable versioning on location ' +
-                'constraint with supportsVersioning set to true',
+                msg:
+                    'should successfully enable versioning on location ' +
+                    'constraint with supportsVersioning set to true',
                 input: xmlEnableVersioning,
                 output: { Status: 'Enabled' },
             },
             {
-                msg: 'should successfully suspend versioning on location ' +
-                'constraint with supportsVersioning set to true',
+                msg:
+                    'should successfully suspend versioning on location ' +
+                    'constraint with supportsVersioning set to true',
                 input: xmlSuspendVersioning,
                 output: { Status: 'Suspended' },
             },
         ];
-        tests.forEach(test => it(test.msg, done => {
-            const request = _putVersioningRequest(test.input);
-            bucketPutVersioning(authInfo, request, log, err => {
-                assert.ifError(err,
-                    `Expected success, but got err: ${err}`);
-                metadata.getBucket(bucketName, log, (err, bucket) => {
-                    assert.ifError(err,
-                        `Expected success, but got err: ${err}`);
-                    assert.deepStrictEqual(bucket._versioningConfiguration,
-                        test.output);
-                    done();
+        tests.forEach(test =>
+            it(test.msg, done => {
+                const request = _putVersioningRequest(test.input);
+                bucketPutVersioning(authInfo, request, log, err => {
+                    assert.ifError(err, `Expected success, but got err: ${err}`);
+                    metadata.getBucket(bucketName, log, (err, bucket) => {
+                        assert.ifError(err, `Expected success, but got err: ${err}`);
+                        assert.deepStrictEqual(bucket._versioningConfiguration, test.output);
+                        done();
+                    });
                 });
-            });
-        }));
+            }),
+        );
 
         it('should not suspend versioning on bucket with replication', done => {
-            async.series([
-                // Enable versioning to allow putting a replication config.
-                next => {
-                    const request = _putVersioningRequest(xmlEnableVersioning);
-                    bucketPutVersioning(authInfo, request, log, next);
-                },
-                // Put the replication config on the bucket.
-                next => {
-                    const request =
-                        _putReplicationRequest(xmlReplicationConfiguration);
-                    bucketPutReplication(authInfo, request, log, next);
-                },
-                // Attempt to suspend versioning.
-                next => {
-                    const request = _putVersioningRequest(xmlSuspendVersioning);
-                    bucketPutVersioning(authInfo, request, log, err => {
-                        assert(err.is.InvalidBucketState);
-                        next();
-                    });
-                },
-            ], done);
+            async.series(
+                [
+                    // Enable versioning to allow putting a replication config.
+                    next => {
+                        const request = _putVersioningRequest(xmlEnableVersioning);
+                        bucketPutVersioning(authInfo, request, log, next);
+                    },
+                    // Put the replication config on the bucket.
+                    next => {
+                        const request = _putReplicationRequest(xmlReplicationConfiguration);
+                        bucketPutReplication(authInfo, request, log, next);
+                    },
+                    // Attempt to suspend versioning.
+                    next => {
+                        const request = _putVersioningRequest(xmlSuspendVersioning);
+                        bucketPutVersioning(authInfo, request, log, err => {
+                            assert(err.is.InvalidBucketState);
+                            next();
+                        });
+                    },
+                ],
+                done,
+            );
         });
     });
 
@@ -154,28 +155,28 @@ describe('bucketPutVersioning API', () => {
 
         const tests = [
             {
-                msg: 'should return error if enabling versioning on location ' +
-                'constraint with supportsVersioning set to false',
+                msg:
+                    'should return error if enabling versioning on location ' +
+                    'constraint with supportsVersioning set to false',
                 input: xmlEnableVersioning,
-                output: { error: errorInstances.NotImplemented.customizeDescription(
-                    externalVersioningErrorMessage) },
+                output: { error: errorInstances.NotImplemented.customizeDescription(externalVersioningErrorMessage) },
             },
             {
-                msg: 'should return error if suspending versioning on ' +
-                ' location constraint with supportsVersioning set to false',
+                msg:
+                    'should return error if suspending versioning on ' +
+                    ' location constraint with supportsVersioning set to false',
                 input: xmlSuspendVersioning,
-                output: { error: errorInstances.NotImplemented.customizeDescription(
-                    externalVersioningErrorMessage) },
+                output: { error: errorInstances.NotImplemented.customizeDescription(externalVersioningErrorMessage) },
             },
         ];
-        tests.forEach(test => it(test.msg, done => {
-            const putBucketVersioningRequest =
-                _putVersioningRequest(test.input);
-            bucketPutVersioning(authInfo, putBucketVersioningRequest, log,
-            err => {
-                assert.deepStrictEqual(err, test.output.error);
-                done();
-            });
-        }));
+        tests.forEach(test =>
+            it(test.msg, done => {
+                const putBucketVersioningRequest = _putVersioningRequest(test.input);
+                bucketPutVersioning(authInfo, putBucketVersioningRequest, log, err => {
+                    assert.deepStrictEqual(err, test.output.error);
+                    done();
+                });
+            }),
+        );
     });
 });

--- a/tests/unit/api/bucketPutVersioning.js
+++ b/tests/unit/api/bucketPutVersioning.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const async = require('async');
+const { promisify } = require('util');
 
 const { errorInstances } = require('arsenal');
 const { bucketPut } = require('../../../lib/api/bucketPut');
@@ -8,6 +9,7 @@ const bucketPutReplication = require('../../../lib/api/bucketPutReplication');
 
 const { cleanup, DummyRequestLogger, makeAuthInfo } = require('../helpers');
 const metadata = require('../../../lib/metadata/wrapper');
+const { locationVersioningErrorMessage } = require('../../../constants');
 
 const xmlEnableVersioning =
     '<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
@@ -29,6 +31,11 @@ const locConstraintNonVersioned =
     '<LocationConstraint>withoutversioning</LocationConstraint>' +
     '</CreateBucketConfiguration>';
 
+const locConstraintGcp =
+    '<CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+    '<LocationConstraint>gcpbackend</LocationConstraint>' +
+    '</CreateBucketConfiguration>';
+
 const xmlReplicationConfiguration =
     '<ReplicationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
     '<Role>arn:aws:iam::account-id:role/src-resource</Role>' +
@@ -42,8 +49,9 @@ const xmlReplicationConfiguration =
     '</Rule>' +
     '</ReplicationConfiguration>';
 
-const externalVersioningErrorMessage =
-    'We do not currently support putting ' + 'a versioned object to a location-constraint of type Azure or GCP.';
+const bucketPutAsync = promisify(bucketPut);
+const bucketPutVersioningAsync = promisify(bucketPutVersioning);
+const getBucketAsync = promisify(metadata.getBucket.bind(metadata));
 
 const log = new DummyRequestLogger();
 const bucketName = 'bucketname';
@@ -159,14 +167,14 @@ describe('bucketPutVersioning API', () => {
                     'should return error if enabling versioning on location ' +
                     'constraint with supportsVersioning set to false',
                 input: xmlEnableVersioning,
-                output: { error: errorInstances.NotImplemented.customizeDescription(externalVersioningErrorMessage) },
+                output: { error: errorInstances.NotImplemented.customizeDescription(locationVersioningErrorMessage) },
             },
             {
                 msg:
                     'should return error if suspending versioning on ' +
                     ' location constraint with supportsVersioning set to false',
                 input: xmlSuspendVersioning,
-                output: { error: errorInstances.NotImplemented.customizeDescription(externalVersioningErrorMessage) },
+                output: { error: errorInstances.NotImplemented.customizeDescription(locationVersioningErrorMessage) },
             },
         ];
         tests.forEach(test =>
@@ -178,5 +186,15 @@ describe('bucketPutVersioning API', () => {
                 });
             }),
         );
+    });
+
+    describe('with GCP location constraint', () => {
+        beforeEach(() => bucketPutAsync(authInfo, _getPutBucketRequest(locConstraintGcp), log));
+
+        it('should successfully enable versioning', async () => {
+            await bucketPutVersioningAsync(authInfo, _putVersioningRequest(xmlEnableVersioning), log);
+            const bucket = await getBucketAsync(bucketName, log);
+            assert.deepStrictEqual(bucket._versioningConfiguration, { Status: 'Enabled' });
+        });
     });
 });

--- a/tests/unit/multipleBackend/VersioningBackendClient.js
+++ b/tests/unit/multipleBackend/VersioningBackendClient.js
@@ -101,8 +101,16 @@ describe('AwsClient::copyObject', () => {
         it(test.msg, done => {
             testClient._supportsVersioning = test.input.supportsVersioning;
             testClient._client.versioning = test.input.enableMockVersioning;
-            testClient.copyObject(copyObjectRequest, null, key, sourceLocationConstraint, null, config, log, err =>
-                test.callback(err, done),
+            testClient.copyObject(
+                copyObjectRequest,
+                null,
+                key,
+                undefined,
+                sourceLocationConstraint,
+                null,
+                config,
+                log,
+                err => test.callback(err, done),
             );
         }),
     );

--- a/tests/unit/multipleBackend/VersioningBackendClient.js
+++ b/tests/unit/multipleBackend/VersioningBackendClient.js
@@ -7,8 +7,7 @@ const DummyService = require('../DummyService');
 const { DummyRequestLogger } = require('../helpers');
 
 const missingVerIdInternalError = errorInstances.InternalError.customizeDescription(
-    'Invalid state. Please ensure versioning is enabled ' +
-    'in AWS for the location constraint and try again.'
+    'Invalid state. Please ensure versioning is enabled in AWS for the location constraint and try again.',
 );
 
 const log = new DummyRequestLogger();
@@ -43,8 +42,7 @@ const s3Config = {
 };
 
 const assertSuccess = (err, cb) => {
-    assert.ifError(err,
-        `Expected success, but got error ${err}`);
+    assert.ifError(err, `Expected success, but got error ${err}`);
     cb();
 };
 
@@ -54,26 +52,22 @@ const assertFailure = (err, cb) => {
 };
 const genTests = [
     {
-        msg: 'should return success if supportsVersioning === true ' +
-        'and backend versioning is enabled',
+        msg: 'should return success if supportsVersioning === true and backend versioning is enabled',
         input: { supportsVersioning: true, enableMockVersioning: true },
         callback: assertSuccess,
     },
     {
-        msg: 'should return success if supportsVersioning === false ' +
-        'and backend versioning is enabled',
+        msg: 'should return success if supportsVersioning === false and backend versioning is enabled',
         input: { supportsVersioning: false, enableMockVersioning: true },
         callback: assertSuccess,
     },
     {
-        msg: 'should return error if supportsVersioning === true ' +
-        'and backend versioning is disabled',
+        msg: 'should return error if supportsVersioning === true and backend versioning is disabled',
         input: { supportsVersioning: true, enableMockVersioning: false },
         callback: assertFailure,
     },
     {
-        msg: 'should return success if supportsVersioning === false ' +
-        'and backend versioning is disabled',
+        msg: 'should return success if supportsVersioning === false and backend versioning is disabled',
         input: { supportsVersioning: false, enableMockVersioning: false },
         callback: assertSuccess,
     },
@@ -86,12 +80,13 @@ describe('AwsClient::putObject', () => {
         testClient = new AwsClient(s3Config);
         testClient._client = new DummyService({ versioning: true });
     });
-    genTests.forEach(test => it(test.msg, done => {
-        testClient._supportsVersioning = test.input.supportsVersioning;
-        testClient._client.versioning = test.input.enableMockVersioning;
-        testClient.put('', 0, { bucketName: bucket, objectKey: key },
-        reqUID, err => test.callback(err, done));
-    }));
+    genTests.forEach(test =>
+        it(test.msg, done => {
+            testClient._supportsVersioning = test.input.supportsVersioning;
+            testClient._client.versioning = test.input.enableMockVersioning;
+            testClient.put('', 0, { bucketName: bucket, objectKey: key }, reqUID, err => test.callback(err, done));
+        }),
+    );
 });
 
 describe('AwsClient::copyObject', () => {
@@ -102,13 +97,15 @@ describe('AwsClient::copyObject', () => {
         testClient._client = new DummyService({ versioning: true });
     });
 
-    genTests.forEach(test => it(test.msg, done => {
-        testClient._supportsVersioning = test.input.supportsVersioning;
-        testClient._client.versioning = test.input.enableMockVersioning;
-        testClient.copyObject(copyObjectRequest, null, key,
-        sourceLocationConstraint, null, config, log,
-        err => test.callback(err, done));
-    }));
+    genTests.forEach(test =>
+        it(test.msg, done => {
+            testClient._supportsVersioning = test.input.supportsVersioning;
+            testClient._client.versioning = test.input.enableMockVersioning;
+            testClient.copyObject(copyObjectRequest, null, key, sourceLocationConstraint, null, config, log, err =>
+                test.callback(err, done),
+            );
+        }),
+    );
 });
 
 describe('AwsClient::completeMPU', () => {
@@ -118,13 +115,14 @@ describe('AwsClient::completeMPU', () => {
         testClient = new AwsClient(s3Config);
         testClient._client = new DummyService({ versioning: true });
     });
-    genTests.forEach(test => it(test.msg, done => {
-        testClient._supportsVersioning = test.input.supportsVersioning;
-        testClient._client.versioning = test.input.enableMockVersioning;
-        const uploadId = 'externalBackendTestUploadId';
-        testClient.completeMPU(jsonList, null, key, uploadId,
-        bucket, log, err => test.callback(err, done));
-    }));
+    genTests.forEach(test =>
+        it(test.msg, done => {
+            testClient._supportsVersioning = test.input.supportsVersioning;
+            testClient._client.versioning = test.input.enableMockVersioning;
+            const uploadId = 'externalBackendTestUploadId';
+            testClient.completeMPU(jsonList, null, key, uploadId, bucket, log, err => test.callback(err, done));
+        }),
+    );
 });
 
 describe('AwsClient::healthcheck', () => {
@@ -159,34 +157,31 @@ describe('AwsClient::healthcheck', () => {
 
     const tests = [
         {
-            msg: 'should return success if supportsVersioning === true ' +
-            'and backend versioning is enabled',
+            msg: 'should return success if supportsVersioning === true and backend versioning is enabled',
             input: { supportsVersioning: true, enableMockVersioning: true },
             callback: assertSuccessVersioned,
         },
         {
-            msg: 'should return success if supportsVersioning === false ' +
-            'and backend versioning is enabled',
+            msg: 'should return success if supportsVersioning === false and backend versioning is enabled',
             input: { supportsVersioning: false, enableMockVersioning: true },
             callback: assertSuccessNonVersioned,
         },
         {
-            msg: 'should return error if supportsVersioning === true ' +
-            ' and backend versioning is disabled',
+            msg: 'should return error if supportsVersioning === true and backend versioning is disabled',
             input: { supportsVersioning: true, enableMockVersioning: false },
             callback: assertFailure,
         },
         {
-            msg: 'should return success if supportsVersioning === false ' +
-            'and backend versioning is disabled',
+            msg: 'should return success if supportsVersioning === false and backend versioning is disabled',
             input: { supportsVersioning: false, enableMockVersioning: false },
             callback: assertSuccessNonVersioned,
         },
     ];
-    tests.forEach(test => it(test.msg, done => {
-        testClient._supportsVersioning = test.input.supportsVersioning;
-        testClient._client.versioning = test.input.enableMockVersioning;
-        testClient.healthcheck('backend',
-        (err, resp) => test.callback(resp.backend, done));
-    }));
+    tests.forEach(test =>
+        it(test.msg, done => {
+            testClient._supportsVersioning = test.input.supportsVersioning;
+            testClient._client.versioning = test.input.enableMockVersioning;
+            testClient.healthcheck('backend', (err, resp) => test.callback(resp.backend, done));
+        }),
+    );
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5838,9 +5838,9 @@ arraybuffer.prototype.slice@^1.0.4:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#8.5.15":
+"arsenal@git+https://github.com/scality/arsenal#23293b993b12c30fc0f564d7f00327363e027599":
   version "8.5.15"
-  resolved "git+https://github.com/scality/arsenal#0bbe970dd72b2e235c47910474883af9b9c13eb1"
+  resolved "git+https://github.com/scality/arsenal#23293b993b12c30fc0f564d7f00327363e027599"
   dependencies:
     "@aws-sdk/client-kms" "^3.975.0"
     "@aws-sdk/client-s3" "^3.975.0"


### PR DESCRIPTION
### Not handled yet

| Gap | Impact | What it would take |
|---|---|---|
| Object versioning on the GCS bucket is a hard requirement: without it, the delete issued behind a delete marker destroys the data instead of archiving it | Silent data loss | Block writes on a non-versioned bucket, instead of only reporting it in the healthcheck |
| GCS lifecycle rules on noncurrent versions (`isLive: false`, `daysSinceNoncurrentTime`, `numNewerVersions`) can reap generations that S3 still serves as current | Deferred and silent data loss, with no error at write time | Document the precondition, and consider detecting such rules at configuration time |
| GCS never promotes a noncurrent generation, so the backend state diverges from the S3 view after an undelete or a version delete | Confusing during support, and the root cause of the lifecycle exposure above | Optional: promote by copy, accepting the new generation, the non-atomicity and the storage class reset |