### PR TITLE
CLDSRV-992: Bound and settle the 1000-object writes in Multi-Object Delete setup

### DIFF
--- a/tests/functional/aws-node-sdk/test/object/multiObjectDelete.js
+++ b/tests/functional/aws-node-sdk/test/object/multiObjectDelete.js
@@ -74,22 +74,27 @@ describe('Multi-Object Delete Success', function success() {
                 objects.push(`${key}${i}`);
             }
             const parallel = 20;
-            const queued = [];
-            const putObjectWithLimit = async key => {
-                while (queued.length >= parallel) {
-                    await Promise.race(queued);
-                    queued.splice(0, queued.findIndex(p => p === queued[0]) + 1);
+            // Fixed pool draining a shared queue. The previous limiter peaked
+            // at 999 concurrent puts and abandoned the rest on first failure.
+            const pending = objects.slice();
+            const putErrors = [];
+            await Promise.all(Array.from({ length: parallel }, async () => {
+                while (pending.length > 0) {
+                    const objectKey = pending.shift();
+                    try {
+                        await s3.send(new PutObjectCommand({
+                            Bucket: bucketName,
+                            Key: objectKey,
+                            Body: 'somebody',
+                        }));
+                    } catch (err) {
+                        putErrors.push(err);
+                    }
                 }
-                const result = s3.send(new PutObjectCommand({
-                    Bucket: bucketName,
-                    Key: key,
-                    Body: 'somebody',
-                }));
-                queued.push(result);
-                return result;
-            };
-            const putPromises = objects.map(key => putObjectWithLimit(key));
-            await Promise.all(putPromises);
+            }));
+            if (putErrors.length > 0) {
+                throw putErrors[0];
+            }
         } catch (err) {
             process.stdout.write(`Error creating objects: ${err}\n`);
             throw err;


### PR DESCRIPTION
The `Multi-Object Delete Success` setup uploads 1000 objects behind what looks like a concurrency limiter of 20, and it is not one. `objects.map()` invokes all 1000 async calls synchronously; the first 20 push and the other 980 park on the same `Promise.race`, then on the first settle each waiter splices one entry off the head of the queue regardless of whether that entry had settled, so the queue empties and the remaining puts all fire together. Lifting the limiter verbatim into a harness with an instrumented stub gives a peak of **999 concurrent puts** against an intended 20, which is where the ServiceUnavailable and the `Socket timed out without establishing a connection within 5000 ms` come from.

It also explains why one failure becomes seven. `Promise.all` rejects on the first error while the other puts are still in flight, so the hook throws with writes outstanding; teardown then empties the bucket, the stragglers land, and `deleteBucket` fails with BucketNotEmpty. All four suites in the file share the bucket name `multi-object-delete-234-634`, so once it is left behind non-empty every later suite's cleanup fails the same way.

The limiter becomes a fixed pool of 20 workers draining a shared queue, so concurrency is genuinely bounded and every put has settled before the hook returns, including on the failure path. Errors are collected and the first is rethrown, so the diagnostic CI reports is unchanged. The replacement measures a peak of exactly 20 with nothing in flight at return, on the happy path and with an injected mid-run failure. Clears row F1's two Multi-Object Delete hooks; hotfix/9.2.36 needs this plus a cleanup change it never received, in #6279.