### PR TITLE
CLDSRV-992: Capture cloudserver's log on the s3c functional jobs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -666,6 +666,15 @@ jobs:
         run: |-
           set -o pipefail;
           yarn run ft_scripts | tee /tmp/artifacts/${{ matrix.job-name }}/ft_scripts.log
+      # cloudserver runs as a container on these jobs and its log is never
+      # captured, so a server-side stall or 503 here cannot be diagnosed after
+      # the fact. Runs before teardown, while the containers still exist.
+      - name: Capture cloudserver logs
+        run: |-
+          docker compose logs --no-color --timestamps cloudserver-sse-before-migration \
+            > /tmp/artifacts/${{ matrix.job-name }}/s3.log 2>&1 || true
+        working-directory: .github/docker
+        if: always()
       - name: Teardown CI services
         run: docker compose down redis sproxyd metadata-standalone vault cloudserver-sse-before-migration
         working-directory: .github/docker


### PR DESCRIPTION
The s3c-ft-tests jobs upload sproxyd, bucketd, repd and vault logs but never cloudserver's own, because its output goes to the container's stdout and is discarded. Any failure originating in cloudserver on these jobs is therefore undiagnosable and becomes hypothetical.

Chasing a fresh occurrence of F8's ServiceUnavailable through the artifacts that do exist: nginx logged zero 5xx, sproxyd zero errors, and bucketd zero 503s with its only connection errors at a single startup instant. So cloudserver produced that 503 itself and nothing recorded why. S

The job now dumps cloudserver's container log to its artifacts directory before teardown, while the containers still exist. The step is `if: always()` and ends in `|| true`, so it runs on failure, which is when it matters, and can never itself fail a job; a passing run pays one `docker compose logs` call. If it were wrong we would see an empty or missing s3.log in the very next run's artifacts.