### PR TITLE
CLDSRV-992: Build the uploadPartCopy fixtures once per suite, not per test

### DIFF
--- a/tests/functional/aws-node-sdk/test/object/get.js
+++ b/tests/functional/aws-node-sdk/test/object/get.js
@@ -908,7 +908,7 @@ describe('GET object', () => {
                 const partOneBody = Buffer.concat(bufs, partOneSize);
                 const partTwoBody = Buffer.alloc(partSize, 4);
 
-                beforeEach(done => async.waterfall([
+                before(done => async.waterfall([
                     next => completeMPU(orderedPartNumbers, next),
                     next => createMPUAndPutTwoParts(partTwoBody, next),
                     (uploadId, ETags, next) =>
@@ -931,7 +931,7 @@ describe('GET object', () => {
                         })).then(() => next()).catch(next),
                 ], done));
 
-                afterEach(async () => {
+                after(async () => {
                     await s3.send(new DeleteObjectCommand({
                         Bucket: bucketName,
                         Key: copyPartKey,
@@ -955,7 +955,7 @@ describe('GET object', () => {
                     Buffer.alloc(partSize, n));
                 const partTwoBody = Buffer.concat(bufs, partTwoSize);
 
-                beforeEach(done => async.waterfall([
+                before(done => async.waterfall([
                     next => completeMPU(orderedPartNumbers, next),
                     next => createMPUAndPutTwoParts(partTwoBody, next),
                     /* eslint-disable no-param-reassign */
@@ -1004,7 +1004,7 @@ describe('GET object', () => {
                         })).then(() => next()).catch(next),
                 ], done));
 
-                afterEach(async () => {
+                after(async () => {
                     await s3.send(new DeleteObjectCommand({
                         Bucket: bucketName,
                         Key: copyPartKey,


### PR DESCRIPTION
## Intent: why does this change exist?

NEW FIX. Both `uploadPartCopy` describes in the PartNumber tests rebuild a ~200 MB MPU fixture in a `beforeEach`, though all four of their tests only issue a GetObject. The redundant second build is what exceeds the 40 s mocha timeout. Clears CLDSRV-992 row F4.

## System impact: what's affected, including downstream?

One functional test file, setup and teardown only. No product code, no assertions touched. hotfix/9.2.36 needs the same change and has #6280.

## Preserved behavior: what explicitly stays the same?

The fixture is identical and both tests read exactly what they read before. No timeout raised, no retry added, nothing skipped.

## Intended change: what's different after this PR?

Setup moves to `before` and cleanup to `after`, so each describe builds its fixture once. The enclosing describe already owns the bucket in its own `before`/`after`, so the fixture safely outlives the tests.

## Verification: how do we know this worked, or how would we know if it didn't?

The cost is arithmetic from the fixture itself: a serial 10x5 MB completeMPU, a 50 MB UploadPartCopy, a 50 MB UploadPart, then a further 5 MB part and second 50 MB copy. Both tests are pure GetObject calls, so the second build did no work they depended on. s3c-ft-tests-v0-null-compat stressed 10x on this branch.