### PR TITLE
CLDSRV-986: Pass overhead fields when abortMPU cleans up after completeMPU (hotfix/9.2.36)

### DIFF
--- a/lib/api/apiUtils/object/abortMultipartUpload.js
+++ b/lib/api/apiUtils/object/abortMultipartUpload.js
@@ -167,6 +167,7 @@ function abortMultipartUpload(authInfo, bucketName, objectKey, uploadId, log,
             const options = preprocessingVersioningDelete(
                 bucketName, destBucket, objectMD, objectMD.versionId, config.nullVersionCompatMode);
             options.replayId = uploadId;
+            options.overheadField = constants.overheadField;
             // This is a ghost metadata, without data loss, so skip oplog
             options.doesNotNeedOpogUpdate = true;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenko/cloudserver",
-  "version": "9.2.36-1",
+  "version": "9.2.36-2",
   "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
   "main": "index.js",
   "engines": {

--- a/tests/unit/api/apiUtils/object/abortMultipartUpload.spec.js
+++ b/tests/unit/api/apiUtils/object/abortMultipartUpload.spec.js
@@ -5,6 +5,7 @@ const { errors } = require('arsenal');
 const async = require('async');
 const crypto = require('crypto');
 
+const { overheadField } = require('../../../../../constants');
 const abortMultipartUpload = require('../../../../../lib/api/apiUtils/object/abortMultipartUpload');
 const { bucketPut } = require('../../../../../lib/api/bucketPut');
 const initiateMultipartUpload = require('../../../../../lib/api/initiateMultipartUpload');
@@ -305,6 +306,8 @@ describe('abortMultipartUpload', () => {
                 assert.ifError(err);
                 sinon.assert.calledOnce(deleteObjectMDStub);
                 assert.strictEqual(deleteObjectMDStub.getCall(0).args[2].versionId, 'orphan-vid');
+                assert.deepStrictEqual(
+                    deleteObjectMDStub.getCall(0).args[2].overheadField, overheadField);
                 done();
             }, { ...abortRequest, query: { uploadId: 'abort-id' } });
         });


### PR DESCRIPTION
Cherry-picked from #6268.