### PR TITLE
Report scal-replica for replicas without the isReplica flag

### DIFF
--- a/lib/utilities/collectResponseHeaders.js
+++ b/lib/utilities/collectResponseHeaders.js
@@ -91,7 +91,7 @@ function collectResponseHeaders(objectMD, corsHeaders, versioningCfg, returnTagC
     }
     if (objectMD.replicationInfo) {
         const { isReplica, status } = objectMD.replicationInfo;
-        if (isReplica) {
+        if (isReplica || status === 'REPLICA') {
             const hasReplicated = !status || status === 'COMPLETED';
             responseMetaHeaders['x-amz-replication-status'] = hasReplicated ? 'REPLICA' : status;
             responseMetaHeaders['x-amz-meta-scal-replica'] = 'true';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zenko/cloudserver",
-    "version": "9.4.3",
+    "version": "9.4.4",
     "description": "Zenko CloudServer, an open-source Node.js implementation of a server handling the Amazon S3 protocol",
     "main": "index.js",
     "engines": {

--- a/tests/unit/utils/collectResponseHeaders.js
+++ b/tests/unit/utils/collectResponseHeaders.js
@@ -17,6 +17,13 @@ describe('Middleware: Collect Response Headers', () => {
         assert.deepStrictEqual(headers['x-amz-meta-scal-replica'], 'true');
     });
 
+    it('should mark a replica written without the isReplica flag', () => {
+        const objectMD = { replicationInfo: { status: 'REPLICA' } };
+        const headers = collectResponseHeaders(objectMD);
+        assert.deepStrictEqual(headers['x-amz-replication-status'], 'REPLICA');
+        assert.deepStrictEqual(headers['x-amz-meta-scal-replica'], 'true');
+    });
+
     it('should default to REPLICA when isReplica is true and status is absent', () => {
         const objectMD = { replicationInfo: { isReplica: true } };
         const headers = collectResponseHeaders(objectMD);


### PR DESCRIPTION
The isReplica field was introduced in 9.4 with no metadata migration, so objects replicated before the upgrade only carry the legacy encoding status === 'REPLICA' and never got the x-amz-meta-scal-replica header. Accept both encodings, same semantics as arsenal ObjectMD.getReplicationIsReplica().

Issue: CLDSRV-994
