### PR TITLE
CLDSRV-992: Fix missing s3 logs artifact for cloudserver

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -513,7 +513,7 @@ jobs:
       S3DATA: scality
       S3METADATA: scality
       S3VAULT: scality
-      CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}
+      CLOUDSERVER_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}-testcoverage
       MPU_TESTING: "yes"
       DEFAULT_BUCKET_KEY_FORMAT: ${{ matrix.vformat }}
       ENABLE_NULL_VERSION_COMPAT_MODE: ${{ matrix.enable-null-compat }}


### PR DESCRIPTION
Backport of CLDSRV-942, from #6216 (`30a06a609`), cherry-picked unchanged: a one-line switch of the s3c-ft-tests job to the `-testcoverage` image. That fix landed on development/9.2 and reached 9.3, 9.4, 9.5 and hotfix/9.3.13, but never this branch.

Why it matters here: the plain image runs `yarn start` with output left on the container stdout, so cloudserver's log is never written to `/artifacts` and never uploaded. The `-testcoverage` image runs `docker-test-with-coverage.sh`, which does `nyc yarn start > /artifacts/s3.log 2> /artifacts/s3-stderr.log`, which is how every other functional job already captures it. Verified on real runs: a development/9.3 s3c bundle contains a 38 MB `s3.log`; this branch's F8 run (33647777908) uploaded 19 files and none of them was cloudserver's. That is why CLDSRV-992 row F8's ServiceUnavailable could not be root-caused on this branch: nginx, sproxyd and bucketd all logged clean and there was no cloudserver log to read.

One behavioural note for the reviewer: this puts the hotfix s3c job on the `nyc`-instrumented image, the same one 9.3 and later already run for this job. Nothing else changes.