### PR TITLE
CLDSRV-992: Wait for a mongo primary before waiting for the S3 API

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -336,6 +336,8 @@ jobs:
       - name: Run multiple backend test
         run: |-
           set -o pipefail;
+          # start-up blocks on mongo, so a slow mongo looks like 8000 never binding
+          bash wait_for_mongo_primary.bash 120
           bash wait_for_local_port.bash 8000 40
           bash wait_for_local_port.bash 81 40
           yarn run multiple_backend_test | tee /tmp/artifacts/${{ github.job }}/tests.log
@@ -398,6 +400,8 @@ jobs:
       - name: Run functional tests
         run: |-
           set -o pipefail;
+          # start-up blocks on mongo, so a slow mongo looks like 8000 never binding
+          bash wait_for_mongo_primary.bash 120
           bash wait_for_local_port.bash 8000 40
           yarn run ft_test | tee /tmp/artifacts/${{ github.job }}/tests.log
         env:
@@ -459,6 +463,8 @@ jobs:
       - name: Run functional tests
         run: |-
           set -o pipefail;
+          # start-up blocks on mongo, so a slow mongo looks like 8000 never binding
+          bash wait_for_mongo_primary.bash 120
           bash wait_for_local_port.bash 8000 40
           yarn run ft_test | tee /tmp/artifacts/${{ github.job }}/tests.log
           yarn run ft_mixed_bucket_format_version | tee /tmp/artifacts/${{ github.job }}/mixed-tests.log
@@ -771,6 +777,8 @@ jobs:
       - name: Run SUR-related tests
         run: |-
           set -ex -o pipefail;
+          # start-up blocks on mongo, so a slow mongo looks like 8000 never binding
+          bash wait_for_mongo_primary.bash 120
           bash wait_for_local_port.bash 8000 40
           yarn run test_sur | tee /tmp/artifacts/${{ github.job }}/tests.log
       - name: Cleanup and upload coverage

--- a/wait_for_mongo_primary.bash
+++ b/wait_for_mongo_primary.bash
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Wait until the mongo replica set has elected a primary.
+#
+# mongo-run.sh starts mongod immediately but backgrounds rs.initiate() behind a
+# `sleep 5`, so the port answers well before the set exists. A TCP check
+# therefore lets tests start against a mongo with no primary, and cloudserver,
+# which blocks on its metadata backend during start-up, then never binds 8000.
+#
+# usage: wait_for_mongo_primary.bash [timeout_seconds]
+set -uo pipefail
+
+timeout=${1:-120}
+count=0
+
+# compose was brought up from .github/docker, so resolve the project from there
+cd "$(dirname "$0")/.github/docker" || exit 1
+
+mongo_state() {
+    docker compose exec -T mongo \
+        mongo --port 27018 --quiet --eval 'rs.status().myState' 2>/dev/null \
+        | tr -dc '0-9'
+}
+
+echo "waiting for mongo replica set primary"
+while [ "$count" -lt "$timeout" ]; do
+    # myState 1 is PRIMARY; anything else, or a failed exec, means not ready
+    if [ "$(mongo_state)" = "1" ]; then
+        echo ""
+        echo "Mongo primary ready in ~${count} seconds. Starting test now..."
+        exit 0
+    fi
+    echo -n .
+    sleep 1
+    count=$((count + 1))
+done
+
+echo ""
+echo "Mongo replica set had no primary after ${timeout} seconds. Exiting..."
+docker compose exec -T mongo \
+    mongo --port 27018 --quiet --eval 'rs.status()' 2>&1 | tail -30 || true
+exit 1


### PR DESCRIPTION
## Intent: why does this change exist?

NEW FIX. The mongodb-backed jobs wait up to 40 s for port 8000 but nothing waits for MongoDB, and cloudserver's start-up blocks on its metadata backend, so a mongo that is up-but-not-yet-elected appears as the S3 API never binding 8000. The job then dies on "Server did not start in less than 40 seconds" with no clue why. Clears CLDSRV-992 row F5.

## System impact: what's affected, including downstream?

CI only, no product or test code. One new helper at the repo root beside `wait_for_local_port.bash`, and four jobs gain the gate: multiple-backend, mongo-v0-ft-tests, mongo-v1-ft-tests, sur-tests.

## Preserved behavior: what explicitly stays the same?

A healthy run pays nothing; the wait returns as soon as a primary is reported. No test, assertion or timeout is changed, and the existing 8000 wait keeps its 40 s.

## Intended change: what's different after this PR?

Each job waits for an elected primary, `rs.status().myState == 1`, before waiting for 8000. A plain `nc -z 27018` would not do: `mongo-run.sh` starts mongod immediately but backgrounds `rs.initiate()` behind a `sleep 5`, so the port answers at least five seconds before the replica set exists. On timeout the helper dumps `rs.status()`.

## Verification: how do we know this worked, or how would we know if it didn't?

**Probable cause, not proven, and I would rather say so.** The failing attempt's server log is gone: artifacts bundles are per run, so the successful re-run overwrote it. What the surviving log establishes is that multiple-backend bound 8000 at t+19.4 s on a *passing* attempt, against a 40 s budget that must also cover image pull, container create and replica-set init; a runner half as fast fails, matching a job that dies at the port wait and passes on re-run. The eval was checked against a real container, which reported `myState: 1`. The change also has diagnostic value independent of whether it is the cause.