### PR TITLE
CLDSRV-992: Wait for the file data daemon before the S3 API

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -442,6 +442,8 @@ jobs:
     - name: Run file ft tests
       run: |-
         set -o pipefail;
+        # the data daemon binds after 8000 and nothing in startup waits for it
+        bash wait_for_local_port.bash 9991 120
         bash wait_for_local_port.bash 8000 40
         yarn run ft_test | tee /tmp/artifacts/${{ matrix.job-name }}/tests.log
     - name: Cleanup and upload coverage
@@ -728,6 +730,8 @@ jobs:
     - name: Run file KMIP tests
       run: |-
         set -ex -o pipefail;
+        # the data daemon binds after 8000 and nothing in startup waits for it
+        bash wait_for_local_port.bash 9991 120
         bash wait_for_local_port.bash 8000 40
         bash wait_for_local_port.bash 5696 40
         yarn run ft_kmip | tee /tmp/artifacts/${{ github.job }}/tests.log
@@ -803,6 +807,8 @@ jobs:
         S3_END_TO_END: true # to use the default credentials profile and not vault profile
       run: |-
         set -ex -o pipefail;
+        # the data daemon binds after 8000 and nothing in startup waits for it
+        bash wait_for_local_port.bash 9991 120
         bash wait_for_local_port.bash 8000 40
         bash wait_for_local_port.bash 5696 40
         yarn run ft_kmip_cluster | tee /tmp/artifacts/${{ github.job }}/tests.log
@@ -903,6 +909,8 @@ jobs:
     - name: Wait for services vault and s3
       run: |-
         bash wait_for_local_port.bash 8500 40
+        # the data daemon binds after 8000 and nothing in startup waits for it
+        bash wait_for_local_port.bash 9991 120
         bash wait_for_local_port.bash 8000 40
     - name: Ensure old version of cloudserver and vault is used
       run: |-
@@ -947,6 +955,8 @@ jobs:
       run: |-
         bash wait_for_local_port.bash ${{ matrix.kms.port }} 40
         bash wait_for_local_port.bash 8500 40
+        # the data daemon binds after 8000 and nothing in startup waits for it
+        bash wait_for_local_port.bash 9991 120
         bash wait_for_local_port.bash 8000 40
     - name: Ensure latest version of cloudserver and vault is used
       run: |-


### PR DESCRIPTION
`yarn start` launches the S3 API and the file daemons as separate parallel processes, so they race. On run 33734792029 the API bound :8000 at t+10s and served writes from t+15s while the dataserver only bound :9991 at t+84s, and the ten HTTP 500s in between are all `ECONNREFUSED 0.0.0.0:9991`; the same subdir pre-creation step took 2.7s on a healthy runner, which is why it is intermittent.

Context on why cloudserver does not catch this itself: `metadata.setup()` opens the metadata client and throws if 9990 is unreachable, so the API cannot bind without working metadata. I checked this branch pins Arsenal 8.2.34 and that its `BucketFileInterface.setup()` behaves identically, so only the data daemon needs gating. Nothing guards it, because `clientCheck` returns a hardcoded `{ code: 200, message: 'OK' }` for clients that implement no probe and `DataFileInterface` implements none. So the deep healthcheck only really checks metadata, and only for the mongo and bucketd clients.

Backport of #6277. The four jobs on the file data backend now wait on :9991 before :8000, including the second startup phase of sse-kms-migration-tests where a fresh cloudserver container is started. Note the run-block indentation on this line differs from 9.3+, so the change is written for this branch rather than cherry-picked.