### PR TITLE
CLDSRV-992: Match server access log entries instead of asserting an exact count

### DIFF
--- a/tests/functional/aws-node-sdk/test/serverAccessLogs/testServerAccessLogFile.js
+++ b/tests/functional/aws-node-sdk/test/serverAccessLogs/testServerAccessLogFile.js
@@ -22,29 +22,76 @@ function truncateLogFileIfExists(filePath) {
     }
 }
 
-async function waitForLogs(filePath, expectedLines, maxRetries, delayMs) {
-    for (let attempt = 0; attempt < maxRetries; attempt++) {
-        const logEntries = fs.readFileSync(filePath, 'utf8');
-        const lines = logEntries.trim().split('\n').filter(line => line.length > 0);
-        if (lines.length >= expectedLines) {
-            try {
-                return lines.map(line => JSON.parse(line));
-            } catch (err) {
-                // FIXME(CLDSRV-800): readFileSync may read partial lines making JSON.parse fail, so we need to retry.
-                if (attempt == maxRetries) {
-                    throw new Error(`Failed to read log entries from ${filePath} after ${maxRetries} attempts: ${err}`);
-                }
+function readLogLines(filePath) {
+    return fs
+        .readFileSync(filePath, 'utf8')
+        .trim()
+        .split('\n')
+        .filter(line => line.length > 0);
+}
+
+// Whether a collected log entry satisfies an expected entry's constrained
+// fields (same semantics as validateLogEntry). Lets us ignore unrelated lines
+// from other suites sharing the server's access log file (CLDSRV-923).
+function entryMatchesExpected(entry, properties) {
+    for (const [key, val] of Object.entries(properties)) {
+        if (key === 'unordered') {
+            continue;
+        }
+        if (val === null) {
+            if (key in entry) {
+                return false;
             }
+        } else if (entry[key] !== val) {
+            return false;
+        }
+    }
+    return true;
+}
+
+async function waitForExpectedLogs(filePath, expectedEntries, maxRetries, delayMs) {
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+        const lines = readLogLines(filePath);
+        try {
+            const entries = lines.map(line => JSON.parse(line));
+            const available = [...entries];
+            const allFound = expectedEntries.every(exp => {
+                const idx = available.findIndex(entry => entryMatchesExpected(entry, exp));
+                if (idx === -1) {
+                    return false;
+                }
+                available.splice(idx, 1);
+                return true;
+            });
+            if (allFound) {
+                return entries;
+            }
+        } catch {
+            // FIXME(CLDSRV-800): readFileSync may read partial lines making JSON.parse fail, so we need to retry.
         }
         await sleep(delayMs);
     }
-    throw new Error(`Failed to read log entries from ${filePath} after ${maxRetries} attempts`);
+    // Report which expected entries never showed up, to make CI failures diagnosable.
+    const missing = [];
+    try {
+        const available = readLogLines(filePath).map(line => JSON.parse(line));
+        for (const exp of expectedEntries) {
+            const idx = available.findIndex(entry => entryMatchesExpected(entry, exp));
+            if (idx === -1) {
+                missing.push(exp.action || JSON.stringify(exp));
+            } else {
+                available.splice(idx, 1);
+            }
+        }
+    } catch {
+        // ignore parse errors on the diagnostic path
+    }
+    throw new Error(`Missing expected log entries after ${maxRetries} attempts: ${missing.join(', ')} (${filePath})`);
 }
 
 async function waitForAction(filePath, action, maxRetries, delayMs) {
     for (let attempt = 0; attempt < maxRetries; attempt++) {
-        const logEntries = fs.readFileSync(filePath, 'utf8');
-        const lines = logEntries.trim().split('\n').filter(line => line.length > 0);
+        const lines = readLogLines(filePath);
         for (const line of lines) {
             try {
                 const obj = JSON.parse(line);
@@ -2712,46 +2759,30 @@ describe('Server Access Logs - File Output', async () => {
         for (const operation of operations) {
             it(`should log correct ${operation.methodName} operation with all required fields`, async () => {
                 await operation.method();
-                // Count total expected logs, including unordered entries
-                let totalExpected = 0;
-                for (const exp of operation.expected) {
-                    totalExpected += exp.unordered ? exp.unordered.length : 1;
-                }
-                const logEntries = await waitForLogs(logFilePath, totalExpected,
-                    TEST_CONFIG.MAX_LOG_WAIT_RETRIES, TEST_CONFIG.LOG_POLL_DELAY_MS);
-                assert.strictEqual(logEntries.length, totalExpected,
-                    `Expected ${totalExpected} log entries, got ${logEntries.length}`);
+                // Flatten unordered groups; each entry is matched independently.
+                const expectedEntries = operation.expected.flatMap(exp => (exp.unordered ? exp.unordered : [exp]));
+                // The access log file is shared across the server process and a
+                // line can be written on a late res 'close', so other suites'
+                // lines can interleave. Match expected entries by field and ignore
+                // the rest instead of asserting an exact count (CLDSRV-923).
+                const logEntries = await waitForExpectedLogs(
+                    logFilePath,
+                    expectedEntries,
+                    TEST_CONFIG.MAX_LOG_WAIT_RETRIES,
+                    TEST_CONFIG.LOG_POLL_DELAY_MS,
+                );
 
-                let logIdx = 0;
-
-                // Validate entries (ordered or unordered)
-                for (let i = 0; i < operation.expected.length; i++) {
-                    const expected = operation.expected[i];
-
-                    if (expected.unordered) {
-                        // Handle unordered entries
-                        const unorderedLogs = logEntries.slice(logIdx, logIdx + expected.unordered.length);
-                        const remaining = [...expected.unordered];
-
-                        for (const logEntry of unorderedLogs) {
-                            const matchIdx = remaining.findIndex(exp => exp.objectKey === logEntry.objectKey);
-
-                            assert.notStrictEqual(matchIdx, -1,
-                                `Unexpected log entry with objectKey: ${logEntry.objectKey}`);
-
-                            validateLogEntry(logEntry, remaining[matchIdx]);
-                            remaining.splice(matchIdx, 1);
-                        }
-
-                        assert.strictEqual(remaining.length, 0,
-                            `Missing expected entries: ${JSON.stringify(remaining)}`);
-
-                        logIdx += expected.unordered.length;
-                    } else {
-                        // Handle ordered entry
-                        validateLogEntry(logEntries[logIdx], expected);
-                        logIdx++;
-                    }
+                const available = [...logEntries];
+                for (const expected of expectedEntries) {
+                    const idx = available.findIndex(entry => entryMatchesExpected(entry, expected));
+                    const keyInfo = expected.objectKey ? ` (objectKey ${expected.objectKey})` : '';
+                    assert.notStrictEqual(
+                        idx,
+                        -1,
+                        `Missing expected log entry for action ${expected.action}${keyInfo}`,
+                    );
+                    validateLogEntry(available[idx], expected);
+                    available.splice(idx, 1);
                 }
             });
         }


### PR DESCRIPTION
Backport of CLDSRV-923, from #6211 (`6aa67d9b6`). That fix landed on development/9.4 and 9.5 only and nothing forward-ports into hotfix lines, so this branch still asserts an exact log-entry count and is still exposed to the flake. The access-log file is shared by the whole server process and a line is written on the response `close` event, which under keep-alive can fire much later, during another suite's truncate window; a foreign GetObject on `buckettestgetobject` from `test/object/get.js` therefore inflates the count, which is why the victim test varied between runs.

**Cherry-picked from #6211, unchanged.** The whole functional change: `waitForLogs` is replaced by `readLogLines` + `entryMatchesExpected` + `waitForExpectedLogs`, which match each expected entry against the collected entries by field and ignore anything else, instead of asserting `logEntries.length === totalExpected`. Unordered groups are flattened and matched independently. The failure message now also names which expected entries never arrived, rather than only reporting a count mismatch.

**Changed by hand.** Three conflict hunks, because this branch's copy of the file differs from the 9.3 line. All three were resolved by taking the incoming (upstream) side, the same resolution used for the 9.3 backports in #6275 and #6276:

1. the `waitForLogs` function body, replaced wholesale by the three new helpers;
2. `waitForAction`'s inline file read, switched to `readLogLines(filePath)`;
3. the call site in the `it(...)` block, dropping the `totalExpected` computation and the exact-count assertion in favour of `waitForExpectedLogs`.

**No prettier commit here, unlike #6275 and #6276, because prettier is not used on this branch.** `hotfix/9.2.36` has no prettier dependency, no `prettier:diff` script and no `prettier.config.cjs`/`.prettierignore`; development/9.3 and hotfix/9.3.13 have all of them, which is why the backports there carry the upstream formatting commit. Adding one here would mean introducing prettier to the branch, which is well outside a flaky-test fix, so the change is the 83-line functional pick and nothing else.

**How I checked the pick is faithful.** The resulting file still differs from development/9.4 in 1123 lines, but none of those differences fall in the code this fix touches (`waitForExpectedLogs`, `entryMatchesExpected`, `readLogLines`, `totalExpected`); the remainder is pre-existing formatting drift on this branch. `waitForLogs` has no remaining references, and CI-equivalent eslint and `node --check` both pass.
